### PR TITLE
add tagging functionality to pester describes

### DIFF
--- a/Functions/Describe.ps1
+++ b/Functions/Describe.ps1
@@ -50,11 +50,20 @@ Invoke-Pester
 about_TestDrive
 
 #>
+
 param(
-        $name, 
+
+        [Parameter(Mandatory = $true, Position = 0)] $name,
+
+        $tags=@(),
+
+        [Parameter(Mandatory = $true, Position = 1)]
         [ScriptBlock] $fixture
 )
+
     if($testName -ne '' -and $testName.ToLower() -ne $name.ToLower()) {return}
+    if($arr_testTags -ne '' -and @(Compare-Object $tags $arr_testTags -IncludeEqual -ExcludeDifferent).count -eq 0) {return}
+
     Setup
 
     $results = Get-GlobalTestResults

--- a/Pester.psm1
+++ b/Pester.psm1
@@ -73,13 +73,17 @@ about_pester
         [Parameter(Position=2,Mandatory=0)]
         [switch]$EnableExit, 
         [Parameter(Position=3,Mandatory=0)]
-        [string]$OutputXml = ''
+        [string]$OutputXml = '',
+        [Parameter(Position=4,Mandatory=0)]
+        [string]$Tags = $null
     )
     Reset-GlobalTestResults
     . "$PSScriptRoot\ObjectAdaptations\PesterFailure.ps1"
     Update-TypeData -pre "$PSScriptRoot\ObjectAdaptations\types.ps1xml" -ErrorAction SilentlyContinue
 
     $fixtures_path = Resolve-Path $relative_path
+    $arr_testTags=$Tags.Split(' ')
+
     Write-Host Executing all tests in $fixtures_path
 
     Get-ChildItem $fixtures_path -Include "*.ps1" -Recurse |


### PR DESCRIPTION
This is an initial attempt to add tagging functionality to pester.  I am new to pester in general, so if I am going about this wrong let me know.  

Do changes to the code typically require their own pester testing?

```
cli usage:
pester <specific test> -Tags "<tag1><space><optionaltag2>"

describe usage:
Describe "Add-Numbers" -Tags 'adder','calculator' {...}
```
