### PR TITLE
Run on nano server (and Pi 2 with Windows IoT)

### DIFF
--- a/Functions/Assertions/PesterThrow.Tests.ps1
+++ b/Functions/Assertions/PesterThrow.Tests.ps1
@@ -55,7 +55,7 @@ InModuleScope Pester {
     }
 
     Describe 'PesterThrowFailureMessage' {
-        $testScriptPath = Join-Path $TestDrive.FullName test.ps1
+        $testScriptPath = Join-Path $TestDrive test.ps1
 
         It 'returns false if the actual message is not the same as the expected message' {
             $unexpectedErrorMessage = 'unexpected'
@@ -75,7 +75,7 @@ InModuleScope Pester {
     }
 
     Describe 'NotPesterThrowFailureMessage' {
-        $testScriptPath = Join-Path $TestDrive.FullName test.ps1
+        $testScriptPath = Join-Path $TestDrive test.ps1
 
         It 'returns false if the actual message is not the same as the expected message' {
             $unexpectedErrorMessage = 'unexpected'

--- a/Functions/Context.Tests.ps1
+++ b/Functions/Context.Tests.ps1
@@ -8,7 +8,7 @@ Describe 'Testing Context' {
         $parameter = $command.Parameters['Fixture']
         $parameter | Should Not Be $null
 
-        $attribute = $parameter.Attributes | Where-Object { $_.TypeId -eq [System.Management.Automation.ParameterAttribute] }
+        $attribute = $parameter.Attributes | Where-Object { $_ -is [System.Management.Automation.ParameterAttribute] }
         $isMandatory = $null -ne $attribute -and $attribute.Mandatory
 
         $isMandatory | Should Be $false

--- a/Functions/Describe.Tests.ps1
+++ b/Functions/Describe.Tests.ps1
@@ -8,7 +8,7 @@ Describe 'Testing Describe' {
         $parameter = $command.Parameters['Fixture']
         $parameter | Should Not Be $null
 
-        $attribute = $parameter.Attributes | Where-Object { $_.TypeId -eq [System.Management.Automation.ParameterAttribute] }
+        $attribute = $parameter.Attributes | Where-Object { $_ -is [System.Management.Automation.ParameterAttribute] }
         $isMandatory = $null -ne $attribute -and $attribute.Mandatory
 
         $isMandatory | Should Be $false

--- a/Functions/It.Tests.ps1
+++ b/Functions/It.Tests.ps1
@@ -213,7 +213,6 @@ Describe 'Get-PesterResult' {
     }
     Context 'failed tests in another file' {
         $errorRecord = $null
-
         $testPath = Join-Path $TestDrive test.ps1
         $escapedTestPath = [regex]::Escape($testPath)
 

--- a/Functions/TestDrive.Tests.ps1
+++ b/Functions/TestDrive.Tests.ps1
@@ -148,15 +148,12 @@ Describe "Cleanup when Remove-Item is mocked" {
 }
 
 InModuleScope Pester {
-    Describe "New-RandomTempDirectory" {
-        It "creates randomly named directory" {
-            $first = New-RandomTempDirectory
-            $second = New-RandomTempDirectory
+    Describe "New-RandomTempDirectoryPath" {
+        It "creates randomly named path" {
+            $first = New-RandomTempDirectoryPath
+            $second = New-RandomTempDirectoryPath
 
-            $first | Remove-Item -Force
-            $second | Remove-Item -Force
-
-            $first.name | Should Not Be $second.name
+            $first | Should Not Be $second
 
         }
     }

--- a/Functions/TestDrive.ps1
+++ b/Functions/TestDrive.ps1
@@ -1,23 +1,20 @@
 #
 function New-TestDrive ([Switch]$PassThru) {
-    $Path = New-RandomTempDirectory
+    $Path = New-RandomTempDirectoryPath
     $DriveName = "TestDrive"
 
-    if (-not (& $SafeCommands['Test-Path'] -Path $Path))
-    {
-        & $SafeCommands['New-Item'] -ItemType Container -Path $Path | & $SafeCommands['Out-Null']
-    }
+    $Directory = & $SafeCommands['New-Item'] -ItemType Container -Path $Path
 
     #setup the test drive
     if ( -not (& $SafeCommands['Test-Path'] "${DriveName}:\") )
     {
-        & $SafeCommands['New-PSDrive'] -Name $DriveName -PSProvider FileSystem -Root $Path -Scope Global -Description "Pester test drive" | & $SafeCommands['Out-Null']
+        & $SafeCommands['New-PSDrive'] -Name $DriveName -PSProvider FileSystem -Root $Directory.FullName -Scope Global -Description "Pester test drive" | & $SafeCommands['Out-Null']
     }
 
     #publish the global TestDrive variable used in few places within the module
     if (-not (& $SafeCommands['Test-Path'] "Variable:Global:DriveName"))
     {
-        & $SafeCommands['New-Variable'] -Name $DriveName -Scope Global -Value $Path
+        & $SafeCommands['New-Variable'] -Name $DriveName -Scope Global -Value $Directory.FullName
     }
 
     if ( $PassThru ) { & $SafeCommands['Get-PSDrive'] -Name $DriveName }
@@ -36,13 +33,13 @@ function Clear-TestDrive ([String[]]$Exclude) {
     }
 }
 
-function New-RandomTempDirectory {
+function New-RandomTempDirectoryPath {
     do
     {
         $Path = & $SafeCommands['Join-Path'] -Path $env:TEMP -ChildPath ([Guid]::NewGuid())
     } until (-not (& $SafeCommands['Test-Path'] -Path $Path ))
 
-    & $SafeCommands['New-Item'] -ItemType Container -Path $Path
+    return $Path
 }
 
 function Get-TestDriveItem {

--- a/Functions/TestResults.ps1
+++ b/Functions/TestResults.ps1
@@ -410,10 +410,10 @@ function Write-NUnitTestCaseAttributes($TestResult, [System.Xml.XmlWriter] $XmlW
 }
 function Get-RunTimeEnvironment() {
     #Get-WmiObject does not exist on Windows Nano Server
-    if ($psVersionTable.PSVersion.Major -le 2) 
+    if ($psVersionTable.PSVersion.Major -le 2)
     {
         $osSystemInformation = (& $SafeCommands['Get-WmiObject'] Win32_OperatingSystem)
-    } 
+    }
     else
     {
         $osSystemInformation = (& $SafeCommands['Get-CimInstance'] Win32_OperatingSystem)

--- a/Functions/TestResults.ps1
+++ b/Functions/TestResults.ps1
@@ -409,7 +409,15 @@ function Write-NUnitTestCaseAttributes($TestResult, [System.Xml.XmlWriter] $XmlW
     }
 }
 function Get-RunTimeEnvironment() {
-    $osSystemInformation = (& $SafeCommands['Get-WmiObject'] Win32_OperatingSystem)
+    #Get-WmiObject does not exist on Windows Nano Server
+    if ($psVersionTable.PSVersion.Major -le 2) 
+    {
+        $osSystemInformation = (& $SafeCommands['Get-WmiObject'] Win32_OperatingSystem)
+    } 
+    else
+    {
+        $osSystemInformation = (& $SafeCommands['Get-CimInstance'] Win32_OperatingSystem)
+    }
     @{
         'nunit-version' = '2.5.8.0'
         'os-version' = $osSystemInformation.Version

--- a/Pester.psm1
+++ b/Pester.psm1
@@ -19,7 +19,6 @@ else
 
 $script:SafeCommands = @{
     'Add-Member'          = Get-Command -Name Add-Member          -Module Microsoft.PowerShell.Utility    -CommandType Cmdlet -ErrorAction Stop
-    'Add-Type'            = Get-Command -Name Add-Type            -Module Microsoft.PowerShell.Utility    -CommandType Cmdlet -ErrorAction Stop
     'Compare-Object'      = Get-Command -Name Compare-Object      -Module Microsoft.PowerShell.Utility    -CommandType Cmdlet -ErrorAction Stop
     'Export-ModuleMember' = Get-Command -Name Export-ModuleMember -Module Microsoft.PowerShell.Core       -CommandType Cmdlet -ErrorAction Stop
     'ForEach-Object'      = Get-Command -Name ForEach-Object      -Module Microsoft.PowerShell.Core       -CommandType Cmdlet -ErrorAction Stop
@@ -34,7 +33,6 @@ $script:SafeCommands = @{
     'Get-Module'          = Get-Command -Name Get-Module          -Module Microsoft.PowerShell.Core       -CommandType Cmdlet -ErrorAction Stop
     'Get-PSDrive'         = Get-Command -Name Get-PSDrive         -Module Microsoft.PowerShell.Management -CommandType Cmdlet -ErrorAction Stop
     'Get-Variable'        = Get-Command -Name Get-Variable        -Module Microsoft.PowerShell.Utility    -CommandType Cmdlet -ErrorAction Stop
-    'Get-WmiObject'       = Get-Command -Name Get-WmiObject       -Module Microsoft.PowerShell.Management -CommandType Cmdlet -ErrorAction Stop
     'Group-Object'        = Get-Command -Name Group-Object        -Module Microsoft.PowerShell.Utility    -CommandType Cmdlet -ErrorAction Stop
     'Join-Path'           = Get-Command -Name Join-Path           -Module Microsoft.PowerShell.Management -CommandType Cmdlet -ErrorAction Stop
     'Measure-Object'      = Get-Command -Name Measure-Object      -Module Microsoft.PowerShell.Utility    -CommandType Cmdlet -ErrorAction Stop
@@ -67,6 +65,18 @@ $script:SafeCommands = @{
     'Write-Verbose'       = Get-Command -Name Write-Verbose       -Module Microsoft.PowerShell.Utility    -CommandType Cmdlet -ErrorAction Stop
     'Write-Warning'       = Get-Command -Name Write-Warning       -Module Microsoft.PowerShell.Utility    -CommandType Cmdlet -ErrorAction Stop
 }
+
+if ($PsVersionTable.PsVersion.Major -le 2) 
+{
+	$script:SafeCommands.Add(
+	'Get-WmiObject', (Get-Command -Name Get-WmiObject -Module Microsoft.PowerShell.Management -CommandType Cmdlet -ErrorAction Stop ))
+}
+else 
+{
+	$script:SafeCommands.Add(
+	'Get-CimInstance', (Get-Command -Name Get-CimInstance -Module CimCmdlets -CommandType Cmdlet -ErrorAction Stop) )
+}
+
 
 # little sanity check to make sure we don't blow up a system with a typo up there
 # (not that I've EVER done that by, for example, mapping New-Item to Remove-Item...)


### PR DESCRIPTION
There were two changes that needed to be made to make Pester work on
Nano server. First I had to conditionally import Get-CimSession instead
of Get-WmiObject that is not available on nano server.  The other thing
that I replaced was the BraceFinder that was written and compiled via
Add-Type. The PowerShell implementation is about 10 times slower (but
it's 1 vs 10 milliseconds).

The rest of the fixes needed to be done in test files.
1) DirectoryInfo serializes to just Name instead of FullName which
caused the most of the failed tests, so I had to resort to storing the
full name in the Global:TestDrive variable instead of the DirectoryInfo
object. This is a breaking change, but I don't see a better option.

2) I had to conditionally skip some of the xml tests because the
required properties and methods to handle schema validation are not
available on .net core.
