### PR TITLE
Why not return the number of failing tests from Invoke-Pester?

### DIFF
--- a/Pester.psm1
+++ b/Pester.psm1
@@ -118,6 +118,8 @@ about_pester
         Write-NunitTestReport (Get-GlobalTestResults) $OutputXml 
     }
     if ($EnableExit) { Exit-WithCode }
+	
+	return $Pester.TestResults.FailedTestsCount
 }
 
 function Write-UsageForCreateFixture {


### PR DESCRIPTION
I tend to call Invoke-Pester from within build scripts, so being able to
just simply get the number of failed tests would be great!

Warning: I wasn't sure if it would be possible for
the $pester or the $pester.TestResults objects to be null at this point
in the execution, because there are no tests for the cmdlets within the
.psm1
