### PR TITLE
make Get-TestTime culture agnostic

### DIFF
--- a/Functions/TestResults.Tests.ps1
+++ b/Functions/TestResults.Tests.ps1
@@ -192,3 +192,34 @@ Describe "Write nunit test results" {
     }
 }
 
+Describe "Get-TestTime" {
+	function Using-Culture {
+		param (
+			[Parameter(Mandatory = $true, ValueFromPipeline = $true)]
+			[ScriptBlock]$ScriptBlock,
+			[System.Globalization.CultureInfo]$Culture='en-US'
+		)
+		
+		$oldCulture = [System.Threading.Thread]::CurrentThread.CurrentCulture
+		try 
+		{
+			[System.Threading.Thread]::CurrentThread.CurrentCulture = $Culture
+			$ExecutionContext.InvokeCommand.InvokeScript($ScriptBlock)
+		}
+		finally 
+		{
+			[System.Threading.Thread]::CurrentThread.CurrentCulture = $oldCulture
+		}
+	}
+	
+	It "output is culture agnostic" {
+		#on cs-CZ, de-DE and other systems where decimal separator is ",". value [double]3.5 is output as 3,5 
+		#this makes some of the tests fail, it could also leak to the nUnit report if the time was output
+				
+		$TestResult = New-Object -TypeName psObject -Property @{ Time = 3.5 }
+		
+		#using the string formatter here to know how the string will be output to screen
+		$Result = { Get-TestTime -Tests $TestResult | Out-String -Stream } | Using-Culture -Culture de-DE
+		$Result | Should Be "3.5"
+	}
+}

--- a/Functions/TestResults.ps1
+++ b/Functions/TestResults.ps1
@@ -80,7 +80,7 @@ function Get-TestTime($tests) {
     $tests | %{
         $totalTime += $_.time
     }
-    return $totalTime;
+    return [string]$totalTime;
 }
 
 function Get-TestSuccess($tests) {


### PR DESCRIPTION
On systems with culture set to CZ, DE and other systems where decimal separator is different than ".". Value [double]3.5 is output as 3,5 (or similar). Currently this only makes some of the tests fail, but it could also leak to the nUnit report if the time was output.
