### PR TITLE
Assert-MockCalled fix

### DIFF
--- a/Functions/Mock.ps1
+++ b/Functions/Mock.ps1
@@ -454,6 +454,11 @@ param(
     [ValidateSet('Describe','Context','It')]
     [string] $Scope
 )
+    if (-not $PSBoundParameters.ContainsKey('ModuleName') -and $null -ne $pester.SessionState.Module)
+    {
+        $ModuleName = $pester.SessionState.Module.Name
+    }
+
     $mock = $script:mockTable["$ModuleName||$commandName"]
 
     $moduleMessage = ''


### PR DESCRIPTION
The value of the `ModuleName` parameter in `Assert-MockCalled` now defaults to Pester's current SessionState's module.  As a result, inside an `InModuleScope` block, you no longer need to explicitly specify `-ModuleName` when calling `Assert-MockCalled` for mocks in the same module.  (This brings `Assert-MockCalled` functionality back in line with the `Mock` command, which also doesn't require you to specify `-ModuleName` inside an InModuleScope block.)
