### PR TITLE
BeforeEach / etc enhancements, and Should Be bug fix

### DIFF
--- a/Functions/Assertions/Be.ps1
+++ b/Functions/Assertions/Be.ps1
@@ -50,8 +50,10 @@ function NotPesterBeExactlyFailureMessage($value, $expected) {
 function Get-CompareStringMessage {
     param(
         [Parameter(Mandatory=$true)]
+        [AllowEmptyString()]
         [String]$Expected,
         [Parameter(Mandatory=$true)]
+        [AllowEmptyString()]
         [String]$Actual,
         [switch]$CaseSensitive
     )
@@ -104,6 +106,7 @@ function Get-CompareStringMessage {
 function Expand-SpecialCharacters {
     param (
     [Parameter(Mandatory=$true,ValueFromPipeline=$true,ValueFromPipelineByPropertyName=$true)]
+    [AllowEmptyString()]
     [string[]]$InputObject)
     process {
         $InputObject -replace "`n","\n" -replace "`r","\r" -replace "`t","\t" -replace "`0", "\0" -replace "`b","\b"

--- a/Functions/SetupTeardown.Tests.ps1
+++ b/Functions/SetupTeardown.Tests.ps1
@@ -157,4 +157,30 @@ Describe 'Finishing TestGroup Setup and Teardown tests' {
     }
 }
 
+
+if ($PSVersionTable.PSVersion.Major -ge 3)
+{
+    $thisTestScriptFilePath = $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($PSCommandPath)
+
+    Describe 'Script Blocks and file association (testing automatic variables)' {
+        BeforeEach {
+            $commandPath = $PSCommandPath
+        }
+
+        $beforeEachBlock = InModuleScope Pester {
+            $pester.BeforeEach[0].ScriptBlock
+        }
+
+        It 'Creates script block objects associated with the proper file' {
+            $scriptBlockFilePath = $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($beforeEachBlock.File)
+
+            $scriptBlockFilePath | Should Be $thisTestScriptFilePath
+        }
+
+        It 'Has the correct automatic variable values inside the BeforeEach block' {
+            $commandPath | Should Be $PSCommandPath
+        }
+    }
+}
+
 #Testing if failing setup or teardown will fail 'It' is done in the TestsRunningInCleanRunspace.Tests.ps1 file

--- a/Functions/SetupTeardown.ps1
+++ b/Functions/SetupTeardown.ps1
@@ -141,6 +141,61 @@ function Add-SetupAndTeardown
         [scriptblock] $ScriptBlock
     )
 
+    if ($PSVersionTable.PSVersion.Major -le 2)
+    {
+        Add-SetupAndTeardownV2 -ScriptBlock $ScriptBlock
+    }
+    else
+    {
+        Add-SetupAndTeardownV3 -ScriptBlock $ScriptBlock
+    }
+}
+
+function Add-SetupAndTeardownV3
+{
+    param (
+        [scriptblock] $ScriptBlock
+    )
+
+    $pattern = '^(?:Before|After)(?:Each|All)$'
+    $predicate = {
+        param ([System.Management.Automation.Language.Ast] $Ast)
+
+        $Ast -is [System.Management.Automation.Language.CommandAst] -and
+        $Ast.CommandElements.Count -eq 2 -and
+        $Ast.CommandElements[0].ToString() -match $pattern -and
+        $Ast.CommandElements[1] -is [System.Management.Automation.Language.ScriptBlockExpressionAst]
+    }
+
+    $searchNestedBlocks = $false
+
+    $calls = $ScriptBlock.Ast.FindAll($predicate, $searchNestedBlocks)
+
+    foreach ($call in $calls)
+    {
+        # For some reason, calling ScriptBlockAst.GetScriptBlock() sometimes blows up due to failing semantics
+        # checks, even though the code is perfectly valid.  So we'll poke around with reflection again to skip
+        # that part and just call the internal ScriptBlock constructor that we need
+
+        $iPmdProviderType = [scriptblock].Assembly.GetType('System.Management.Automation.Language.IParameterMetadataProvider')
+
+        $flags = [System.Reflection.BindingFlags]'Instance, NonPublic'
+        $constructor = [scriptblock].GetConstructor($flags, $null, [Type[]]@($iPmdProviderType, [bool]), $null)
+
+        $block = $constructor.Invoke(@($call.CommandElements[1].ScriptBlock, $false))
+
+        Set-ScriptBlockScope -ScriptBlock $block -SessionState $pester.SessionState
+        $commandName = $call.CommandElements[0].ToString()
+        Add-SetupOrTeardownScriptBlock -CommandName $commandName -ScriptBlock $block
+    }
+}
+
+function Add-SetupAndTeardownV2
+{
+    param (
+        [scriptblock] $ScriptBlock
+    )
+
     $codeText = $ScriptBlock.ToString()
     $tokens = ParseCodeIntoTokens -CodeText $codeText
 
@@ -152,7 +207,10 @@ function Add-SetupAndTeardown
             (IsSetupOrTeardownCommand -CommandName $token.Content))
         {
             $openBraceIndex, $closeBraceIndex = Get-BraceIndecesForCommand -Tokens $tokens -CommandIndex $i
-            Add-SetupTeardownFromTokens -Tokens $tokens -CommandIndex $i -OpenBraceIndex $openBraceIndex -CloseBraceIndex $closeBraceIndex -CodeText $codeText
+
+            $block = Get-ScriptBlockFromTokens -Tokens $Tokens -OpenBraceIndex $openBraceIndex -CloseBraceIndex $closeBraceIndex -CodeText $codeText
+            Add-SetupOrTeardownScriptBlock -CommandName $token.Content -ScriptBlock $block
+
             $i = $closeBraceIndex
         }
         elseif ($type -eq [System.Management.Automation.PSTokenType]::GroupStart)
@@ -291,48 +349,55 @@ function Get-GroupCloseTokenIndex
     return $closeIndex
 }
 
-function Add-SetupTeardownFromTokens
+function Get-ScriptBlockFromTokens
 {
     param (
         [System.Management.Automation.PSToken[]] $Tokens,
-        [int] $CommandIndex,
         [int] $OpenBraceIndex,
         [int] $CloseBraceIndex,
         [string] $CodeText
     )
 
-    $commandName = $Tokens[$CommandIndex].Content
-
     $blockStart = $Tokens[$OpenBraceIndex + 1].Start
     $blockLength = $Tokens[$CloseBraceIndex].Start - $blockStart
     $setupOrTeardownCodeText = $codeText.Substring($blockStart, $blockLength)
 
-    $setupOrTeardownBlock = [scriptblock]::Create($setupOrTeardownCodeText)
-    Set-ScriptBlockScope -ScriptBlock $setupOrTeardownBlock -SessionState $pester.SessionState
+    $scriptBlock = [scriptblock]::Create($setupOrTeardownCodeText)
+    Set-ScriptBlockScope -ScriptBlock $scriptBlock -SessionState $pester.SessionState
 
-    $isSetupCommand = IsSetupCommand -CommandName $commandName
-    $isGroupCommand = IsTestGroupCommand -CommandName $commandName
+    return $scriptBlock
+}
+
+function Add-SetupOrTeardownScriptBlock
+{
+    param (
+        [string] $CommandName,
+        [scriptblock] $ScriptBlock
+    )
+
+    $isSetupCommand = IsSetupCommand -CommandName $CommandName
+    $isGroupCommand = IsTestGroupCommand -CommandName $CommandName
 
     if ($isSetupCommand)
     {
         if ($isGroupCommand)
         {
-            Add-BeforeAll -ScriptBlock $setupOrTeardownBlock
+            Add-BeforeAll -ScriptBlock $ScriptBlock
         }
         else
         {
-            Add-BeforeEach -ScriptBlock $setupOrTeardownBlock
+            Add-BeforeEach -ScriptBlock $ScriptBlock
         }
     }
     else
     {
         if ($isGroupCommand)
         {
-            Add-AfterAll -ScriptBlock $setupOrTeardownBlock
+            Add-AfterAll -ScriptBlock $ScriptBlock
         }
         else
         {
-            Add-AfterEach -ScriptBlock $setupOrTeardownBlock
+            Add-AfterEach -ScriptBlock $ScriptBlock
         }
     }
 }


### PR DESCRIPTION
Fixes for #329 and #319 included for v3+.  Also fixes a bug with Should Be / Should BeExactly where they would blow up if empty strings were piped in.