### PR TITLE
Change colors of output to dimmer colors.

### DIFF
--- a/Functions/Context.ps1
+++ b/Functions/Context.ps1
@@ -44,7 +44,7 @@ param(
     $pester.margin = " " * $pester.results.TestDepth
     $pester.results.TestDepth += 1
 
-    Write-Host -fore yellow $pester.margin $name
+    Write-Host -ForegroundColor Magenta $pester.margin $name
     & $fixture
 
     Cleanup

--- a/Functions/Describe.ps1
+++ b/Functions/Describe.ps1
@@ -72,7 +72,7 @@ param(
     }
 
     $pester.output = $pester.margin + "Describing " + $name
-    Write-Host -fore yellow $($pester.output)
+    Write-Host -ForegroundColor Magenta $($pester.output)
     & $fixture
 
     $pester.Scope = "Describe" #may have been switched to context

--- a/Functions/It.ps1
+++ b/Functions/It.ps1
@@ -106,7 +106,7 @@ function write-PesterResult{
     $pester.output = " $($pester.margin)$name"
     $pester.humanSeconds = Get-HumanTime $pester.testTime.TotalSeconds
     if($pester.testResult.success) {
-        "[+] $($pester.output) $($pester.humanSeconds)" | Write-Host -ForegroundColor green;
+        "[+] $($pester.output) $($pester.humanSeconds)" | Write-Host -ForegroundColor DarkGreen;
     }
     else {
         "[-] $($pester.output) $($pester.humanSeconds)" | Write-Host -ForegroundColor red

--- a/Pester.psm1
+++ b/Pester.psm1
@@ -97,7 +97,7 @@ about_pester
     Reset-GlobalTestResults
 
     if ($EnableLegacyExpectations) {
-        "WARNING: Enabling deprecated legacy expectations. " | Write-Host -Fore Yellow
+        "WARNING: Enabling deprecated legacy expectations. " | Write-Host -Fore Yellow -Back DarkGray
         . "$PSScriptRoot\ObjectAdaptations\PesterFailure.ps1"
         Update-TypeData -pre "$PSScriptRoot\ObjectAdaptations\types.ps1xml" -ErrorAction SilentlyContinue
     }
@@ -130,9 +130,9 @@ function Create-File($file_path, $contents = "") {
 
     if (-not (Test-Path $file_path)) {
         $contents | Out-File $file_path -Encoding ASCII
-        "Creating" | Write-Host -Fore Green -NoNewLine
+        "Creating" | Write-Host -Fore DarkGreen -NoNewLine
     } else {
-        "Skipping" | Write-Host -Fore Yellow -NoNewLine
+        "Skipping" | Write-Host -Fore Magenta -NoNewLine
     }
     " => $file_path" | Write-Host
 }


### PR DESCRIPTION
Changed the color of the output to make it readable on white as well as on dark blue/black background. Describe is now magenta instead of yellow and passed tests are dark green. In the picture you can see the new output followed by the old output.
![pestercolorchange](https://f.cloud.github.com/assets/5735905/1888829/adfc8f68-7a12-11e3-9982-ed7138356237.PNG)
