### PR TITLE
Describe / Context error output fix

### DIFF
--- a/Functions/Context.ps1
+++ b/Functions/Context.ps1
@@ -52,7 +52,7 @@ param(
     }
     catch
     {
-        $firstStackTraceLine = $_.ScriptStackTrace -split '\r?\n' | Select-Object -First 1
+        $firstStackTraceLine = $_.InvocationInfo.PositionMessage.Trim() -split '\r?\n' | Select-Object -First 1
         $Pester.AddTestResult('Error occurred in Context block', $false, $null, $_.Exception.Message, $firstStackTraceLine)
         $Pester.TestResult[-1] | Write-PesterResult
     }

--- a/Functions/Describe.ps1
+++ b/Functions/Describe.ps1
@@ -86,7 +86,7 @@ param(
     }
     catch
     {
-        $firstStackTraceLine = $_.ScriptStackTrace -split '\r?\n' | Select-Object -First 1
+        $firstStackTraceLine = $_.InvocationInfo.PositionMessage.Trim() -split '\r?\n' | Select-Object -First 1
         $Pester.AddTestResult('Error occurred in Describe block', $false, $null, $_.Exception.Message, $firstStackTraceLine)
         $Pester.TestResult[-1] | Write-PesterResult
     }


### PR DESCRIPTION
Previous code was relying on the ScriptStackTrace property of ErrorRecord objects, which doesn't exist in PowerShell 2.0.  Code updated to use ErrorRecord.InvocationInfo.PositionMessage instead.
