### PR TITLE
Build script update

### DIFF
--- a/Pester.nuspec
+++ b/Pester.nuspec
@@ -16,7 +16,7 @@
     <file src="Pester.psm1" target="tools" />
     <file src="Pester.psd1" target="tools" />
     <file src="Pester.Tests.ps1" target="tools" />
-    <file src="LICENSE" target="tools" />
+    <file src="LICENSE*" target="tools" />
     <file src="chocolateyInstall.ps1" />
 	<file src="nunit_schema_2.5.xsd" target="tools" />
     <file src="bin\*.*" target="tools\bin" />

--- a/build.psake.ps1
+++ b/build.psake.ps1
@@ -3,7 +3,7 @@ properties {
     $currentDir = resolve-path .
     $Invocation = (Get-Variable MyInvocation -Scope 1).Value
     $baseDir = $psake.build_script_dir
-    $version = git describe --abbrev=0 --tags
+    $version = git.exe describe --abbrev=0 --tags
     $nugetExe = "$baseDir\vendor\tools\nuget"
 }
 
@@ -13,14 +13,14 @@ Task Package -depends Version-Module, Pack-Nuget, Unversion-Module
 Task Release -depends Build, Push-Nuget
 
 Task Test {
-    CD "$baseDir"
+    Set-Location "$baseDir"
     exec {."$baseDir\bin\Pester.bat"}
-    CD $currentDir
+    Set-Location $currentDir
 }
 
 Task Version-Module{
-    $v = git describe --abbrev=0 --tags
-    $changeset=(git log -1 $($v + '..') --pretty=format:%H)
+    $v = git.exe describe --abbrev=0 --tags
+    $changeset=(git.exe log -1 $($v + '..') --pretty=format:%H)
     (Get-Content "$baseDir\Pester.psm1") `
       | % {$_ -replace "\`$version\`$", "$version" } `
       | % {$_ -replace "\`$sha\`$", "$changeset" } `
@@ -28,7 +28,9 @@ Task Version-Module{
 }
 
 Task Unversion-Module{
-    git checkout -- .\Pester.psm1
+    Set-Location $baseDir
+    git.exe checkout -- $baseDir\Pester.psm1
+    Set-Location $currentDir
 }
 
 Task Pack-Nuget {


### PR DESCRIPTION
nuget apparently has a bug when adding files that have no extension, and the recent addition of LICENSE was causing the pack step to fail.  There's a workaround for this to add a * character to the end of the file name, which appears to work.

I've also tweaked the psake build script slightly to make sure the unversion step works regardless of the $currentDir.