### PR TITLE
Fixes #303

### DIFF
--- a/Functions/Mock.Tests.ps1
+++ b/Functions/Mock.Tests.ps1
@@ -413,11 +413,18 @@ Describe 'When calling Mock on a module-internal function.' {
         function InternalFunction2 { 'I am the second module, second function' }
         function PublicFunction   { InternalFunction }
         function PublicFunction2 { InternalFunction2 }
-        Export-ModuleMember -Function PublicFunction, PublicFunction2
+
+        function FuncThatOverwritesExecutionContext {
+            param ($ExecutionContext)
+
+            InternalFunction
+        }
+
+        Export-ModuleMember -Function PublicFunction, PublicFunction2, FuncThatOverwritesExecutionContext
     } | Import-Module -Force
 
     It 'Should fail to call the internal module function' {
-        { TestModule\InternalFuncTion } | Should Throw
+        { TestModule\InternalFunction } | Should Throw
     }
 
     It 'Should call the actual internal module function from the public function' {
@@ -453,6 +460,10 @@ Describe 'When calling Mock on a module-internal function.' {
 
         It 'Should call mocks from inside another mock' {
             TestModule2\PublicFunction2 | Should Be "I'm the mock who's been passed parameter Test"
+        }
+
+        It 'Should work even if the function is weird and steps on the automatic $ExecutionContext variable.' {
+            TestModule2\FuncThatOverwritesExecutionContext | Should Be 'I am the second module internal function'
         }
     }
 

--- a/Functions/Mock.ps1
+++ b/Functions/Mock.ps1
@@ -244,6 +244,9 @@ about_Mocking
         }
 
         $newContent = Microsoft.PowerShell.Management\Get-Content function:\MockPrototype
+        $newContent = $newContent -replace '#FUNCTIONNAME#', $CommandName
+        $newContent = $newContent -replace '#MODULENAME#', $ModuleName
+
         $mockScript = [scriptblock]::Create("$cmdletBinding`r`nparam( $paramBlock )`r`n$dynamicParamBlock`r`nprocess{`r`n$newContent}")
 
         $mock = @{
@@ -613,13 +616,8 @@ function MockPrototype {
     # parameters of the same names with a different type.  We don't actually care about overwriting the
     # variables, since they're going to be passed along with $PSBoundParameters anyway.
 
-    [string] $functionName = $MyInvocation.MyCommand.Name
-
-    [string] $moduleName = ''
-    if ($ExecutionContext.SessionState.Module)
-    {
-        $moduleName = $ExecutionContext.SessionState.Module.Name
-    }
+    [string] $functionName = '#FUNCTIONNAME#'
+    [string] $moduleName = '#MODULENAME#'
 
     if ($PSVersionTable.PSVersion.Major -ge 3)
     {


### PR DESCRIPTION
Function and Module names are now injected into the script blocks created based on MockPrototype as plain strings, instead of being read dynamically from the $MyInvocation / $ExecutionContext automatic variables at execution time.  This way, it'll still work even if some goofy code declares parameters with those names.