### PR TITLE
Got NUnit export working on PowerShell v2 again.

### DIFF
--- a/Functions/TestResults.ps1
+++ b/Functions/TestResults.ps1
@@ -39,7 +39,6 @@ function Export-NUnitReport {
 	$settings = New-Object -TypeName Xml.XmlWriterSettings
 	$settings.Indent = $true
 	$settings.NewLineOnAttributes = $false
-	$settings.WriteEndDocumentOnClose = $true # Gets or sets a value that indicates whether the XmlWriter will add closing tags to all unclosed element tags when the Close method is called.
 	try {
 		$XmlWriter = [Xml.XmlWriter]::Create($Path,$settings)
 		
@@ -185,8 +184,11 @@ function Convert-TimeSpan {
 }
 function Get-TestTime($tests) {
     [TimeSpan]$totalTime = 0;
-    $tests | %{
-        $totalTime += $_.time
+    if ($tests)
+    {
+        $tests | %{
+            $totalTime += $_.time
+        }
     }
     $totalTime | Convert-TimeSpan
 }


### PR DESCRIPTION
Fixes #153

Assignment to WriteEndDocumentOnClose was unnecessary, since it defaults to True anyway.  The property doesn't exist prior to .NET 4.5, and the code appears to generate identical files either way.

While running the unit tests on PowerShell 2.0, also came across another instance of v2 weirdness (foreach on a null collection executing the body once.)  Added test for null before enumerating.
