### PR TITLE
Add descriptive variables to New-Fixture test template #57

### DIFF
--- a/Functions/New-Fixture.Tests.ps1
+++ b/Functions/New-Fixture.Tests.ps1
@@ -7,7 +7,7 @@ Describe "New-Fixture" {
     It "Name parameter is mandatory:" {
         (get-command New-Fixture ).Parameters.Name.ParameterSets.__AllParameterSets.IsMandatory | Should Be $true
     }
-	
+    
     Context "Only Name parameter is specified:" {
         
         It "Creates fixture in current directory:" {
@@ -23,10 +23,10 @@ Describe "New-Fixture" {
             
         }
     }
-	
+    
     Context "Name and Path parameter is specified:" {
-	#use different fixture names to avoid interference among the test cases
-	#claning up would be also possible, but difficult if the assertion fails
+    #use different fixture names to avoid interference among the test cases
+    #claning up would be also possible, but difficult if the assertion fails
         It "Creates fixture in full Path:" {
             $name = "Test-Fixture"
             $path = "TestDrive:\full"
@@ -35,9 +35,9 @@ Describe "New-Fixture" {
             
             Join-Path -Path $path -ChildPath "$name.ps1" | Should Exist
             Join-Path -Path $path -ChildPath "$name.Tests.ps1" | Should Exist
-			
-			#cleanup
-			Join-Path -Path "$path" -ChildPath "$name.ps1" | Remove-Item -Force
+            
+            #cleanup
+            Join-Path -Path "$path" -ChildPath "$name.ps1" | Remove-Item -Force
             Join-Path -Path "$path" -ChildPath "$name.Tests.ps1" | Remove-Item -Force
         }
         
@@ -63,7 +63,7 @@ Describe "New-Fixture" {
             Join-Path -Path "$path" -ChildPath "$name.ps1" | Should Exist
             Join-Path -Path "$path" -ChildPath "$name.Tests.ps1" | Should Exist          
         }
-		It "Creates fixture if Path is set to '(pwd)':" {
+        It "Creates fixture if Path is set to '(pwd)':" {
             $name = "Relative3-Fixture"
             $path = "TestDrive:\"
             
@@ -74,32 +74,32 @@ Describe "New-Fixture" {
             Join-Path -Path "$path" -ChildPath "$name.ps1" | Should Exist
             Join-Path -Path "$path" -ChildPath "$name.Tests.ps1" | Should Exist
         }
-		It "Writes warning if file exists" {
+        It "Writes warning if file exists" {
             $name = "Warning-Fixture"
             $path = "TestDrive:\"
             
-			#Create the same files twice
-	        New-Fixture -Name $name -Path $path | Out-Null
-					
-			#TODO find a better way to test this
-			#weird way to test this, but I can't redirect the Warning easily without breaking PowerShell v2 compatibility 
-			$message = &{
-				try 
-				{ 
-					
-					$ErrorActionPreference = 'SilentlyContinue'
-					$WarningPreference = 'Stop'
-					New-Fixture -Name $name -Path $path | Out-Null
-				} 
-				catch 
-				{ 
-					"$_"
-				}
-			}
-			$message | Should Match 'WarningPreference'
+            #Create the same files twice
+            New-Fixture -Name $name -Path $path | Out-Null
+                    
+            #TODO find a better way to test this
+            #weird way to test this, but I can't redirect the Warning easily without breaking PowerShell v2 compatibility 
+            $message = &{
+                try 
+                { 
+                    
+                    $ErrorActionPreference = 'SilentlyContinue'
+                    $WarningPreference = 'Stop'
+                    New-Fixture -Name $name -Path $path | Out-Null
+                } 
+                catch 
+                { 
+                    "$_"
+                }
+            }
+            $message | Should Match 'WarningPreference'
         }
-		
+        
     }
-	#TODO add tests that validate the contents of default files
+    #TODO add tests that validate the contents of default files
 }
 

--- a/Functions/New-Fixture.ps1
+++ b/Functions/New-Fixture.ps1
@@ -83,8 +83,9 @@ Describe "#name#" {
 
     It "does something useful" {
         $expectedValue = $true
-        $returnedValue = $false
-        $returnedValue | Should Be $expectedValue
+        $actualValue = $false
+        
+        $actualValue | Should Be $expectedValue
     }
 }' -replace "#name#",$name
     

--- a/Functions/New-Fixture.ps1
+++ b/Functions/New-Fixture.ps1
@@ -13,8 +13,8 @@
     The script defining the funciton: .\Clean.ps1:
     
     function Clean { 
-	
-	}
+    
+    }
     
     The script containg the example test .\Clean.Tests.ps1:
     
@@ -60,27 +60,35 @@
     about_Should
     #>
     
-    param (    
-        [String]$Path = $PWD,
+    param (
         [Parameter(Mandatory=$true)]
-        [String]$Name
+        [String]$Name,
+        [String]$Path = $PWD
     )
-	#region File contents 
-	#keep this formatted as is. the forma is output to the file as is, including indentation
-	$scriptCode = "function $name {`r`n`r`n}"
+    #region File contents 
+    #keep this formatted as is. the forma is output to the file as is, including indentation
+    $scriptCode = @"
+function $name {
+    
+    [CmdletBinding()]
+    Param()
+}
+"@
 
-	$testCode = '$here = Split-Path -Parent $MyInvocation.MyCommand.Path
+    $testCode = '$here = Split-Path -Parent $MyInvocation.MyCommand.Path
 $sut = (Split-Path -Leaf $MyInvocation.MyCommand.Path).Replace(".Tests.", ".")
 . "$here\$sut"
 
 Describe "#name#" {
 
-		It "does something useful" {
-		$true | Should Be $false
-	}
+    It "does something useful" {
+        $expectedValue = $true
+        $returnedValue = $false
+        $returnedValue | Should Be $expectedValue
+    }
 }' -replace "#name#",$name
-	
-	#endregion
+    
+    #endregion
     
     $Path = $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($Path)
     


### PR DESCRIPTION
Added a couple features as well.  Feel free to discuss.

###### Add CmdletBinding to new function
- I use "Write-Verbose" frequently, so having [CmdletBinding()] in the new function saves keystrokes.
```powershell
# Output:
function Test {
    
    [CmdletBinding()]
    Param()
}
```
###### Swap New-Fixture params to simplify
- This lets you run New-Fixture by just passing the name param as an arg instead of having to specify "-Name"
```powershell
# Command:
New-Fixture Test

# Generates:
Mode                LastWriteTime     Length Name
----                -------------     ------ ----
-a---         3/13/2014   7:08 AM         66 Test.ps1
-a---         3/13/2014   7:08 AM        340 Test.Tests.ps1
```