### PR TITLE
Fully-qualified commands

### DIFF
--- a/Functions/It.ps1
+++ b/Functions/It.ps1
@@ -66,7 +66,7 @@ param(
 )
 
 	
-    $Time = Measure-Command {
+    $Time = Microsoft.PowerShell.Utility\Measure-Command {
         try{
            &{ &$test }
         } catch {

--- a/Functions/Mock.Tests.ps1
+++ b/Functions/Mock.Tests.ps1
@@ -48,6 +48,21 @@ Describe "When calling Mock on existing function" {
     }
 }
 
+Describe "When the caller mocks a command Pester uses internally" {
+    Mock Write-Host { }
+
+    Context "Context run when Write-Host is mocked" {
+        It "does not make extra calls to the mocked command" {
+            Write-Host 'Some String'
+            Assert-MockCalled 'Write-Host' -Exactly 1
+        }
+
+        It "retains the correct mock count after the first test completes" {
+            Assert-MockCalled 'Write-Host' -Exactly 1
+        }
+    }
+}
+
 Describe "When calling Mock on existing cmdlet" {
     Mock Get-Process {return "I am not Get-Process"}
 

--- a/Functions/Mock.ps1
+++ b/Functions/Mock.ps1
@@ -391,11 +391,11 @@ function Validate-Command([string]$commandName, [string]$moduleName) {
     $module = $null
     $origCommand = $null
     $fqCommandName = $commandName
-    $fqCommandModuleName = $fqCommandName | Split-Path
+    $fqCommandModuleName = $fqCommandName | Microsoft.PowerShell.Management\Split-Path
 
     # Give preference to fq command's module name
     if ($fqCommandModuleName) {
-        $commandName = $commandName | Split-Path -Leaf
+        $commandName = $commandName | Microsoft.PowerShell.Management\Split-Path -Leaf
         $module = Microsoft.PowerShell.Core\Get-Module $fqCommandModuleName -All
     }
     
@@ -406,7 +406,10 @@ function Validate-Command([string]$commandName, [string]$moduleName) {
     
     # Use the context of the module (if available) to get the command
     if ($module) {
-        $module = $module | sort ModuleType | where { ($origCommand = & $_ { $ExecutionContext.InvokeCommand.GetCommand($args[0], 'All') } $commandName) } | select -First 1
+        $module = $module |
+        Microsoft.PowerShell.Utility\Sort-Object ModuleType |
+        Microsoft.PowerShell.Core\Where-Object { ($origCommand = & $_ { $ExecutionContext.InvokeCommand.GetCommand($args[0], 'All') } $commandName) } |
+        Microsoft.PowerShell.Utility\Select-Object -First 1
     }
     
     $session = $ExecutionContext.SessionState

--- a/Functions/PesterState.ps1
+++ b/Functions/PesterState.ps1
@@ -38,11 +38,11 @@
         
     function EnterContext ($Name) {
 			if ( -not $CurrentDescribe ) {  
-				throw New-Object InvalidOperationException "Cannot enter Context before entering Describe"
+				throw Microsoft.PowerShell.Utility\New-Object InvalidOperationException "Cannot enter Context before entering Describe"
 			}
       
       if ( $CurrentContext ) {  
-				throw New-Object InvalidOperationException "You already are in Context, you cannot enter Context twice"
+				throw Microsoft.PowerShell.Utility\New-Object InvalidOperationException "You already are in Context, you cannot enter Context twice"
 			}
 			
       $Script:CurrentContext = $Name
@@ -110,7 +110,7 @@ function Write-Context {
 	)
 	process {
 		$margin = "   "
-		Write-Host ${margin}Context $Name -ForegroundColor Magenta
+		Microsoft.PowerShell.Utility\Write-Host ${margin}Context $Name -ForegroundColor Magenta
 	}
 }
 function Write-PesterResult {
@@ -128,12 +128,12 @@ function Write-PesterResult {
 	    $output = $TestResult.name
 	    $humanTime = Get-HumanTime $TestResult.Time.TotalSeconds
 	    if($TestResult.Passed) {
-	        "$margin[+] $output $humanTime" | Write-Host -ForegroundColor DarkGreen
+	        "$margin[+] $output $humanTime" | Microsoft.PowerShell.Utility\Write-Host -ForegroundColor DarkGreen
 	    }
 	    else {
-	        "$margin[-] $output $humanTime" | Write-Host -ForegroundColor red
-	         Write-Host -ForegroundColor red $error_margin$($TestResult.failureMessage)
-	         Write-Host -ForegroundColor red $error_margin$($TestResult.stackTrace)
+	        "$margin[-] $output $humanTime" | Microsoft.PowerShell.Utility\Write-Host -ForegroundColor red
+	         Microsoft.PowerShell.Utility\Write-Host -ForegroundColor red $error_margin$($TestResult.failureMessage)
+	         Microsoft.PowerShell.Utility\Write-Host -ForegroundColor red $error_margin$($TestResult.stackTrace)
 	    }
 	}
 }

--- a/Functions/TestDrive.ps1
+++ b/Functions/TestDrive.ps1
@@ -28,13 +28,13 @@ function New-TestDrive ([Switch]$PassThru) {
 
 function Clear-TestDrive ([String[]]$Exclude) {
     
-    $Path = (Get-PSDrive -Name TestDrive).Root
-	if (Test-Path -Path $Path )
+    $Path = (Microsoft.PowerShell.Management\Get-PSDrive -Name TestDrive).Root
+	if (Microsoft.PowerShell.Management\Test-Path -Path $Path )
 	{
 		#Get-ChildItem -Exclude did not seem to work with full paths
-		Get-ChildItem -Recurse -Path $Path |
-			Sort-Object -Descending  -Property "FullName" |
-			where { $Exclude -NotContains $_.FullName } |
+		Microsoft.PowerShell.Management\Get-ChildItem -Recurse -Path $Path |
+			Microsoft.PowerShell.Utility\Sort-Object -Descending  -Property "FullName" |
+			Microsoft.PowerShell.Core\Where-Object { $Exclude -NotContains $_.FullName } |
 			Microsoft.PowerShell.Management\Remove-Item -Force -Recurse
 	}
 }
@@ -56,10 +56,10 @@ function Get-TestDriveItem {
 }
 
 function Get-TestDriveChildItem {
-	$Path = (Get-PSDrive -Name TestDrive).Root
-	if (Test-Path -Path $Path )
+	$Path = (Microsoft.PowerShell.Management\Get-PSDrive -Name TestDrive).Root
+	if (Microsoft.PowerShell.Management\Test-Path -Path $Path )
 	{
-		Get-ChildItem -Recurse -Path $Path
+		Microsoft.PowerShell.Management\Get-ChildItem -Recurse -Path $Path
 	}
 }
 


### PR DESCRIPTION
Fixes #73

Several calls to built-in PowerShell commands are now module-qualified, making Pester behave properly internally, even if the caller has mocked these commands.

Note:  These changes were only made in functions that are called from either Context, Mock or It.  If a caller has hidden the default versions of PowerShell commands elsewhere, it can still cause problems.  It's possible to qualify all such commands in the Pester module, if that's desirable, but that would be a much higher number of changes.
