### PR TITLE
Fixes #76

### DIFF
--- a/Functions/Assertions/Should.Tests.ps1
+++ b/Functions/Assertions/Should.Tests.ps1
@@ -12,6 +12,11 @@ Describe "Parse-ShouldArgs" {
         $parsedArgs.AssertionMethod | Should Be PesterTestFunction
     }
 
+    It "works with strict mode when using 'switch' style tests" {
+        Set-StrictMode -Version Latest
+        { throw 'Test' } | Should Throw
+    }
+
     Context "for positive assertions" {
 
         $parsedArgs = Parse-ShouldArgs testMethod, 1

--- a/Functions/Assertions/Should.ps1
+++ b/Functions/Assertions/Should.ps1
@@ -1,18 +1,34 @@
 
 function Parse-ShouldArgs([array] $shouldArgs) {
-    $parsedArgs = @{ PositiveAssertion = $true }
+    if ($null -eq $shouldArgs) { $shouldArgs = @() }
+
+    $parsedArgs = @{
+        PositiveAssertion = $true
+        ExpectedValue = $null
+    }
 
     $assertionMethodIndex = 0
     $expectedValueIndex   = 1
 
-    if ($shouldArgs[0].ToLower() -eq "not") {
+    if ($shouldArgs.Count -gt 0 -and $shouldArgs[0].ToLower() -eq "not") {
         $parsedArgs.PositiveAssertion = $false
         $assertionMethodIndex += 1
         $expectedValueIndex   += 1
     }
 
-    $parsedArgs.ExpectedValue = $shouldArgs[$expectedValueIndex]
-    $parsedArgs.AssertionMethod = "Pester$($shouldArgs[$assertionMethodIndex])"
+    if ($assertionMethodIndex -lt $shouldArgs.Count)
+    {
+        $parsedArgs.AssertionMethod = "Pester$($shouldArgs[$assertionMethodIndex])"
+    }
+    else
+    {
+        throw 'You cannot call Should without specifying an assertion method.'
+    }
+
+    if ($expectedValueIndex -lt $shouldArgs.Count)
+    {
+        $parsedArgs.ExpectedValue = $shouldArgs[$expectedValueIndex]
+    }
 
     return $parsedArgs
 }


### PR DESCRIPTION
Parse-ShouldArgs now works properly if StrictMode has been enabled, performing bounds checking on the $shouldArgs array before indexing.  It also throws an error if no AssertionMethod was passed (ie, ( | Should ) or ( | Should not )).
