### PR TITLE
Mocking public module functions

### DIFF
--- a/Functions/Mock.Tests.ps1
+++ b/Functions/Mock.Tests.ps1
@@ -371,9 +371,14 @@ Describe 'When calling Mock on a module-public function called by a standalone f
         StandaloneFunction | Should Be 'I am the public function'
     }
 
-    It 'Should call the mocked function' {
-        Mock PublicFunction { 'I am the mock test' } -moduleName TestModule
+    It 'Should call the mocked function using only the function name' {
+        Mock PublicFunction { 'I am the mock test' }
         StandaloneFunction | Should Be 'I am the mock test'
+    }
+
+    It 'Should call the mocked function using its fully qualified name' {
+        Mock PublicFunction { 'I am the mock test' } -moduleName TestModule
+        TestModule\StandaloneFunction | Should Be 'I am the mock test'
     }
 
     Remove-Module TestModule -Force
@@ -403,13 +408,13 @@ Describe 'When calling Mock on a module-public function called by another module
     }
 
     It 'Should call the mocked function using only the function name' {
-        Mock SlavePublicFunction { 'I am the mock test' } -moduleName SlaveTestModule
+        Mock SlavePublicFunction { 'I am the mock test' }
         MasterPublicFunction | Should Be 'I am the mock test'
     }
 
     It 'Should call the mocked function using its fully qualified name' {
         Mock SlavePublicFunction { 'I am the mock test' } -moduleName SlaveTestModule
-        TestModule\MasterPublicFunction | Should Be 'I am the mock test'
+        MasterPublicFunction | Should Be 'I am the mock test'
     }
 
     Remove-Module SlaveTestModule -Force


### PR DESCRIPTION
Hi,

I'm having issues **mocking public module functions**.

In the example below, I'm creating a module called `TestModule` containing a public function called `PublicFunction`. I also declare a function called `StandaloneFunction`, that uses the `TestModule`'s `PublicFunction`:

```
New-Module -Name TestModule {
    function PublicFunction { 'I am the public function' }
    Export-ModuleMember -Function PublicFunction
} | Import-Module -Force

function StandaloneFunction {
    PublicFunction
}
```

Then, when I try to mock the `PublicFunction` function:

```
It 'Should call the mocked function' {
    Mock PublicFunction { 'I am the mock test' } -moduleName TestModule
    StandaloneFunction | Should Be 'I am the mock test'
}
```

The test above fails.
1. Did I do something wrong?
2. Is it a Pester bug, or is it something which is impossible to achieve with PowerShell?

**I have included unit tests with this PR to show the problem.**

Please note that I'm a PowerShell beginner and I don't have the necessary skills to submit a patch yet.
