### PR TITLE
When PesterThrow catches an unexpected exception, record the source of the exception into the exception message

### DIFF
--- a/Functions/Assertions/PesterThrow.Tests.ps1
+++ b/Functions/Assertions/PesterThrow.Tests.ps1
@@ -2,7 +2,6 @@ $here = Split-Path -Parent $MyInvocation.MyCommand.Path
 . "$here\Test-Assertion.ps1"
 . "$here\PesterThrow.ps1"
 
-
 Describe "PesterThrow" {
 
     It "returns true if the statement throws an exception" {
@@ -64,7 +63,7 @@ Describe 'PesterThrowFailureMessage' {
         $expectedErrorMessage = 'some expected message'
         PesterThrow { throw $unexpectedErrorMessage } $expectedErrorMessage > $null
         $result = PesterThrowFailureMessage $unexpectedErrorMessage $expectedErrorMessage
-        $result | Should Be "Expected: the expression to throw an exception with message {$expectedErrorMessage}, an exception was raised, message was {$unexpectedErrorMessage}"
+        $result | Should Match "^Expected: the expression to throw an exception with message {$expectedErrorMessage}, an exception was raised, message was {$unexpectedErrorMessage}`n    from $([RegEx]::Escape("$here\PesterThrow.Tests.ps1")):\d+ char:\d+"
     }
 
     It 'returns true if the actual message is the same as the expected message' {
@@ -80,12 +79,12 @@ Describe 'NotPesterThrowFailureMessage' {
         $expectedErrorMessage = 'some expected message'
         PesterThrow { throw $unexpectedErrorMessage } $expectedErrorMessage > $null
         $result = NotPesterThrowFailureMessage $unexpectedErrorMessage $expectedErrorMessage
-        $result | Should Be "Expected: the expression not to throw an exception with message {$expectedErrorMessage}, an exception was raised, message was {$unexpectedErrorMessage}"
+    $result | Should Match "^Expected: the expression not to throw an exception with message {$expectedErrorMessage}, an exception was raised, message was {$unexpectedErrorMessage}`n    from $([RegEx]::Escape("$here\PesterThrow.Tests.ps1")):\d+ char:\d+"
     }
 
     It 'returns true if the actual message is the same as the expected message' {
         PesterThrow { throw 'error message' } > $null
         $result = NotPesterThrowFailureMessage 'error message'
-        $result | Should Be 'Expected: the expression not to throw an exception. Message was {error message}'
+    $result | Should Match "^Expected: the expression not to throw an exception. Message was {error message}`n    from $([RegEx]::Escape("$here\PesterThrow.Tests.ps1")):\d+ char:\d+"
     }
 }

--- a/Functions/Assertions/PesterThrow.ps1
+++ b/Functions/Assertions/PesterThrow.ps1
@@ -14,6 +14,7 @@ function PesterThrow([scriptblock] $script, $expectedErrorMessage) {
     } catch {
         $Script:ActualExceptionWasThrown = $true
         $Script:ActualExceptionMessage = $_.Exception.Message
+        $Script:ActualExceptionLine = Get-ExceptionLineInfo $_.InvocationInfo
     }
 
     if ($ActualExceptionWasThrown) {
@@ -27,10 +28,15 @@ function Get-DoMessagesMatch($value, $expected) {
     return $value.Contains($expected)
 }
 
+function Get-ExceptionLineInfo($info) {
+    return ($info.PositionMessage -replace "^At ","from ")
+
+}
+
 function PesterThrowFailureMessage($value, $expected) {
     if ($expected) {
-      return "Expected: the expression to throw an exception with message {{{0}}}, an exception was {2}raised, message was {{{1}}}" -f
-              $expected, $ActualExceptionMessage,(@{$true="";$false="not "}[$ActualExceptionWasThrown])
+      return "Expected: the expression to throw an exception with message {{{0}}}, an exception was {2}raised, message was {{{1}}}`n    {3}" -f
+              $expected, $ActualExceptionMessage,(@{$true="";$false="not "}[$ActualExceptionWasThrown]),($ActualExceptionLine  -replace "`n","`n    ")
     } else {
       return "Expected: the expression to throw an exception"
     }
@@ -38,10 +44,9 @@ function PesterThrowFailureMessage($value, $expected) {
 
 function NotPesterThrowFailureMessage($value, $expected) {
     if ($expected) {
-        return "Expected: the expression not to throw an exception with message {{{0}}}, an exception was {2}raised, message was {{{1}}}" -f
-              $expected, $ActualExceptionMessage,(@{$true="";$false="not "}[$ActualExceptionWasThrown])
+        return "Expected: the expression not to throw an exception with message {{{0}}}, an exception was {2}raised, message was {{{1}}}`n    {3}" -f
+              $expected, $ActualExceptionMessage,(@{$true="";$false="not "}[$ActualExceptionWasThrown]),($ActualExceptionLine  -replace "`n","`n    ")
     } else {
-        return "Expected: the expression not to throw an exception. Message was {{{0}}}" -f $ActualExceptionMessage
+        return "Expected: the expression not to throw an exception. Message was {{{0}}}`n    {1}" -f $ActualExceptionMessage,($ActualExceptionLine  -replace "`n","`n    ")
     }
 }
-


### PR DESCRIPTION
this captures the invocation info from the original unexpected exception, and incorporates that into the output text, so that it's easier to locate the source of an unexpected exception from the log output.
