### PR TITLE
Switched from dot syntax to pipe syntax as noted in #49

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Describe "BuildIfChanged" {
           Assert-VerifiableMocks
       }
       It "returns the next version number" {
-          $result.Should.Be(1.2)
+          $result | Should Be 1.2
       }
     }
   Context "When there are no Changes" {


### PR DESCRIPTION
In line with the edit I made to the wiki page on 5th July.
