### PR TITLE
Make the New-Fixture function accepts "." (the current workding director...

### DIFF
--- a/Pester.psm1
+++ b/Pester.psm1
@@ -189,10 +189,19 @@ param(
         return
     }
 
-    # TODO clean up $path cleanup
-    $path = $path.TrimStart(".")
-    $path = $path.TrimStart("\")
-    $path = $path.TrimStart("/")
+    if ($path -eq ".") {
+        $path = (pwd).path
+    }
+    else {
+        # TODO clean up $path cleanup
+        $path = $path.TrimStart(".")
+        $path = $path.TrimStart("\")
+        $path = $path.TrimStart("/")
+    
+        if (-not (Test-Path $path)) {
+            & md $path | Out-Null
+        } 
+    }
 
     if (-not (Test-Path $path)) {
         & md $path | Out-Null


### PR DESCRIPTION
...y) as the $path parameter

In the past when we run the follow code, we will get errors.

PS C:\temp> New-Fixture . HelloWorld
Test-Path : Cannot bind argument to parameter 'Path' because it is an empty string.
At C:\Users\eyang\Documents\WindowsPowerShell\Modules\Pester\Pester.psm1:197 char:25
-     if (-not (Test-Path $path)) {
-                         ~~~~~
  - CategoryInfo          : InvalidData: (:) [Test-Path], ParameterBindingValidationException
  - FullyQualifiedErrorId : ParameterArgumentValidationErrorEmptyStringNotAllowed,Microsoft.PowerShell.Commands.TestPathCommand

Creating => \HelloWorld.ps1
Creating => \HelloWorld.Tests.ps1
PS C:\temp>

Now the $path parameter accepts ".". 

PS C:\temp> New-Fixture . HelloWorld
Creating => C:\temp\HelloWorld.ps1
Creating => C:\temp\HelloWorld.Tests.ps1
PS C:\temp>
