### PR TITLE
Still more DynamicParam fixes

### DIFF
--- a/Pester.psd1
+++ b/Pester.psd1
@@ -43,6 +43,7 @@ FunctionsToExport = @(
     'BeforeEach',
     'AfterEach',
     'Get-DynamicParametersForCmdlet',
+    'Get-DynamicParametersForMockedFunction',
     'Set-DynamicParameterVariables'
 )
 

--- a/Pester.psm1
+++ b/Pester.psm1
@@ -220,4 +220,4 @@ function Get-ScriptBlockScope
 
 Export-ModuleMember Describe, Context, It, In, Mock, Assert-VerifiableMocks, Assert-MockCalled
 Export-ModuleMember New-Fixture, Get-TestDriveItem, Should, Invoke-Pester, Setup, InModuleScope, Invoke-Mock
-Export-ModuleMember BeforeEach, AfterEach, Get-DynamicParametersForCmdlet, Set-DynamicParameterVariables
+Export-ModuleMember BeforeEach, AfterEach, Get-DynamicParametersForCmdlet, Get-DynamicParametersForMockedFunction, Set-DynamicParameterVariables


### PR DESCRIPTION
To retrieve the dynamic parameters for a function, the code now executes a script block which is bound to the scope of the same module as the mocked function's original location.  This allows the dynamic parameters to be fetched successfully even when they reference script-scoped variables, and the caller is in a different module scope.
