### PR TITLE
Added chocolateyInstall.ps1

### DIFF
--- a/Pester.nuspec
+++ b/Pester.nuspec
@@ -6,7 +6,7 @@
     <title>Pester</title>
     <summary>A BDD style testing tool for Powershell</summary>
     <description>Pester provides a framework for running BDD style Tests to execute and validate PowerShell commands inside of PowerShell and offers a powerful set of Mocking Functions that allow tests to mimic and mock the functionality of any command inside of a piece of powershell code being tested. Pester tests can execute any command or script that is accesible to a pester test file. This can include functions, Cmdlets, Modules and scripts. Pester can be run in ad hoc style in a console or it can be integrated into the Build scripts of a Continuous Integration system.</description>
-    <tags>powershell unit testing bdd tdd mocking</tags>
+    <tags>powershell unit testing bdd tdd mocking admin</tags>
     <authors>Pester Team</authors>
     <iconUrl>http://pesterbdd.com/images/Pester.png</iconUrl>
     <projectUrl>https://github.com/Pester/Pester</projectUrl>
@@ -15,6 +15,8 @@
   <files>
     <file src="Pester.psm1" target="tools" />
     <file src="Pester.psd1" target="tools" />
+    <file src="Pester.Tests.ps1" target="tools" />
+    <file src="chocolateyInstall.ps1" />
 	<file src="nunit_schema_2.5.xsd" target="tools" />
     <file src="bin\*.*" target="tools\bin" />
     <file src="Examples\**\*.*" target="tools\Examples" />

--- a/chocolateyInstall.ps1
+++ b/chocolateyInstall.ps1
@@ -1,0 +1,148 @@
+[CmdletBinding()]
+param ( )
+
+end
+{
+    $modulePath = Join-Path $env:ProgramFiles WindowsPowerShell\Modules
+    $targetDirectory = Join-Path $modulePath Pester
+
+    $scriptRoot = Split-Path $MyInvocation.MyCommand.Path -Parent
+    $sourceDirectory = Join-Path $scriptRoot Tools
+
+    Update-Directory -Source $sourceDirectory -Destination $targetDirectory
+
+    if ($PSVersionTable.PSVersion.Major -lt 4)
+    {
+        $modulePaths = [Environment]::GetEnvironmentVariable('PSModulePath', 'Machine') -split ';'
+        if ($modulePaths -notcontains $modulePath)
+        {
+            Write-Verbose "Adding '$modulePath' to PSModulePath."
+
+            $modulePaths = @(
+                $modulePath
+                $modulePaths
+            )
+
+            $newModulePath = $modulePaths -join ';'
+
+            [Environment]::SetEnvironmentVariable('PSModulePath', $newModulePath, 'Machine')
+            $env:PSModulePath += ";$modulePath"
+        }
+    }
+}
+
+begin
+{
+    function Update-Directory
+    {
+        [CmdletBinding()]
+        param (
+            [Parameter(Mandatory = $true)]
+            [string] $Source,
+
+            [Parameter(Mandatory = $true)]
+            [string] $Destination
+        )
+
+        $Source = $PSCmdlet.GetUnresolvedProviderPathFromPSPath($Source)
+        $Destination = $PSCmdlet.GetUnresolvedProviderPathFromPSPath($Destination)
+
+        if (-not (Test-Path -LiteralPath $Destination))
+        {
+            $null = New-Item -Path $Destination -ItemType Directory -ErrorAction Stop
+        }
+
+        try
+        {
+            $sourceItem = Get-Item -LiteralPath $Source -ErrorAction Stop
+            $destItem = Get-Item -LiteralPath $Destination -ErrorAction Stop
+
+            if ($sourceItem -isnot [System.IO.DirectoryInfo] -or $destItem -isnot [System.IO.DirectoryInfo])
+            {
+                throw 'Not Directory Info'
+            }
+        }
+        catch
+        {
+            throw 'Both Source and Destination must be directory paths.'
+        }
+
+        $sourceFiles = Get-ChildItem -Path $Source -Recurse |
+                       Where-Object { -not $_.PSIsContainer }
+
+        foreach ($sourceFile in $sourceFiles)
+        {
+            $relativePath = Get-RelativePath $sourceFile.FullName -RelativeTo $Source
+            $targetPath = Join-Path $Destination $relativePath
+
+            $sourceHash = Get-FileHash -Path $sourceFile.FullName
+            $destHash = Get-FileHash -Path $targetPath
+
+            if ($sourceHash -ne $destHash)
+            {
+                $targetParent = Split-Path $targetPath -Parent
+
+                if (-not (Test-Path -Path $targetParent -PathType Container))
+                {
+                    $null = New-Item -Path $targetParent -ItemType Directory -ErrorAction Stop
+                }
+
+                Write-Verbose "Updating file $relativePath to new version."
+                Copy-Item $sourceFile.FullName -Destination $targetPath -Force -ErrorAction Stop
+            }
+        }
+
+        $targetFiles = Get-ChildItem -Path $Destination -Recurse |
+                       Where-Object { -not $_.PSIsContainer }
+    
+        foreach ($targetFile in $targetFiles)
+        {
+            $relativePath = Get-RelativePath $targetFile.FullName -RelativeTo $Destination
+            $sourcePath = Join-Path $Source $relativePath        
+
+            if (-not (Test-Path $sourcePath -PathType Leaf))
+            {
+                Write-Verbose "Removing unknown file $relativePath from module folder."
+                Remove-Item -LiteralPath $targetFile.FullName -Force -ErrorAction Stop
+            }
+        }
+
+    }
+
+    function Get-RelativePath
+    {
+        param ( [string] $Path, [string] $RelativeTo )
+        return $Path -replace "^$([regex]::Escape($RelativeTo))\\?"
+    }
+
+    function Get-FileHash
+    {
+        param ([string] $Path)
+
+        if (-not (Test-Path -LiteralPath $Path -PathType Leaf))
+        {
+            return $null
+        }
+
+        $item = Get-Item -LiteralPath $Path
+        if ($item -isnot [System.IO.FileSystemInfo])
+        {
+            return $null
+        }
+
+        $stream = $null
+
+        try
+        {
+            $sha = New-Object System.Security.Cryptography.SHA256CryptoServiceProvider
+            $stream = $item.OpenRead()
+            $bytes = $sha.ComputeHash($stream)
+            return [convert]::ToBase64String($bytes)
+        }
+        finally
+        {
+            if ($null -ne $stream) { $stream.Close() }
+            if ($null -ne $sha)    { $sha.Clear() }
+        }
+    }
+}


### PR DESCRIPTION
When users install our nupkg from Chocolatey, the module will automatically be instaled to $env:ProgramFiles\WindowsPowerShell\Modules\Pester .  For downlevel systems where this isn't part of the default PSModulePath, the machine PSModulePath environment variable will also be updated.
