### PR TITLE
Support for should.not_be

### DIFF
--- a/Examples/Calculator/Add-Numbers.Tests.ps1
+++ b/Examples/Calculator/Add-Numbers.Tests.ps1
@@ -22,5 +22,9 @@ Describe "Add-Numbers" {
         $sum = Add-Numbers two three
         $sum.should.be("twothree")
     }
-
+    
+    It "should not be 0" {
+        $sum = Add-Numbers 2 3
+        $sum.should.not_be(0)
+    }
 }

--- a/ObjectAdaptations/types.ps1xml
+++ b/ObjectAdaptations/types.ps1xml
@@ -12,6 +12,10 @@
                         param($expected)
                         if ($expected -ne $this.actual) {throw New-Object PesterFailure($expected,$this.actual)}
                     } -PassThru |
+                    Add-Member ScriptMethod not_be {
+                        param($expected)
+                        if ($expected -eq $this.actual) {throw New-Object PesterFailure($expected,$this.actual)}
+                    } -PassThru |
                     Add-Member ScriptMethod have_count_of {
                         param($expected_count)
 
@@ -22,6 +26,9 @@
                     } -PassThru |
                     Add-Member ScriptMethod exist {
                         if (-not (Test-Path $this.actual)) { throw New-Object PesterFailure("$($this.actual) should exist","$($this.actual) not found")}
+                    } -PassThru |
+                    Add-Member ScriptMethod not_exist {
+                        if (Test-Path $this.actual) { throw New-Object PesterFailure("$($this.actual) should not exist","$($this.actual) exists")}
                     } -PassThru |
                     Add-Member ScriptMethod match {
                         param($expected_match)


### PR DESCRIPTION
This was a simple addition of the types.ps1xml to add support for not_be. This was a requirement of mine when writing some scripts to work out a file location
