### PR TITLE
Rolling back some earlier Pester Scope changes

### DIFF
--- a/Functions/It.ps1
+++ b/Functions/It.ps1
@@ -66,7 +66,6 @@ about_should
     )
 
     $Pester.EnterTest($name)
-    $TestDriveContent = Get-TestDriveChildItem
     Invoke-SetupBlocks
 
     $PesterException = $null   
@@ -81,7 +80,6 @@ about_should
     $Pester.testresult[-1] | Write-PesterResult
 
     Invoke-TeardownBlocks
-    Clear-TestDrive -Exclude ($TestDriveContent | select -ExpandProperty FullName)
     Clear-Mocks
     $Pester.LeaveTest()
 }

--- a/Functions/Mock.Tests.ps1
+++ b/Functions/Mock.Tests.ps1
@@ -641,7 +641,7 @@ Describe 'Testing mock history behavior from each scope' {
 
     Context 'Without overriding the mock in lower scopes' {
         It "Reports that zero calls have been made to in the describe scope" {
-            Assert-MockCalled MockHistoryChecker -Exactly 0
+            Assert-MockCalled MockHistoryChecker -Exactly 0 -Scope Describe
         }
 
         It 'Calls the describe mock' {
@@ -653,21 +653,21 @@ Describe 'Testing mock history behavior from each scope' {
         }
 
         It "Reports one Context-scoped call" {
-            Assert-MockCalled MockHistoryChecker -Exactly 1 -Scope Context
+            Assert-MockCalled MockHistoryChecker -Exactly 1
         }
 
         It "Reports one Describe-scoped call" {
-            Assert-MockCalled MockHistoryChecker -Exactly 1
+            Assert-MockCalled MockHistoryChecker -Exactly 1 -Scope Describe
         }
     }
 
     Context 'After exiting the previous context' {
         It 'Reports zero context-scoped calls in the new context.' {
-            Assert-MockCalled MockHistoryChecker -Exactly 0 -Scope Context
+            Assert-MockCalled MockHistoryChecker -Exactly 0
         }
 
         It 'Reports one describe-scoped call from the previous context' {
-            Assert-MockCalled MockHistoryChecker -Exactly 1
+            Assert-MockCalled MockHistoryChecker -Exactly 1 -Scope Describe
         }
     }
 
@@ -679,11 +679,11 @@ Describe 'Testing mock history behavior from each scope' {
         }
 
         It 'Reports one context-scoped call' {
-            Assert-MockCalled MockHistoryChecker -Exactly 1 -Scope Context
+            Assert-MockCalled MockHistoryChecker -Exactly 1
         }
 
         It 'Reports two describe-scoped calls, even when one is an override mock in a lower scope' {
-            Assert-MockCalled MockHistoryChecker -Exactly 2
+            Assert-MockCalled MockHistoryChecker -Exactly 2 -Scope Describe
         }
 
         It 'Calls an It-scoped mock' {
@@ -692,12 +692,16 @@ Describe 'Testing mock history behavior from each scope' {
         }
 
         It 'Reports 2 context-scoped calls' {
-            Assert-MockCalled MockHistoryChecker -Exactly 2 -Scope Context
+            Assert-MockCalled MockHistoryChecker -Exactly 2
         }
 
         It 'Reports 3 describe-scoped calls' {
-            Assert-MockCalled MockHistoryChecker -Exactly 3
+            Assert-MockCalled MockHistoryChecker -Exactly 3 -Scope Describe
         }
+    }
+
+    It 'Reports 3 describe-scoped calls using the default scope in a Describe block' {
+        Assert-MockCalled MockHistoryChecker -Exactly 3
     }
 }
 

--- a/Functions/TestDrive.Tests.ps1
+++ b/Functions/TestDrive.Tests.ps1
@@ -104,13 +104,12 @@ Describe "TestDrive scoping" {
             'TestDrive:\It' | Should Exist
         }
         
-        It "Clears It-scoped contents on exit" {
-            'TestDrive:\It' | Should Not Exist
+        It "Does not clear It-scoped contents on exit" {
+            'TestDrive:\It' | Should Exist
         }
 	}
 
 	It "Context file are removed when returning to Describe" {
-		
 		"TestDrive:\Context" | Should Not Exist
 	}
 	


### PR DESCRIPTION
Per discussions with @nohwnd, the idea of having `it` be its own Pester scope (clearing `mock`s and `TestDrive` contents the same way `context` and `describe` do) feels a bit awkward in practice.  We're starting to roll back those changes until we find the right balance; for now, `mock`s are still affected by `it` scopes, but `TestDrive` has reverted back to Pester 2.0 behavior (only rolling back `TestDrive` contents when exiting a `context` or `describe` block.)

Also, default behavior of `Assert-MockCalled` has changed to be more in line with Pester 2.0 behavior, possibly allowing old test scripts to function without any modifications.  The default value for the `-Scope` parameter is now either `context` or `describe`, depending on whether there is a currently-active `context` block.  You can still pass in `-Scope <Describe | Context | It>` to override this behavior, if desired.

Tests of these bits have been updated to match the new behavior.  Possibly more changes coming along these lines, once we've tested this revision a bit.
