### PR TITLE
Case insensitive replacement of Test

### DIFF
--- a/Functions/New-Fixture.ps1
+++ b/Functions/New-Fixture.ps1
@@ -70,7 +70,7 @@ function New-Fixture {
     $scriptCode = "function $name {`r`n`r`n}"
 
     $testCode = '$here = Split-Path -Parent $MyInvocation.MyCommand.Path
-$sut = (Split-Path -Leaf $MyInvocation.MyCommand.Path).Replace(".Tests.", ".")
+$sut = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -replace ''\.Tests\.'', ''.''
 . "$here\$sut"
 
 Describe "#name#" {


### PR DESCRIPTION
Generate case insensitive replacement of 'Test' when converting from
test file name to SUT file name

Fixes  #428