### PR TITLE
Add ability to specify a specific test to run and fix bugs with exit codes and test summary report

### DIFF
--- a/Functions/It.ps1
+++ b/Functions/It.ps1
@@ -1,5 +1,6 @@
 function It($name, [ScriptBlock] $test) 
 {
+    if($test_name -ne $Null -and $test_name.ToLower() -ne $name) {return}
     $results = Get-GlobalTestResults
     $margin = " " * $results.TestDepth
     $error_margin = $margin * 2

--- a/Functions/TestResults.ps1
+++ b/Functions/TestResults.ps1
@@ -23,8 +23,8 @@ function Reset-GlobalTestResults {
 
 function Write-TestReport {
     $results = $Global:TestResults
-    Write-Host Tests completed in (Get-HumanTime $results.TotalTime)
-    Write-Host Passed: $($results.TestCount - $results.FailedTestsCount) Failed: $($results.FailedTestsCount)
+    Write-Host "Tests completed in $(Get-HumanTime $results.TotalTime)"
+    Write-Host "Passed: $($results.TestCount - $results.FailedTestsCount) Failed: $($results.FailedTestsCount)"
 }
 
 function Get-HumanTime($seconds) {
@@ -126,7 +126,7 @@ function Get-RunTimeEnvironment() {
 
 
 function Exit-WithCode {
-    $failedTestCount = $Global:TestResults.FailedTests.Length
+    $failedTestCount = $Global:TestResults.FailedTestsCount
     $host.SetShouldExit($failedTestCount)
 }
 

--- a/Pester.psm1
+++ b/Pester.psm1
@@ -2,7 +2,7 @@ Resolve-Path $PSScriptRoot\Functions\*.ps1 |
     ? { -not ($_.ProviderPath.Contains(".Tests.")) } |
     % { . $_.ProviderPath }
 
-function Invoke-Pester($relative_path = ".", [switch] $EnableExit, $OutputXml = $null) {
+function Invoke-Pester($relative_path = ".", $test_name = $null, [switch] $EnableExit) {
     Reset-GlobalTestResults
     . "$PSScriptRoot\ObjectAdaptations\PesterFailure.ps1"
     Update-TypeData -pre "$PSScriptRoot\ObjectAdaptations\types.ps1xml" -ErrorAction SilentlyContinue

--- a/bin/pester.bat
+++ b/bin/pester.bat
@@ -8,7 +8,7 @@ if '%1'=='/help' goto usage
 if '%1'=='help' goto usage
 if '%1'=='new-fixture' goto newfixture
 
-@PowerShell -NonInteractive -NoProfile -ExecutionPolicy unrestricted -Command "& Import-Module '%DIR%..\Pester.psm1'; & { Invoke-Pester -OutputXml Test.xml -EnableExit; exit $LastExitCode}"
+@PowerShell -NonInteractive -NoProfile -ExecutionPolicy unrestricted -Command "& Import-Module '%DIR%..\Pester.psm1'; & { Invoke-Pester -OutputXml Test.xml -EnableExit %*}"
 
 goto finish
 :newfixture


### PR DESCRIPTION
I'm closing my previous pull request and replacing it with this updated one. This continues to add a argument allowing one to specify an individual test to run.

This also fixes a few bugs I recently came accross while cleaning up chocolatey tests:

1.The Test Result summary string was throwing a syntax error in certain scenarios. Namely for tests written in Chocolatey source where write-host is overridden.
2. Failed tests are not throwing a non-zero exit code. A regression bug from a recent change.
3. Running the tests via the .bat file do not receive a failed exit code ue to the redundant exit command.
