### PR TITLE
Small fix for PowerShell v2

### DIFF
--- a/Pester.psm1
+++ b/Pester.psm1
@@ -274,7 +274,7 @@ about_pester
 
     Set-ScriptBlockScope -ScriptBlock $invokeTestScript -SessionState $PSCmdlet.SessionState
 
-    $testScripts = ResolveTestScripts $Script
+    $testScripts = @(ResolveTestScripts $Script)
 
     foreach ($testScript in $testScripts)
     {


### PR DESCRIPTION
Noticed that Invoke-Pester was throwing an exception if no Tests.ps1 files are found, but only in PowerShell v2.  It's due to the behavior of the foreach loop when it enumerates over `$null`, which is a common v2 gotcha.