### PR TITLE
fix for Issue 58

### DIFF
--- a/Functions/Assertions/PesterThrow.Tests.ps1
+++ b/Functions/Assertions/PesterThrow.Tests.ps1
@@ -17,6 +17,10 @@ Describe "PesterThrow" {
         Test-PositiveAssertion (PesterThrow { throw "expected error"} "expected error")
     }    
 
+    It "returns false if the statement throws an exception and the actual error does not match the case of the expected error text" {
+        Test-NegativeAssertion (PesterThrow { throw "expected error"} "EXPECTED ERROR")
+    }     
+    
     It "returns true if the statement throws an exception and the actual error text matches the expected error pattern" {
         Test-PositiveAssertion (PesterThrow { throw "expected error"} "expected*")
     }     

--- a/Functions/Assertions/PesterThrow.ps1
+++ b/Functions/Assertions/PesterThrow.ps1
@@ -4,12 +4,13 @@
 function PesterThrow([scriptblock] $script, $expectedErrorMessage) {
     $itThrew = $false
 	$pester.ActualExceptionMessage = $null
+  $pester.ActualExceptionWasThrown = $false
     try {
         # Piping to Out-Null so results of script exeution
         # does not remain on the pipeline
         & $script | Out-Null
     } catch {
-
+        $pester.ActualExceptionWasThrown = $true
         $pester.ActualExceptionMessage = $_.Exception.Message
         if (($expectedErrorMessage) -and $pester.ActualExceptionMessage -cnotlike $expectedErrorMessage) {
             $itThrew = $false
@@ -23,7 +24,8 @@ function PesterThrow([scriptblock] $script, $expectedErrorMessage) {
 
 function PesterThrowFailureMessage($value, $expected) {
     if ($expected) {
-      return "Expected: the expression to throw an exception with message {{{0}}}, But message was {{{1}}}" -f $expected, $pester.ActualExceptionMessage
+      return "Expected: the expression to throw an exception with message {{{0}}}, an exception was {2}raised, message was {{{1}}}" -f 
+              $expected, $pester.ActualExceptionMessage,(@{$true="";$false="not "}[$pester.ActualExceptionWasThrown])
     } else {
       return "Expected: the expression to throw an exception"
     }
@@ -31,7 +33,8 @@ function PesterThrowFailureMessage($value, $expected) {
 
 function NotPesterThrowFailureMessage($value, $expected) {
     if ($expected) {
-        return "Expected: the expression to not throw an exception with message {{{0}}}, But message was {{{1}}}" -f $expected, $pester.ActualExceptionMessage
+        return "Expected: the expression to not throw an exception with message {{{0}}}, an exception was {2}raised, message was {{{1}}}" -f 
+              $expected, $pester.ActualExceptionMessage,(@{$true="";$false="not "}[$pester.ActualExceptionWasThrown])
     } else {
         return "Expected: the expression to not throw an exception. Message was {{{0}}}" -f $pester.ActualExceptionMessage
     }


### PR DESCRIPTION
addresses issue 58 by extending PesterThrow to store the actual error message and whether an error was thrown or not in the main `$pester` object
