### PR TITLE
Fix for #436

### DIFF
--- a/Functions/Assertions/Should.ps1
+++ b/Functions/Assertions/Should.ps1
@@ -34,7 +34,7 @@ function Parse-ShouldArgs([array] $shouldArgs) {
 
 function Get-TestResult($shouldArgs, $value) {
     $assertionMethod = $shouldArgs.AssertionMethod
-    $command = Get-Command $assertionMethod -CommandType Function -ErrorAction $script:IgnoreErrorPreference
+    $command = & $SafeCommands['Get-Command'] $assertionMethod -CommandType Function -ErrorAction $script:IgnoreErrorPreference
 
     if ($null -eq $command)
     {

--- a/Functions/It.ps1
+++ b/Functions/It.ps1
@@ -391,7 +391,7 @@ function Get-ParameterDictionary
     try
     {
         & $SafeCommands['Set-Content'] function:\$guid $ScriptBlock
-        $metadata = [System.Management.Automation.CommandMetadata](Get-Command -Name $guid -CommandType Function)
+        $metadata = [System.Management.Automation.CommandMetadata](& $SafeCommands['Get-Command'] -Name $guid -CommandType Function)
 
         return $metadata.Parameters
     }

--- a/Functions/Mock.Tests.ps1
+++ b/Functions/Mock.Tests.ps1
@@ -1507,3 +1507,12 @@ Describe 'Assert-MockCalled with Aliases' {
         { Assert-MockCalled TestFunction } | Should Not Throw
     }
 }
+
+Describe 'Mocking Get-Command' {
+    # This was reported as a bug in 3.3.12; we were relying on Get-Command to safely invoke other commands.
+    # Mocking Get-Command, though, would result in infinite recursion.
+
+    It 'Does not break when Get-Command is mocked' {
+        { Mock Get-Command } | Should Not Throw
+    }
+}

--- a/Functions/Mock.ps1
+++ b/Functions/Mock.ps1
@@ -330,7 +330,7 @@ about_Mocking
             $mock.Alias = "$($mock.OriginalCommand.ModuleName)\$($CommandName)"
 
             $scriptBlock = {
-                $setAlias = Get-Command -Name Set-Alias -CommandType Cmdlet -Module Microsoft.PowerShell.Utility
+                $setAlias = & (Pester\SafeGetCommand) -Name Set-Alias -CommandType Cmdlet -Module Microsoft.PowerShell.Utility
                 & $setAlias -Name $args[0] -Value $args[1] -Scope Script
             }
 
@@ -720,8 +720,8 @@ function Validate-Command([string]$CommandName, [string]$ModuleName) {
     $commandInfo = & $SafeCommands['New-Object'] psobject -Property @{ Command = $null; Scope = '' }
 
     $scriptBlock = {
-        $getContentCommand = Get-Command Get-Content -Module Microsoft.PowerShell.Management -CommandType Cmdlet
-        $newObjectCommand  = Get-Command New-Object  -Module Microsoft.PowerShell.Utility    -CommandType Cmdlet
+        $getContentCommand = & (Pester\SafeGetCommand) Get-Content -Module Microsoft.PowerShell.Management -CommandType Cmdlet
+        $newObjectCommand  = & (Pester\SafeGetCommand) New-Object  -Module Microsoft.PowerShell.Utility    -CommandType Cmdlet
 
         $command = $ExecutionContext.InvokeCommand.GetCommand($args[0], 'All')
         while ($null -ne $command -and $command.CommandType -eq [System.Management.Automation.CommandTypes]::Alias)
@@ -793,7 +793,7 @@ function MockPrototype {
         [string] ${ignore preference} = 'SilentlyContinue'
     }
 
-    ${get Variable Command} = Get-Command -Name Get-Variable -Module Microsoft.PowerShell.Utility -CommandType Cmdlet
+    ${get Variable Command} = & (Pester\SafeGetCommand) -Name Get-Variable -Module Microsoft.PowerShell.Utility -CommandType Cmdlet
 
     [object] ${a r g s} = & ${get Variable Command} -Name args -ValueOnly -Scope Local -ErrorAction ${ignore preference}
     if ($null -eq ${a r g s}) { ${a r g s} = @() }
@@ -1265,7 +1265,7 @@ function Get-DynamicParametersForCmdlet
 
     try
     {
-        $command = Get-Command -Name $CmdletName -CommandType Cmdlet -ErrorAction Stop
+        $command = & $SafeCommands['Get-Command'] -Name $CmdletName -CommandType Cmdlet -ErrorAction Stop
 
         if (@($command).Count -gt 1)
         {

--- a/Functions/PesterState.ps1
+++ b/Functions/PesterState.ps1
@@ -52,10 +52,10 @@ function New-PesterState
 
         $script:SafeCommands = @{}
 
-        $script:SafeCommands['New-Object']          = Get-Command -Name New-Object          -Module Microsoft.PowerShell.Utility -CommandType Cmdlet
-        $script:SafeCommands['Select-Object']       = Get-Command -Name Select-Object       -Module Microsoft.PowerShell.Utility -CommandType Cmdlet
-        $script:SafeCommands['Export-ModuleMember'] = Get-Command -Name Export-ModuleMember -Module Microsoft.PowerShell.Core    -CommandType Cmdlet
-        $script:SafeCommands['Add-Member']          = Get-Command -Name Add-Member          -Module Microsoft.PowerShell.Utility -CommandType Cmdlet
+        $script:SafeCommands['New-Object']          = & (Pester\SafeGetCommand) -Name New-Object          -Module Microsoft.PowerShell.Utility -CommandType Cmdlet
+        $script:SafeCommands['Select-Object']       = & (Pester\SafeGetCommand) -Name Select-Object       -Module Microsoft.PowerShell.Utility -CommandType Cmdlet
+        $script:SafeCommands['Export-ModuleMember'] = & (Pester\SafeGetCommand) -Name Export-ModuleMember -Module Microsoft.PowerShell.Core    -CommandType Cmdlet
+        $script:SafeCommands['Add-Member']          = & (Pester\SafeGetCommand) -Name Add-Member          -Module Microsoft.PowerShell.Utility -CommandType Cmdlet
 
         function EnterDescribe([string]$Name)
         {

--- a/Pester.psd1
+++ b/Pester.psd1
@@ -46,7 +46,8 @@ FunctionsToExport = @(
     'AfterAll'
     'Get-MockDynamicParameters',
     'Set-DynamicParameterVariables',
-    'Set-TestInconclusive'
+    'Set-TestInconclusive',
+    'SafeGetCommand'
 )
 
 # # Cmdlets to export from this module


### PR DESCRIPTION
I didn't like exporting another "ignore this" command from Pester, but it's the only way I could think of to solve #436 while not also introducing a regression of #303 .  This way, the only way someone should be able to break things is by mocking Pester's SafeGetCommand function, and I'm comfortable with just saying "don't do that" more than I would be for telling people not to mock Get-Command or not to name a parameter $ExecutionContext (though the latter is pretty iffy; people should really be careful not to overwrite automatic variables.)