### PR TITLE
Exit-WithCode Error

### DIFF
--- a/Functions/TestResults.ps1
+++ b/Functions/TestResults.ps1
@@ -124,7 +124,7 @@ function Get-RunTimeEnvironment() {
 
 
 function Exit-WithCode {
-    $failedTestsCount = $Global:TestResults.FailedTestsCount
+    $failedTestsCount = $Pester.TestResults.FailedTestsCount
     $host.SetShouldExit($failedTestsCount)
 }
 


### PR DESCRIPTION
$Global:TestResults.FailedTestsCount was null.

I was trying to figure out why the ($p = Start-Process -FilePath
Powershell -ArgumentList "invoke-pester -enableExit") returned process,
wasn't reporting an error code above zero ($p.ExitCode == 0) when there
were pester errors.  I tracked it down to this line.

I've never done a pull request, but we use Pester within production (AWESOME tool by the way, thank you so much!) and wanted to get this change incorporated into the source so that PsGet is updated, therefore our development and build machines are as well.
