### PR TITLE
Tweak Contain and Contain Exactly

### DIFF
--- a/Functions/Assertions/Contain.Tests.ps1
+++ b/Functions/Assertions/Contain.Tests.ps1
@@ -3,7 +3,7 @@ Set-StrictMode -Version Latest
 InModuleScope Pester {
     Describe "PesterContain" {
         Context "when testing file contents" {
-            Setup -File "test.txt" "this is line 1`nrush is awesome"
+            Setup -File "test.txt" "this is line 1`nis rush awesome?`none last line"
             It "returns true if the file contains the specified content" {
                 Test-PositiveAssertion (PesterContain "$TestDrive\test.txt" "rush")
             }
@@ -13,6 +13,18 @@ InModuleScope Pester {
 
             It "returns false if the file does not contain the specified content" {
                 Test-NegativeAssertion (PesterContain "$TestDrive\test.txt" "slime")
+            }
+
+            It "works with more than one line" {
+                Test-PositiveAssertion (PesterContain "$TestDrive\test.txt" "line 1`nis rush")
+            }
+
+            It "escapes regular expression characters" {
+                Test-PositiveAssertion (PesterContain "$TestDrive\test.txt" "awesome?")
+            }
+
+            It "works on strings too, not just files" {
+                Test-PositiveAssertion (PesterContain "This is a test`nIsn't it awesome?" "awesome?")
             }
         }
     }

--- a/Functions/Assertions/Contain.ps1
+++ b/Functions/Assertions/Contain.ps1
@@ -1,13 +1,19 @@
 
-function PesterContain($file, $contentExpecation) {
-    return ((Get-Content $file) -match $contentExpecation)
+function PesterContain($file, $contentExpectation) {
+    $re = [regex]::escape($contentExpectation)
+    $ofs = "`n"
+    if($file -is [string] -and !(Test-Path $file -ErrorAction SilentlyContinue)) {
+        return "$file" -match $re
+    } else {
+        return "$(Get-Content $file)" -match $re
+    }
 }
 
-function PesterContainFailureMessage($file, $contentExpecation) {
-    return "Expected: file ${file} to contain {$contentExpecation}"
+function PesterContainFailureMessage($file, $contentExpectation) {
+    return "Expected: file ${file} to contain {$contentExpectation}"
 }
 
-function NotPesterContainFailureMessage($file, $contentExpecation) {
-    return "Expected: file {$file} to not contain ${contentExpecation} but it did"
+function NotPesterContainFailureMessage($file, $contentExpectation) {
+    return "Expected: file {$file} to not contain ${contentExpectation} but it did"
 }
 

--- a/Functions/Assertions/ContainExactly.Tests.ps1
+++ b/Functions/Assertions/ContainExactly.Tests.ps1
@@ -3,13 +3,25 @@ Set-StrictMode -Version Latest
 InModuleScope Pester {
     Describe "PesterContainExactly" {
         Context "when testing file contents" {
-            Setup -File "test.txt" "this is line 1`nPester is awesome"
+            Setup -File "test.txt" "Is this line 1?`nPester is awesome"
             It "returns true if the file contains the specified content exactly" {
                 Test-PositiveAssertion (PesterContainExactly "$TestDrive\test.txt" "Pester")
             }
 
             It "returns false if the file does not contain the specified content exactly" {
                 Test-NegativeAssertion (PesterContainExactly "$TestDrive\test.txt" "pESTER")
+            }
+
+            It "works with more than one line" {
+                Test-PositiveAssertion (PesterContainExactly "$TestDrive\test.txt" "line 1?`nPester")
+            }
+
+            It "escapes regular expression characters" {
+                Test-PositiveAssertion (PesterContainExactly "$TestDrive\test.txt" "1?")
+            }
+
+            It "works on strings too, not just files" {
+                Test-PositiveAssertion (PesterContainExactly "This is a test`nIsn't it awesome?" "awesome?")
             }
         }
     }

--- a/Functions/Assertions/ContainExactly.ps1
+++ b/Functions/Assertions/ContainExactly.ps1
@@ -1,13 +1,19 @@
 
-function PesterContainExactly($file, $contentExpecation) {
-    return ((Get-Content $file) -cmatch $contentExpecation)
+function PesterContainExactly($file, $contentExpectation) {
+    $re = [regex]::escape($contentExpectation)
+    $ofs = "`n"
+    if($file -is [string] -and !(Test-Path $file -ErrorAction SilentlyContinue)) {
+        return "$file" -cmatch $re
+    } else {
+        return "$(Get-Content $file)" -cmatch $re
+    }
 }
 
-function PesterContainExactlyFailureMessage($file, $contentExpecation) {
-    return "Expected: file ${file} to contain exactly {$contentExpecation}"
+function PesterContainExactlyFailureMessage($file, $contentExpectation) {
+    return "Expected: file ${file} to contain exactly {$contentExpectation}"
 }
 
-function NotPesterContainExactlyFailureMessage($file, $contentExpecation) {
-    return "Expected: file {$file} to not contain exactly ${contentExpecation} but it did"
+function NotPesterContainExactlyFailureMessage($file, $contentExpectation) {
+    return "Expected: file {$file} to not contain exactly ${contentExpectation} but it did"
 }
 

--- a/Functions/Assertions/Match.Tests.ps1
+++ b/Functions/Assertions/Match.Tests.ps1
@@ -2,6 +2,8 @@ Set-StrictMode -Version Latest
 
 InModuleScope Pester {
     Describe "Match" {
+        Setup -File "test.txt" "this is line 1`nisn't Pester awesome?`nyes it is!"
+
         It "returns true for things that match" {
             PesterMatch "foobar" "ob" | Should Be $true
         }
@@ -16,6 +18,10 @@ InModuleScope Pester {
 
         It "uses regular expressions" {
             PesterMatch "foobar" "\S{6}" | Should Be $true
+        }
+
+        It "searches the content of FileInfo objects" {
+            Test-PositiveAssertion (PesterMatch (Get-Item "$TestDrive\test.txt") "awesome?")
         }
     }
 }

--- a/Functions/Assertions/Match.ps1
+++ b/Functions/Assertions/Match.ps1
@@ -1,6 +1,11 @@
 
 function PesterMatch($value, $expectedMatch) {
-    return ($value -match $expectedMatch)
+    $ofs = "`n"
+    if($value -isnot [string] -and $value -isnot [string[]] -and (Test-Path $value -ErrorAction SilentlyContinue)) {
+        return "$(Get-Content $value)" -match $expectedMatch
+    } else {
+        return "$value" -match $expectedMatch
+    }
 }
 
 function PesterMatchFailureMessage($value, $expectedMatch) {

--- a/Functions/Assertions/MatchExactly.Tests.ps1
+++ b/Functions/Assertions/MatchExactly.Tests.ps1
@@ -2,6 +2,8 @@ Set-StrictMode -Version Latest
 
 InModuleScope Pester {
     Describe "MatchExactly" {
+        Setup -File "test.txt" "this is line 1`nisn't Pester awesome?`nyes it is!"
+
         It "returns true for things that match exactly" {
             PesterMatchExactly "foobar" "ob" | Should Be $true
         }
@@ -12,6 +14,10 @@ InModuleScope Pester {
 
         It "uses regular expressions" {
             PesterMatchExactly "foobar" "\S{6}" | Should Be $true
+        }
+
+        It "searches the content of FileInfo objects" {
+            Test-PositiveAssertion (PesterMatch (Get-Item "$TestDrive\test.txt") "awesome?")
         }
     }
 }

--- a/Functions/Assertions/MatchExactly.ps1
+++ b/Functions/Assertions/MatchExactly.ps1
@@ -1,6 +1,11 @@
 
 function PesterMatchExactly($value, $expectedMatch) {
-    return ($value -cmatch $expectedMatch)
+    $ofs = "`n"
+    if($value -isnot [string] -and (Test-Path $file -ErrorAction SilentlyContinue)) {
+        return "$(Get-Content $value)" -cmatch $expectedMatch
+    } else {
+        return "$value" -cmatch $expectedMatch
+    }
 }
 
 function PesterMatchExactlyFailureMessage($value, $expectedMatch) {


### PR DESCRIPTION
Fix Should Contain and Should ContainExactly
- You should be able to specify more than one line for the test, as in `| Should Contain "line`nanother"`
- You shouldn't have to think about RegEx in a "contains" test
- You should be able to do: `"Some string" | Should Contain "string"`

After doing that, I also tweaked Match so it could be used on file content if you pass a FileInfo object (not just a path): `get-item TestDrive:\Test.txt | Should match "the contents"`
