### PR TITLE
Better error messages when exported commands are called out of order

### DIFF
--- a/Functions/Assertions/Should.ps1
+++ b/Functions/Assertions/Should.ps1
@@ -71,6 +71,7 @@ function New-ShouldException ($Message,$Line) {
 
 function Should {
     begin {
+        Assert-DescribeInProgress -CommandName Should
         $parsedArgs = Parse-ShouldArgs $args
     }
 

--- a/Functions/Context.ps1
+++ b/Functions/Context.ps1
@@ -40,6 +40,8 @@ param(
     [ValidateNotNull()]
     [ScriptBlock] $fixture = $(Throw "No test script block is provided. (Have you put the open curly brace on the next line?)")
 )
+    Assert-DescribeInProgress -CommandName Context
+
     $Pester.EnterContext($name)
     $TestDriveContent = Get-TestDriveChildItem
 

--- a/Functions/Describe.ps1
+++ b/Functions/Describe.ps1
@@ -97,3 +97,11 @@ param(
     $Pester.LeaveDescribe()
 }
 
+function Assert-DescribeInProgress
+{
+    param ($CommandName)
+    if ($null -eq $pester -or [string]::IsNullOrEmpty($pester.CurrentDescribe))
+    {
+        throw "The $CommandName command may only be used inside a Describe block."
+    }
+}

--- a/Functions/In.ps1
+++ b/Functions/In.ps1
@@ -21,6 +21,7 @@ param(
     $path,
     [ScriptBlock] $execute
 )
+    Assert-DescribeInProgress -CommandName In
 
     $old_pwd = $pwd
     pushd $path

--- a/Functions/It.ps1
+++ b/Functions/It.ps1
@@ -65,6 +65,8 @@ about_should
         [ScriptBlock] $test = $(Throw "No test script block is provided. (Have you put the open curly brace on the next line?)")
     )
 
+    Assert-DescribeInProgress -CommandName It
+
     $Pester.EnterTest($name)
     Invoke-SetupBlocks
 

--- a/Functions/Mock.ps1
+++ b/Functions/Mock.ps1
@@ -185,6 +185,8 @@ about_Mocking
         [string]$ModuleName
     )
 
+    Assert-DescribeInProgress -CommandName Mock
+
     $filterTest = Test-ParameterFilter -ScriptBlock $ParameterFilter
 
     if ($filterTest -isnot [bool]) { throw [System.Management.Automation.PSArgumentException] 'The Parameter Filter must return a boolean' }
@@ -309,6 +311,8 @@ Assert-VerifiableMocks
 This will not throw an exception because the mock was invoked.
 
 #>
+    Assert-DescribeInProgress -CommandName Assert-VerifiableMocks
+
     $unVerified=@{}
     $mockTable.Keys | % {
         $m=$_; $mockTable[$m].blocks | ? { $_.Verifiable } | % { $unVerified[$m]=$_ }
@@ -454,6 +458,9 @@ param(
     [ValidateSet('Describe','Context','It')]
     [string] $Scope
 )
+    
+    Assert-DescribeInProgress -CommandName Assert-MockCalled
+
     if (-not $PSBoundParameters.ContainsKey('ModuleName') -and $null -ne $pester.SessionState.Module)
     {
         $ModuleName = $pester.SessionState.Module.Name

--- a/Functions/SetupTeardown.ps1
+++ b/Functions/SetupTeardown.ps1
@@ -1,5 +1,12 @@
-function BeforeEach { }
-function AfterEach { }
+function BeforeEach
+{
+    Assert-DescribeInProgress -CommandName BeforeEach
+}
+
+function AfterEach
+{
+    Assert-DescribeInProgress -CommandName AfterEach
+}
 
 function Clear-SetupAndTeardown
 {

--- a/Functions/TestDrive.ps1
+++ b/Functions/TestDrive.ps1
@@ -48,8 +48,9 @@ function New-RandomTempDirectory {
 function Get-TestDriveItem {
     #moved here from Pester.psm1
     param( [string]$Path )
-    $result = Get-Item $(Join-Path $TestDrive $Path )
-    return $result
+
+    Assert-DescribeInProgress -CommandName Get-TestDriveItem
+    Get-Item $(Join-Path $TestDrive $Path )
 }
 
 function Get-TestDriveChildItem {
@@ -97,6 +98,8 @@ function Setup {
     $Content = "",
     [switch]$PassThru
     )
+
+    Assert-DescribeInProgress -CommandName Setup
 
     $TestDriveName = Get-PSDrive TestDrive | Select -ExpandProperty Root
 


### PR DESCRIPTION
Most Pester commands are intended to be used inside a Describe block, and if you called them in other situations, you'd typically get many errors instead of a single terminating error at the start of a function.

This has been changed for all commands except for Invoke-Pester and New-Fixture (which are intended to be called outside of a running test).
