### PR TITLE
Bug fix in mocking

### DIFF
--- a/Functions/Mock.Tests.ps1
+++ b/Functions/Mock.Tests.ps1
@@ -974,3 +974,21 @@ Describe "Mocking Get-ItemProperty" {
     }
 }
 
+Describe 'When mocking a command with parameters that match internal variable names' {
+    function Test-Function
+    {
+        [CmdletBinding()]
+        param (
+            [string] $ArgumentList,
+            [int] $FunctionName,
+            [double] $ModuleName
+        )
+    }
+
+    Mock Test-Function { return 'Mocked!' }
+
+    It 'Should execute the mocked command successfully' {
+        { Test-Function } | Should Not Throw
+        Test-Function | Should Be 'Mocked!'
+    }
+}

--- a/Functions/Mock.ps1
+++ b/Functions/Mock.ps1
@@ -601,15 +601,19 @@ function Validate-Command([string]$CommandName, [string]$ModuleName) {
 }
 
 function MockPrototype {
-    $functionName = $MyInvocation.MyCommand.Name
+    # It's necessary to strongly type our variable assignments here, just in case the mocked command has
+    # parameters of the same names with a different type.  We don't actually care about overwriting the
+    # variables, since they're going to be passed along with $PSBoundParameters anyway.
 
-    $moduleName = ''
+    [string] $functionName = $MyInvocation.MyCommand.Name
+
+    [string] $moduleName = ''
     if ($ExecutionContext.SessionState.Module)
     {
         $moduleName = $ExecutionContext.SessionState.Module.Name
     }
 
-    $ArgumentList = Get-Variable -Name args -ValueOnly -Scope Local -ErrorAction SilentlyContinue
+    [object] $ArgumentList = Get-Variable -Name args -ValueOnly -Scope Local -ErrorAction SilentlyContinue
     if ($null -eq $ArgumentList) { $ArgumentList = @() }
 
     Invoke-Mock -CommandName $functionName -ModuleName $moduleName -BoundParameters $PSBoundParameters -ArgumentList $ArgumentList


### PR DESCRIPTION
Mocking functions which had typed parameters matching variable names used by the MockPrototype bootstrap function could cause problems, due to the values assigned to those variables in MockPrototype being converted to the parameter's type.  $null would become an empty string for [string] parameters, etc.

Fixes #214 .
