### PR TITLE
added support for -PassThru on the Setup function

### DIFF
--- a/Functions/Setup.Tests.ps1
+++ b/Functions/Setup.Tests.ps1
@@ -67,3 +67,21 @@ Describe "Create a file with content" {
     }
 }
 
+Describe "Create file with passthru" {
+	$thefile = Setup -File "thefile" -PassThru
+	
+	It "returns the file from the temp location" {
+		$thefile.Directory.Name | Should Be "pester"
+		$thefile.Exists | Should Be $true
+	}
+}
+
+Describe "Create directory with passthru" {
+	$thedir = Setup -Dir "thedir" -PassThru
+	
+	It "returns the directory from the temp location" {
+		$thedir.Parent.Name | Should Be "pester"
+		$thedir.Exists | Should Be $true
+	}
+}
+

--- a/Functions/Setup.ps1
+++ b/Functions/Setup.ps1
@@ -1,18 +1,29 @@
 $global:TestDrive = "$env:Temp\pester"
 
-function Initialize-Setup() {
+function Initialize-Setup {
     if (Test-Path TestDrive:) { return }
 
     New-Item -Name pester -Path $env:Temp -Type Container -Force | Out-Null
     New-PSDrive -Name TestDrive -PSProvider FileSystem -Root "$($env:Temp)\pester" -Scope Global | Out-Null
 }
 
-function Setup([switch] $Dir, [switch] $File, $Path, $Content = "") {
+function Setup {
+	param(
+		[switch]$Dir, 
+		[switch]$File, 
+		$Path, 
+		$Content = "",
+		[switch]$PassThru
+	)
     Initialize-Setup
 
     if ($Dir) {
-        New-Item -Name $Path -Path TestDrive: -Type Container -Force | Out-Null
+        $item = New-Item -Name $Path -Path TestDrive: -Type Container -Force
     } elseif ($File) {
-        $Content | New-Item -Name $Path -Path TestDrive: -Type File -Force | Out-Null
+        $item = $Content | New-Item -Name $Path -Path TestDrive: -Type File -Force
     }
+	
+	if($PassThru) {
+		return $item
+	}
 }


### PR DESCRIPTION
Sometimes you want to start working with the file (or directory) you create right away. I've added support for that via the -PassThru switch parameter on the Setup function.
Tests to prove my point supplied of course.
