### PR TITLE
added fix for cleanup when remove-item is mocked

### DIFF
--- a/Functions/Cleanup.Tests.ps1
+++ b/Functions/Cleanup.Tests.ps1
@@ -13,6 +13,25 @@ Describe "Cleanup" {
 
     It "should also remove the TestDrive:" {
         Test-Path "TestDrive:\foo" | Should Not Exist
-    }
+    }	
+
+}
+
+Describe "Cleanup when Remove-Item is mocked" {
+	
+	Mock Remove-Item {}
+	
+	Context "add a temp directory" {
+		Setup -Dir "foo"
+	}
+	
+	Context "next context" {
+	
+		It "should have removed the temp folder" {
+			"$TestDrive\foo" | Should Not Exist
+		}
+		
+	}
+
 }
 

--- a/Functions/Cleanup.ps1
+++ b/Functions/Cleanup.ps1
@@ -1,7 +1,8 @@
-function Cleanup() {
-    if (Test-Path $TestDrive) {
-        Remove-Item $TestDrive -Recurse -Force
+function Cleanup {    
+	Clear-Mocks
+	
+	if (Test-Path $TestDrive) {
+        Microsoft.PowerShell.Management\Remove-Item $TestDrive -Recurse -Force
         Remove-PSDrive -Name TestDrive -Scope Global -Force
-    }
-    Clear-Mocks
+    }    	
 }


### PR DESCRIPTION
When remove-item is mocked the cleanup function doesn't work.
I've added a test to prove that and fixed it.
