### PR TITLE
improved suport for pipeline processing with begin block

### DIFF
--- a/Pester.psd1
+++ b/Pester.psd1
@@ -45,7 +45,8 @@ FunctionsToExport = @(
     'BeforeAll',
     'AfterAll'
     'Get-MockDynamicParameters',
-    'Set-DynamicParameterVariables'
+    'Set-DynamicParameterVariables',
+    'Select-NonPipelinedBoundParameters'
 )
 
 # # Cmdlets to export from this module

--- a/Pester.psm1
+++ b/Pester.psm1
@@ -379,6 +379,6 @@ if ((Test-Path -Path Variable:\psise) -and ($null -ne $psISE) -and ($PSVersionTa
 }
 
 Export-ModuleMember Describe, Context, It, In, Mock, Assert-VerifiableMocks, Assert-MockCalled
-Export-ModuleMember New-Fixture, Get-TestDriveItem, Should, Invoke-Pester, Setup, InModuleScope, Invoke-Mock
+Export-ModuleMember New-Fixture, Get-TestDriveItem, Should, Invoke-Pester, Setup, InModuleScope, Invoke-Mock, Select-NonPipelinedBoundParameters
 Export-ModuleMember BeforeEach, AfterEach, BeforeAll, AfterAll
 Export-ModuleMember Get-MockDynamicParameters, Set-DynamicParameterVariables


### PR DESCRIPTION
This fixes scenarios where a mocked function is an advanced function and initializes state in a `Begin` block. Here is an example:
```
function PipelineInputFunction {
    param(
        [Parameter(ValueFromPipeline=$True)]
        [int]$PipeInt1
    )
    begin{
        $p = 0
    }
    process {
        foreach($i in $input)
        {
            $p += 1
            write-output $p
        }
    }
}
```
Currently, if pester mock the above function and the function is called piping an array as input, the `Begin` block will be called for each item in the array.

This PR fixes this.

First, it changes the mock prototype to be wrapped in an `End` block and batches any pipeline input into an array. Then it filters out all bound parameters that were bound from the pipeline and finally calls the mock (or the original function if the parameter filter does not pass) with the original calling pipeline and bound parameters.

This definitely got more hairy than I would have liked.  was really hoping NOT to have to written the `Select-NonPipelinedBoundParameters` function but could find no invocation metadata getting me what I needed. In the event that the parameter filtering breaks, I have pester fall back to the original non pipelining call and I'm hoping all the tests catch the edge cases.