### PR TITLE
It blocks are processed in memory.

### DIFF
--- a/Functions/It.Tests.ps1
+++ b/Functions/It.Tests.ps1
@@ -1,4 +1,4 @@
-$here = Split-Path -Parent $MyInvocation.MyCommand.Path
+﻿$here = Split-Path -Parent $MyInvocation.MyCommand.Path
 . "$here\Describe.ps1"
 
 function List-ExtraKeys($baseHash, $otherHash) {
@@ -13,16 +13,16 @@ function List-ExtraKeys($baseHash, $otherHash) {
 }
 
 Describe "It" {
-    [ScriptBlock]$script={"something"}
-    $test="something"
     It "records the correct stack line number of failed tests" {
-        try{"something" | should be "nothing"}catch{ $ex=$_} #line 1
+		#the $script scriptblock below is used as a position marker to determine 
+		#on which line the test failed.
+        try{"something" | should be "nothing"}catch{ $ex=$_} ; $script={}
         $result = Get-PesterResult $script $ex
-        $result.Stacktrace | should match "at line: $($script.startPosition.StartLine+1) in "
-        $test="something"
+        $result.Stacktrace | should match "at line: $($script.startPosition.StartLine) in "
     }
 
     It "should pass if assertions pass" {
+		$test = 'something'
         $test | should be "something"
     }
 

--- a/Functions/It.ps1
+++ b/Functions/It.ps1
@@ -1,4 +1,4 @@
-function It {
+﻿function It {
 <#
 .SYNOPSIS
 Validates the results of a test inside of a Describe block.
@@ -67,9 +67,6 @@ param(
     $pester.results = Get-GlobalTestResults
     $pester.results.TestCount += 1
 
-    Setup-TestFunction
-    . $TestDrive\temp.ps1
-
     $pester.ThisTest=$test
     try{
         [object]$test=(get-variable -name test -scope 1 -errorAction Stop).value
@@ -79,7 +76,7 @@ param(
     }
     $pester.testTime = Measure-Command {
         try{
-            temp
+            &{ &$pester.ThisTest }
         } catch {
             $pester.results.FailedTestsCount += 1
             $PesterException = $_
@@ -90,14 +87,6 @@ param(
     $pester.results.CurrentDescribe.Tests += $pester.testResult
     $pester.results.TotalTime += $pester.testTime.TotalSeconds
     Write-PesterResult
-}
-
-function Setup-TestFunction {
-@"
-function temp {
-$test
-}
-"@ | Microsoft.Powershell.Utility\Out-File $TestDrive\temp.ps1
 }
 
 function write-PesterResult{
@@ -135,8 +124,7 @@ function Get-PesterResult{
         else {
             $line=$exception.InvocationInfo.ScriptLineNumber
         }
-        $failureLine = $test.StartPosition.StartLine + ($line-2)
-        $testResult.stackTrace = "at line: $failureLine in $($test.File)"
+        $testResult.stackTrace = "at line: $Line in $($test.File)"
     }
     return $testResult
 }


### PR DESCRIPTION
The temp.ps1 script is not created for each It block, invoking
scriptblock inside an anonymous function is used instead.

Originally the $test was dumped into a Temp function (+1 scope ), which was created
in a separate script (+1 scope) and then dot-sourced (-1 scope) to the main script, from which
it was invoked (+1 scope in result). Now just creating a function (+1 scope) is used so it keeps the behaviour,
minus the overhead.

Also I cleaned up the mess in the It.Tests.
