### PR TITLE
Fixed mocking of New-Object

### DIFF
--- a/Functions/Mock.Tests.ps1
+++ b/Functions/Mock.Tests.ps1
@@ -1328,3 +1328,18 @@ Describe 'When mocking a command that has an ArgumentList parameter with validat
         $hash.Result | Should Be 'mocked'
     }
 }
+
+# These assertions won't actually "fail"; we had an infinite recursion bug in Get-DynamicParametersForCmdlet
+# if the caller mocked New-Object.  It should be fixed by making that call to New-Object module-qualified,
+# and this test will make sure it's working properly.  If this test fails, it'll take a really long time
+# to execute, and then will throw a stack overflow error.
+
+Describe 'Mocking New-Object' {
+    It 'Works properly' {
+        Mock New-Object
+
+        $result = New-Object -TypeName Object
+        $result | Should Be $null
+        Assert-MockCalled New-Object
+    }
+}

--- a/Functions/Mock.ps1
+++ b/Functions/Mock.ps1
@@ -1122,7 +1122,7 @@ function Get-DynamicParametersForCmdlet
         $PSCmdlet.ThrowTerminatingError($_)
     }
 
-    $cmdlet = New-Object $command.ImplementingType.FullName
+    $cmdlet = Microsoft.PowerShell.Utility\New-Object $command.ImplementingType.FullName
     if ($cmdlet -isnot [System.Management.Automation.IDynamicParameters])
     {
         return


### PR DESCRIPTION
Dynamic parameter code had an unqualified call to New-Object, which would cause an infinite recursion / stack overflow error if the tests mocked New-Object.