### PR TITLE
Fix Unicode issue in `Contain` and `ContainExactly`.

### DIFF
--- a/Functions/Assertions/Contain.Tests.ps1
+++ b/Functions/Assertions/Contain.Tests.ps1
@@ -1,18 +1,24 @@
-Set-StrictMode -Version Latest
+﻿Set-StrictMode -Version Latest
 
 InModuleScope Pester {
     Describe "PesterContain" {
         Context "when testing file contents" {
-            Setup -File "test.txt" "this is line 1`nrush is awesome"
+            Setup -File "test.txt" "this is line 1`nrush is awesome`nAnd this is Unicode: ☺"
+
             It "returns true if the file contains the specified content" {
                 Test-PositiveAssertion (PesterContain "$TestDrive\test.txt" "rush")
             }
+
             It "returns true if the file contains the specified content with different case" {
                 Test-PositiveAssertion (PesterContain "$TestDrive\test.txt" "RUSH")
             }
 
             It "returns false if the file does not contain the specified content" {
                 Test-NegativeAssertion (PesterContain "$TestDrive\test.txt" "slime")
+            }
+
+            It "returns true if the file contains the specified UTF8 content" {
+                Test-PositiveAssertion (PesterContain "$TestDrive\test.txt" "☺")
             }
         }
     }

--- a/Functions/Assertions/Contain.ps1
+++ b/Functions/Assertions/Contain.ps1
@@ -1,6 +1,6 @@
 
 function PesterContain($file, $contentExpecation) {
-    return ((Get-Content $file) -match $contentExpecation)
+    return ((Get-Content -Encoding UTF8 $file) -match $contentExpecation)
 }
 
 function PesterContainFailureMessage($file, $contentExpecation) {

--- a/Functions/Assertions/ContainExactly.Tests.ps1
+++ b/Functions/Assertions/ContainExactly.Tests.ps1
@@ -1,15 +1,19 @@
-Set-StrictMode -Version Latest
+﻿Set-StrictMode -Version Latest
 
 InModuleScope Pester {
     Describe "PesterContainExactly" {
         Context "when testing file contents" {
-            Setup -File "test.txt" "this is line 1`nPester is awesome"
+            Setup -File "test.txt" "this is line 1`nPester is awesome`nAnd this is Unicode: ☺"
             It "returns true if the file contains the specified content exactly" {
                 Test-PositiveAssertion (PesterContainExactly "$TestDrive\test.txt" "Pester")
             }
 
             It "returns false if the file does not contain the specified content exactly" {
                 Test-NegativeAssertion (PesterContainExactly "$TestDrive\test.txt" "pESTER")
+            }
+
+            It "returns true if the file contains the specified Unicode content exactyle" {
+                Test-PositiveAssertion (PesterContainExactly "$TestDrive\test.txt" "☺")
             }
         }
     }

--- a/Functions/Assertions/ContainExactly.ps1
+++ b/Functions/Assertions/ContainExactly.ps1
@@ -1,6 +1,5 @@
-
 function PesterContainExactly($file, $contentExpecation) {
-    return ((Get-Content $file) -cmatch $contentExpecation)
+    return ((Get-Content -Encoding UTF8 $file) -cmatch $contentExpecation)
 }
 
 function PesterContainExactlyFailureMessage($file, $contentExpecation) {


### PR DESCRIPTION
fix #377

These are the only places where `Get-Content` is used in assertions.