### PR TITLE
Fix for mocking aliases

### DIFF
--- a/Functions/Mock.Tests.ps1
+++ b/Functions/Mock.Tests.ps1
@@ -118,7 +118,7 @@ Describe 'When calling Mock on an alias' {
 }
 
 Describe 'When calling Mock on an alias that refers to a function Pester can''t see' {
-    It 'tst' {
+    It 'Mocks the aliased command successfully' {
         # This function is defined in a non-global scope; code inside the Pester module can't see it directly.
         function orig {'orig'}
         New-Alias 'ali' orig

--- a/Functions/Mock.Tests.ps1
+++ b/Functions/Mock.Tests.ps1
@@ -117,6 +117,20 @@ Describe 'When calling Mock on an alias' {
     }
 }
 
+Describe 'When calling Mock on an alias that refers to a function Pester can''t see' {
+    It 'tst' {
+        # This function is defined in a non-global scope; code inside the Pester module can't see it directly.
+        function orig {'orig'}
+        New-Alias 'ali' orig
+
+        ali | Should Be 'orig'
+
+        { mock ali {'mck'} } | Should Not Throw
+
+        ali | Should Be 'mck'
+    }
+}
+
 Describe 'When calling Mock on a filter' {
     Mock FilterUnderTest {return 'I am not FilterUnderTest'}
 


### PR DESCRIPTION
Apparently the ResolvedCommand property on an AliasInfo object is sensitive to the scope from which it's queried; when we're crossing script module boundaries, we need to fetch the value of ResolvedCommand in the scope where the alias was found, not in Pester.