### PR TITLE
Initial implementation of BeforeEach / AfterEach

### DIFF
--- a/Functions/Context.ps1
+++ b/Functions/Context.ps1
@@ -34,7 +34,10 @@ about_TestDrive
 
 #>
 param(
+    [Parameter(Mandatory = $true)]
     $name,
+
+    [Parameter(Mandatory = $true)]
     [ScriptBlock] $fixture
 )
     $Pester.EnterContext($name)
@@ -42,8 +45,12 @@ param(
 	
     $Pester.CurrentContext | Write-Context
 
+    # Should we handle errors here resulting from syntax, or just let them go to the caller and abort the whole test operation?
+    Add-SetupAndTeardown -ScriptBlock $fixture
+
 	$null = & $fixture
 	
+    Clear-SetupAndTeardown
 	Clear-TestDrive -Exclude ($TestDriveContent | select -ExpandProperty FullName)
    	Clear-Mocks
     $Pester.LeaveContext()

--- a/Functions/Describe.ps1
+++ b/Functions/Describe.ps1
@@ -54,7 +54,7 @@ about_TestDrive
 param(
         [Parameter(Mandatory = $true, Position = 0)] $name,
         $tags=@(),
-        [Parameter(Position = 1)]
+        [Parameter(Mandatory = $true, Position = 1)]
         [ScriptBlock] $fixture = $(Throw "No test script block is provided. (Have you put the open curly brace on the next line?)")
 )
 
@@ -78,9 +78,13 @@ param(
 	$Pester.EnterDescribe($Name)
     $Pester.CurrentDescribe | Write-Describe
 	New-TestDrive
+
+    # Should we handle errors here resulting from syntax, or just let them go to the caller and abort the whole test operation?
+    Add-SetupAndTeardown -ScriptBlock $fixture
 	
 	$null = & $fixture
 	
+    Clear-SetupAndTeardown
 	Remove-TestDrive
 	Clear-Mocks 
 	$Pester.LeaveDescribe()

--- a/Functions/It.ps1
+++ b/Functions/It.ps1
@@ -67,9 +67,9 @@ about_should
 
     $Pester.EnterTest($name)
     $TestDriveContent = Get-TestDriveChildItem
-    
-    $PesterException = $null
-   
+    Invoke-SetupBlocks
+
+    $PesterException = $null   
     try{
         $null = & $test
     } catch {
@@ -80,6 +80,7 @@ about_should
     $Pester.AddTestResult($Result.name, $Result.Success, $null, $result.failuremessage, $result.StackTrace ) 
     $Pester.testresult[-1] | Write-PesterResult
 
+    Invoke-TeardownBlocks
     Clear-TestDrive -Exclude ($TestDriveContent | select -ExpandProperty FullName)
     Clear-Mocks
     $Pester.LeaveTest()

--- a/Functions/PesterState.ps1
+++ b/Functions/PesterState.ps1
@@ -29,6 +29,8 @@
         $script:Stopwatch = [System.Diagnostics.Stopwatch]::StartNew()
         $script:MostRecentTimestamp = 0
         $script:CommandCoverage = @()
+        $script:BeforeEach = @()
+        $script:AfterEach = @()
 		
 		$script:TestResult = @()
 		
@@ -123,7 +125,9 @@
                              "CurrentDescribe",
                              "CurrentTest",
                              "SessionState",
-                             "CommandCoverage"
+                             "CommandCoverage",
+                             "BeforeEach",
+                             "AfterEach"
         
         $ExportedFunctions = "EnterContext", 
                              "LeaveContext", 

--- a/Functions/SetupTeardown.Tests.ps1
+++ b/Functions/SetupTeardown.Tests.ps1
@@ -1,0 +1,100 @@
+Describe 'Describe-Scoped setup' {
+    BeforeEach {
+        $testVariable = 'From BeforeEach'
+    }
+
+    $testVariable = 'Set in Describe'
+
+    It 'Assigns the correct value in first test' {
+        $testVariable | Should Be 'From BeforeEach'
+        $testVariable = 'Set in It'
+    }
+
+    It 'Assigns the correct value in subsequent tests' {
+        $testVariable | Should Be 'From BeforeEach'        
+    }
+}
+
+Describe 'Context-scoped setup' {
+    $testVariable = 'Set in Describe'
+
+    Context 'The context' {
+        BeforeEach {
+            $testVariable = 'From BeforeEach'
+        }
+
+        It 'Assigns the correct value inside the context' {
+            $testVariable | Should Be 'From BeforeEach'
+        }
+    }
+
+    It 'Reports the original value after the Context' {
+        $testVariable | Should Be 'Set in Describe'
+    }
+}
+
+Describe 'Multiple setup blocks' {
+    $testVariable = 'Set in Describe'
+
+    BeforeEach {
+        $testVariable = 'Set in Describe BeforeEach'
+    }
+
+    Context 'The context' {
+        It 'Executes Describe setup blocks first, then Context blocks in the order they were defined (even if they are defined after the It block.)' {
+            $testVariable | Should Be 'Set in the second Context BeforeEach'
+        }
+
+        BeforeEach {
+            $testVariable = 'Set in the first Context BeforeEach'
+        }
+
+        BeforeEach {
+            $testVariable = 'Set in the second Context BeforeEach'
+        }
+    }
+
+    It 'Continues to execute Describe setup blocks after the Context' {
+        $testVariable | Should Be 'Set in Describe BeforeEach'
+    }
+}
+
+Describe 'Describe-scoped teardown' {
+    $testVariable = 'Set in Describe'
+
+    AfterEach {
+        $testVariable = 'Set in AfterEach'
+    }
+
+    It 'Does not modify the variable before the first test' {
+        $testVariable | Should Be 'Set in Describe'
+    }
+
+    It 'Modifies the variable after the first test' {
+        $testVariable | Should Be 'Set in AfterEach'
+    }
+}
+
+Describe 'Multiple teardown blocks' {
+    $testVariable = 'Set in Describe'
+
+    AfterEach {
+        $testVariable = 'Set in Describe AfterEach'
+    }
+
+    Context 'The context' {
+        AfterEach {
+            $testVariable = 'Set in the first Context AfterEach'
+        }
+
+        It 'Performs a test in Context' { }
+
+        It 'Executes Describe teardown blocks after Context teardown blocks' {
+            $testVariable | Should Be 'Set in the second Describe AfterEach'
+        }
+    }
+
+    AfterEach {
+        $testVariable = 'Set in the second Describe AfterEach'
+    }
+}

--- a/Functions/SetupTeardown.ps1
+++ b/Functions/SetupTeardown.ps1
@@ -1,0 +1,245 @@
+function BeforeEach { }
+function AfterEach { }
+
+function Clear-SetupAndTeardown
+{
+    $pester.BeforeEach = @( $pester.BeforeEach | Where-Object { $_.Scope -ne $pester.Scope } )
+    $pester.AfterEach  = @( $pester.AfterEach  | Where-Object { $_.Scope -ne $pester.Scope } )
+}
+
+function Invoke-SetupBlocks
+{
+    $orderedSetupBlocks = @(
+        $pester.BeforeEach | Where-Object { $_.Scope -eq 'Describe' }
+        $pester.BeforeEach | Where-Object { $_.Scope -eq 'Context'  }
+    )
+
+    foreach ($setupBlock in $orderedSetupBlocks)
+    {
+        try
+        {
+            . $setupBlock.ScriptBlock
+        }
+        catch
+        {
+            Write-Error -ErrorRecord $_
+        }
+    }
+}
+
+function Invoke-TeardownBlocks
+{
+    $orderedTeardownBlocks = @(
+        $pester.AfterEach | Where-Object { $_.Scope -eq 'Context'  }
+        $pester.AfterEach | Where-Object { $_.Scope -eq 'Describe' }
+    )
+
+    foreach ($teardownBlock in $orderedTeardownBlocks)
+    {
+        try
+        {
+            . $teardownBlock.ScriptBlock
+        }
+        catch
+        {
+            Write-Error -ErrorRecord $_
+        }
+    }
+}
+
+function Add-SetupAndTeardown
+{
+    param (
+        [scriptblock] $ScriptBlock
+    )
+
+    $codeText = $ScriptBlock.ToString()
+    $tokens = ParseCodeIntoTokens -CodeText $codeText
+
+    for ($i = 0; $i -lt $tokens.Count; $i++)
+    {
+        if ($tokens[$i].Type -eq [System.Management.Automation.PSTokenType]::Command -and
+            (IsSetupOrTeardownCommand -CommandName $tokens[$i].Content))
+        {
+            $openBraceIndex, $closeBraceIndex = Get-BraceIndecesForCommand -Tokens $tokens -CommandIndex $i
+            Add-SetupTeardownFromTokens -Tokens $tokens -CommandIndex $i -OpenBraceIndex $openBraceIndex -CloseBraceIndex $closeBraceIndex -CodeText $codeText
+            $i = $closeBraceIndex
+        }
+        elseif ($tokens[$i].Type -eq [System.Management.Automation.PSTokenType]::GroupStart)
+        {
+            # We don't want to parse Setup or Teardown commands in child scopes here, so anything
+            # bounded by a GroupStart / GroupEnd token pair which is not immediately preceded by
+            # a setup / teardown command name is ignored.
+            $i = Get-GroupCloseTokenIndex -Tokens $tokens -GroupStartTokenIndex $i
+        }
+    }
+}
+
+function ParseCodeIntoTokens
+{
+    param ([string] $CodeText)
+
+    $parseErrors = $null
+    $tokens = [System.Management.Automation.PSParser]::Tokenize($CodeText, [ref] $parseErrors)
+
+    if ($parseErrors.Count -gt 0)
+    {
+        $currentScope = $pester.Scope
+        throw "The current $currentScope block contains syntax errors."
+    }
+
+    return $tokens
+}
+
+function IsSetupOrTeardownCommand
+{
+    param ([string] $CommandName)
+    return (IsSetupCommand -CommandName $CommandName) -or (IsTeardownCommand -CommandName $CommandName)
+}
+
+function IsSetupCommand
+{
+    param ([string] $CommandName)
+    return $CommandName -eq 'BeforeEach'
+}
+
+function IsTeardownCommand
+{
+    param ([string] $CommandName)
+    return $CommandName -eq 'AfterEach'
+}
+
+function Get-BraceIndecesForCommand
+{
+    param (
+        [System.Management.Automation.PSToken[]] $Tokens,
+        [int] $CommandIndex
+    )
+
+    $openingGroupTokenIndex = Get-GroupStartTokenForCommand -Tokens $Tokens -CommandIndex $CommandIndex
+    $closingGroupTokenIndex = Get-GroupCloseTokenIndex -Tokens $Tokens -GroupStartTokenIndex $openingGroupTokenIndex
+
+    return $openingGroupTokenIndex, $closingGroupTokenIndex
+}
+
+function Get-GroupStartTokenForCommand
+{
+    param (
+        [System.Management.Automation.PSToken[]] $Tokens,
+        [int] $CommandIndex
+    )
+
+    # We may want to allow newlines, other parameters, etc at some point.  For now it's good enough to
+    # just verify that the next token after our BeforeEach or AfterEach command is an opening curly brace.
+
+    $commandName = $Tokens[$CommandIndex].Content
+
+    if ($CommandIndex + 1 -ge $tokens.Count -or
+        $tokens[$CommandIndex + 1].Type -ne [System.Management.Automation.PSTokenType]::GroupStart -or
+        $tokens[$CommandIndex + 1].Content -ne '{')
+    {
+        throw "The $commandName command must be immediately followed by the opening brace of a script block."
+    }
+
+    return $CommandIndex + 1
+}
+
+function Get-GroupCloseTokenIndex
+{
+    param (
+        [System.Management.Automation.PSToken[]] $Tokens,
+        [int] $GroupStartTokenIndex
+    )
+
+    $groupLevel = 1
+
+    for ($i = $GroupStartTokenIndex + 1; $i -lt $Tokens.Count; $i++)
+    {
+        switch ($Tokens[$i].Type)
+        {
+            ([System.Management.Automation.PSTokenType]::GroupStart)
+            {
+                $groupLevel++
+                break
+            }
+
+            ([System.Management.Automation.PSTokenType]::GroupEnd)
+            {
+                $groupLevel--
+
+                if ($groupLevel -le 0)
+                {
+                    return $i
+                }
+
+                break
+            }
+        }
+    }
+
+    throw 'No corresponding GroupEnd token was found.'
+}
+
+function Add-SetupTeardownFromTokens
+{
+    param (
+        [System.Management.Automation.PSToken[]] $Tokens,
+        [int] $CommandIndex,
+        [int] $OpenBraceIndex,
+        [int] $CloseBraceIndex,
+        [string] $CodeText
+    )
+
+    $commandName = $Tokens[$CommandIndex].Content
+
+    $blockStart = $Tokens[$OpenBraceIndex + 1].Start
+    $blockLength = $Tokens[$CloseBraceIndex].Start - $blockStart
+    $setupOrTeardownCodeText = $codeText.Substring($blockStart, $blockLength)
+
+    $setupOrTeardownBlock = [scriptblock]::Create($setupOrTeardownCodeText)
+    Set-ScriptBlockScope -ScriptBlock $setupOrTeardownBlock -SessionState $pester.SessionState
+
+    if (IsSetupCommand -CommandName $commandName)
+    {
+        Add-BeforeEach -ScriptBlock $setupOrTeardownBlock
+    }
+    else
+    {
+        Add-AfterEach -ScriptBlock $setupOrTeardownBlock
+    }
+}
+
+function Add-BeforeEach
+{
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true)]
+        [scriptblock]
+        $ScriptBlock
+    )
+
+    $props = @{
+        Scope       = $pester.Scope
+        ScriptBlock = $ScriptBlock
+    }
+
+    $pester.BeforeEach += @(New-Object psobject -Property $props)
+
+}
+
+function Add-AfterEach
+{
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true)]
+        [scriptblock]
+        $ScriptBlock
+    )
+
+    $props = @{
+        Scope       = $pester.Scope
+        ScriptBlock = $ScriptBlock
+    }
+
+    $pester.AfterEach += @(New-Object psobject -Property $props)
+}

--- a/Pester.psm1
+++ b/Pester.psm1
@@ -186,3 +186,4 @@ function Set-ScriptBlockScope
 
 Export-ModuleMember Describe, Context, It, In, Mock, Assert-VerifiableMocks, Assert-MockCalled
 Export-ModuleMember New-Fixture, Get-TestDriveItem, Should, Invoke-Pester, Setup, InModuleScope, Invoke-Mock
+Export-ModuleMember BeforeEach, AfterEach


### PR DESCRIPTION
User-Defined setup and teardown blocks that execute before and after each "It" block.  Scope rules based on what I read in rspec's documentation; Setup blocks are executed from the Describe scope first, then Context.  For teardown, it's in reverse; the innermost (Context) teardown blocks are executed, then the outer (Describe) blocks.

For now, the code allows you to define multiple blocks in the same scope, and they are executed in the order they were defined.

BeforeEach and AfterEach blocks can be defined anywhere within a Context or Describe block; they are parsed and loaded before the body of the Context / Describe is executed.  This is different from how PowerShell code normally behaves, but was a desired feature in the initial discussion.

PR of code from discussion in issue #157
