### PR TITLE
Parameter set updates

### DIFF
--- a/Functions/It.ps1
+++ b/Functions/It.ps1
@@ -62,8 +62,10 @@ about_should
     
     [CmdletBinding(DefaultParameterSetName = 'Normal')]
     param(
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory = $true, Position = 0)]
         [string]$name,
+
+        [Parameter(Position = 1)]
         [ScriptBlock] $test = {},
 
         [Parameter(ParameterSetName = 'Pending')]


### PR DESCRIPTION
`-Pending` and `-Skip` can't be used together, and you no longer get an exception if the test block has not been specified if you're also using either `-Pending` or `-Skip`.  These two lines are valid:

``` posh
It 'Is skipped' -Skip
It 'Is pending' -Pending
```
