### PR TITLE
Added array comparison support for Be / BeNullOrEmpty / BeExactly

### DIFF
--- a/Functions/Assertions/Be.Tests.ps1
+++ b/Functions/Assertions/Be.Tests.ps1
@@ -25,6 +25,35 @@ InModuleScope Pester {
 
             $array | Should Be $arrayWithCaps
         }
+
+        It 'Handles reference types properly' {
+            $object1 = New-Object psobject -Property @{ Value = 'Test' }
+            $object2 = New-Object psobject -Property @{ Value = 'Test' }
+
+            $object1 | Should Be $object1
+            $object1 | Should Not Be $object2
+        }
+
+        It 'Handles arrays with nested arrays' {
+            $array1 = @(
+                @(1,2,3,4,5),
+                @(6,7,8,9,0)
+            )
+
+            $array2 = @(
+                @(1,2,3,4,5),
+                @(6,7,8,9,0)
+            )
+
+            $array1 | Should Be $array2
+
+            $array3 = @(
+                @(1,2,3,4,5),
+                @(6,7,8,9,0, 'Oops!')
+            )
+
+            $array1 | Should Not Be $array3
+        }
     }
 
     Describe "PesterBeFailureMessage" {

--- a/Functions/Assertions/Be.Tests.ps1
+++ b/Functions/Assertions/Be.Tests.ps1
@@ -12,7 +12,21 @@ InModuleScope Pester {
         It "returns false if the 2 arguments are not equal" {
             Test-NegativeAssertion (PesterBe 1 2)
         }
+
+        It 'Compares Arrays properly' {
+            $array = @(1,2,3,4,'I am a string', (New-Object psobject -Property @{ IAm = 'An Object' }))
+            $array | Should Be $array
+        }
+
+        It 'Compares arrays with correct case-insensitive behavior' {
+            $string = 'I am a string'
+            $array = @(1,2,3,4,$string)
+            $arrayWithCaps = @(1,2,3,4,$string.ToUpper())
+
+            $array | Should Be $arrayWithCaps
+        }
     }
+
     Describe "PesterBeFailureMessage" {
         #the correctness of difference index value and the arrow pointing to the correct place
         #are not tested here thoroughly, but the behaviour was visually checked and is
@@ -58,12 +72,27 @@ InModuleScope Pester {
         It "passes if letter case matches" {
             'a' | Should BeExactly 'a'
         }
+
         It "fails if letter case doesn't match" {
             'A' | Should Not BeExactly 'a'
         }
+
         It "passes for numbers" {
             1 | Should BeExactly 1
             2.15 | Should BeExactly 2.15
+        }
+
+        It 'Compares Arrays properly' {
+            $array = @(1,2,3,4,'I am a string', (New-Object psobject -Property @{ IAm = 'An Object' }))
+            $array | Should BeExactly $array
+        }
+
+        It 'Compares arrays with correct case-sensitive behavior' {
+            $string = 'I am a string'
+            $array = @(1,2,3,4,$string)
+            $arrayWithCaps = @(1,2,3,4,$string.ToUpper())
+
+            $array | Should Not BeExactly $arrayWithCaps
         }
     }
 

--- a/Functions/Assertions/Be.ps1
+++ b/Functions/Assertions/Be.ps1
@@ -139,8 +139,11 @@ function ArraysAreEqual
         [switch] $CaseSensitive
     )
 
-    $firstNullOrEmpty  = ArrayOrSingleElementIsNullOrEmpty -Array $First
-    $secondNullOrEmpty = ArrayOrSingleElementIsNullOrEmpty -Array $Second
+    # Do not remove the subexpression @() operators in the following two lines; doing so can cause a
+    # silly error in PowerShell v3.  (Null Reference exception from the PowerShell engine in a
+    # method called CheckAutomationNullInCommandArgumentArray(System.Object[]) ).
+    $firstNullOrEmpty  = ArrayOrSingleElementIsNullOrEmpty -Array @($First)
+    $secondNullOrEmpty = ArrayOrSingleElementIsNullOrEmpty -Array @($Second)
 
     if ($firstNullOrEmpty -or $secondNullOrEmpty)
     {

--- a/Functions/Assertions/BeGreaterThan.ps1
+++ b/Functions/Assertions/BeGreaterThan.ps1
@@ -12,3 +12,8 @@ function NotPesterBeGreaterThanFailureMessage($value,$expected)
 {
     return "Expected {$value} to be less than or equal to {$expected}"
 }
+
+Add-AssertionOperator -Name                      BeGreaterThan `
+                      -Test                      $function:PesterBeGreaterThan `
+                      -GetPositiveFailureMessage $function:PesterBeGreaterThanFailureMessage `
+                      -GetNegativeFailureMessage $function:NotPesterBeGreaterThanFailureMessage

--- a/Functions/Assertions/BeLessThan.ps1
+++ b/Functions/Assertions/BeLessThan.ps1
@@ -12,3 +12,8 @@ function NotPesterBeLessThanFailureMessage($value,$expected)
 {
     return "Expected {$value} to be greater than or equal to {$expected}"
 }
+
+Add-AssertionOperator -Name                      BeLessThan `
+                      -Test                      $function:PesterBeLessThan `
+                      -GetPositiveFailureMessage $function:PesterBeLessThanFailureMessage `
+                      -GetNegativeFailureMessage $function:NotPesterBeLessThanFailureMessage

--- a/Functions/Assertions/BeNullOrEmpty.ps1
+++ b/Functions/Assertions/BeNullOrEmpty.ps1
@@ -1,16 +1,17 @@
 
-function PesterBeNullOrEmpty($value) {
-    if ($null -eq $value) {
+function PesterBeNullOrEmpty([object[]] $value) {
+    if ($null -eq $value -or $value.Count -eq 0)
+    {
         return $true
     }
-    if ([String] -eq $value.GetType()) {
-        return [String]::IsNullOrEmpty($value)
+    elseif ($value.Count -eq 1)
+    {
+        return [String]::IsNullOrEmpty($value[0])
     }
-    if ($null -ne $value.PSObject.Properties['Count'] -and
-        $null -ne $value.Count) {
-        return $value.Count -lt 1
+    else
+    {
+        return $false
     }
-    return $false
 }
 
 function PesterBeNullOrEmptyFailureMessage($value) {
@@ -21,3 +22,8 @@ function NotPesterBeNullOrEmptyFailureMessage {
     return "Expected: value to not be empty"
 }
 
+Add-AssertionOperator -Name                      BeNullOrEmpty `
+                      -Test                      $function:PesterBeNullOrEmpty `
+                      -GetPositiveFailureMessage $function:PesterBeNullOrEmptyFailureMessage `
+                      -GetNegativeFailureMessage $function:NotPesterBeNullOrEmptyFailureMessage `
+                      -SupportsArrayInput

--- a/Functions/Assertions/Contain.ps1
+++ b/Functions/Assertions/Contain.ps1
@@ -11,3 +11,7 @@ function NotPesterContainFailureMessage($file, $contentExpecation) {
     return "Expected: file {$file} to not contain ${contentExpecation} but it did"
 }
 
+Add-AssertionOperator -Name                      Contain `
+                      -Test                      $function:PesterContain `
+                      -GetPositiveFailureMessage $function:PesterContainFailureMessage `
+                      -GetNegativeFailureMessage $function:NotPesterContainFailureMessage

--- a/Functions/Assertions/ContainExactly.ps1
+++ b/Functions/Assertions/ContainExactly.ps1
@@ -11,3 +11,7 @@ function NotPesterContainExactlyFailureMessage($file, $contentExpecation) {
     return "Expected: file {$file} to not contain exactly ${contentExpecation} but it did"
 }
 
+Add-AssertionOperator -Name                      ContainExactly `
+                      -Test                      $function:PesterContainExactly `
+                      -GetPositiveFailureMessage $function:PesterContainExactlyFailureMessage `
+                      -GetNegativeFailureMessage $function:NotPesterContainExactlyFailureMessage

--- a/Functions/Assertions/Exist.ps1
+++ b/Functions/Assertions/Exist.ps1
@@ -12,3 +12,7 @@ function NotPesterExistFailureMessage($value) {
 }
 
 
+Add-AssertionOperator -Name                      Exist `
+                      -Test                      $function:PesterExist `
+                      -GetPositiveFailureMessage $function:PesterExistFailureMessage `
+                      -GetNegativeFailureMessage $function:NotPesterExistFailureMessage

--- a/Functions/Assertions/Match.ps1
+++ b/Functions/Assertions/Match.ps1
@@ -1,6 +1,6 @@
 
 function PesterMatch($value, $expectedMatch) {
-    return ($value -match $expectedMatch)
+    return [bool]($value -match $expectedMatch)
 }
 
 function PesterMatchFailureMessage($value, $expectedMatch) {
@@ -11,3 +11,7 @@ function NotPesterMatchFailureMessage($value, $expectedMatch) {
     return "Expected: ${value} to not match the expression ${expectedMatch}"
 }
 
+Add-AssertionOperator -Name                      Match `
+                      -Test                      $function:PesterMatch `
+                      -GetPositiveFailureMessage $function:PesterMatchFailureMessage `
+                      -GetNegativeFailureMessage $function:NotPesterMatchFailureMessage

--- a/Functions/Assertions/MatchExactly.ps1
+++ b/Functions/Assertions/MatchExactly.ps1
@@ -1,6 +1,6 @@
 
 function PesterMatchExactly($value, $expectedMatch) {
-    return ($value -cmatch $expectedMatch)
+    return [bool]($value -cmatch $expectedMatch)
 }
 
 function PesterMatchExactlyFailureMessage($value, $expectedMatch) {
@@ -11,3 +11,7 @@ function NotPesterMatchExactlyFailureMessage($value, $expectedMatch) {
     return "Expected: ${value} to not match the expression ${expectedMatch} exactly"
 }
 
+Add-AssertionOperator -Name                      MatchExactly `
+                      -Test                      $function:PesterMatchExactly `
+                      -GetPositiveFailureMessage $function:PesterMatchExactlyFailureMessage `
+                      -GetNegativeFailureMessage $function:NotPesterMatchExactlyFailureMessage

--- a/Functions/Assertions/PesterThrow.ps1
+++ b/Functions/Assertions/PesterThrow.ps1
@@ -51,3 +51,8 @@ function NotPesterThrowFailureMessage($value, $expected) {
         return "Expected: the expression not to throw an exception. Message was {{{0}}}`n    {1}" -f $ActualExceptionMessage,($ActualExceptionLine  -replace "`n","`n    ")
     }
 }
+
+Add-AssertionOperator -Name                      Throw `
+                      -Test                      $function:PesterThrow `
+                      -GetPositiveFailureMessage $function:PesterThrowFailureMessage `
+                      -GetNegativeFailureMessage $function:NotPesterThrowFailureMessage

--- a/Functions/Assertions/Should.ps1
+++ b/Functions/Assertions/Should.ps1
@@ -79,7 +79,8 @@ function Should {
 
     end
     {
-        $inputArray = @(foreach ($object in $input) { $object })
+        $inputArray = New-Object System.Collections.ArrayList
+        foreach ($object in $input) { $null = $inputArray.Add($object) }
 
         $lineNumber = $MyInvocation.ScriptLineNumber
         $lineText   = $MyInvocation.Line.TrimEnd("`n")
@@ -90,7 +91,7 @@ function Should {
         }
         if ($entry.SupportsArrayInput)
         {
-            Invoke-Assertion $entry $parsedArgs $inputArray $lineNumber $lineText
+            Invoke-Assertion $entry $parsedArgs $inputArray.ToArray() $lineNumber $lineText
         }
         else
         {

--- a/Functions/Assertions/Should.ps1
+++ b/Functions/Assertions/Should.ps1
@@ -1,4 +1,4 @@
-function Parse-ShouldArgs([array] $shouldArgs) {
+function Parse-ShouldArgs([object[]] $shouldArgs) {
     if ($null -eq $shouldArgs) { $shouldArgs = @() }
 
     $parsedArgs = @{
@@ -9,7 +9,7 @@ function Parse-ShouldArgs([array] $shouldArgs) {
     $assertionMethodIndex = 0
     $expectedValueIndex   = 1
 
-    if ($shouldArgs.Count -gt 0 -and $shouldArgs[0].ToLower() -eq "not") {
+    if ($shouldArgs.Count -gt 0 -and $shouldArgs[0] -eq "not") {
         $parsedArgs.PositiveAssertion = $false
         $assertionMethodIndex += 1
         $expectedValueIndex   += 1
@@ -17,7 +17,7 @@ function Parse-ShouldArgs([array] $shouldArgs) {
 
     if ($assertionMethodIndex -lt $shouldArgs.Count)
     {
-        $parsedArgs.AssertionMethod = "Pester$($shouldArgs[$assertionMethodIndex])"
+        $parsedArgs.AssertionMethod = "$($shouldArgs[$assertionMethodIndex])"
     }
     else
     {
@@ -32,33 +32,29 @@ function Parse-ShouldArgs([array] $shouldArgs) {
     return $parsedArgs
 }
 
-function Get-TestResult($shouldArgs, $value) {
-    $assertionMethod = $shouldArgs.AssertionMethod
-    $command = Get-Command $assertionMethod -ErrorAction $script:IgnoreErrorPreference
+function Get-TestResult($assertionEntry, $shouldArgs, $value) {
+    $testResult = (& $assertionEntry.Test $value $shouldArgs.ExpectedValue)
 
-    if ($null -eq $command)
-    {
-        $assertionMethod = $assertionMethod -replace '^Pester'
-        throw "'$assertionMethod' is not a valid Should operator."
-    }
-
-    $testResult = (& $assertionMethod $value $shouldArgs.ExpectedValue)
-
-    if ($shouldArgs.PositiveAssertion) {
+    if (-not $shouldArgs.PositiveAssertion) {
         return -not $testResult
     }
 
     return $testResult
 }
 
-function Get-FailureMessage($shouldArgs, $value) {
-    $failureMessageFunction = "$($shouldArgs.AssertionMethod)FailureMessage"
-    if (-not $shouldArgs.PositiveAssertion) {
-        $failureMessageFunction = "Not$failureMessageFunction"
+function Get-FailureMessage($assertionEntry, $shouldArgs, $value) {
+    if ($shouldArgs.PositiveAssertion)
+    {
+        $failureMessageFunction = $assertionEntry.GetPositiveFailureMessage
+    }
+    else
+    {
+        $failureMessageFunction = $assertionEntry.GetNegativeFailureMessage
     }
 
     return (& $failureMessageFunction $value $shouldArgs.ExpectedValue)
 }
+
 function New-ShouldException ($Message, $Line, $LineText) {
     $exception = New-Object Exception $Message
     $errorID = 'PesterAssertionFailed'
@@ -73,24 +69,45 @@ function Should {
     begin {
         Assert-DescribeInProgress -CommandName Should
         $parsedArgs = Parse-ShouldArgs $args
+
+        $entry = Get-AssertionOperatorEntry -Name $parsedArgs.AssertionMethod
+        if ($null -eq $entry)
+        {
+            throw "'$($parsedArgs.AssertionMethod)' is not a valid Should operator."
+        }
     }
 
-    end {
-        $input.MoveNext()
-        do {
-            $value = $input.Current
+    end
+    {
+        $inputArray = @(foreach ($object in $input) { $object })
 
-            $testFailed = Get-TestResult $parsedArgs $value
+        $lineNumber = $MyInvocation.ScriptLineNumber
+        $lineText   = $MyInvocation.Line.TrimEnd("`n")
 
-            if ($testFailed) {
-                $ShouldExceptionLineText = $MyInvocation.Line.TrimEnd("`n")
-                $ShouldExceptionLine = $MyInvocation.ScriptLineNumber
-
-                $failureMessage = Get-FailureMessage $parsedArgs $value
-
-
-                throw ( New-ShouldException -Message $failureMessage -Line $ShouldExceptionLine -LineText $ShouldExceptionLineText)
+        if ($inputArray.Count -eq 0)
+        {
+            Invoke-Assertion $entry $parsedArgs $null $lineNumber $lineText
+        }
+        if ($entry.SupportsArrayInput)
+        {
+            Invoke-Assertion $entry $parsedArgs $inputArray $lineNumber $lineText
+        }
+        else
+        {
+            foreach ($object in $inputArray)
+            {
+                Invoke-Assertion $entry $parsedArgs $object $lineNumber $lineText
             }
-        } until ($input.MoveNext() -eq $false)
+        }
+    }
+}
+
+function Invoke-Assertion($assertionEntry, $shouldArgs, $valueToTest, $lineNumber, $lineText)
+{
+    $testSucceeded = Get-TestResult $assertionEntry $shouldArgs $valueToTest
+    if (-not $testSucceeded)
+    {
+        $failureMessage = Get-FailureMessage $assertionEntry $shouldArgs $valueToTest
+        throw ( New-ShouldException -Message $failureMessage -Line $lineNumber -LineText $lineText )
     }
 }

--- a/Functions/TestResults.Tests.ps1
+++ b/Functions/TestResults.Tests.ps1
@@ -52,8 +52,8 @@ InModuleScope Pester {
             $xmlTestResult = $xmlResult.'test-results'
             $xmlTestResult.total    | Should Be 1
             $xmlTestResult.failures | Should Be 0
-            $xmlTestResult.date     | Should Be $true
-            $xmlTestResult.time     | Should Be $true
+            $xmlTestResult.date     | Should Not BeNullOrEmpty
+            $xmlTestResult.time     | Should Not BeNullOrEmpty
         }
 
         it "should write the test-suite information" {
@@ -185,8 +185,8 @@ InModuleScope Pester {
             $xmlResult = [xml] (Get-Content $testFile)
 
             $xmlEnvironment = $xmlResult.'test-results'.'environment'
-            $xmlEnvironment.'os-Version'    | Should Be $true
-            $xmlEnvironment.platform        | Should Be $true
+            $xmlEnvironment.'os-Version'    | Should Not BeNullOrEmpty
+            $xmlEnvironment.platform        | Should Not BeNullOrEmpty
             $xmlEnvironment.cwd             | Should Be (Get-Location).Path
             if ($env:Username) {
                 $xmlEnvironment.user        | Should Be $env:Username
@@ -343,8 +343,8 @@ InModuleScope Pester {
             $xmlTestResult = $xmlResult.'test-results'
             $xmlTestResult.total    | Should Be 1
             $xmlTestResult.failures | Should Be 0
-            $xmlTestResult.date     | Should Be $true
-            $xmlTestResult.time     | Should Be $true
+            $xmlTestResult.date     | Should Not BeNullOrEmpty
+            $xmlTestResult.time     | Should Not BeNullOrEmpty
         }
 
         it "should write the test-suite information" {
@@ -404,8 +404,8 @@ InModuleScope Pester {
             $xmlResult = [xml] (Get-Content $testFile)
 
             $xmlEnvironment = $xmlResult.'test-results'.'environment'
-            $xmlEnvironment.'os-Version'    | Should Be $true
-            $xmlEnvironment.platform        | Should Be $true
+            $xmlEnvironment.'os-Version'    | Should Not BeNullOrEmpty
+            $xmlEnvironment.platform        | Should Not BeNullOrEmpty
             $xmlEnvironment.cwd             | Should Be (Get-Location).Path
             if ($env:Username) {
                 $xmlEnvironment.user        | Should Be $env:Username

--- a/Pester.psm1
+++ b/Pester.psm1
@@ -11,6 +11,49 @@ else
     $script:IgnoreErrorPreference = 'SilentlyContinue'
 }
 
+$script:AssertionOperators = @{}
+
+function Add-AssertionOperator
+{
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true)]
+        [string] $Name,
+
+        [Parameter(Mandatory = $true)]
+        [scriptblock] $Test,
+
+        [Parameter(Mandatory = $true)]
+        [scriptblock] $GetPositiveFailureMessage,
+
+        [Parameter(Mandatory = $true)]
+        [scriptblock] $GetNegativeFailureMessage,
+
+        [switch] $SupportsArrayInput
+    )
+
+    $key = $Name.ToLower()
+
+    if ($script:AssertionOperators.ContainsKey($key))
+    {
+        throw "Assertion operator '$Name' already exists in the global assertions table."
+    }
+
+    $entry = New-Object psobject -Property @{
+        Test = $Test
+        GetPositiveFailureMessage = $GetPositiveFailureMessage
+        GetNegativeFailureMessage = $GetNegativeFailureMessage
+        SupportsArrayInput = [bool]$SupportsArrayInput
+    }
+
+    $script:AssertionOperators[$key] = $entry
+}
+
+function Get-AssertionOperatorEntry([string] $Name)
+{
+    return $script:AssertionOperators[$Name.ToLower()]
+}
+
 $moduleRoot = Split-Path -Path $MyInvocation.MyCommand.Path
 
 "$moduleRoot\Functions\*.ps1", "$moduleRoot\Functions\Assertions\*.ps1" |


### PR DESCRIPTION
This will be to address issue #246 .  It may not be ready to merge as-is yet; I just dusted off the old code I was working on to fix this problem a few months ago, but had thrown out due to difficulties telling the difference between an empty array and a $null value when the pipeline is involved.

This is a first attempt at improving the behavior of Should when multiple objects are piped in.  The Should Be, Should BeExactly, and Should BeNullOrEmpty assertions will now be performed against the entire input set, instead of once for each input object.  Also, arrays will no longer be fed straight to the -eq / -ceq operators (which carries some tricky baggage in PowerShell).  Instead, PowerShell will enumerate the arrays together and make sure their scalar elements are equal.

Other operators still behave as they always have, since passing an array to something like Should Exist doesn't make sense (unless your intention is to make sure that every file name in the array exists, in which case the old behavior is correct.)

I was running into some performance problems with the new code; calling Get-Command multiple times in our Should code seems to slow it down quite a bit, particularly if the command doesn't exist.  I've updated the Should code to have each operator register itself in a hashtable at module load time, instead of relying on a naming convention and Get-Command.  This keeps our performance at a consistent level regardless of how we tweak Should operator features.

There were a few old tests that worked, but only due to some odd buggy behavior (piping objects of an arbitrary non-boolean type to "should be $true"; they started to fail in this update.  I've changed those tests to use "Should Not BeNullOrEmpty" instead.