### PR TITLE
Missing snippets directory causes Import to fail

### DIFF
--- a/Pester.psm1
+++ b/Pester.psm1
@@ -260,9 +260,10 @@ function Get-ScriptBlockScope
     [scriptblock].GetProperty('SessionStateInternal', $flags).GetValue($ScriptBlock, $null)
 }
 
-if (($null -ne $psISE) -and ($PSVersionTable.PSVersion.Major -ge 3))
+$snippetsDirectoryPath = "$PSScriptRoot\Snippets"
+if (($null -ne $psISE) -and ($PSVersionTable.PSVersion.Major -ge 3) -and (Test-Path $snippetsDirectoryPath))
 {
-    Import-IseSnippet -Path $PSScriptRoot\Snippets
+    Import-IseSnippet -Path $snippetsDirectoryPath
 }
 
 Export-ModuleMember Describe, Context, It, In, Mock, Assert-VerifiableMocks, Assert-MockCalled


### PR DESCRIPTION
When attempting to Import the module when running a script through Powershell ISE, a missing snippets directory will cause the import to fail.