### PR TITLE
Export-NUnitReport function was missing a close tag

### DIFF
--- a/Functions/TestResults.ps1
+++ b/Functions/TestResults.ps1
@@ -125,6 +125,7 @@ function Export-NUnitReport {
                     $XmlWriter.WriteStartElement("failure")
                     $xmlWriter.WriteElementString("message", $_.FailureMessage)
                     $XmlWriter.WriteElementString("stack-trace", $_.StackTrace)
+                    $XmlWriter.WriteEndElement() # Close failure tag
                 }
                 $XmlWriter.WriteEndElement() #Close test-case tag
             }


### PR DESCRIPTION
Failed test cases weren't closing their failure tag, which resulted in the whole file structure being thrown off.  (test-case elements were being nested inside other test-case elements, etc.)
