### PR TITLE
add missing text example for Powershell function "Build"

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,11 @@ A Pester Test
 BuildChanges.ps1
 
 ```powershell
+
+function Build ($version) {
+  write-host "a build was run for version: $version"
+}
+
 function BuildIfChanged {
   $thisVersion=Get-Version
   $nextVersion=Get-NextVersion


### PR DESCRIPTION
The example in the ReadMe is incomplete and does not currently work.  This commit reinstates the missing powershell function in the example.
