### PR TITLE
Make errors in BeforeEach and AfterEach fail the test

### DIFF
--- a/Functions/SetupTeardown.Tests.ps1
+++ b/Functions/SetupTeardown.Tests.ps1
@@ -156,3 +156,5 @@ Describe 'Finishing TestGroup Setup and Teardown tests' {
         $script:ContextAfterAllCounter   | Should Be 1
     }
 }
+
+#Testing if failing setup or teardown will fail 'It' is done in the TestsRunningInCleanRunspace.Tests.ps1 file

--- a/Functions/SetupTeardown.ps1
+++ b/Functions/SetupTeardown.ps1
@@ -131,15 +131,7 @@ function Invoke-Blocks
     foreach ($block in $ScriptBlock)
     {
         if ($null -eq $block) { continue }
-
-        try
-        {
-            . $block
-        }
-        catch
-        {
-            Write-Error -ErrorRecord $_
-        }
+        . $block
     }
 }
 


### PR DESCRIPTION
The BeforeEach will fail the test if it throws any error. The After each
is guaranteed to run even if test fails and will also fail the test if
it throws any errors.