### PR TITLE
Fix for invoke-pester from inside ChocolateyInstall.ps1

### DIFF
--- a/Functions/TestResults.ps1
+++ b/Functions/TestResults.ps1
@@ -23,8 +23,10 @@ function Reset-GlobalTestResults {
 
 function Write-TestReport {
     $results = $Global:TestResults
-    Write-Host "Tests completed in $(Get-HumanTime $results.TotalTime)"
-    Write-Host "Passed: $($results.TestCount - $results.FailedTestsCount) Failed: $($results.FailedTestsCount)"
+    $out = "Tests completed in $(Get-HumanTime $results.TotalTime)"
+    Write-Host "$out"
+    $out = "Passed: $($results.TestCount - $results.FailedTestsCount) Failed: $($results.FailedTestsCount)"
+    Write-Host "$out"
 }
 
 function Get-HumanTime($seconds) {

--- a/Pester.psm1
+++ b/Pester.psm1
@@ -22,7 +22,7 @@ function Invoke-Pester {
     Update-TypeData -pre "$PSScriptRoot\ObjectAdaptations\types.ps1xml" -ErrorAction SilentlyContinue
 
     $fixtures_path = Resolve-Path $relative_path
-    Write-Host Executing all tests in $fixtures_path
+    Write-Host "Executing all tests in $fixtures_path"
 
     Get-ChildItem $fixtures_path -Include "*.ps1" -Recurse |
         ? { $_.Name -match "\.Tests\." } |

--- a/default.ps1
+++ b/default.ps1
@@ -2,7 +2,7 @@ $psake.use_exit_on_error = $true
 properties {
     $currentDir = resolve-path .
     $Invocation = (Get-Variable MyInvocation -Scope 1).Value
-    $baseDir = Split-Path -parent $Invocation.MyCommand.Definition | split-path -parent | split-path -parent | split-path -parent | split-path -parent
+    $baseDir = $psake.build_script_dir
     echo $baseDir
     $version = git describe --abbrev=0 --tags
     $buildNumber = '-alpha-' + (git log $($version + '..') --pretty=oneline | measure-object).Count
@@ -15,9 +15,7 @@ Task Package -depends Version-Module, Pack-Nuget, Unversion-Module
 Task Release -depends Strip-BuildNumber, Build, Push-Nuget
 
 Task Test {
-    CD "$baseDir"
-    ."$baseDir\bin\Pester.bat"
-    CD $currentDir
+    "$baseDir\bin\Pester.bat"
 }
 
 Task Strip-BuildNumber {


### PR DESCRIPTION
When I run invoke-pester from inside ChocolateyInstall.ps1, exceptions are thrown because off the way Chocolatey overrides Write-Host and its use of parameter splatting. Basically, I just put the text going to Write-Host in quotes, and that fixed it.

I also had to modify the psake script so it works on my machine (and hopefully and everyone else's as well).

A little background:
I'm scripting out the installation/configuration of web server VM's using Chocolatey packages, and each package has a pester test file embedded in it. Once all packages are installed, I run pester to validate that everything is working as expected.
