### PR TITLE
Workaround for GetDynamicParameters() bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## Unreleased
+  - Added workaround for GetDynamicParameters() bug that was affecting mocks on the ActiveDirectory module in Windows 7. [GH-295]
+
 ## 3.3.6 (March 19, 2015)
   - Fix for mocking aliases for commands that are in scopes that Pester can't normally see. [GH-267]
   - Added line information to test failure output in Should assertion failures. [GH-266]

--- a/Functions/Mock.ps1
+++ b/Functions/Mock.ps1
@@ -1010,11 +1010,22 @@ function Get-DynamicParametersForCmdlet
 
     try
     {
-        $cmdlet.GetDynamicParameters()
+        # This unary comma is important in some cases.  On Windows 7 systems, the ActiveDirectory module cmdlets
+        # return objects from this method which implement IEnumerable for some reason, and even cause PowerShell
+        # to throw an exception when it tries to cast the object to that interface.
+
+        # We avoid that problem by wrapping the result of GetDynamicParameters() in a one-element array with the
+        # unary comma.  PowerShell enumerates that array instead of trying to enumerate the goofy object, and
+        # everyone's happy.
+
+        # Love the comma.  Don't delete it.  We don't have a test for this yet, unless we can get the AD module
+        # on a Server 2008 R2 build server, or until we write some C# code to reproduce its goofy behavior.
+
+        ,$cmdlet.GetDynamicParameters()
     }
     catch [System.NotImplementedException]
     {
-        #ignore the exception
+        # Some cmdlets implement IDynamicParameters but then throw a NotImplementedException.  I have no idea why.  Ignore them.
     }
 }
 


### PR DESCRIPTION
Weird ActiveDirectory module is weird.

Fixes #294.  There are no automated tests to verify this yet; we either need to run the test on a 2008 R2 system with the RSAT feature installed, or write some C# code to reproduce the behavior of the AD module.  (The latter would be preferable, but will take some more time.)