### PR TITLE
Mocks are no longer tied to the It scope.

### DIFF
--- a/Functions/Context.ps1
+++ b/Functions/Context.ps1
@@ -59,7 +59,7 @@ param(
 
     Clear-SetupAndTeardown
     Clear-TestDrive -Exclude ($TestDriveContent | select -ExpandProperty FullName)
-    Clear-Mocks
+    Exit-MockScope
     $Pester.LeaveContext()
 }
 

--- a/Functions/Describe.ps1
+++ b/Functions/Describe.ps1
@@ -93,7 +93,7 @@ param(
 
     Clear-SetupAndTeardown
     Remove-TestDrive
-    Clear-Mocks
+    Exit-MockScope
     $Pester.LeaveDescribe()
 }
 

--- a/Functions/It.ps1
+++ b/Functions/It.ps1
@@ -80,7 +80,7 @@ about_should
     $Pester.testresult[-1] | Write-PesterResult
 
     Invoke-TeardownBlocks
-    Clear-Mocks
+    Exit-MockScope
     $Pester.LeaveTest()
 }
 

--- a/Functions/Mock.Tests.ps1
+++ b/Functions/Mock.Tests.ps1
@@ -616,21 +616,21 @@ Describe "Using Pester Scopes (Describe,Context,It)" {
         It "should use the describe mock" {
             FunctionUnderTest | should be "I am the paramless mock test"
         }
+
         It "should use the describe parameterized mock" {
             FunctionUnderTest "one" | should be "I am the first mock test"
         }
     }
 
-    Context "Testing It-scoped mocks" {
-        Mock FunctionUnderTest { return "I am the context mock" }
+    Context 'When someone calls Mock from inside an It block' {
+        Mock FunctionUnderTest { return 'I am the context mock' }
 
-        It "Should call the It mock" {
-            Mock FunctionUnderTest { return "I am the It mock" }
-            FunctionUnderTest | Should Be "I am the It mock"
+        It 'Sets the mock' {
+            Mock FunctionUnderTest { return 'I am the It mock' }
         }
 
-        It "Should revert to calling the Context mock in the next test" {
-            FunctionUnderTest | Should Be "I am the context mock"
+        It 'Leaves the mock active in the parent scope' {
+            FunctionUnderTest | Should Be 'I am the It mock'
         }
     }
 }


### PR DESCRIPTION
When Mock is called from an It block, the mock's lifetime is tied to whatever the parent scope of the It block is (either Context or Describe).  The concept of an "It" scope still exists, but only for use in calls to Assert-MockCalled.
