### PR TITLE
Fix Module Manifest

### DIFF
--- a/Pester.psd1
+++ b/Pester.psd1
@@ -15,8 +15,11 @@ Author = 'Pester Team'
 # Company or vendor of this module
 CompanyName = 'Pester'
 
+# Copyright statement for this module
+Copyright = 'Copyright (c) 2014 by Pester Team, licensed under Apache 2.0 License.'
+
 # Description of the functionality provided by this module
-Description = 'Pester provides a framework for running Unit Tests to execute and validate PowerShell commands inside of PowerShell.'
+Description = 'Pester provides a framework for running BDD style Tests to execute and validate PowerShell commands inside of PowerShell and offers a powerful set of Mocking Functions that allow tests to mimic and mock the functionality of any command inside of a piece of powershell code being tested. Pester tests can execute any command or script that is accesible to a pester test file. This can include functions, Cmdlets, Modules and scripts. Pester can be run in ad hoc style in a console or it can be integrated into the Build scripts of a Continuous Integration system.'
 
 # Minimum version of the Windows PowerShell engine required by this module
 PowerShellVersion = '2.0'
@@ -85,7 +88,7 @@ PrivateData = @{
 
         # Indicates this is a pre-release/testing version of the module.
         IsPrerelease = 'True'
-}
+    }
 }
 
 # HelpInfo URI of this module


### PR DESCRIPTION
Well, you can read the commit messages, but basically, this makes it compatible with PowerShell 2 and 5 (adding support for PowerShellGet packaging). I also copied in the description from the NuGet package, because this description will end up being used in the (NuGet) packages PowerShellGet generates.
