### PR TITLE
Adding some Write-Progress output to It

### DIFF
--- a/Functions/It.ps1
+++ b/Functions/It.ps1
@@ -230,6 +230,8 @@ function Invoke-Test
     }
     else
     {
+        Write-Progress -Activity "Running test '$Name'" -Status Processing
+
         $errorRecord = $null
         try
         {
@@ -264,6 +266,7 @@ function Invoke-Test
         $result = Get-PesterResult -Test $ScriptBlock -ErrorRecord $errorRecord
         $orderedParameters = Get-OrderedParameterDictionary -ScriptBlock $ScriptBlock -Dictionary $Parameters
         $Pester.AddTestResult( $result.name, $result.Result, $null, $result.FailureMessage, $result.StackTrace, $ParameterizedSuiteName, $orderedParameters )
+        Write-Progress -Activity "Running test '$Name'" -Completed -Status Processing
     }
 
     if ($null -ne $OutputScriptBlock)

--- a/Pester.psm1
+++ b/Pester.psm1
@@ -185,6 +185,8 @@ about_pester
     $pester = New-PesterState -TestNameFilter $TestName -TagFilter ($Tag -split "\s") -ExcludeTagFilter ($ExcludeTag -split "\s") -SessionState $PSCmdlet.SessionState -Strict:$Strict -Quiet:$Quiet
     Enter-CoverageAnalysis -CodeCoverage $CodeCoverage -PesterState $pester
 
+    Write-Screen "`r`n`r`n`r`n`r`n"
+
     $invokeTestScript = {
         param (
             [Parameter(Position = 0)]


### PR DESCRIPTION
Potential fix for #321 

I added a few blank lines to the console output at the beginning of `Invoke-Pester`, to make room for the Progress display.  Tests that finish quickly may not wind up displaying any progress output at all, but long-running tests will provide the user with some feedback about what's happening.