### PR TITLE
Add hit commands property to CodeCoverage object

### DIFF
--- a/Functions/Coverage.Tests.ps1
+++ b/Functions/Coverage.Tests.ps1
@@ -64,6 +64,14 @@ InModuleScope Pester {
                 $coverageReport.MissedCommands[0].Command | Should Be "'I am function two.  I never get called.'"
             }
 
+            It 'Reports the proper number of hit commands' {
+                $coverageReport.HitCommands.Count | Should Be 6
+            }
+
+            It 'Reports the correct hit command' {
+                $coverageReport.HitCommands[0].Command | Should Be "'I am the nested function.'"
+            }
+
             Exit-CoverageAnalysis -PesterState $testState
         }
 
@@ -95,6 +103,10 @@ InModuleScope Pester {
                 $coverageReport.MissedCommands[0].Command | Should Be "'I am function two.  I never get called.'"
             }
 
+            It 'Reports the proper number of hit commands' {
+                $coverageReport.HitCommands.Count | Should Be 0
+            }
+
             Exit-CoverageAnalysis -PesterState $testState
         }
 
@@ -122,6 +134,14 @@ InModuleScope Pester {
                 $coverageReport.MissedCommands.Count | Should Be 0
             }
 
+            It 'Reports the proper number of hit commands' {
+                $coverageReport.HitCommands.Count | Should Be 5
+            }
+
+            It 'Reports the correct hit command' {
+                $coverageReport.HitCommands[0].Command | Should Be "'I am the nested function.'"
+            }
+
             Exit-CoverageAnalysis -PesterState $testState
         }
 
@@ -147,6 +167,14 @@ InModuleScope Pester {
 
             It 'Reports the proper number of missed commands' {
                 $coverageReport.MissedCommands.Count | Should Be 0
+            }
+
+            It 'Reports the proper number of hit commands' {
+                $coverageReport.HitCommands.Count | Should Be 2
+            }
+
+            It 'Reports the correct hit command' {
+                $coverageReport.HitCommands[0].Command | Should Be "'I am functionOne'"
             }
 
             Exit-CoverageAnalysis -PesterState $testState
@@ -182,6 +210,14 @@ InModuleScope Pester {
 
             It 'Reports the correct missed command' {
                 $coverageReport.MissedCommands[0].Command | Should Be "'I am function two.  I never get called.'"
+            }
+
+            It 'Reports the proper number of hit commands' {
+                $coverageReport.HitCommands.Count | Should Be 5
+            }
+
+            It 'Reports the correct hit command' {
+                $coverageReport.HitCommands[0].Command | Should Be "'I am the nested function.'"
             }
 
             Exit-CoverageAnalysis -PesterState $testState

--- a/Functions/Coverage.ps1
+++ b/Functions/Coverage.ps1
@@ -474,6 +474,12 @@ function Get-CoverageMissedCommands
     $CommandCoverage | Where-Object { $_.Breakpoint.HitCount -eq 0 }
 }
 
+function Get-CoverageHitCommands
+{
+    param ([object[]] $CommandCoverage)
+    $CommandCoverage | Where-Object { $_.Breakpoint.HitCount -gt 0 }
+}
+
 function Get-CoverageReport
 {
     param ([object] $PesterState)
@@ -481,6 +487,7 @@ function Get-CoverageReport
     $totalCommandCount = $PesterState.CommandCoverage.Count
 
     $missedCommands = @(Get-CoverageMissedCommands -CommandCoverage $PesterState.CommandCoverage | Select-Object File, Line, Function, Command)
+    $hitCommands = @(Get-CoverageHitCommands -CommandCoverage $PesterState.CommandCoverage | Select-Object File, Line, Function, Command)
     $analyzedFiles = @($PesterState.CommandCoverage | Select-Object -ExpandProperty File -Unique)
     $fileCount = $analyzedFiles.Count
 
@@ -492,6 +499,7 @@ function Get-CoverageReport
         NumberOfCommandsExecuted = $executedCommandCount
         NumberOfCommandsMissed   = $missedCommands.Count
         MissedCommands           = $missedCommands
+        HitCommands              = $hitCommands
         AnalyzedFiles            = $analyzedFiles
     }
 }


### PR DESCRIPTION
Add hit commands property to CodeCoverage object, by exposing the data pester already has.

I believe this helps address #212 by allowing the creation of adapter/translators that can create code coverage reports rather than making pester proper responsible for it.

This would not prevent pester for generating reports itself in the future, but different users may have different needs and I cannot find a clear solution to which report is best. This method would allow for easier experimentation.