### PR TITLE
Fixing a mocking parameter bug

### DIFF
--- a/Functions/Mock.Tests.ps1
+++ b/Functions/Mock.Tests.ps1
@@ -77,6 +77,10 @@ Describe "When calling Mock on existing cmdlet" {
     It "Should Invoke the mocked script" {
         $result | Should Be "I am not Get-Process"
     }
+
+    It 'Should not resolve $args to the parent scope' {
+        { $args = 'From', 'Parent', 'Scope'; Get-Process SomeName } | Should Not Throw
+    }
 }
 
 Describe 'When calling Mock on an alias' {

--- a/Functions/Mock.ps1
+++ b/Functions/Mock.ps1
@@ -598,7 +598,9 @@ function MockPrototype {
         $moduleName = $ExecutionContext.SessionState.Module.Name
     }
 
-    Invoke-Mock -CommandName $functionName -ModuleName $moduleName -BoundParameters $PSBoundParameters -ArgumentList $args
+    $ArgumentList = @(Get-Variable -Name args -ValueOnly -Scope Local -ErrorAction SilentlyContinue)
+
+    Invoke-Mock -CommandName $functionName -ModuleName $moduleName -BoundParameters $PSBoundParameters -ArgumentList $ArgumentList
 }
 
 function Invoke-Mock {


### PR DESCRIPTION
@Jaykul pointed out a problem where the `$args` variable in a mock's stub function can resolve to the value of `$args` in a parent scope; the automatic version of `$args` only exists for functions without the CmdletBinding attribute.  (Mocks of cmdlets and advanced functions can demonstrate the bug, if a variable named `$args` is defined in a parent scope of the call to the mocked command.)

The prototype function used to generate these stubs now looks specifically for a variable named args in the local scope, not allowing it to fetch the parent scope's values.
