### PR TITLE
Add case sensitive assertions

### DIFF
--- a/Functions/Assertions/Be.Tests.ps1
+++ b/Functions/Assertions/Be.Tests.ps1
@@ -7,6 +7,9 @@ Describe "PesterBe" {
     It "returns true if the 2 arguments are equal" {
         Test-PositiveAssertion (PesterBe 1 1)
     }
+	It "returns true if the 2 arguments are equal and have different case" {
+        Test-PositiveAssertion (PesterBe "A" "a")
+    }
 
     It "returns false if the 2 arguments are not equal" {
         Test-NegativeAssertion (PesterBe 1 2)

--- a/Functions/Assertions/BeExactly.Tests.ps1
+++ b/Functions/Assertions/BeExactly.Tests.ps1
@@ -1,0 +1,16 @@
+$here = Split-Path -Parent $MyInvocation.MyCommand.Path
+$sut = (Split-Path -Leaf $MyInvocation.MyCommand.Path).Replace(".Tests.", ".")
+. "$here\$sut"
+
+Describe "BeExactly" {
+    It "passes if letter case matches" {
+		'a' | Should BeExactly 'a'
+    }
+	It "fails if letter case doesn't match" {
+		'A' | Should Not BeExactly 'a'
+    }
+	It "passes for numbers" {
+		1 | Should BeExactly 1
+		2.15 | Should BeExactly 2.15
+	}
+}

--- a/Functions/Assertions/BeExactly.ps1
+++ b/Functions/Assertions/BeExactly.ps1
@@ -1,0 +1,13 @@
+
+function PesterBeExactly($value, $expected) {
+    return ($expected -ceq $value)
+}
+
+function PesterBeExactlyFailureMessage($value, $expected) {
+    return "Expected: exactly {$expected}, But was {$value}"
+}
+
+function NotPesterBeExactlyFailureMessage($value, $expected) {
+    return "Expected: value was {$value}, but should not have been exactly the same"
+}
+

--- a/Functions/Assertions/Contain.Tests.ps1
+++ b/Functions/Assertions/Contain.Tests.ps1
@@ -2,17 +2,21 @@ $here = Split-Path -Parent $MyInvocation.MyCommand.Path
 . "$here\Test-Assertion.ps1"
 . "$here\Contain.ps1"
 
-Describe "PesterExist" {
+Describe "PesterContain" {
 
     Context "when testing file contents" {
         Setup -File "test.txt" "this is line 1`nrush is awesome"
         It "returns true if the file contains the specified content" {
             Test-PositiveAssertion (PesterContain "$TestDrive\test.txt" "rush")
         }
+		It "returns true if the file contains the specified content with different case" {
+            Test-PositiveAssertion (PesterContain "$TestDrive\test.txt" "RUSH")
+        }
 
         It "returns false if the file does not contain the specified content" {
             Test-NegativeAssertion (PesterContain "$TestDrive\test.txt" "slime")
         }
+		
     }
 }
 

--- a/Functions/Assertions/ContainExactly.Tests.ps1
+++ b/Functions/Assertions/ContainExactly.Tests.ps1
@@ -1,0 +1,18 @@
+$here = Split-Path -Parent $MyInvocation.MyCommand.Path
+. "$here\Test-Assertion.ps1"
+. "$here\ContainExactly.ps1"
+
+Describe "PesterContainExactly" {
+
+    Context "when testing file contents" {
+        Setup -File "test.txt" "this is line 1`nPester is awesome"
+        It "returns true if the file contains the specified content exactly" {
+            Test-PositiveAssertion (PesterContainExactly "$TestDrive\test.txt" "Pester")
+        }
+
+        It "returns false if the file does not contain the specified content exactly" {
+            Test-NegativeAssertion (PesterContainExactly "$TestDrive\test.txt" "pESTER")
+        }
+    }
+}
+

--- a/Functions/Assertions/ContainExactly.ps1
+++ b/Functions/Assertions/ContainExactly.ps1
@@ -1,0 +1,13 @@
+
+function PesterContainExactly($file, $contentExpecation) {
+    return ((Get-Content $file) -cmatch $contentExpecation)
+}
+
+function PesterContainExactlyFailureMessage($file, $contentExpecation) {
+    return "Expected: file ${file} to contain exactly {$contentExpecation}"
+}
+
+function NotPesterContainExactlyFailureMessage($file, $contentExpecation) {
+    return "Expected: file {$file} to not contain exactly ${contentExpecation} but it did"
+}
+

--- a/Functions/Assertions/Match.Tests.ps1
+++ b/Functions/Assertions/Match.Tests.ps1
@@ -9,8 +9,17 @@ Describe "Match" {
     }
 
     It "returns false for things that do not match" {
-        PesterExist "foobar" "slime" | Should Be $false
+        PesterMatch "foobar" "slime" | Should Be $false
     }
+	
+	It "passes for strings with different case" {
+		PesterMatch "foobar" "FOOBAR" | Should Be $true
+	}
+	
+	It "uses regular expressions" {
+		PesterMatch "foobar" "\S{6}" | Should Be $true
+	}
+	
 
 
 }

--- a/Functions/Assertions/MatchExactly.Tests.ps1
+++ b/Functions/Assertions/MatchExactly.Tests.ps1
@@ -1,0 +1,21 @@
+$here = Split-Path -Parent $MyInvocation.MyCommand.Path
+. "$here\Should.ps1"
+. "$here\MatchExactly.ps1"
+
+Describe "MatchExactly" {
+
+    It "returns true for things that match exactly" {
+        PesterMatchExactly "foobar" "ob" | Should Be $true
+    }
+
+    It "returns false for things that do not match exactly" {
+        PesterMatchExactly "foobar" "FOOBAR" | Should Be $false
+    }
+	
+	It "uses regular expressions" {
+        PesterMatchExactly "foobar" "\S{6}" | Should Be $true
+    }
+
+
+}
+

--- a/Functions/Assertions/MatchExactly.ps1
+++ b/Functions/Assertions/MatchExactly.ps1
@@ -1,0 +1,13 @@
+
+function PesterMatchExactly($value, $expectedMatch) {
+    return ($value -cmatch $expectedMatch)
+}
+
+function PesterMatchExactlyFailureMessage($value, $expectedMatch) {
+    return "Expected: {$value} to exactly match the expression {$expectedMatch}"
+}
+
+function NotPesterMatchExactlyFailureMessage($value, $expectedMatch) {
+    return "Expected: ${value} to not match the expression ${expectedMatch} exactly"
+}
+


### PR DESCRIPTION
Assertions are by default case insensitive and there is no intuitive way to make an assertion case sensitive.
Adding new _Exactly assertions that use -c_ operators to be case sensitive.
Also naming fixes in the Contains and Match assertions.
