### PR TITLE
Initial fix for #286

### DIFF
--- a/Functions/GlobalMock-A.Tests.ps1
+++ b/Functions/GlobalMock-A.Tests.ps1
@@ -1,0 +1,30 @@
+# This script exists to create and mock a global function, then exit.  The actual behavior
+# that we need to test is covered in GlobalMock-B.Tests.ps1, where we make sure that the
+# global function was properly restored in its scope.
+
+$functionName = '01c1a57716fe4005ac1a7bf216f38ad0'
+
+if (Test-Path Function:\$functionName)
+{
+    Remove-Item Function:\$functionName -Force -ErrorAction Stop
+}
+
+function global:01c1a57716fe4005ac1a7bf216f38ad0
+{
+    return 'Original Function'
+}
+
+function script:Testing
+{
+    return 'Script scope'
+}
+
+Describe 'Mocking Global Functions - Part One' {
+    Mock $functionName {
+        return 'Mocked'
+    }
+
+    It 'Mocks the global function' {
+        & $functionName | Should Be 'Mocked'
+    }
+}

--- a/Functions/GlobalMock-B.Tests.ps1
+++ b/Functions/GlobalMock-B.Tests.ps1
@@ -1,0 +1,23 @@
+# This test depends on some state set up in GlobalMock-A.Tests.ps1.  The behavior we're verifying
+# is that global functions that have been mocked are still properly set up even after the test
+# script exits its scope.
+
+$functionName = '01c1a57716fe4005ac1a7bf216f38ad0'
+
+try
+{
+    Describe 'Mocking Global Functions - Part Two' {
+        It 'Restored the global function properly' {
+            $globalFunctionExists = Test-Path Function:\global:$functionName
+            $globalFunctionExists | Should Be $true
+            & $functionName | Should Be 'Original Function'
+        }
+    }
+}
+finally
+{
+    if (Test-Path Function:\$functionName)
+    {
+        Remove-Item Function:\$functionName -Force
+    }
+}

--- a/Functions/Mock.ps1
+++ b/Functions/Mock.ps1
@@ -583,7 +583,8 @@ function Exit-MockScope {
 function Validate-Command([string]$CommandName, [string]$ModuleName) {
     $module = $null
     $origCommand = $null
-    $commandInfo = $null
+
+    $commandInfo = New-Object psobject -Property @{ Command = $null; Scope = '' }
 
     $scriptBlock = {
         $command = $ExecutionContext.InvokeCommand.GetCommand($args[0], 'All')


### PR DESCRIPTION
This works, but there might be some weirdness that can still happen if you mock a global function in conjunction with -ModuleName or InModuleScope.  (The global function gets renamed for the duration of the mock, but the mock is only available from that single module.  You can't mock the same global function from two different modules at once.)

Not sure if it's worth worrying about that edge case, since this "mocking global functions" scenario  is already pretty rare to begin with.

Creating the PR to start discussion on this fix.