### PR TITLE
Mocking bug fix

### DIFF
--- a/Functions/Mock.Tests.ps1
+++ b/Functions/Mock.Tests.ps1
@@ -319,6 +319,23 @@ Describe "When calling Mock on existing function with matching unbound arguments
     }
 }
 
+Describe 'When calling Mock on a function that has no parameters' {
+    function Test-Function { }
+    Mock Test-Function { return $args.Count }
+
+    It 'Sends the $args variable properly with 2+ elements' {
+        Test-Function 1 2 3 4 5 | Should Be 5
+    }
+
+    It 'Sends the $args variable properly with 1 element' {
+        Test-Function 1 | Should Be 1
+    }
+
+    It 'Sends the $args variable properly with 0 elements' {
+        Test-Function | Should Be 0
+    }
+}
+
 Describe "When calling Mock on cmdlet Used by Mock" {
     Mock Set-Item {return "I am not Set-Item"}
     Mock Set-Item {return "I am not Set-Item"}

--- a/Functions/Mock.ps1
+++ b/Functions/Mock.ps1
@@ -609,7 +609,8 @@ function MockPrototype {
         $moduleName = $ExecutionContext.SessionState.Module.Name
     }
 
-    $ArgumentList = @(Get-Variable -Name args -ValueOnly -Scope Local -ErrorAction SilentlyContinue)
+    $ArgumentList = Get-Variable -Name args -ValueOnly -Scope Local -ErrorAction SilentlyContinue
+    if ($null -eq $ArgumentList) { $ArgumentList = @() }
 
     Invoke-Mock -CommandName $functionName -ModuleName $moduleName -BoundParameters $PSBoundParameters -ArgumentList $ArgumentList
 }


### PR DESCRIPTION
Mocking functions with no param block (or mocking executables) was producing single-element $args array, where the element was itself another array.  Not sure why; PowerShell's @() operator is not supposed to do that, but the code has been updated to work properly now.
