### PR TITLE
Bugfixed test file output

### DIFF
--- a/Functions/It.ps1
+++ b/Functions/It.ps1
@@ -16,14 +16,14 @@ function It($name, [ScriptBlock] $test)
     Start-PesterConsoleTranscript
     try{
         temp
-        $output | Write-Host -ForegroundColor green;
+        "[+] $output " | Write-Host -ForegroundColor green;
     } catch {
         $failure_message = $_.toString() -replace "Exception calling", "Assert failed on"
         $temp_line_number =  $_.InvocationInfo.ScriptLineNumber - 2
         $failure_line_number = $start_line_position + $temp_line_number
 
         $results.FailedTests += $name
-        $output | Write-Host -ForegroundColor red
+        "[-] $output" | Write-Host -ForegroundColor red
 
         Write-Host -ForegroundColor red $error_margin$failure_message
         Write-Host -ForegroundColor red $error_margin$error_margin"at line: $failure_line_number in  $test_file"


### PR DESCRIPTION
There was a bug in how test.ps1 was written (verifiable in my environment at least)
I also thought it would be nice to have simple + / - style prefixes to passing / failing tests like other frameworks
