### PR TITLE
[fixes #130] Changed ExecutionPolicy to Bypass to avoid failure.

### DIFF
--- a/bin/pester.bat
+++ b/bin/pester.bat
@@ -8,7 +8,7 @@ if '%1'=='?' goto usage
 if '%1'=='/help' goto usage
 if '%1'=='help' goto usage
 
-@PowerShell -NonInteractive -NoProfile -ExecutionPolicy unrestricted -Command ^
+@PowerShell -NonInteractive -NoProfile -ExecutionPolicy Bypass -Command ^
  "& Import-Module '%DIR%..\Pester.psm1'; & { Invoke-Pester -OutputXml Test.xml -EnableExit %ARGS%}"
 
 goto finish
@@ -27,7 +27,7 @@ echo.
 goto finish
 
 :help
-@PowerShell -NonInteractive -NoProfile -ExecutionPolicy unrestricted -Command ^
+@PowerShell -NonInteractive -NoProfile -ExecutionPolicy Bypass -Command ^
   "& Import-Module '%DIR%..\Pester.psm1'; & { Get-Help %2}"
 
 :finish


### PR DESCRIPTION
It would appear combining the flags -ExecutionPolicy Unrestricted and
 -NonInteractive causes the following error;

Import-Module : File E:\Pester\Pester.psm1 cannot be loaded. The file
E:\Pester\Pester.psm1 is not digitally signed. The script will not execute
on the system. Please see "get-help about_signing" for more details..

See the following TechNet article for details on ExecutionPolicy settings;

http://technet.microsoft.com/en-us/library/hh849812.aspx
