### PR TITLE
Improve stack trace and exception console output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## Unreleased
+  - improve stack trace and exception console output
+
 ## 3.3.11 (September 8, 2015)
   - Fixed a bug where mocking New-Object would cause a stack overflow.  [GH-405]
 

--- a/Functions/Context.ps1
+++ b/Functions/Context.ps1
@@ -69,7 +69,7 @@ about_TestDrive
     catch
     {
         $firstStackTraceLine = $_.InvocationInfo.PositionMessage.Trim() -split '\r?\n' | Select-Object -First 1
-        $Pester.AddTestResult('Error occurred in Context block', "Failed", $null, $_.Exception.Message, $firstStackTraceLine)
+        $Pester.AddTestResult('Error occurred in Context block', "Failed", $null, $_.Exception.Message, $firstStackTraceLine, $null, $null, $_)
         $Pester.TestResult[-1] | Write-PesterResult
     }
     finally

--- a/Functions/Describe.ps1
+++ b/Functions/Describe.ps1
@@ -103,7 +103,7 @@ about_TestDrive
     catch
     {
         $firstStackTraceLine = $_.InvocationInfo.PositionMessage.Trim() -split '\r?\n' | Select-Object -First 1
-        $Pester.AddTestResult('Error occurred in Describe block', "Failed", $null, $_.Exception.Message, $firstStackTraceLine)
+        $Pester.AddTestResult('Error occurred in Describe block', "Failed", $null, $_.Exception.Message, $firstStackTraceLine, $null, $null, $_)
         $Pester.TestResult[-1] | Write-PesterResult
     }
     finally

