### PR TITLE
Performance improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## Unreleased
+  - Performance Improvements
+
 ## 3.3.1 (January 12, 2015)
   - Import ISESteroids snippets on load
   - Updated Code Coverage analysis to be compatible with the PowerShell 5.0 AST when analyzing DSC configurations. [GH-249]

--- a/Functions/Assertions/Should.ps1
+++ b/Functions/Assertions/Should.ps1
@@ -34,7 +34,7 @@ function Parse-ShouldArgs([array] $shouldArgs) {
 
 function Get-TestResult($shouldArgs, $value) {
     $assertionMethod = $shouldArgs.AssertionMethod
-    $command = Get-Command $assertionMethod -ErrorAction (Get-IgnoreErrorPreference)
+    $command = Get-Command $assertionMethod -ErrorAction $script:IgnoreErrorPreference
 
     if ($null -eq $command)
     {

--- a/Functions/Describe.ps1
+++ b/Functions/Describe.ps1
@@ -65,7 +65,7 @@ about_TestDrive
         [ScriptBlock] $Fixture = $(Throw "No test script block is provided. (Have you put the open curly brace on the next line?)")
     )
 
-    if ($null -eq (Get-Variable -Name Pester -ValueOnly -ErrorAction (Get-IgnoreErrorPreference)))
+    if ($null -eq (Get-Variable -Name Pester -ValueOnly -ErrorAction $script:IgnoreErrorPreference))
     {
         # User has executed a test script directly instead of calling Invoke-Pester
         $Pester = New-PesterState -Path (Resolve-Path .) -TestNameFilter $null -TagFilter @() -SessionState $PSCmdlet.SessionState

--- a/Functions/InModuleScope.ps1
+++ b/Functions/InModuleScope.ps1
@@ -61,7 +61,7 @@ function InModuleScope
         $ScriptBlock
     )
 
-    if ($null -eq (Get-Variable -Name Pester -ValueOnly -ErrorAction (Get-IgnoreErrorPreference)))
+    if ($null -eq (Get-Variable -Name Pester -ValueOnly -ErrorAction $script:IgnoreErrorPreference))
     {
         # User has executed a test script directly instead of calling Invoke-Pester
         $Pester = New-PesterState -Path (Resolve-Path .) -TestNameFilter $null -TagFilter @() -ExcludeTagFilter @() -SessionState $PSCmdlet.SessionState

--- a/Functions/Mock.ps1
+++ b/Functions/Mock.ps1
@@ -620,7 +620,16 @@ function MockPrototype {
         $moduleName = $ExecutionContext.SessionState.Module.Name
     }
 
-    [object] $ArgumentList = Get-Variable -Name args -ValueOnly -Scope Local -ErrorAction (Get-IgnoreErrorPreference)
+    if ($PSVersionTable.PSVersion.Major -ge 3)
+    {
+        [string] $IgnoreErrorPreference = 'Ignore'
+    }
+    else
+    {
+        [string] $IgnoreErrorPreference = 'SilentlyContinue'
+    }
+
+    [object] $ArgumentList = Get-Variable -Name args -ValueOnly -Scope Local -ErrorAction $IgnoreErrorPreference
     if ($null -eq $ArgumentList) { $ArgumentList = @() }
 
     Invoke-Mock -CommandName $functionName -ModuleName $moduleName -BoundParameters $PSBoundParameters -ArgumentList $ArgumentList

--- a/Functions/TestDrive.ps1
+++ b/Functions/TestDrive.ps1
@@ -64,7 +64,7 @@ function Get-TestDriveChildItem {
 function Remove-TestDrive {
 
     $DriveName = "TestDrive"
-    $Drive = Get-PSDrive -Name $DriveName -ErrorAction (Get-IgnoreErrorPreference)
+    $Drive = Get-PSDrive -Name $DriveName -ErrorAction $script:IgnoreErrorPreference
     $Path = ($Drive).Root
 
 
@@ -76,7 +76,7 @@ function Remove-TestDrive {
 
     if ( $Drive )
     {
-        $Drive | Remove-PSDrive -Force -ErrorAction (Get-IgnoreErrorPreference)
+        $Drive | Remove-PSDrive -Force -ErrorAction $script:IgnoreErrorPreference
     }
 
     if (Microsoft.PowerShell.Management\Test-Path -Path $Path)
@@ -84,7 +84,7 @@ function Remove-TestDrive {
         Microsoft.PowerShell.Management\Remove-Item -Path $Path -Force -Recurse
     }
 
-    if (Get-Variable -Name $DriveName -Scope Global -ErrorAction (Get-IgnoreErrorPreference)) {
+    if (Get-Variable -Name $DriveName -Scope Global -ErrorAction $script:IgnoreErrorPreference) {
         Remove-Variable -Scope Global -Name $DriveName -Force
     }
 }

--- a/Pester.psd1
+++ b/Pester.psd1
@@ -45,8 +45,7 @@ FunctionsToExport = @(
     'BeforeAll',
     'AfterAll'
     'Get-MockDynamicParameters',
-    'Set-DynamicParameterVariables',
-    'Get-IgnoreErrorPreference'
+    'Set-DynamicParameterVariables'
 )
 
 # # Cmdlets to export from this module

--- a/Pester.psd1
+++ b/Pester.psd1
@@ -4,7 +4,7 @@
 ModuleToProcess = 'Pester.psm1'
 
 # Version number of this module.
-ModuleVersion = '3.3.1'
+ModuleVersion = '3.3.2'
 
 # ID used to uniquely identify this module
 GUID = 'a699dea5-2c73-4616-a270-1f7abb777e71'

--- a/Pester.psm1
+++ b/Pester.psm1
@@ -2,6 +2,15 @@
 # Version: $version$
 # Changeset: $sha$
 
+if ($PSVersionTable.PSVersion.Major -ge 3)
+{
+    $script:IgnoreErrorPreference = 'Ignore'
+}
+else
+{
+    $script:IgnoreErrorPreference = 'SilentlyContinue'
+}
+
 $moduleRoot = Split-Path -Path $MyInvocation.MyCommand.Path
 
 "$moduleRoot\Functions\*.ps1", "$moduleRoot\Functions\Assertions\*.ps1" |
@@ -251,19 +260,6 @@ function Get-ScriptBlockScope
     [scriptblock].GetProperty('SessionStateInternal', $flags).GetValue($ScriptBlock, $null)
 }
 
-function Get-IgnoreErrorPreference
-{
-    if ($PSVersionTable.PSVersion.Major -ge 3)
-    {
-        return 'Ignore'
-    }
-    else
-    {
-        return 'SilentlyContinue'
-    }
-
-}
-
 if (($null -ne $psISE) -and ($PSVersionTable.PSVersion.Major -ge 3))
 {
     Import-IseSnippet -Path $PSScriptRoot\Snippets
@@ -273,4 +269,3 @@ Export-ModuleMember Describe, Context, It, In, Mock, Assert-VerifiableMocks, Ass
 Export-ModuleMember New-Fixture, Get-TestDriveItem, Should, Invoke-Pester, Setup, InModuleScope, Invoke-Mock
 Export-ModuleMember BeforeEach, AfterEach, BeforeAll, AfterAll
 Export-ModuleMember Get-MockDynamicParameters, Set-DynamicParameterVariables
-Export-ModuleMember Get-IgnoreErrorPreference


### PR DESCRIPTION
I did some profiling of the module today, and identified several hotspots that have been improved in this commit.  The main three are:

ScriptProperties on the PesterState object (FailedCount, etc) have been replaced with normal properties that are incremented in the AddTestResult function.

Parsing performed for the BeforeEach / AfterEach commands is run a lot and was expensive; this code has been moved into some compiled C# for more speed.

Calls to Get-IgnoreErrorPreference were also adding up quite a bit.  These have been replaced with a lookup of a script-scope variable instead.  This results in a tiny bit of duplication in the Mock code, but it's well worth it.

There are a few lesser changes as well.  On my WMF 5.0 system, the time it takes to execute Pester's own test suite has gone down by around one third.