### PR TITLE
Added do {} until ($true) loops around test script block calls.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
   - Improved error message when InModuleScope finds multiple modules loaded with the same name. [GH-276]
   - Updated build script to allow for custom root folder in the nupkg. [GH-254]
   - Improved error messages for InModuleScope and Mock -ModuleName when multiple modules with the same name are loaded. Also enabled these commands to work if only one of the loaded modules is a Script module. [GH-278]
+  - Added some graceful handling of test code that has a misplaced break or continue statement. [GH-290]
 
 ## 3.3.5 (January 23, 2015)
   - Updated tests to allow PRs to be automatically tested, with status updates to GitHub, by our CI server.

--- a/Functions/BreakAndContinue.Tests.ps1
+++ b/Functions/BreakAndContinue.Tests.ps1
@@ -1,0 +1,14 @@
+Describe 'Clean handling of break and continue' {
+    # If this test 'fails', it'll just cause most of the rest of the tests to never execute (and we won't see any actual failures.)
+    # The CI job monitors metrics, though, and will fail the build if the number of tests drops too much.
+
+    Context 'Break' {
+        break
+    }
+
+    Context 'Continue' {
+        continue
+    }
+
+    It 'Did not abort the whole test run' { $null = $null }
+}

--- a/Functions/Context.ps1
+++ b/Functions/Context.ps1
@@ -60,7 +60,11 @@ about_TestDrive
     {
         Add-SetupAndTeardown -ScriptBlock $Fixture
         Invoke-TestGroupSetupBlocks -Scope $pester.Scope
-        $null = & $Fixture
+
+        do
+        {
+            $null = & $Fixture
+        } until ($true)
     }
     catch
     {

--- a/Functions/Describe.ps1
+++ b/Functions/Describe.ps1
@@ -94,7 +94,11 @@ about_TestDrive
 
         Add-SetupAndTeardown -ScriptBlock $Fixture
         Invoke-TestGroupSetupBlocks -Scope $pester.Scope
-        $null = & $Fixture
+
+        do
+        {
+            $null = & $Fixture
+        } until ($true)
     }
     catch
     {

--- a/Functions/InModuleScope.ps1
+++ b/Functions/InModuleScope.ps1
@@ -79,7 +79,10 @@ function InModuleScope
 
         Set-ScriptBlockScope -ScriptBlock $ScriptBlock -SessionState $module.SessionState
 
-        & $ScriptBlock
+        do
+        {
+            & $ScriptBlock
+        } until ($true)
     }
     finally
     {

--- a/Functions/It.ps1
+++ b/Functions/It.ps1
@@ -234,7 +234,10 @@ function Invoke-Test
 
         $errorRecord = $null
         try{
-            $null = & $ScriptBlock @Parameters
+            do
+            {
+                $null = & $ScriptBlock @Parameters
+            } until ($true)
         } catch {
             $errorRecord = $_
         }

--- a/Pester.Tests.ps1
+++ b/Pester.Tests.ps1
@@ -1,7 +1,7 @@
 ﻿$here = Split-Path -Parent $MyInvocation.MyCommand.Path
 
 $manifestPath   = "$here\Pester.psd1"
-$changellogPath = "$here\CHANGELOG.md"
+$changeLogPath = "$here\CHANGELOG.md"
 
 # DO NOT CHANGE THIS TAG NAME; IT AFFECTS THE CI BUILD.
 
@@ -28,7 +28,7 @@ Describe -Tags 'VersionChecks' "Pester manifest and changelog" {
     $script:changelogVersion = $null
     It "has a valid version in the changelog" {
 
-        foreach ($line in (Get-Content $changellogPath))
+        foreach ($line in (Get-Content $changeLogPath))
         {
             if ($line -match "^\D*(?<Version>(\d+\.){1,3}\d+)")
             {

--- a/Pester.psd1
+++ b/Pester.psd1
@@ -4,7 +4,7 @@
 ModuleToProcess = 'Pester.psm1'
 
 # Version number of this module.
-ModuleVersion = '3.3.5'
+ModuleVersion = '3.3.6'
 
 # ID used to uniquely identify this module
 GUID = 'a699dea5-2c73-4616-a270-1f7abb777e71'

--- a/Pester.psm1
+++ b/Pester.psm1
@@ -205,7 +205,10 @@ about_pester
     {
         try
         {
-            & $invokeTestScript -Path $testScript.Path -Arguments $testScript.Arguments -Parameters $testScript.Parameters
+            do
+            {
+                & $invokeTestScript -Path $testScript.Path -Arguments $testScript.Arguments -Parameters $testScript.Parameters
+            } until ($true)
         }
         catch
         {
@@ -268,7 +271,7 @@ function ResolveTestScripts
             {
                 $unresolvedPath = [string] $object
                 $arguments      = @()
-                $parameters     = @{}            
+                $parameters     = @{}
             }
 
             if ($unresolvedPath -notmatch '[\*\?\[\]]' -and


### PR DESCRIPTION
This way if the test code (or code under test) has a misplaced break or continue statement, it won't cause the whole Pester run to abort.  (Break / continue statements with labels will still cause this to happen, unfortunately; not sure if there's anything we can do about that.)

Fixes #289