--- a/Functions/It.Tests.ps1
+++ b/Functions/It.Tests.ps1
@@ -185,15 +185,20 @@ $thisScriptRegex = [regex]::Escape($MyInvocation.MyCommand.Path)
 Describe 'Get-PesterResult' {
     $getPesterResult = InModuleScope Pester { ${function:Get-PesterResult} }
 
-    It 'records the correct stack line number of failed tests in the Tests file' {
+    Context 'failed tests in Tests file' {
         #the $script scriptblock below is used as a position marker to determine
         #on which line the test failed.
         $errorRecord = $null
         try{'something' | should be 'nothing'}catch{ $errorRecord=$_} ; $script={}
         $result = & $getPesterResult 0 $errorRecord
-        $result.Stacktrace | should match "at line: $($script.startPosition.StartLine) in $thisScriptRegex"
+        It 'records the correct stack line number' {
+            $result.Stacktrace | should match "at line: $($script.startPosition.StartLine) in $thisScriptRegex"
+        }
+        It 'records the correct error record' {
+            $result.ErrorRecord -is [System.Management.Automation.ErrorRecord] | Should be $true
+            $result.ErrorRecord.Exception.Message | Should match 'Expected: {nothing}'
+        }
     }
-
     It 'Does not modify the error message from the original exception' {
         $object = New-Object psobject
         $message = 'I am an error.'
@@ -206,8 +211,7 @@ Describe 'Get-PesterResult' {
 
         $pesterResult.FailureMessage | Should Be $errorRecord.Exception.Message
     }
-
-    It 'records the correct stack line number of failed tests in another file' {
+    Context 'failed tests in another file' {
         $errorRecord = $null
 
         $testPath = Join-Path $TestDrive test.ps1
@@ -226,6 +230,13 @@ Describe 'Get-PesterResult' {
 
         $result = & $getPesterResult 0 $errorRecord
 
-        $result.Stacktrace | should match "at line: 2 in $escapedTestPath"
+
+        It 'records the correct stack line number' {
+            $result.Stacktrace | should match "at line: 2 in $escapedTestPath"
+        }
+        It 'records the correct error record' {
+            $result.ErrorRecord -is [System.Management.Automation.ErrorRecord] | Should be $true
+            $result.ErrorRecord.Exception.Message | Should match 'Expected: {Two}'
+        }
     }
 }

--- a/Functions/It.ps1
+++ b/Functions/It.ps1
@@ -276,7 +276,7 @@ function Invoke-Test
 
         $result = Get-PesterResult -ErrorRecord $errorRecord
         $orderedParameters = Get-OrderedParameterDictionary -ScriptBlock $ScriptBlock -Dictionary $Parameters
-        $Pester.AddTestResult( $result.name, $result.Result, $null, $result.FailureMessage, $result.StackTrace, $ParameterizedSuiteName, $orderedParameters )
+        $Pester.AddTestResult( $result.name, $result.Result, $null, $result.FailureMessage, $result.StackTrace, $ParameterizedSuiteName, $orderedParameters, $result.ErrorRecord )
         Write-Progress -Activity "Running test '$Name'" -Completed -Status Processing
     }
 
@@ -300,6 +300,7 @@ function Get-PesterResult {
         time = $time
         failureMessage = ""
         stackTrace = ""
+        ErrorRecord = $null
         success = $false
         result = "Failed"
     };
@@ -331,6 +332,7 @@ function Get-PesterResult {
 
     $testResult.failureMessage = $failureMessage
     $testResult.stackTrace = "at line: $line in ${file}${lineText}"
+    $testResult.ErrorRecord = $ErrorRecord
 
     return $testResult
 }

--- a/Pester.psm1
+++ b/Pester.psm1
@@ -215,7 +215,7 @@ about_pester
         catch
         {
             $firstStackTraceLine = $_.ScriptStackTrace -split '\r?\n' | Select-Object -First 1
-            $pester.AddTestResult("Error occurred in test script '$($testScript.Path)'", "Failed", $null, $_.Exception.Message, $firstStackTraceLine)
+            $pester.AddTestResult("Error occurred in test script '$($testScript.Path)'", "Failed", $null, $_.Exception.Message, $firstStackTraceLine, $null, $null, $_)
             $pester.TestResult[-1] | Write-PesterResult
         }
     }


### PR DESCRIPTION
*Note: This is my first PR.  While I'm fairly confident about PowerShell and Pester, I'm a git/github novice.*

------

This pull request improves the stack traces and exceptions that Pester outputs to the console.  This is similar to PR #228 except that it (hopefully) addresses the concerns with that PR.

Stack trace outputs are complicated by the fact that `ErrorRecord.ScriptStackTrace` is not available in PowerShell 2.  I did not find a good substitute for `.ScriptStackTrace` under PowerShell 2.  Rather, I opted to use `ErrorRecord.InvocationInfo` to produce a single-line "stack trace" for PowerShell 2.  This is the same technique as is already used in `Get-PesterResult` to produce `TestResult.stackTrace`.

The improvements of this PR over master and #228 are as follows:
 * Console Output:
     * When `ErrorRecord` is a result of `PesterAssertionFailed`:
        * If `.ScriptStackTrace` is **not** available: No changes. The "Expected...But was" messages stay the same and there are no changes to the stack trace because `.ScriptStackTrace` is unavailable.
        * If `.ScriptScriptTrace` is available: The typical single line stack trace changes from eg. `at line: 36 in C:\temp\scriptpath.ps1` to `at <ScriptBlock>, C:\temp\scriptpath.ps1: line 36`.  The rest of the output is "Expected...But was", etc and remains unchanged.
     * When an exception other than `PesterAssertionFailed` produces the `ErrorRecord`:
        * Messages from exceptions are prefixed with their type name.
        * The full chain of nested exceptions are output instead of just the outer exception.
        * When `.ScriptStackTrace` is available the full unit-under-test stack trace is output.  The lines of the stack trace that reference Pester internals are omitted.
 * Implementation:
    * Adds plumbing to get `.ErrorRecord` into `TestResult` for later use.  This aspect is similar to #228 which didn't seem to be a concern at that time.
    * Implements `ConvertTo-FailureLines` - This does the heavy-lifting of extracting, re-ordering, and formatting just the right script trace and exception details from `ErrorRecord`.
    * Adds call to `ConvertTo-FailureLines` to Write-PesterResult.

### Console Output Comparison

These comparisons are using PowerShell 4.

![image](https://cloud.githubusercontent.com/assets/11237922/11202422/ec2c022a-8c9c-11e5-8766-7882ba320ef7.png)

On the left is prior to this PR.  On the right is with this PR.  Note the following:
 * The first `throws` shows the full three lines of stack trace from the unit under test.
 * The second `throws` shows the nested exceptions and name prefixes `ArgumentException` and `FormatException`.
 * The `should` shows the slight difference in the way failed assertions are formatted.

Here is another output comparison from an integration test of a deeply nest project I'm working on.  First the original output from Pester:

![image](https://cloud.githubusercontent.com/assets/11237922/11202576/58ad6654-8c9e-11e5-88af-5db08578abc5.png)

That is rather short and unhelpful during integration.  The following is the exact same output except with this PR applied:

![image](https://cloud.githubusercontent.com/assets/11237922/11202614/c2c58d8c-8c9e-11e5-8954-3142d1431fd0.png)

Note the completeness of the exceptions and stack trace.  This is my motivation for this PR.  It speeds iteration during integration because you get this information up-front without having to spend time setting breakpoints and stepping through code to get the same information.


### Next Steps

Please tell me whether you think this PR could become a candidate for merging into master.  I'm happy to put more work into improving/polishing/overhauling this PR.  But I'd like to get some feedback to make sure I'm on the right track before spending more time on this.