### PR TITLE
Two simple fixes

### DIFF
--- a/Functions/It.ps1
+++ b/Functions/It.ps1
@@ -241,8 +241,6 @@ function Invoke-Test
     }
     else
     {
-        Write-Progress -Activity "Running test '$Name'" -Status Processing
-
         $errorRecord = $null
         try
         {
@@ -277,7 +275,6 @@ function Invoke-Test
         $result = Get-PesterResult -ErrorRecord $errorRecord
         $orderedParameters = Get-OrderedParameterDictionary -ScriptBlock $ScriptBlock -Dictionary $Parameters
         $Pester.AddTestResult( $result.name, $result.Result, $null, $result.FailureMessage, $result.StackTrace, $ParameterizedSuiteName, $orderedParameters )
-        Write-Progress -Activity "Running test '$Name'" -Completed -Status Processing
     }
 
     if ($null -ne $OutputScriptBlock)

--- a/Functions/PesterState.ps1
+++ b/Functions/PesterState.ps1
@@ -110,6 +110,7 @@ function New-PesterState
             }
 
             $script:CurrentTest = $Name
+            $script:MostRecentTimestamp = $script:Stopwatch.Elapsed
         }
 
         function LeaveTest

--- a/Pester.psm1
+++ b/Pester.psm1
@@ -185,8 +185,6 @@ about_pester
     $pester = New-PesterState -TestNameFilter $TestName -TagFilter ($Tag -split "\s") -ExcludeTagFilter ($ExcludeTag -split "\s") -SessionState $PSCmdlet.SessionState -Strict:$Strict -Quiet:$Quiet
     Enter-CoverageAnalysis -CodeCoverage $CodeCoverage -PesterState $pester
 
-    Write-Screen "`r`n`r`n`r`n`r`n"
-
     $invokeTestScript = {
         param (
             [Parameter(Position = 0)]
@@ -205,6 +203,7 @@ about_pester
 
     foreach ($testScript in $testScripts)
     {
+        Write-Progress -Activity 'Running Tests... ' -Status $testScript.Path -PercentComplete ((($cnt++ +1)/ $testScripts.Count) * 100);
         try
         {
             do

--- a/Pester.psm1
+++ b/Pester.psm1
@@ -199,11 +199,12 @@ about_pester
 
     Set-ScriptBlockScope -ScriptBlock $invokeTestScript -SessionState $PSCmdlet.SessionState
 
-    $testScripts = ResolveTestScripts $Script
+    # force array type so we always have a length property, even in case only a single test script is used.
+    [Array] $testScripts = ResolveTestScripts $Script
 
     foreach ($testScript in $testScripts)
     {
-        Write-Progress -Activity 'Running Tests... ' -Status $testScript.Path -PercentComplete ((($cnt++ +1)/ $testScripts.Count) * 100);
+        Write-Progress -Activity 'Running Tests... ' -Status $testScript.Path -PercentComplete ((($cnt++) / $testScripts.Length) * 100)
         try
         {
             do


### PR DESCRIPTION
The calls to Write-Progress are now simplified, and the progress bar now displays incremental progress.
Timing measurements are now more accurate for the first tests in a context as well.
