### PR TITLE
Direct test execution fix

### DIFF
--- a/Functions/Mock.Tests.ps1
+++ b/Functions/Mock.Tests.ps1
@@ -267,7 +267,6 @@ Describe "When calling Mock on existing function with matching bound params" {
     }
 }
 
-
 Describe "When calling Mock on existing function without matching unbound arguments" {
     Mock FunctionUnderTestWithoutParams {return "fake results"} -parameterFilter {$param1 -eq "test" -and $args[0] -eq 'notArg0'}
 
@@ -682,5 +681,23 @@ Describe "Using a single no param Describe" {
         It "Should use the context mock" {
             FunctionUnderTest | should be "I am the context mock test"
         }
+    }
+}
+
+Describe 'Dot Source Test' {
+    # This test is only meaningful if this test file is dot-sourced in the global scope.  If it's executed without
+    # dot-sourcing or run by Invoke-Pester, there's no problem.
+    
+    function TestFunction { Test-Path -Path 'Test' }
+    Mock Test-Path { }
+
+    $null = TestFunction
+
+    It "Calls the mock with parameter 'Test'" {
+        Assert-MockCalled Test-Path -Exactly 1 -ParameterFilter { $Path -eq 'Test' }
+    }
+
+    It "Doesn't call the mock with any other parameters" {
+        Assert-MockCalled Test-Path -Exactly 0 -ParameterFilter { $Path -ne 'Test' }
     }
 }

--- a/Functions/Mock.ps1
+++ b/Functions/Mock.ps1
@@ -620,11 +620,18 @@ function Invoke-Mock {
                 $mock.CallHistory += @{CommandName = "$ModuleName||$CommandName"; BoundParams = $BoundParameters; Args = $ArgumentList; Scope = $pester.Scope }
 
                 & $block.Mock @ArgumentList @BoundParameters
-
                 return
             }
         }
 
+        & $mock.OriginalCommand @ArgumentList @BoundParameters
+    }
+    elseif ($mock = $mockTable["||$CommandName"])
+    {
+        # This situation can happen if the test script is dot-sourced in the global scope.  Under these conditions,
+        # a module can wind up executing Invoke-Mock when that was not the intent of the test.  Try to recover from
+        # this by executing the original command.
+        
         & $mock.OriginalCommand @ArgumentList @BoundParameters
     }
     else


### PR DESCRIPTION
Corrects a bug that occurs when a test script is dot-sourced into the global scope.  In that situation, mocks can wind up being executed by modules that were not intended to see the mock (including Pester itself.)
