### PR TITLE
Allows a user to provide templates for New-Fixture

### DIFF
--- a/Functions/New-Fixture.Tests.ps1
+++ b/Functions/New-Fixture.Tests.ps1
@@ -96,7 +96,7 @@ Describe "New-Fixture" {
 
             $functionFilePath | Should Exist
 
-            (Get-Content -Path $functionFilePath -Raw) | Should Be ("function #name# {`r`n`r`n}`r`n" -replace "#name#",$name)
+            [System.IO.File]::ReadAllText( (Get-Item $functionFilePath).FullName ) | Should Be ("function #name# {`r`n`r`n}`r`n" -replace "#name#",$name)
         }
 
         It "Creates the default test template" {
@@ -124,15 +124,18 @@ Describe "#name#" {
 '@
             $expectedTestFileContent = $expectedTestFileContent -replace "#name#",$name
 
-            (Get-Content -Path $testFilePath -Raw) | Should Be ($expectedTestFileContent)
+            [System.IO.File]::ReadAllText( (Get-Item $testFilePath).FullName ) | Should Be ($expectedTestFileContent)
         }
     }
 
     Context "Custom fixture templates are in Env:\USERPROFILE\WindowsPowerShell\Pester" {
         It "Copies the content of NewFixtureTestTemplate.ps1 to the test file" {
+			$PesterTemplatePath = Join-Path -Path (Get-Item -Path "TestDrive:\").Fullname -ChildPath "WindowsPowerShell\Pester"
+			$TestTemplatePath = Join-Path -Path $PesterTemplatePath -ChildPath "NewFixtureTestTemplate.ps1"
+			New-Item -Path $PesterTemplatePath -ItemType Directory -Force | Out-Null
+			[System.IO.File]::WriteAllText($TestTemplatePath, "TEST TEMPLATE CONTENT")
             
-            Mock -ModuleName Pester Test-Path -ParameterFilter { $path -eq (Join-Path $env:USERPROFILE "WindowsPowerShell\Pester\NewFixtureTestTemplate.ps1") } -MockWith { $true }
-            Mock -ModuleName Pester Get-Content -ParameterFilter { $path -eq (Join-Path $env:USERPROFILE "WindowsPowerShell\Pester\NewFixtureTestTemplate.ps1") } -MockWith { "TEST TEMPLATE CONTENT" } 
+			Mock -ModuleName Pester Join-Path -ParameterFilter { $path -eq $env:USERPROFILE -and $childPath -eq "WindowsPowerShell\Pester\NewFixtureTestTemplate.ps1" } -MockWith { "TestDrive:\WindowsPowerShell\Pester\NewFixtureTestTemplate.ps1" }
 
             $path = "TestDrive:\"
             $name = "TestTemplate-Fixture"
@@ -140,23 +143,25 @@ Describe "#name#" {
             New-Fixture -Name $name -Path $path | Out-Null
             $testFilePath = Join-Path -Path $path -ChildPath "$name.Tests.ps1"
             $testFilePath | Should Exist
-            Get-Content $testFilePath -Raw | Should Be "TEST TEMPLATE CONTENT`r`n"
+            [System.IO.File]::ReadAllText( (Get-Item $testFilePath).FullName ) | Should Be "TEST TEMPLATE CONTENT`r`n"
         }
 
         It "Copies the content of NewFixtureFunctionTemplate.ps1 to the function file" {
+			$PesterTemplatePath = Join-Path -Path (Get-Item -Path "TestDrive:\").Fullname -ChildPath "WindowsPowerShell\Pester"
+			$FunctionTemplatePath = Join-Path -Path $PesterTemplatePath -ChildPath "NewFixtureFunctionTemplate.ps1"
+			New-Item -Path $PesterTemplatePath -ItemType Directory -Force | Out-Null
+			[System.IO.File]::WriteAllText($FunctionTemplatePath, "FUNCTION TEMPLATE CONTENT")
+			
+			Mock -ModuleName Pester Join-Path -ParameterFilter { $path -eq $env:USERPROFILE -and $childPath -eq "WindowsPowerShell\Pester\NewFixtureFunctionTemplate.ps1" } -MockWith { "TestDrive:\WindowsPowerShell\Pester\NewFixtureFunctionTemplate.ps1" }
             
-            Mock -ModuleName Pester Test-Path -ParameterFilter { $path -eq (Join-Path $env:USERPROFILE "WindowsPowerShell\Pester\NewFixtureFunctionTemplate.ps1") } -MockWith { $true }
-            Mock -ModuleName Pester Get-Content -ParameterFilter { $path -eq (Join-Path $env:USERPROFILE "WindowsPowerShell\Pester\NewFixtureFunctionTemplate.ps1") } -MockWith { "TEST TEMPLATE CONTENT" }
-
             $path = "TestDrive:\"
             $name = "FunctionTemplate-Fixture"
 
             New-Fixture -Name $name -Path $path | Out-Null
             $testFilePath = Join-Path -Path $path -ChildPath "$name.ps1"
             $testFilePath | Should Exist
-            Get-Content $testFilePath -Raw | Should Be "TEST TEMPLATE CONTENT`r`n"
+            [System.IO.File]::ReadAllText( (Get-Item $testFilePath).FullName ) | Should Be "FUNCTION TEMPLATE CONTENT`r`n"
         }
-
     }
 
 }

--- a/Functions/New-Fixture.Tests.ps1
+++ b/Functions/New-Fixture.Tests.ps1
@@ -128,14 +128,14 @@ Describe "#name#" {
         }
     }
 
-    Context "Custom fixture templates are in Env:\USERPROFILE\WindowsPowerShell\Pester" {
+    Context "Custom fixture templates are in Env:\USERPROFILE\Documents\WindowsPowerShell\Pester" {
         It "Copies the content of NewFixtureTestTemplate.ps1 to the test file" {
-			$PesterTemplatePath = Join-Path -Path (Get-Item -Path "TestDrive:\").Fullname -ChildPath "WindowsPowerShell\Pester"
+			$PesterTemplatePath = Join-Path -Path (Get-Item -Path "TestDrive:\").Fullname -ChildPath "Documents\WindowsPowerShell\Pester"
 			$TestTemplatePath = Join-Path -Path $PesterTemplatePath -ChildPath "NewFixtureTestTemplate.ps1"
 			New-Item -Path $PesterTemplatePath -ItemType Directory -Force | Out-Null
 			[System.IO.File]::WriteAllText($TestTemplatePath, "TEST TEMPLATE CONTENT")
             
-			Mock -ModuleName Pester Join-Path -ParameterFilter { $path -eq $env:USERPROFILE -and $childPath -eq "WindowsPowerShell\Pester\NewFixtureTestTemplate.ps1" } -MockWith { "TestDrive:\WindowsPowerShell\Pester\NewFixtureTestTemplate.ps1" }
+			Mock -ModuleName Pester Join-Path -ParameterFilter { $path -eq $env:USERPROFILE -and $childPath -eq "Documents\WindowsPowerShell\Pester\NewFixtureTestTemplate.ps1" } -MockWith { Join-Path -Path "TestDrive:\" -ChildPath $ChildPath  }
 
             $path = "TestDrive:\"
             $name = "TestTemplate-Fixture"
@@ -147,12 +147,12 @@ Describe "#name#" {
         }
 
         It "Copies the content of NewFixtureFunctionTemplate.ps1 to the function file" {
-			$PesterTemplatePath = Join-Path -Path (Get-Item -Path "TestDrive:\").Fullname -ChildPath "WindowsPowerShell\Pester"
+			$PesterTemplatePath = Join-Path -Path (Get-Item -Path "TestDrive:\").Fullname -ChildPath "Documents\WindowsPowerShell\Pester"
 			$FunctionTemplatePath = Join-Path -Path $PesterTemplatePath -ChildPath "NewFixtureFunctionTemplate.ps1"
 			New-Item -Path $PesterTemplatePath -ItemType Directory -Force | Out-Null
 			[System.IO.File]::WriteAllText($FunctionTemplatePath, "FUNCTION TEMPLATE CONTENT")
 			
-			Mock -ModuleName Pester Join-Path -ParameterFilter { $path -eq $env:USERPROFILE -and $childPath -eq "WindowsPowerShell\Pester\NewFixtureFunctionTemplate.ps1" } -MockWith { "TestDrive:\WindowsPowerShell\Pester\NewFixtureFunctionTemplate.ps1" }
+			Mock -ModuleName Pester Join-Path -ParameterFilter { $path -eq $env:USERPROFILE -and $childPath -eq "Documents\WindowsPowerShell\Pester\NewFixtureFunctionTemplate.ps1" } -MockWith { Join-Path -Path "TestDrive:\" -ChildPath $ChildPath }
             
             $path = "TestDrive:\"
             $name = "FunctionTemplate-Fixture"

--- a/Functions/New-Fixture.Tests.ps1
+++ b/Functions/New-Fixture.Tests.ps1
@@ -110,8 +110,7 @@ Describe "New-Fixture" {
 
             $testFilePath | Should Exist
 
-            $expectedTestFileContent = @'
-$here = Split-Path -Parent $MyInvocation.MyCommand.Path
+            $expectedTestFileContent = '$here = Split-Path -Parent $MyInvocation.MyCommand.Path
 $sut = (Split-Path -Leaf $MyInvocation.MyCommand.Path).Replace(".Tests.", ".")
 . "$here\$sut"
 
@@ -119,12 +118,11 @@ Describe "#name#" {
     It "does something useful" {
         $true | Should Be $false
     }
-}
-
-'@
+}'
             $expectedTestFileContent = $expectedTestFileContent -replace "#name#",$name
+			Set-Content -Path TestDrive:\ExpectedContent.txt -Value $expectedTestFileContent -Encoding UTF8
 
-            [System.IO.File]::ReadAllText( (Get-Item $testFilePath).FullName ) | Should Be ($expectedTestFileContent)
+            [System.IO.File]::ReadAllText( (Get-Item $testFilePath).FullName ) | Should Be ([System.IO.File]::ReadAllText( (Get-Item "TestDrive:\ExpectedContent.txt").FullName))
         }
     }
 

--- a/Functions/New-Fixture.Tests.ps1
+++ b/Functions/New-Fixture.Tests.ps1
@@ -127,5 +127,37 @@ Describe "#name#" {
             (Get-Content -Path $testFilePath -Raw) | Should Be ($expectedTestFileContent)
         }
     }
+
+    Context "Custom fixture templates are in Env:\USERPROFILE\WindowsPowerShell\Pester" {
+        It "Copies the content of NewFixtureTestTemplate.ps1 to the test file" {
+            
+            Mock -ModuleName Pester Test-Path -ParameterFilter { $path -eq (Join-Path $env:USERPROFILE "WindowsPowerShell\Pester\NewFixtureTestTemplate.ps1") } -MockWith { $true }
+            Mock -ModuleName Pester Get-Content -ParameterFilter { $path -eq (Join-Path $env:USERPROFILE "WindowsPowerShell\Pester\NewFixtureTestTemplate.ps1") } -MockWith { "TEST TEMPLATE CONTENT" } 
+
+            $path = "TestDrive:\"
+            $name = "TestTemplate-Fixture"
+
+            New-Fixture -Name $name -Path $path | Out-Null
+            $testFilePath = Join-Path -Path $path -ChildPath "$name.Tests.ps1"
+            $testFilePath | Should Exist
+            Get-Content $testFilePath -Raw | Should Be "TEST TEMPLATE CONTENT`r`n"
+        }
+
+        It "Copies the content of NewFixtureFunctionTemplate.ps1 to the function file" {
+            
+            Mock -ModuleName Pester Test-Path -ParameterFilter { $path -eq (Join-Path $env:USERPROFILE "WindowsPowerShell\Pester\NewFixtureFunctionTemplate.ps1") } -MockWith { $true }
+            Mock -ModuleName Pester Get-Content -ParameterFilter { $path -eq (Join-Path $env:USERPROFILE "WindowsPowerShell\Pester\NewFixtureFunctionTemplate.ps1") } -MockWith { "TEST TEMPLATE CONTENT" }
+
+            $path = "TestDrive:\"
+            $name = "FunctionTemplate-Fixture"
+
+            New-Fixture -Name $name -Path $path | Out-Null
+            $testFilePath = Join-Path -Path $path -ChildPath "$name.ps1"
+            $testFilePath | Should Exist
+            Get-Content $testFilePath -Raw | Should Be "TEST TEMPLATE CONTENT`r`n"
+        }
+
+    }
+
 }
 

--- a/Functions/New-Fixture.Tests.ps1
+++ b/Functions/New-Fixture.Tests.ps1
@@ -83,11 +83,11 @@ Describe "New-Fixture" {
         }
 
     }
-	
+
     Context "Custom fixture templates are not found so default values are used" {
         It "Creates the default function template" {
             Mock -ModuleName Pester Test-Path -ParameterFilter { $path -eq (Join-Path $env:USERPROFILE "WindowsPowerShell\Pester\NewFixtureTestTemplate.ps1") } -MockWith { $false }
-            
+
             $path = "TestDrive:\"
             $name = "DefaultFunctionTemplate-Fixture"
 
@@ -101,7 +101,7 @@ Describe "New-Fixture" {
 
         It "Creates the default test template" {
             Mock -ModuleName Pester Test-Path -ParameterFilter { $path -eq (Join-Path $env:USERPROFILE "WindowsPowerShell\Pester\NewFixtureTestTemplate.ps1") } -MockWith { $false }
-            
+
             $path = "TestDrive:\"
             $name = "DefaultTestTemplate-Fixture"
 
@@ -130,12 +130,12 @@ Describe "#name#" {
 
     Context "Custom fixture templates are in Env:\USERPROFILE\Documents\WindowsPowerShell\Pester" {
         It "Copies the content of NewFixtureTestTemplate.ps1 to the test file" {
-			$PesterTemplatePath = Join-Path -Path (Get-Item -Path "TestDrive:\").Fullname -ChildPath "Documents\WindowsPowerShell\Pester"
-			$TestTemplatePath = Join-Path -Path $PesterTemplatePath -ChildPath "NewFixtureTestTemplate.ps1"
-			New-Item -Path $PesterTemplatePath -ItemType Directory -Force | Out-Null
-			[System.IO.File]::WriteAllText($TestTemplatePath, "TEST TEMPLATE CONTENT")
-            
-			Mock -ModuleName Pester Join-Path -ParameterFilter { $path -eq $env:USERPROFILE -and $childPath -eq "Documents\WindowsPowerShell\Pester\NewFixtureTestTemplate.ps1" } -MockWith { Join-Path -Path "TestDrive:\" -ChildPath $ChildPath  }
+            $PesterTemplatePath = Join-Path -Path (Get-Item -Path "TestDrive:\").Fullname -ChildPath "Documents\WindowsPowerShell\Pester"
+            $TestTemplatePath = Join-Path -Path $PesterTemplatePath -ChildPath "NewFixtureTestTemplate.ps1"
+            New-Item -Path $PesterTemplatePath -ItemType Directory -Force | Out-Null
+            [System.IO.File]::WriteAllText($TestTemplatePath, "TEST TEMPLATE CONTENT")
+
+            Mock -ModuleName Pester Join-Path -ParameterFilter { $path -eq $env:USERPROFILE -and $childPath -eq "Documents\WindowsPowerShell\Pester\NewFixtureTestTemplate.ps1" } -MockWith { Join-Path -Path "TestDrive:\" -ChildPath $ChildPath  }
 
             $path = "TestDrive:\"
             $name = "TestTemplate-Fixture"
@@ -147,13 +147,13 @@ Describe "#name#" {
         }
 
         It "Copies the content of NewFixtureFunctionTemplate.ps1 to the function file" {
-			$PesterTemplatePath = Join-Path -Path (Get-Item -Path "TestDrive:\").Fullname -ChildPath "Documents\WindowsPowerShell\Pester"
-			$FunctionTemplatePath = Join-Path -Path $PesterTemplatePath -ChildPath "NewFixtureFunctionTemplate.ps1"
-			New-Item -Path $PesterTemplatePath -ItemType Directory -Force | Out-Null
-			[System.IO.File]::WriteAllText($FunctionTemplatePath, "FUNCTION TEMPLATE CONTENT")
-			
-			Mock -ModuleName Pester Join-Path -ParameterFilter { $path -eq $env:USERPROFILE -and $childPath -eq "Documents\WindowsPowerShell\Pester\NewFixtureFunctionTemplate.ps1" } -MockWith { Join-Path -Path "TestDrive:\" -ChildPath $ChildPath }
-            
+            $PesterTemplatePath = Join-Path -Path (Get-Item -Path "TestDrive:\").Fullname -ChildPath "Documents\WindowsPowerShell\Pester"
+            $FunctionTemplatePath = Join-Path -Path $PesterTemplatePath -ChildPath "NewFixtureFunctionTemplate.ps1"
+            New-Item -Path $PesterTemplatePath -ItemType Directory -Force | Out-Null
+            [System.IO.File]::WriteAllText($FunctionTemplatePath, "FUNCTION TEMPLATE CONTENT")
+
+            Mock -ModuleName Pester Join-Path -ParameterFilter { $path -eq $env:USERPROFILE -and $childPath -eq "Documents\WindowsPowerShell\Pester\NewFixtureFunctionTemplate.ps1" } -MockWith { Join-Path -Path "TestDrive:\" -ChildPath $ChildPath }
+
             $path = "TestDrive:\"
             $name = "FunctionTemplate-Fixture"
 

--- a/Functions/New-Fixture.ps1
+++ b/Functions/New-Fixture.ps1
@@ -69,7 +69,7 @@ function New-Fixture {
     #keep this formatted as is. the format is output to the file as is, including indentation
     $userFunctionTemplatePath = Join-Path -Path $env:USERPROFILE -ChildPath "WindowsPowerShell\Pester\NewFixtureFunctionTemplate.ps1"
     if( Test-Path -Path $userFunctionTemplatePath ) {
-        $scriptCode = Get-Content -Raw -Path $userFunctionTemplatePath
+        $scriptCode = [System.IO.File]::ReadAllText( (Get-Item $userFunctionTemplatePath).Fullname )
     } else {
         $scriptCode = "function #name# {`r`n`r`n}"
     }
@@ -78,7 +78,7 @@ function New-Fixture {
 
     $userTestTemplatePath = Join-Path -Path $env:USERPROFILE -ChildPath "WindowsPowerShell\Pester\NewFixtureTestTemplate.ps1"
     if( Test-Path -Path $UserTestTemplatePath ) {
-        $testCode = Get-Content -Raw -Path $userTestTemplatePath
+        $testCode = [System.IO.File]::ReadAllText( (Get-Item $userTestTemplatePath).Fullname )
     } else {
         $testCode = '$here = Split-Path -Parent $MyInvocation.MyCommand.Path
 $sut = (Split-Path -Leaf $MyInvocation.MyCommand.Path).Replace(".Tests.", ".")

--- a/Functions/New-Fixture.ps1
+++ b/Functions/New-Fixture.ps1
@@ -73,7 +73,7 @@ function New-Fixture {
     } else {
         $scriptCode = "function #name# {`r`n`r`n}"
     }
-    
+
     $scriptCode = $scriptCode -replace "#name#",$name
 
     $userTestTemplatePath = Join-Path -Path $env:USERPROFILE -ChildPath "Documents\WindowsPowerShell\Pester\NewFixtureTestTemplate.ps1"

--- a/Functions/New-Fixture.ps1
+++ b/Functions/New-Fixture.ps1
@@ -66,10 +66,21 @@ function New-Fixture {
         [String]$Name
     )
     #region File contents
-    #keep this formatted as is. the forma is output to the file as is, including indentation
-    $scriptCode = "function $name {`r`n`r`n}"
+    #keep this formatted as is. the format is output to the file as is, including indentation
+    $userFunctionTemplatePath = Join-Path -Path $env:USERPROFILE -ChildPath "WindowsPowerShell\Pester\NewFixtureFunctionTemplate.ps1"
+    if( Test-Path -Path $userFunctionTemplatePath ) {
+        $scriptCode = Get-Content -Raw -Path $userFunctionTemplatePath
+    } else {
+        $scriptCode = "function #name# {`r`n`r`n}"
+    }
+    
+    $scriptCode = $scriptCode -replace "#name#",$name
 
-    $testCode = '$here = Split-Path -Parent $MyInvocation.MyCommand.Path
+    $userTestTemplatePath = Join-Path -Path $env:USERPROFILE -ChildPath "WindowsPowerShell\Pester\NewFixtureTestTemplate.ps1"
+    if( Test-Path -Path $UserTestTemplatePath ) {
+        $testCode = Get-Content -Raw -Path $userTestTemplatePath
+    } else {
+        $testCode = '$here = Split-Path -Parent $MyInvocation.MyCommand.Path
 $sut = (Split-Path -Leaf $MyInvocation.MyCommand.Path).Replace(".Tests.", ".")
 . "$here\$sut"
 
@@ -77,7 +88,10 @@ Describe "#name#" {
     It "does something useful" {
         $true | Should Be $false
     }
-}' -replace "#name#",$name
+}'
+    }
+
+    $testCode = $testCode -replace "#name#",$name
 
     #endregion
 

--- a/Functions/New-Fixture.ps1
+++ b/Functions/New-Fixture.ps1
@@ -67,7 +67,7 @@ function New-Fixture {
     )
     #region File contents
     #keep this formatted as is. the format is output to the file as is, including indentation
-    $userFunctionTemplatePath = Join-Path -Path $env:USERPROFILE -ChildPath "WindowsPowerShell\Pester\NewFixtureFunctionTemplate.ps1"
+    $userFunctionTemplatePath = Join-Path -Path $env:USERPROFILE -ChildPath "Documents\WindowsPowerShell\Pester\NewFixtureFunctionTemplate.ps1"
     if( Test-Path -Path $userFunctionTemplatePath ) {
         $scriptCode = [System.IO.File]::ReadAllText( (Get-Item $userFunctionTemplatePath).Fullname )
     } else {
@@ -76,7 +76,7 @@ function New-Fixture {
     
     $scriptCode = $scriptCode -replace "#name#",$name
 
-    $userTestTemplatePath = Join-Path -Path $env:USERPROFILE -ChildPath "WindowsPowerShell\Pester\NewFixtureTestTemplate.ps1"
+    $userTestTemplatePath = Join-Path -Path $env:USERPROFILE -ChildPath "Documents\WindowsPowerShell\Pester\NewFixtureTestTemplate.ps1"
     if( Test-Path -Path $UserTestTemplatePath ) {
         $testCode = [System.IO.File]::ReadAllText( (Get-Item $userTestTemplatePath).Fullname )
     } else {


### PR DESCRIPTION
Searches $ENV:UserProfile\Documents\WindowsPowerShell\Pester for NewFixtureTestTemplate.ps1 or NewFixtureFunctionTemplate.ps1 to use in place of the default templates.
