### PR TITLE
Allow NuGet package to be build with module in root

### DIFF
--- a/Pester.nuspec
+++ b/Pester.nuspec
@@ -13,15 +13,14 @@
     <licenseUrl>http://www.apache.org/licenses/LICENSE-2.0.html</licenseUrl>
   </metadata>
   <files>
-    <file src="Pester.psm1" target="tools" />
-    <file src="Pester.psd1" target="tools" />
-    <file src="Pester.Tests.ps1" target="tools" />
+    <file src="Pester.psm1" target="$targetBase$" />
+    <file src="Pester.psd1" target="$targetBase$" />
+    <file src="Pester.Tests.ps1" target="$targetBase$" />
     <file src="chocolateyInstall.ps1" />
-	<file src="nunit_schema_2.5.xsd" target="tools" />
-    <file src="bin\*.*" target="tools\bin" />
-    <file src="Examples\**\*.*" target="tools\Examples" />
-    <file src="Functions\**\*.*" target="tools\Functions" />
-    <file src="en-US\*.*" target="tools\en-US" />
+	<file src="nunit_schema_2.5.xsd" target="$targetBase$" />
+    <file src="bin\*.*" target="$targetBase$\bin" />
+    <file src="Examples\**\*.*" target="$targetBase$\Examples" />
+    <file src="Functions\**\*.*" target="$targetBase$\Functions" />
+    <file src="en-US\*.*" target="$targetBase$\en-US" />
   </files>
 </package>
-

--- a/build.psake.ps1
+++ b/build.psake.ps1
@@ -5,7 +5,7 @@ properties {
     $baseDir = $psake.build_script_dir
     $version = git describe --abbrev=0 --tags
     $nugetExe = "$baseDir\vendor\tools\nuget"
-	$targetBase = "tools"
+    $targetBase = "tools"
 }
 
 Task default -depends Build

--- a/build.psake.ps1
+++ b/build.psake.ps1
@@ -5,6 +5,7 @@ properties {
     $baseDir = $psake.build_script_dir
     $version = git describe --abbrev=0 --tags
     $nugetExe = "$baseDir\vendor\tools\nuget"
+	$targetBase = "tools"
 }
 
 Task default -depends Build
@@ -44,7 +45,7 @@ Task Pack-Nuget {
     mkdir "$baseDir\build"
     exec {
       . $nugetExe pack "$baseDir\Pester.nuspec" -OutputDirectory "$baseDir\build" `
-      -NoPackageAnalysis -version $version
+      -NoPackageAnalysis -version $version -Properties targetBase=$targetBase
     }
 }
 


### PR DESCRIPTION
PowerShellGet packages are currently built expecting the module to be in the root of the NuGet package, so this change allows the build script to specify a custom base for the target in the NuSpec so it can build either Chocolatey or PowerShellGet style packages.

I've left the default behavior to match the current folder structure, but a PowerShellGet module can be built using:

`Invoke-PSake .\build.psake.ps1 -properties @{targetBase = "" }`