### PR TITLE
Making Pester StrictMode compliant again.

### DIFF
--- a/Functions/Assertions/BeNullOrEmpty.ps1
+++ b/Functions/Assertions/BeNullOrEmpty.ps1
@@ -6,7 +6,8 @@ function PesterBeNullOrEmpty($value) {
     if ([String] -eq $value.GetType()) {
         return [String]::IsNullOrEmpty($value)
     }
-    if ($null -ne $value.Count) {
+    if ($null -ne $value.PSObject.Properties['Count'] -and
+        $null -ne $value.Count) {
         return $value.Count -lt 1
     }
     return $false

--- a/Functions/It.ps1
+++ b/Functions/It.ps1
@@ -129,6 +129,10 @@ function ItImpl
 
     Assert-DescribeInProgress -CommandName It
 
+    # Jumping through hoops to make strict mode happy.
+    if ($PSCmdlet.ParameterSetName -ne 'Skip') { $Skip = $false }
+    if ($PSCmdlet.ParameterSetName -ne 'Pending') { $Pending = $false }
+
     #unless Skip or Pending is specified you must specify a ScriptBlock to the Test parameter
     if (-not ($PSBoundParameters.ContainsKey('test') -or $Skip -or $Pending))
     {

--- a/Functions/Mock.ps1
+++ b/Functions/Mock.ps1
@@ -513,7 +513,7 @@ param(
     )
 
     if($qualifiedCalls.Length -ne $times -and ($Exactly -or ($times -eq 0))) {
-        throw "Expected ${commandName}${$moduleMessage} to be called $times times exactly but was called $($qualifiedCalls.Length.ToString()) times"
+        throw "Expected ${commandName}${moduleMessage} to be called $times times exactly but was called $($qualifiedCalls.Length.ToString()) times"
     } elseif($qualifiedCalls.Length -lt $times) {
         throw "Expected ${commandName}${moduleMessage} to be called at least $times times but was called $($qualifiedCalls.Length) times"
     }
@@ -842,7 +842,7 @@ function IsCommonParameter
     {
         if ([System.Management.Automation.Internal.CommonParameters].GetProperty($Name)) { return $true }
         if ($Metadata.SupportsShouldProcess -and [System.Management.Automation.Internal.ShouldProcessParameters].GetProperty($Name)) { return $true }
-        if ($Metadata.SupportsPaging -and [System.Management.Automation.PagingParameters].GetProperty($Name)) { return $true }
+        if ($PSVersionTable.PSVersion.Major -ge 3 -and $Metadata.SupportsPaging -and [System.Management.Automation.PagingParameters].GetProperty($Name)) { return $true }
         if ($Metadata.SupportsTransactions -and [System.Management.Automation.Internal.TransactionParameters].GetProperty($Name)) { return $true }
     }
 

--- a/Functions/TestResults.Tests.ps1
+++ b/Functions/TestResults.Tests.ps1
@@ -69,12 +69,19 @@ InModuleScope Pester {
             $xmlResult = [xml] (Get-Content $testFile)
 
             $xmlTestResult = $xmlResult.'test-results'.'test-suite'.results.'test-suite'
-            $xmlTestResult.type        | Should Be "Powershell"
-            $xmlTestResult.name        | Should Be "Mocked Describe"
-            $xmlTestResult.description | Should BeNullOrEmpty
-            $xmlTestResult.result      | Should Be "Success"
-            $xmlTestResult.success     | Should Be "True"
-            $xmlTestResult.time        | Should Be 2.1
+
+            $description = $null
+            if ($xmlTestResult.PSObject.Properties['description'])
+            {
+                $description = $xmlTestResult.description
+            }
+
+            $xmlTestResult.type    | Should Be "Powershell"
+            $xmlTestResult.name    | Should Be "Mocked Describe"
+            $description           | Should BeNullOrEmpty
+            $xmlTestResult.result  | Should Be "Success"
+            $xmlTestResult.success | Should Be "True"
+            $xmlTestResult.time    | Should Be 2.1
         }
 
         it "should write two test-suite elements for two describes" {
@@ -92,18 +99,31 @@ InModuleScope Pester {
             $xmlResult = [xml] (Get-Content $testFile)
 
             $xmlTestSuite1 = $xmlResult.'test-results'.'test-suite'.results.'test-suite'[0]
-            $xmlTestSuite1.name        | Should Be "Describe #1"
-            $xmlTestSuite1.description | Should BeNullOrEmpty
-            $xmlTestSuite1.result      | Should Be "Success"
-            $xmlTestSuite1.success     | Should Be "True"
-            $xmlTestSuite1.time        | Should Be 1.0
+
+            $description = $null
+            if ($xmlTestSuite1.PSObject.Properties['description'])
+            {
+                $description = $xmlTestSuite1.description
+            }
+
+            $xmlTestSuite1.name    | Should Be "Describe #1"
+            $description           | Should BeNullOrEmpty
+            $xmlTestSuite1.result  | Should Be "Success"
+            $xmlTestSuite1.success | Should Be "True"
+            $xmlTestSuite1.time    | Should Be 1.0
 
             $xmlTestSuite2 = $xmlResult.'test-results'.'test-suite'.results.'test-suite'[1]
-            $xmlTestSuite2.name        | Should Be "Describe #2"
-            $xmlTestSuite2.description | Should BeNullOrEmpty
-            $xmlTestSuite2.result      | Should Be "Failure"
-            $xmlTestSuite2.success     | Should Be "False"
-            $xmlTestSuite2.time        | Should Be 2.0
+            $description = $null
+            if ($xmlTestSuite2.PSObject.Properties['description'])
+            {
+                $description = $xmlTestSuite2.description
+            }
+
+            $xmlTestSuite2.name    | Should Be "Describe #2"
+            $description           | Should BeNullOrEmpty
+            $xmlTestSuite2.result  | Should Be "Failure"
+            $xmlTestSuite2.success | Should Be "False"
+            $xmlTestSuite2.time    | Should Be 2.0
         }
 
         it "should write parent results in tree correctly" {
@@ -244,12 +264,18 @@ InModuleScope Pester {
             It 'should write parameterized test results correctly' {
                 $xmlTestSuite = $xmlResult.'test-results'.'test-suite'.'results'.'test-suite'.'results'.'test-suite'
 
-                $xmlTestSuite.name        | Should Be 'Parameterized Testcase <A>'
-                $xmlTestSuite.description | Should BeNullOrEmpty
-                $xmlTestSuite.type        | Should Be 'ParameterizedTest'
-                $xmlTestSuite.result      | Should Be 'Failure'
-                $xmlTestSuite.success     | Should Be 'False'
-                $xmlTestSuite.time        | Should Be '2'
+                $description = $null
+                if ($xmlTestSuite.PSObject.Properties['description'])
+                {
+                    $description = $xmlTestSuite.description
+                }
+
+                $xmlTestSuite.name    | Should Be 'Parameterized Testcase <A>'
+                $description          | Should BeNullOrEmpty
+                $xmlTestSuite.type    | Should Be 'ParameterizedTest'
+                $xmlTestSuite.result  | Should Be 'Failure'
+                $xmlTestSuite.success | Should Be 'False'
+                $xmlTestSuite.time    | Should Be '2'
 
                 foreach ($testCase in $xmlTestSuite.results.'test-case')
                 {

--- a/Functions/TestResults.ps1
+++ b/Functions/TestResults.ps1
@@ -149,7 +149,12 @@ function Write-NUnitCultureInformation($PesterState, [System.Xml.XmlWriter] $Xml
 function Write-NUnitGlobalTestSuiteAttributes($PesterState, [System.Xml.XmlWriter] $XmlWriter, [switch] $LegacyFormat)
 {
     $XmlWriter.WriteAttributeString('type', 'Powershell')
-    $XmlWriter.WriteAttributeString('name', $PesterState.Path)
+
+    # TODO: This used to be writing $PesterState.Path, back when that was a single string (and existed.)
+    #       Better would be to produce a test suite for each resolved file, rather than for the value
+    #       of the path that was passed to Invoke-Pester.
+
+    $XmlWriter.WriteAttributeString('name', 'Pester')
     $XmlWriter.WriteAttributeString('executed', 'True')
 
     $isSuccess = $PesterState.FailedCount -eq 0
@@ -163,23 +168,26 @@ function Write-NUnitGlobalTestSuiteAttributes($PesterState, [System.Xml.XmlWrite
 function Write-NUnitDescribeElements($PesterState, [System.Xml.XmlWriter] $XmlWriter, [switch] $LegacyFormat)
 {
     $Describes = $PesterState.TestResult | Group-Object -Property Describe
-    foreach ($currentDescribe in $Describes)
+    if ($null -ne $Describes)
     {
-        $DescribeInfo = Get-TestSuiteInfo $currentDescribe
+        foreach ($currentDescribe in $Describes)
+        {
+            $DescribeInfo = Get-TestSuiteInfo $currentDescribe
 
-        #Write test suites
-        $XmlWriter.WriteStartElement('test-suite')
+            #Write test suites
+            $XmlWriter.WriteStartElement('test-suite')
 
-        if ($LegacyFormat) { $suiteType = 'PowerShell' } else { $suiteType = 'TestFixture' }
+            if ($LegacyFormat) { $suiteType = 'PowerShell' } else { $suiteType = 'TestFixture' }
 
-        Write-NUnitTestSuiteAttributes -TestSuiteInfo $DescribeInfo -TestSuiteType $suiteType -XmlWriter $XmlWriter -LegacyFormat:$LegacyFormat
+            Write-NUnitTestSuiteAttributes -TestSuiteInfo $DescribeInfo -TestSuiteType $suiteType -XmlWriter $XmlWriter -LegacyFormat:$LegacyFormat
 
-        $XmlWriter.WriteStartElement('results')
+            $XmlWriter.WriteStartElement('results')
 
-        Write-NUnitDescribeChildElements -TestResults $currentDescribe.Group -XmlWriter $XmlWriter -LegacyFormat:$LegacyFormat -DescribeName $DescribeInfo.Name
+            Write-NUnitDescribeChildElements -TestResults $currentDescribe.Group -XmlWriter $XmlWriter -LegacyFormat:$LegacyFormat -DescribeName $DescribeInfo.Name
 
-        $XmlWriter.WriteEndElement()
-        $XmlWriter.WriteEndElement()
+            $XmlWriter.WriteEndElement()
+            $XmlWriter.WriteEndElement()
+        }
     }
 }
 

--- a/Pester.psm1
+++ b/Pester.psm1
@@ -220,7 +220,7 @@ about_pester
     Show-CoverageReport -CoverageReport $coverageReport
     Exit-CoverageAnalysis -PesterState $pester
 
-    if($OutputFile) {
+    if(Get-Variable -Name OutputFile -ValueOnly -ErrorAction $script:IgnoreErrorPreference) {
         Export-PesterResults -PesterState $pester -Path $OutputFile -Format $OutputFormat
     }
 
@@ -368,7 +368,7 @@ function Get-ScriptBlockScope
 }
 
 $snippetsDirectoryPath = "$PSScriptRoot\Snippets"
-if (($null -ne $psISE) -and ($PSVersionTable.PSVersion.Major -ge 3) -and (Test-Path $snippetsDirectoryPath))
+if ((Test-Path -Path Variable:\psise) -and ($null -ne $psISE) -and ($PSVersionTable.PSVersion.Major -ge 3) -and (Test-Path $snippetsDirectoryPath))
 {
     Import-IseSnippet -Path $snippetsDirectoryPath
 }


### PR DESCRIPTION
We received a bug report that Pester was breaking if StrictMode were set for the whole PowerShell session.  (We've been enabling it at the beginning of each test script, but apparently that's not enough to ensure compliance.  We'll need to enable it before calling Invoke-Pester in our build jobs instead.)

All of these errors have been fixed.