### PR TITLE
Fix error message in Testdrive Cleanup

### DIFF
--- a/Functions/TestDrive.ps1
+++ b/Functions/TestDrive.ps1
@@ -33,6 +33,7 @@ function Clear-TestDrive ([String[]]$Exclude) {
 	{
 		#Get-ChildItem -Exclude did not seem to work with full paths
 		Get-ChildItem -Recurse -Path $Path |
+			Sort-Object -Descending  -Property "FullName" |
 			where { $Exclude -NotContains $_.FullName } |
 			Microsoft.PowerShell.Management\Remove-Item -Force -Recurse
 	}


### PR DESCRIPTION
For [GH-128]. Sort the folders before deleting. Avoid an error message
on windows 7
