### PR TITLE
Suppress pipeline output in Context / Describe

### DIFF
--- a/Functions/Context.ps1
+++ b/Functions/Context.ps1
@@ -42,7 +42,7 @@ param(
 	
     $Pester.CurrentContext | Write-Context
 
-	& $fixture
+	$null = & $fixture
 	
 	Clear-TestDrive -Exclude ($TestDriveContent | select -ExpandProperty FullName)
    	Clear-Mocks

--- a/Functions/Describe.ps1
+++ b/Functions/Describe.ps1
@@ -79,7 +79,7 @@ param(
     $Pester.CurrentDescribe | Write-Describe
 	New-TestDrive
 	
-	& $fixture
+	$null = & $fixture
 	
 	Remove-TestDrive
 	Clear-Mocks 


### PR DESCRIPTION
Any pipeline output from Describe and Context blocks is now discarded, just as it already was for It blocks.

(Noted in Adam Driscoll's recent presentation on Pester that some random "True" values kept popping up between lines of Pester's output.  These were coming from commands that were run in Describe or Context blocks, but outside of It blocks.)
