### PR TITLE
Legacy expectations cleanup

### DIFF
--- a/Pester.psm1
+++ b/Pester.psm1
@@ -115,7 +115,6 @@ about_pester
         [Parameter(Position=4,Mandatory=0)]
         [Alias('Tags')]
 		[string]$Tag,
-        [switch]$EnableLegacyExpectations,
 		[switch]$PassThru,
 
         [object[]] $CodeCoverage = @()


### PR DESCRIPTION
Actual legacy expectations functionality was removed back in commit cdcb7d6 , but the switch parameter was still defined on the Invoke-Pester command.
