### PR TITLE
Corrected spelling and capitalization in help and comments.

### DIFF
--- a/Functions/Coverage.ps1
+++ b/Functions/Coverage.ps1
@@ -314,7 +314,7 @@ function IsIgnoredCommand
 
         if (IsChildOfHashtableDynamicKeyword -Command $Command)
         {
-            # The lines inside DSC resource declarations don't trigger their breakpooints when executed,
+            # The lines inside DSC resource declarations don't trigger their breakpoints when executed,
             # just like the "configuration" keyword itself.  I don't know why, at this point, but just like
             # configuration, we'll ignore it so it doesn't clutter up the coverage analysis with useless junk.
             return $true

--- a/Functions/In.ps1
+++ b/Functions/In.ps1
@@ -1,7 +1,7 @@
 function In {
 <#
 .SYNOPSIS
-A convenience function that executes a scrit from a specified path.
+A convenience function that executes a script from a specified path.
 
 .DESCRIPTION
 Before the script block passed to the execute parameter is invoked,

--- a/Functions/New-Fixture.ps1
+++ b/Functions/New-Fixture.ps1
@@ -66,7 +66,7 @@ function New-Fixture {
         [String]$Name
     )
     #region File contents
-    #keep this formatted as is. the forma is output to the file as is, including indentation
+    #keep this formatted as is. the format is output to the file as is, including indentation
     $scriptCode = "function $name {`r`n`r`n}"
 
     $testCode = '$here = Split-Path -Parent $MyInvocation.MyCommand.Path

--- a/en-US/about_BeforeEach_AfterEach.help.txt
+++ b/en-US/about_BeforeEach_AfterEach.help.txt
@@ -4,7 +4,7 @@ BeforeEach, AfterEach, BeforeAll, and AfterAll
 The BeforeEach and AfterEach commands allow you to define setup and teardown tasks that are
 performed at the beginning and end of every It block. This can eliminate duplication of code
 in test scripts, ensure that each test is performed on a pristine state regardless of their
-order, and perform any necessary cleanup tasks after each test.
+order, and perform any necessary clean-up tasks after each test.
 
 BeforeEach and AfterEach blocks may be defined inside of any Describe or Context. If they
 are present in both a Context and its parent Describe, BeforeEach blocks in the Describe scope

--- a/en-US/about_Mocking.help.txt
+++ b/en-US/about_Mocking.help.txt
@@ -10,7 +10,7 @@ SYNOPSIS
 DESCRIPTION
 	With the set of Mocking functions that Pester exposes, one can:
 
-	- Mock the behavior of ANY powershell command.
+	- Mock the behavior of ANY PowerShell command.
 	- Verify that specific commands were (or were not) called.
 	- Verify the number of times a command was called with a set of specified 
 	 parameters.

--- a/en-US/about_Pester.help.txt
+++ b/en-US/about_Pester.help.txt
@@ -6,22 +6,22 @@ SYNOPSIS
 
 DESCRIPTION
 	Pester provides a framework for running Unit Tests to execute and validate 
-	Powershell commands. Pester follows a file naming convention for naming 
+	PowerShell commands. Pester follows a file naming convention for naming 
 	tests to be discovered by pester at test time and a simple set of 
 	functions that expose a Testing DSL for isolating, running, evaluating and 
-	reporting the results of Powershell commands.
+	reporting the results of PowerShell commands.
 
-	Pester tests can execute any command or script that is accesible to a 
-	pester test file. This can include functions, Cmdlets, Modules and scripts. 
+	Pester tests can execute any command or script that is accessible to a 
+	pester test file. This can include functions, cmdlets, modules and scripts. 
 	Pester can be run in ad hoc style in a console or it can be integrated into 
 	the Build scripts of a Continuous Integration system.
 
 	Pester also contains a powerful set of Mocking Functions that allow tests to 
 	mimic and mock the functionality of any command inside of a piece of 
-	powershell code being tested. See about_Mocking.
+	PowerShell code being tested. See about_Mocking.
 
 CREATING A PESTER TEST
-	To start using Pester, You may use the Add-Fixture function to scaffold both 
+	To start using Pester, you may use the Add-Fixture function to scaffold both 
 	a new implementation function and a test function.
 
 	C:\PS>New-Fixture deploy Clean
@@ -52,7 +52,7 @@ CREATING A PESTER TEST
     Each It block should test one thing and throw an exception if the test 
     fails. Pester will consider any It block that throws an exception to be a 
     failed test. Pester provides a set of extensions that can perform various 
-    comparisons between the values emited or altered by a test and an expected 
+    comparisons between the values emitted or altered by a test and an expected 
     value (see about_Should). 
 
 RUNNNING A PESTER TEST
@@ -115,7 +115,7 @@ PESTER AND CONTINUOUS INTEGRATION
 	<Exec Command="cmd /c $(baseDir)pester\bin\pester.bat" />
 	</Target>
 
-	This will start a powershell session, import the Pester Module and call 
+	This will start a PowerShell session, import the Pester Module and call 
 	invoke pester within the current directory. If any test fails, it will 
 	return an exit code equal to the number of failed tests and all test 
 	results will be saved to Test.xml using NUnit's Schema allowing you to 
@@ -126,7 +126,7 @@ OTHER EXAMPLES
 	Pester's own tests. See all files in the Pester Functions folder 
 	containing *Tests.ps1
 	
-	Chocolatey tests. Chocolatey is a popular powershell based Windows 
+	Chocolatey tests. Chocolatey is a popular PowerShell based Windows 
 	package management system. It uses Pester tests to validate its own 
 	functionality.
 

--- a/en-US/about_TestDrive.help.txt
+++ b/en-US/about_TestDrive.help.txt
@@ -6,10 +6,10 @@ SYNOPSIS
 	Context block.
 
 DESCRIPTION	
-	A test may need to work with file operations and validate certain tyes of 
+	A test may need to work with file operations and validate certain types of 
 	file activities. It is usually desirable not to perform file activity tests 
 	that will produce side effects outside of an individual test. Pester 
-	creates a PSDrive inside the user's temporary drive that is accesible via a 
+	creates a PSDrive inside the user's temporary drive that is accessible via a 
 	names PSDrive TestDrive:. Pester will remove this drive after the test 
 	completes. You may use this drive to isolate the file operations of your 
 	test to a temporary store.

--- a/en-US/about_should.help.txt
+++ b/en-US/about_should.help.txt
@@ -44,7 +44,7 @@ SHOULD MEMBERS
 
 	Exist
 		Does not perform any comparison but checks if the object calling Exist 
-		is presnt in a PS Provider. The object must have valid path syntax. It 
+		is present in a PS Provider. The object must have valid path syntax. It 
 		essentially must pass a Test-Path call.
 
         $actual=(Dir . )[0].FullName


### PR DESCRIPTION
Noticed some typos and the like in the help files.