### PR TITLE
Update Pester.psm1

### DIFF
--- a/Pester.psm1
+++ b/Pester.psm1
@@ -6,7 +6,7 @@ $moduleRoot = Split-Path -Path $MyInvocation.MyCommand.Path
 
 "$moduleRoot\Functions\*.ps1", "$moduleRoot\Functions\Assertions\*.ps1" |
 Resolve-Path |
-Where-Object { -not ($_.ProviderPath.Contains(".Tests.")) } |
+Where-Object { -not ($_.ProviderPath.ToLower().Contains(".tests.")) } |
 ForEach-Object { . $_.ProviderPath }
 
 function Invoke-Pester {


### PR DESCRIPTION
relying on case sensitivity on Windows may cause difficulties. If names are normalized to lowercase, importing the module will cause all sorts of trouble as the tests will be executed, sometimes ahead of the non-test file.
