### PR TITLE
Introduce CompareObject matcher

### DIFF
--- a/Functions/Assertions/CompareObject.Tests.ps1
+++ b/Functions/Assertions/CompareObject.Tests.ps1
@@ -1,0 +1,15 @@
+Set-StrictMode -Version Latest
+
+InModuleScope Pester {
+    Describe "CompareObject" {
+        It "return true  for things that are compared as equals" {
+            PesterCompareObject @() @() | Should Be $true
+            PesterCompareObject @(1) @(2) | Should Be $true
+            PesterCompareObject @(10,12,25) @(10,12,25) | Should Be $true
+            PesterCompareObject @(25,12,18) @(18,12,25) | Should Be $true
+        }
+        It "return false for things that are not compared as equals" {
+            PesterCompareObject @("something","is","missed") @("something","is","missed","here") | Should Be $false
+        }
+    }
+}

--- a/Functions/Assertions/CompareObject.ps1
+++ b/Functions/Assertions/CompareObject.ps1
@@ -1,0 +1,12 @@
+function PesterCompareObject($value, $expected) {
+    return (Compare-Object -ReferenceObject $value -DifferenceObject $expected -PassThru).Count -eq 0
+}
+
+function PesterCompareObjectFailureMessage($value, $expected) {
+    return "Expected: {$value} to compare the object {$expected}"
+}
+
+function NotPesterCompareObjectFailureMessage($value, $expected) {
+    return "Expected: ${value} to not compare the object ${expected}"
+}
+


### PR DESCRIPTION
It would be nice to be able to do something like `@(2,1,3) | Should CompareObject @(1,2,3)`
