### PR TITLE
Fix for mocking cmdlets with an -ArgumentList parameter

### DIFF
--- a/Functions/Mock.Tests.ps1
+++ b/Functions/Mock.Tests.ps1
@@ -1292,3 +1292,15 @@ Describe 'Mocking commands with potentially ambigious parameter sets' {
         Assert-MockCalled SomeFunction -ParameterFilter { $p1 -eq 'Whatever' }
     }
 }
+
+Describe 'When mocking a command that has an ArgumentList parameter with validation' {
+    Mock Start-Process { return 'mocked' }
+
+    It 'Calls the mock properly' {
+        $hash = @{ Result = $null }
+        $scriptBlock = { $hash.Result = Start-Process -FilePath cmd.exe -ArgumentList '/c dir c:\' }
+        
+        $scriptBlock | Should Not Throw
+        $hash.Result | Should Be 'mocked'
+    }
+}

--- a/Functions/Mock.Tests.ps1
+++ b/Functions/Mock.Tests.ps1
@@ -1299,7 +1299,7 @@ Describe 'When mocking a command that has an ArgumentList parameter with validat
     It 'Calls the mock properly' {
         $hash = @{ Result = $null }
         $scriptBlock = { $hash.Result = Start-Process -FilePath cmd.exe -ArgumentList '/c dir c:\' }
-        
+
         $scriptBlock | Should Not Throw
         $hash.Result | Should Be 'mocked'
     }

--- a/Functions/Mock.ps1
+++ b/Functions/Mock.ps1
@@ -740,10 +740,10 @@ function MockPrototype {
         [string] $IgnoreErrorPreference = 'SilentlyContinue'
     }
 
-    [object] $ArgumentList = Get-Variable -Name args -ValueOnly -Scope Local -ErrorAction $IgnoreErrorPreference
-    if ($null -eq $ArgumentList) { $ArgumentList = @() }
+    [object] ${a r g s} = Get-Variable -Name args -ValueOnly -Scope Local -ErrorAction $IgnoreErrorPreference
+    if ($null -eq ${a r g s}) { ${a r g s} = @() }
 
-    Invoke-Mock -CommandName '#FUNCTIONNAME#' -ModuleName '#MODULENAME#' -BoundParameters $PSBoundParameters -ArgumentList $ArgumentList
+    Invoke-Mock -CommandName '#FUNCTIONNAME#' -ModuleName '#MODULENAME#' -BoundParameters $PSBoundParameters -ArgumentList ${a r g s}
 }
 
 function Invoke-Mock {


### PR DESCRIPTION
Fixes #353 .  $ArgumentList variable in the MockPrototype code has been renamed to ${a r g s}, to avoid naming / validation conflicts.