### PR TITLE
Fix link to "what's new" wiki page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 __Build Status:__ [![Build status](https://build.powershell.org/guestAuth/app/rest/builds/buildType:(id:Pester_TestPester)/statusIcon)](https://build.powershell.org/project.html?projectId=Pester&tab=projectOverview&guest=1)
 
-Pester 3.0 has been released!  To see a list of changes in this version, refer to the [What's New in Pester 3.0?](https://github.com/pester/Pester/wiki/What's-New-in-Pester-3.0%3F) Wiki page.
+Pester 3.0 has been released!  To see a list of changes in this version, refer to the [What's New in Pester 3.0?](https://github.com/pester/Pester/wiki/What's-New-in-Pester-3.0) Wiki page.
 
 ---
 


### PR DESCRIPTION
The link to the "What's New in Pester 3.0?" wiki article was broken, as it mistakenly included the question mark in the URL (encoded as %3F).