### PR TITLE
fix dynamic parameter mocks post build 10565

### DIFF
--- a/Functions/Mock.ps1
+++ b/Functions/Mock.ps1
@@ -209,6 +209,12 @@ about_Mocking
             $null = $metadata.Parameters.Remove('OutVariable')
             $null = $metadata.Parameters.Remove('OutBuffer')
 
+            # Some versions of powershell may include dynamic parameters here
+            # We will filter them out and add them at the end to be
+            # compatible with both earlier and later versions
+            $dynamicParams = $metadata.Parameters.Values | ? {$_.IsDynamic}
+            $dynamicparams | % { $null = $metadata.Parameters.Remove($_.name) }
+
             $cmdletBinding = [Management.Automation.ProxyCommand]::GetCmdletBindingAttribute($metadata)
             $paramBlock    = [Management.Automation.ProxyCommand]::GetParamBlock($metadata)
 

--- a/Functions/Mock.ps1
+++ b/Functions/Mock.ps1
@@ -213,7 +213,9 @@ about_Mocking
             # We will filter them out and add them at the end to be
             # compatible with both earlier and later versions
             $dynamicParams = $metadata.Parameters.Values | ? {$_.IsDynamic}
-            $dynamicparams | % { $null = $metadata.Parameters.Remove($_.name) }
+            if($dynamicParams -ne $null) {
+                $dynamicparams | % { $null = $metadata.Parameters.Remove($_.name) }
+            }
 
             $cmdletBinding = [Management.Automation.ProxyCommand]::GetCmdletBindingAttribute($metadata)
             $paramBlock    = [Management.Automation.ProxyCommand]::GetParamBlock($metadata)


### PR DESCRIPTION
After updating to the most recent windows 10 insider build 10565, some mocks have started to raise errors during testing. An example is when mocking `Test-Path`. This results in:
```
    [-] Error occurred in Context block 638ms
      A parameter with the name 'OlderThan' was defined multiple times for the command.
```
In previous windows builds, the `Parameters` of a `CommandMetadata` instance will not return dynamic parameters. The dynamic parameters are later added to the mocked command in `Get-DynamicParamBlock`. In build 10565, dynamic parameters are included in the metadata parameters dictionary. So when the dynamic parameters are added later, the mock ends up with duplicate parameters causing the error seen above.

`Test-Path` for instance includes 2 dynamic parameters so mocking it will result in this error.

This PR filters any dynamic parameters up front out of the initial metadata which should keep compatibility with both post 10565 and builds prior since earlier builds will not return any dynamic parameters from the metadata and therefore will not remove any params.