### PR TITLE
Describe and Context fix

### DIFF
--- a/Functions/Context.Tests.ps1
+++ b/Functions/Context.Tests.ps1
@@ -1,0 +1,18 @@
+Set-StrictMode -Version Latest
+
+Describe 'Testing Context' {
+    It 'Has a non-mandatory fixture parameter which throws the proper error message if missing' {
+        $command = Get-Command Context -Module Pester
+        $command | Should Not Be $null
+
+        $parameter = $command.Parameters['Fixture']
+        $parameter | Should Not Be $null
+
+        $attribute = $parameter.Attributes | Where-Object { $_.TypeId -eq [System.Management.Automation.ParameterAttribute] }
+        $isMandatory = $null -ne $attribute -and $attribute.Mandatory
+
+        $isMandatory | Should Be $false
+
+        { Context Bogus } | Should Throw 'No test script block is provided'
+    }
+}

--- a/Functions/Context.ps1
+++ b/Functions/Context.ps1
@@ -37,8 +37,8 @@ param(
     [Parameter(Mandatory = $true)]
     $name,
 
-    [Parameter(Mandatory = $true)]
-    [ScriptBlock] $fixture
+    [ValidateNotNull()]
+    [ScriptBlock] $fixture = $(Throw "No test script block is provided. (Have you put the open curly brace on the next line?)")
 )
     $Pester.EnterContext($name)
     $TestDriveContent = Get-TestDriveChildItem

--- a/Functions/Describe.Tests.ps1
+++ b/Functions/Describe.Tests.ps1
@@ -1,0 +1,18 @@
+Set-StrictMode -Version Latest
+
+Describe 'Testing Describe' {
+    It 'Has a non-mandatory fixture parameter which throws the proper error message if missing' {
+        $command = Get-Command Describe -Module Pester
+        $command | Should Not Be $null
+
+        $parameter = $command.Parameters['Fixture']
+        $parameter | Should Not Be $null
+
+        $attribute = $parameter.Attributes | Where-Object { $_.TypeId -eq [System.Management.Automation.ParameterAttribute] }
+        $isMandatory = $null -ne $attribute -and $attribute.Mandatory
+
+        $isMandatory | Should Be $false
+
+        { Describe Bogus } | Should Throw 'No test script block is provided'
+    }
+}

--- a/Functions/Describe.ps1
+++ b/Functions/Describe.ps1
@@ -54,7 +54,8 @@ about_TestDrive
 param(
         [Parameter(Mandatory = $true, Position = 0)] $name,
         $tags=@(),
-        [Parameter(Mandatory = $true, Position = 1)]
+        [Parameter(Position = 1)]
+        [ValidateNotNull()]
         [ScriptBlock] $fixture = $(Throw "No test script block is provided. (Have you put the open curly brace on the next line?)")
 )
 


### PR DESCRIPTION
Fixture parameters to Describe was mistakenly marked as Mandatory in a recent commit.  Instead of that, its previous behavior was to be optional, but to throw a more user-friendly error message if it's not specified.

Added tests to make sure this doesn't happen again, and also applied the same logic / tests to the Context command.
