### PR TITLE
Feature/issue 363 - Fixes nunit reports generating the incorrect data and also enables an -ignore flag.

### DIFF
--- a/Functions/It.Tests.ps1
+++ b/Functions/It.Tests.ps1
@@ -51,6 +51,11 @@ InModuleScope Pester {
             $scriptBlock | Should Not Throw
         }
 
+        It 'Does not throw an error if the -Ignore switch is used, and no script block is passed' {
+            $scriptBlock = { ItImpl -Pester $testState 'Some Name' -Ignore }
+            $scriptBlock | Should Not Throw
+        }
+
         It 'Creates a pending test for an empty (whitespace and comments only) script block' {
             $scriptBlock = {
                 # Single-Line comment

--- a/Functions/It.ps1
+++ b/Functions/It.ps1
@@ -110,6 +110,7 @@ about_should
         [Switch] $Pending,
 
         [Parameter(ParameterSetName = 'Skip')]
+        [Alias('Ignore')]
         [Switch] $Skip
     )
 
@@ -129,6 +130,7 @@ function ItImpl
         [Switch] $Pending,
 
         [Parameter(ParameterSetName = 'Skip')]
+        [Alias('Ignore')]
         [Switch] $Skip,
 
         $Pester,
@@ -221,6 +223,7 @@ function Invoke-Test
         [Switch] $Pending,
 
         [Parameter(ParameterSetName = 'Skip')]
+        [Alias('Ignore')]
         [Switch] $Skip
     )
 

--- a/Functions/TestResults.Tests.ps1
+++ b/Functions/TestResults.Tests.ps1
@@ -163,7 +163,7 @@ InModuleScope Pester {
 
             $xmlTestSuite2 = $xmlResult.'test-results'.'test-suite'.results.'test-suite'[1]
             $xmlTestSuite2.name     | Should Be "Skipped"
-            $xmlTestSuite2.result   | Should Be "Skipped"
+            $xmlTestSuite2.result   | Should Be "Ignored"
             $xmlTestSuite2.success  | Should Be "True"
 
             $xmlTestSuite3 = $xmlResult.'test-results'.'test-suite'.results.'test-suite'[2]


### PR DESCRIPTION
This pull request addresses Issue #363. I've left the "skip" syntax in place, but have added the alias "ignore" for those who are more familiar with nunit.
I've also modified the nunit reports being generated to not only change from skipped to ignored, but also to fix the run count, removing the number of skipped/ignored count from the number of total tests run.

Please see the screenshot to compare my libraries master branch with that of my pester-tests branch. As you can see, the total number of tests represented is still the same, but it now reports the number of skipped/ignored tests as well.

![](http://i.imgur.com/vTgNHff.png)

Also, [here is a discussion](https://groups.google.com/forum/#!topic/nunit-discuss/GH5Zp_WWOdw) on the topic of ignore vs skip. 