### PR TITLE
Pester.bat no longer enables strict mode.

### DIFF
--- a/bin/pester.bat
+++ b/bin/pester.bat
@@ -9,7 +9,7 @@ if '%1'=='/help' goto usage
 if '%1'=='help' goto usage
 
 @PowerShell -NonInteractive -NoProfile -ExecutionPolicy Bypass -Command ^
- "& Import-Module '%DIR%..\Pester.psm1';  & { Set-StrictMode -Version Latest; Invoke-Pester -OutputXml Test.xml -EnableExit %ARGS%}"
+ "& Import-Module '%DIR%..\Pester.psm1';  & { Invoke-Pester -OutputXml Test.xml -EnableExit %ARGS%}"
 
 goto finish
 :usage


### PR DESCRIPTION
This change was originally made to ensure that Pester's unit tests are run with strict mode enabled, so we would catch any bugs.  However, making this change in Pester.bat affects all users of Pester (or at least the ones who use the convenience batch file for integration.)

Pester's unit test scripts have since each been modified to enable Strict Mode at the beginning of each file, and we should no longer require this to be set in Pester.bat.  This way, users of Pester are not forced to write their test scripts in a way that is StrictMode-compatible.
