### PR TITLE
Fixed PesterThrow to show correct error messages.

### DIFF
--- a/Functions/Assertions/PesterThrow.Tests.ps1
+++ b/Functions/Assertions/PesterThrow.Tests.ps1
@@ -3,56 +3,56 @@ $here = Split-Path -Parent $MyInvocation.MyCommand.Path
 . "$here\PesterThrow.ps1"
 
 
-Describe "PesterThrow" {
+Describe 'PesterThrow' {
 
-    It "returns true if the statement throws an exception" {
+    It 'returns true if the statement throws an exception' {
         Test-PositiveAssertion (PesterThrow { throw })
     }
 
-    It "returns false if the statement does not throw an exception" {
+    It 'returns false if the statement does not throw an exception' {
         Test-NegativeAssertion (PesterThrow { 1 + 1 })
     }
 
-    It "returns true if the statement throws an exception and the actual error text matches the expected error text" {
-        $expectedErrorMessage = "expected error message"
+    It 'returns true if the statement throws an exception and the actual error text matches the expected error text' {
+        $expectedErrorMessage = 'expected error message'
         Test-PositiveAssertion (PesterThrow { throw $expectedErrorMessage } $expectedErrorMessage)
     }
 
-    It "returns false if the statement throws an exception and the actual error does not match the expected error text" {
-        $unexpectedErrorMessage = "unexpected error message"
-        $expectedErrorMessage = "some expected error message"
+    It 'returns false if the statement throws an exception and the actual error does not match the expected error text' {
+        $unexpectedErrorMessage = 'unexpected error message'
+        $expectedErrorMessage = 'some expected error message'
         Test-NegativeAssertion (PesterThrow { throw $unexpectedErrorMessage} $expectedErrorMessage)
     }
 
-    It "returns true if the statement throws an exception and the actual error text matches the expected error pattern" {
-        Test-PositiveAssertion (PesterThrow { throw "expected error"} "error")
+    It 'returns true if the statement throws an exception and the actual error text matches the expected error pattern' {
+        Test-PositiveAssertion (PesterThrow { throw 'expected error'} 'error')
     }
 }
 
-Describe "Get-DoMessagesMatch" {
+Describe 'Get-DoMessagesMatch' {
 
-    It "returns true if the actual message is the same as the expected message" {
-        $expectedErrorMessage = "expected"
-        $actualErrorMesage = "expected"
+    It 'returns true if the actual message is the same as the expected message' {
+        $expectedErrorMessage = 'expected'
+        $actualErrorMesage = 'expected'
         $result = Get-DoMessagesMatch $actualErrorMesage $expectedErrorMessage
         $result | Should Be $True
     }
 
-    It "returns false if the actual message is not the same as the expected message" {
-        $expectedErrorMessage = "some expected message"
-        $actualErrorMesage = "unexpected"
+    It 'returns false if the actual message is not the same as the expected message' {
+        $expectedErrorMessage = 'some expected message'
+        $actualErrorMesage = 'unexpected'
         $result = Get-DoMessagesMatch $actualErrorMesage $expectedErrorMessage
         $result | Should Be $False
     }
 
     It "returns false is there's no expectation" {
-        $result = Get-DoMessagesMatch "" ""
+        $result = Get-DoMessagesMatch '' ''
         $result | Should Be $False
     }
 
-    It "returns true if the expected error is contained in the actual message" {
-        $actualErrorMesage = "this is a long error message"
-        $expectedText = "long error"
+    It 'returns true if the expected error is contained in the actual message' {
+        $actualErrorMesage = 'this is a long error message'
+        $expectedText = 'long error'
         $result = Get-DoMessagesMatch $actualErrorMesage $expectedText
         $result | Should Be $True
     }

--- a/Functions/Assertions/PesterThrow.ps1
+++ b/Functions/Assertions/PesterThrow.ps1
@@ -1,11 +1,11 @@
 
-$ActualExceptionMessage = ""
+$ActualExceptionMessage = ''
 $ActualExceptionWasThrown = $false
 
 # because this is a script block, the user will have to
 # wrap the code they want to assert on in { }
 function PesterThrow([scriptblock] $script, $expectedErrorMessage) {
-    $Script:ActualExceptionMessage = ""
+    $Script:ActualExceptionMessage = ''
     $Script:ActualExceptionWasThrown = $false
 
     try {
@@ -23,25 +23,25 @@ function PesterThrow([scriptblock] $script, $expectedErrorMessage) {
 }
 
 function Get-DoMessagesMatch($value, $expected) {
-    if ($expected -eq "") { return $false }
+    if ($expected -eq '') { return $false }
     return $value.Contains($expected)
 }
 
 function PesterThrowFailureMessage($value, $expected) {
     if ($expected) {
-      return "Expected: the expression to throw an exception with message {{{0}}}, an exception was {2}raised, message was {{{1}}}" -f
-              $expected, $ActualExceptionMessage,(@{$true="";$false="not "}[$ActualExceptionWasThrown])
+      return 'Expected: the expression to throw an exception with message {{{0}}}, an exception was {2}raised, message was {{{1}}}' -f
+              $expected, $ActualExceptionMessage,(@{$true='';$false='not '}[$ActualExceptionWasThrown])
     } else {
-      return "Expected: the expression to throw an exception"
+      return 'Expected: the expression to throw an exception'
     }
 }
 
 function NotPesterThrowFailureMessage($value, $expected) {
     if ($expected) {
-        return "Expected: the expression not to throw an exception with message {{{0}}}, an exception was {2}raised, message was {{{1}}}" -f
-              $expected, $ActualExceptionMessage,(@{$true="";$false="not "}[$ActualExceptionWasThrown])
+        return 'Expected: the expression not to throw an exception with message {{{0}}}, an exception was {2}raised, message was {{{1}}}' -f
+              $expected, $ActualExceptionMessage,(@{$true='';$false='not '}[$ActualExceptionWasThrown])
     } else {
-        return "Expected: the expression not to throw an exception. Message was {{{0}}}" -f $ActualExceptionMessage
+        return 'Expected: the expression not to throw an exception. Message was {{{0}}}' -f $ActualExceptionMessage
     }
 }
 


### PR DESCRIPTION
Fixed PesterThrow to show correct error messages and added 2 corresponding unit tests.

I also ran these two files through a filter that removes trailing whitespace and converts expandable strings to literal strings where possible.

The expandable-to-literal string conversion is the reason for most of the changes. If this is a problem let me know.
