### PR TITLE
Invoke-Pester tests path fix.

### DIFF
--- a/Pester.psm1
+++ b/Pester.psm1
@@ -11,14 +11,14 @@
 function Invoke-Pester {
 <#
 .SYNOPSIS
-Invokes Pester to run all tests (files containing *Tests.ps1) recursively under the Path
+Invokes Pester to run all tests (files containing *.Tests.ps1) recursively under the Path
 
 .DESCRIPTION
 Upon calling Invoke-Pester. All files that have a name containing 
-"*Tests.ps1" will have there tests defined in their Describe blocks 
+"*.Tests.ps1" will have there tests defined in their Describe blocks 
 executed. Invoke-Pester begins at the location of Path and 
 runs recursively through each sub directory looking for 
-*Tests.ps1 files for tests to run. If a TestName is provided, 
+*.Tests.ps1 files for tests to run. If a TestName is provided, 
 Invoke-Pester will only run tests that have a describe block with a 
 matching name. By default, Invoke-Pester will end the test run with a 
 simple report of the number of tests passed and failed output to the 
@@ -65,7 +65,7 @@ Both Function and Path (as well as simple strings passed instead of hashtables) 
 .Example
 Invoke-Pester
 
-This will find all *Tests.ps1 files and run their tests. No exit code will be returned and no log file will be saved.
+This will find all *.Tests.ps1 files and run their tests. No exit code will be returned and no log file will be saved.
 
 .Example
 Invoke-Pester ./tests/Utils*
@@ -134,7 +134,7 @@ about_pester
   $scriptBlock = { & $args[0] }
   Set-ScriptBlockScope -ScriptBlock $scriptBlock -SessionState $PSCmdlet.SessionState
   
-  Get-ChildItem $pester.Path -Filter "*Tests.ps1" -Recurse |
+  Get-ChildItem $pester.Path -Filter "*.Tests.ps1" -Recurse |
   where { -not $_.PSIsContainer } |
   foreach { & $scriptBlock $_.PSPath }
 


### PR DESCRIPTION
At some point while working on the early 3.0 beta code, we changed from executing *.Tests.ps1 with Invoke-Pester to just *Tests.ps1 .  I'm not sure why this was done, but it represents an unnecessary breaking change (and a bug, considering that New-Fixture still assumes that tests file will end in ".Tests.ps1", and the script under test will be named identically without the ".Tests" portion.)

Reverted this filter back to "*.Tests.ps1".
