### PR TITLE
Fix mocking out-file in describe block

### DIFF
--- a/Functions/It.ps1
+++ b/Functions/It.ps1
@@ -97,7 +97,7 @@ function Setup-TestFunction {
 function temp {
 $test
 }
-"@ | out-file $TestDrive\temp.ps1
+"@ | Microsoft.Powershell.Utility\Out-File $TestDrive\temp.ps1
 }
 
 function write-PesterResult{

--- a/Functions/Mock.Tests.ps1
+++ b/Functions/Mock.Tests.ps1
@@ -55,6 +55,15 @@ Describe "When calling Mock on existing cmdlet" {
     }
 }
 
+Describe "When calling Mock in the Describe block" {
+    Mock Out-File {return "I am not Out-File"}
+
+    It "Should mock Out-File successfully" {
+        $outfile = "test" | Out-File "..\testfile.txt"
+        $outfile | Should Be "I am not Out-File"
+    }
+}
+
 Describe "When calling Mock on existing cmdlet to handle pipelined input" {
     Mock Get-ChildItem {
       if($_ -eq 'a'){


### PR DESCRIPTION
When trying to mock "out-file" in a describe block, I ran across this lovely message:

```
. : The term 'C:\Users\user\AppData\Local\Temp\pester\temp.ps1' is not recognized as the name of a 
cmdlet, function, script file, or operable program. Check the spelling of the name, or if a path was 
included, verify that the path is correct and try again.
At C:\path\to\Pester\Functions\It.ps1:71 char:7
+     . $TestDrive\temp.ps1
+       ~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : ObjectNotFound: (C:\Users\user...pester\temp.ps1:String) [], CommandNotFoundException
    + FullyQualifiedErrorId : CommandNotFoundException
```

This was fixed by extending the reference to the actual out-file cmdlet so that the mocked version wouldn't be called in the Pester framework.
