### PR TITLE
Validation of Assertion Method in Should

### DIFF
--- a/Functions/Assertions/Should.Tests.ps1
+++ b/Functions/Assertions/Should.Tests.ps1
@@ -55,6 +55,13 @@ Describe "Parse-ShouldArgs" {
 }
 
 Describe "Get-TestResult" {
+    Context "for assertion name validity checking" {
+        $testShouldArgs = Parse-ShouldArgs BogusAssertionMethod
+
+        It "throws a descriptive error message if invalid assertion method is passed" {
+            { Get-TestResult $testShouldArgs } | Should Throw "'BogusAssertionMethod' is not a valid Should operator."
+        }
+    }
 
     Context "for positive assertions" {
         function PesterTest { return $true }

--- a/Functions/Assertions/Should.ps1
+++ b/Functions/Assertions/Should.ps1
@@ -34,7 +34,16 @@ function Parse-ShouldArgs([array] $shouldArgs) {
 }
 
 function Get-TestResult($shouldArgs, $value) {
-    $testResult = (& $shouldArgs.AssertionMethod $value $shouldArgs.ExpectedValue)
+    $assertionMethod = $shouldArgs.AssertionMethod
+    $command = Get-Command $assertionMethod -ErrorAction SilentlyContinue
+
+    if ($null -eq $command)
+    {
+        $assertionMethod = $assertionMethod -replace '^Pester'
+        throw "'$assertionMethod' is not a valid Should operator."
+    }
+
+    $testResult = (& $assertionMethod $value $shouldArgs.ExpectedValue)
 
     if ($shouldArgs.PositiveAssertion) {
         return -not $testResult


### PR DESCRIPTION
Loosely related to the fix in the Issue76 branch, this update validates user input to the Should function.  Instead of producing the stock command not found exception, Should will now produce an error of "'BeNulOrEmpty' is not a valid Should operator." (where the user had misspelled BeNullOrEmpty, in this case.)

This doesn't affect functionality (all the same tests that failed before this change would still fail), it just produces a more friendly error message, which makes it clear that it's the caller's fault rather than a Pester bug.
