### PR TITLE
Random directory for TestDrive.

### DIFF
--- a/Functions/TestDrive.Tests.ps1
+++ b/Functions/TestDrive.Tests.ps1
@@ -1,10 +1,10 @@
-$here = Split-Path -Parent $MyInvocation.MyCommand.Path
+﻿$here = Split-Path -Parent $MyInvocation.MyCommand.Path
 . "$here\TestDrive.ps1"
 
 Describe "Setup" {
 
     It "returns a location that is in a temp area" {
-        $TestDrive | Should Be "$env:Temp\pester"
+        $TestDrive -like "$env:temp\*"| Should Be $true
     }
 
     It "creates a drive location called TestDrive:" {
@@ -77,7 +77,7 @@ Describe "Create file with passthru" {
 	$thefile = Setup -File "thefile" -PassThru
 	
 	It "returns the file from the temp location" {
-		$thefile.Directory.Name | Should Be "pester"
+		$thefile.FullName -like "$env:TEMP\*" | Should Be $true
 		$thefile.Exists | Should Be $true
 	}
 }
@@ -86,7 +86,7 @@ Describe "Create directory with passthru" {
 	$thedir = Setup -Dir "thedir" -PassThru
 	
 	It "returns the directory from the temp location" {
-		$thedir.Parent.Name | Should Be "pester"
+		$thedir.FullName -like "$env:TEMP\*" | Should Be $true
 		$thedir.Exists | Should Be $true
 	}
 }
@@ -143,5 +143,18 @@ Describe "Cleanup when Remove-Item is mocked" {
 
     }
 
+}
+
+Describe "New-RandomTempDirectory" {
+	It "creates randomly named directory" {
+		$first = New-RandomTempDirectory 
+		$second = New-RandomTempDirectory
+		
+		$first | Remove-Item -Force 
+		$second | Remove-Item -Force 
+		
+		$first.name | Should Not Be $second.name
+		
+	}
 }
 

--- a/Functions/TestDrive.ps1
+++ b/Functions/TestDrive.ps1
@@ -1,8 +1,8 @@
 ﻿#
 function New-TestDrive ([Switch]$PassThru) {
-
+	
     
-	$Path = "$env:TEMP\Pester"
+	$Path = New-RandomTempDirectory
 	$DriveName = "TestDrive"
 	
 	if (-not (Test-Path -Path $Path))
@@ -36,6 +36,15 @@ function Clear-TestDrive ([String[]]$Exclude) {
 			where { $Exclude -NotContains $_.FullName } |
 			Microsoft.PowerShell.Management\Remove-Item -Force -Recurse
 	}
+}
+
+function New-RandomTempDirectory {
+    do 
+    {
+        $Path = Join-Path -Path $env:TEMP -ChildPath ([Guid]::NewGuid())
+	} until (-not ( Test-Path -Path $Path ))
+    
+    New-Item -ItemType Container -Path $Path
 }
 
 function Get-TestDriveItem {


### PR DESCRIPTION
Test drive is set to a random directory. Instead of "Pester" a GUID with check for collision is used as the directory name. Running two Pesters in parallel is possible if started from two separate powershell.exe processes.
The directory is still placed in the $env:temp (user temp). The global $TestDrive variable and the global PSDrive TestDrive are still published. So it is not possible to run two Pesters in the same session at the same time.
