### PR TITLE
Fixes for #315 and #269

### DIFF
--- a/Functions/Mock.Tests.ps1
+++ b/Functions/Mock.Tests.ps1
@@ -611,15 +611,11 @@ Describe "When Calling Assert-MockCalled without exactly" {
     Mock FunctionUnderTest {}
     FunctionUnderTest "one"
     FunctionUnderTest "one"
-
-    try {
-        Assert-MockCalled FunctionUnderTest 3
-    } Catch {
-        $result=$_
-    }
+    FunctionUnderTest "two"
 
     It "Should throw if mock was not called atleast the number of times specified" {
-        $result.Exception.Message | Should Be "Expected FunctionUnderTest to be called at least 3 times but was called 2 times"
+        $scriptBlock = { Assert-MockCalled FunctionUnderTest 4 }
+        $scriptBlock | Should Throw "Expected FunctionUnderTest to be called at least 4 times but was called 3 times"
     }
 
     It "Should not throw if mock was called at least the number of times specified" {
@@ -628,6 +624,11 @@ Describe "When Calling Assert-MockCalled without exactly" {
 
     It "Should not throw if mock was called at exactly the number of times specified" {
         Assert-MockCalled FunctionUnderTest 2 { $param1 -eq "one" }
+    }
+
+    It "Should throw an error if any non-matching calls to the mock are made, and the -NotOtherwise switch is used" {
+        $scriptBlock = { Assert-MockCalled FunctionUnderTest -ParameterFilter { $param1 -eq 'one' } -NotOtherwise }
+        $scriptBlock | Should Throw '1 non-matching calls were made'
     }
 }
 

--- a/Functions/Mock.Tests.ps1
+++ b/Functions/Mock.Tests.ps1
@@ -626,8 +626,8 @@ Describe "When Calling Assert-MockCalled without exactly" {
         Assert-MockCalled FunctionUnderTest 2 { $param1 -eq "one" }
     }
 
-    It "Should throw an error if any non-matching calls to the mock are made, and the -NotOtherwise switch is used" {
-        $scriptBlock = { Assert-MockCalled FunctionUnderTest -ParameterFilter { $param1 -eq 'one' } -NotOtherwise }
+    It "Should throw an error if any non-matching calls to the mock are made, and the -ExclusiveFilter parameter is used" {
+        $scriptBlock = { Assert-MockCalled FunctionUnderTest -ExclusiveFilter { $param1 -eq 'one' } }
         $scriptBlock | Should Throw '1 non-matching calls were made'
     }
 }

--- a/Functions/Mock.ps1
+++ b/Functions/Mock.ps1
@@ -546,7 +546,7 @@ param(
     }
     elseif ($NotOtherwise -and $nonMatchingCalls.Count -gt 0)
     {
-        $failureMessage = "Expected ${commandName}${$moduleMessage} to only be called with with parameters matching the specified filter, but $($nonMatchingCalls.Count) non-matching calls were made"
+        $failureMessage = "Expected ${commandName}${moduleMessage} to only be called with with parameters matching the specified filter, but $($nonMatchingCalls.Count) non-matching calls were made"
         throw ( New-ShouldErrorRecord -Message $failureMessage -Line $line -LineText $lineText)
     }
 }

--- a/Functions/Mock.ps1
+++ b/Functions/Mock.ps1
@@ -377,6 +377,15 @@ An optional filter to qualify wich calls should be counted. Only those
 calls to the mock whose parameters cause this filter to return true
 will be counted.
 
+.PARAMETER ExlusiveFilter
+Like ParameterFilter, except when you use ExclusiveFilter, and there
+were any calls to the mocked command which do not match the filter,
+an exception will be thrown.  This is a convenient way to avoid needing
+to have two calls to Assert-MockCalled like this:
+
+Assert-MockCalled SomeCommand -Times 1 -ParameterFilter { $something -eq $true }
+Assert-MockCalled SomeCommand -Times 0 -ParameterFilter { $something -ne $true }
+
 .PARAMETER Scope
 An optional parameter specifying the Pester scope in which to check for
 calls to the mocked command.  By default, Assert-MockCalled will find
@@ -448,6 +457,13 @@ Describe 'Describe' {
 
 Checks for calls to the mock within the SomeModule module.  Note that both the Mock
 and Assert-MockCalled commands use the same module name.
+
+.EXAMPLE
+Assert-MockCalled Get-ChildItem -ExclusiveFilter { $Path -eq 'C:\' }
+
+Checks to make sure that Get-ChildItem was called at least one time with
+the -Path parameter set to 'C:\', and that it was not called at all with
+the -Path parameter set to any other value.
 
 .NOTES
 The parameter filter passed to Assert-MockCalled does not necessarily have to match the parameter filter


### PR DESCRIPTION
The new parameter for Assert-MockCalled is called `-NotOtherwise` for now, but I think we may want to come up with a better name.  Either way, the functionality is implemented now.

Assert-MockCalled now throws the same type of ErrorRecord objects as the Should command, which gets us better output as noted in #269.