### PR TITLE
Fix Should Exist assertion to handle paths with [ ]

### DIFF
--- a/Functions/Assertions/Exist.Tests.ps1
+++ b/Functions/Assertions/Exist.Tests.ps1
@@ -9,5 +9,11 @@ InModuleScope Pester {
         It "returns false for paths do not exist" {
             Test-NegativeAssertion (PesterExist "$TestDrive\nonexistant")
         }
+
+        It "returns correct value for path that contains [ ]" {
+            $file = New-Item -Path "TestDrive:\[test].txt" -ItemType File
+
+            $file | Should Exist
+        }
     }
 }

--- a/Functions/Assertions/Exist.Tests.ps1
+++ b/Functions/Assertions/Exist.Tests.ps1
@@ -10,10 +10,27 @@ InModuleScope Pester {
             Test-NegativeAssertion (PesterExist "$TestDrive\nonexistant")
         }
 
-        It "returns correct value for path that contains [ ]" {
-            $file = New-Item -Path "TestDrive:\[test].txt" -ItemType File
+        It 'works for path with escaped [ ] characters' {
+            New-Item -Path "TestDrive:\[test].txt" -ItemType File | Out-Null
+            "TestDrive:\``[test``].txt"  | Should Exist
+        }
 
-            $file | Should Exist
+        It 'returns correct result for function drive' {
+            function f1 {}
+
+            'function:f1' | Should Exist
+        }
+
+        It 'returns correct result for env drive' {
+            $env:test = 'somevalue'
+
+            'env:test' | Should Exist
+        }
+
+        It 'returns correct result for env drive' {
+            $env:test = 'somevalue'
+
+            'env:test' | Should Exist
         }
     }
 }

--- a/Functions/Assertions/Exist.ps1
+++ b/Functions/Assertions/Exist.ps1
@@ -1,6 +1,7 @@
 
 function PesterExist($value) {
-    return (Test-Path $value)
+    $resolvedPath = $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($value)
+    Test-Path -LiteralPath $resolvedPath
 }
 
 function PesterExistFailureMessage($value) {
@@ -10,5 +11,3 @@ function PesterExistFailureMessage($value) {
 function NotPesterExistFailureMessage($value) {
     return "Expected: ${value} to not exist, but it was found"
 }
-
-

--- a/Functions/Assertions/Exist.ps1
+++ b/Functions/Assertions/Exist.ps1
@@ -1,7 +1,6 @@
 
 function PesterExist($value) {
-    $resolvedPath = $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($value)
-    Test-Path -LiteralPath $resolvedPath
+    Test-Path $value
 }
 
 function PesterExistFailureMessage($value) {


### PR DESCRIPTION
Fixing bug which caused that paths that contain [ ] wildcard were not
handled correctly by the Should Exist assertion.

It's morning am not 100 % sure that this won't break anything. But my reasoning is that any path that is provided is expanded by PowerShell (like path with environment variables) so no special handling is needed there. Same goes for PS(Provider)Paths... nothing else comes to mind. 

Review please. :)

Fixes #343 