### PR TITLE
Fix for mocking functions with mandatory pipeline parameters

### DIFF
--- a/Functions/Mock.ps1
+++ b/Functions/Mock.ps1
@@ -218,10 +218,21 @@ about_Mocking
             }
             else
             {
+                $metadataWithoutMandatory = [System.Management.Automation.CommandMetaData]$contextInfo.Command
+                foreach ($parameter in $metadataWithoutMandatory.Parameters.Values)
+                {
+                    foreach ($parameterSet in $parameter.ParameterSets.Values)
+                    {
+                        $parameterSet.IsMandatory = $false
+                    }
+                }
+
+                $paramBlockWithoutMandatory = [System.Management.Automation.ProxyCommand]::GetParamBlock($metadataWithoutMandatory)
+
                 $dynamicParamBlock = "dynamicparam { Get-MockDynamicParameters -ModuleName '$ModuleName' -FunctionName '$CommandName' -Parameters `$PSBoundParameters }"
 
                 $dynamicParamStatements = Get-DynamicParamBlock -ScriptBlock $contextInfo.Command.ScriptBlock
-                $dynamicParamScriptBlock = [scriptblock]::Create("$cmdletBinding`r`nparam( $paramBlock )`r`n$dynamicParamStatements")
+                $dynamicParamScriptBlock = [scriptblock]::Create("$cmdletBinding`r`nparam( $paramBlockWithoutMandatory )`r`n$dynamicParamStatements")
 
                 $sessionStateInternal = Get-ScriptBlockScope -ScriptBlock $contextInfo.Command.ScriptBlock
 


### PR DESCRIPTION
The dynamicparam code was failing in a situation where a mocked function defined a mandatory parameter that is able to accept pipeline input, and when the call to the mocked function is taking advantage of that pipeline capability.

The script block that is executed to generate any dynamic parameters (even if the mocked function doesn't have any dynamicparam statements, this still gets called) was defining the same param block as the original command, and the $PSBoundParameters table was being splatted to the dynamicparam script block.  The problem is that when pipeline input is involved, the input objects haven't been bound yet at the time that the dynamicparam code is executed.  Because those parameters were marked as mandatory, this caused the dynamicparam script block to prompt for input (or fail, if -NonInteractive mode is in effect.)

To fix this, I stripped out the Mandatory attribute from all parameters when generating the dynamicparam script block.
