### PR TITLE
Small fix for PesterThrowFailureMessage

### DIFF
--- a/Functions/Assertions/PesterThrow.ps1
+++ b/Functions/Assertions/PesterThrow.ps1
@@ -29,7 +29,9 @@ function Get-DoMessagesMatch($value, $expected) {
 }
 
 function Get-ExceptionLineInfo($info) {
-    return ($info.PositionMessage -replace "^At ","from ")
+    # $info.PositionMessage has a leading blank line that we need to account for in PowerShell 2.0
+    $positionMessage = $info.PositionMessage -split '\r?\n' -match '\S' -join "`r`n"
+    return ($positionMessage -replace "^At ","from ")
 }
 
 function PesterThrowFailureMessage($value, $expected) {


### PR DESCRIPTION
The tests for #147 were failing in PowerShell 2.0 due to the presence of a leading blank line in the ErrorRecord's InvocationInfo.PositionMessage property.  This update strips out any whitespace-only lines from PositionMessage before otherwise manipulating and using it in the output, which gets the tests working regardless of PowerShell version.
