### PR TITLE
Added support for ErrorId to PesterThrow

### DIFF
--- a/Functions/Assertions/PesterThrow.Tests.ps1
+++ b/Functions/Assertions/PesterThrow.Tests.ps1
@@ -29,7 +29,7 @@ InModuleScope Pester {
             { throw 'expected error' } | Should Throw 'error'
             { throw 'expected error' } | Should -Throw 'error'
         }
-        
+
         It "returns true if the statement throws an exception and the actual fully-qualified error id matches the expected error id" {
             $expectedErrorId = "expected error id"
             $ScriptBlock = {
@@ -41,18 +41,18 @@ InModuleScope Pester {
                 )
                 throw $errorRecord
             }
-          
+
             # This syntax only. Not supported by Legacy.
             $ScriptBlock | Should -Throw -ErrorId $expectedErrorId
         }
-        
+
         It "returns false if the statement throws an exception and the actual fully-qualified error id does not match the expected error id" {
             $unexpectedErrorId = "unexpected error id"
             $expectedErrorId = "some expected error id"
             # Likely a known artefact. There's an edge case that breaks the Contains-based comparison.
             # $unexpectedErrorId = "unexpected error id"
             # $expectedErrorId = "expected error id"
-            
+
             $ScriptBlock = {
                 $errorRecord = New-Object System.Management.Automation.ErrorRecord(
                     (New-Object Exception),
@@ -62,10 +62,10 @@ InModuleScope Pester {
                 )
                 throw $errorRecord
             }
-          
+
             $ScriptBlock | Should -Not -Throw -ErrorId $expectedErrorId
         }
-        
+
         It "returns true if the statement throws an exception and the actual error text and the fully-qualified error id match the expected error text and error id" {
             $expectedErrorMessage = "expected error message"
             $expectedErrorId = "some expected error id"
@@ -78,10 +78,10 @@ InModuleScope Pester {
                 )
                 throw $errorRecord
             }
-          
+
             $ScriptBlock | Should -Throw $expectedErrorMessage -ErrorId $expectedErrorId
         }
-        
+
         It "returns false if the statement throws an exception and the actual error text and fully-qualified error id do not match the expected error text and error id" {
             $unexpectedErrorMessage = "unexpected error message"
             $unexpectedErrorId = "unexpected error id"
@@ -96,10 +96,10 @@ InModuleScope Pester {
                 )
                 throw $errorRecord
             }
-          
+
             $ScriptBlock | Should -Not -Throw $expectedErrorMessage -ErrorId $expectedErrorId
         }
-        
+
         It "returns false if the statement throws an exception and the actual fully-qualified error id does not match the expected error id when the actual error text does match the expected error text" {
             $unexpectedErrorId = "unexpected error id"
             $expectedErrorMessage = "some expected error message"
@@ -113,10 +113,10 @@ InModuleScope Pester {
                 )
                 throw $errorRecord
             }
-          
+
             $ScriptBlock | Should -Not -Throw $expectedErrorMessage -ErrorId $expectedErrorId
         }
-        
+
         It "returns false if the statement throws an exception and the actual error text does not match the expected error text when the actual error id does match the expected error id" {
             $unexpectedErrorMessage = "unexpected error message"
             $expectedErrorMessage = "some expected error message"
@@ -130,7 +130,7 @@ InModuleScope Pester {
                 )
                 throw $errorRecord
             }
-          
+
             $ScriptBlock | Should -Not -Throw $expectedErrorMessage -ErrorId $expectedErrorId
         }
     }
@@ -187,7 +187,7 @@ InModuleScope Pester {
             $result | Should Be 'Expected: the expression to throw an exception'
             $result | Should -Be 'Expected: the expression to throw an exception'
         }
-        
+
         It 'returns false if the actual error id is not the same as the expected error id' {
             $unexpectedErrorId = 'unexpected error id'
             $expectedErrorId = 'some expected error id'
@@ -206,7 +206,7 @@ InModuleScope Pester {
             $result | Should Match "^Expected: the expression to throw an exception with error id {$expectedErrorId}, an exception was raised, error id was {$unexpectedErrorId}`n    from $([RegEx]::Escape($testScriptPath)):\d+ char:\d+"
             $result | Should -Match "^Expected: the expression to throw an exception with error id {$expectedErrorId}, an exception was raised, error id was {$unexpectedErrorId}`n    from $([RegEx]::Escape($testScriptPath)):\d+ char:\d+"
         }
-        
+
         It 'returns true if the actual error id is the same as the expected error id' {
             $expectedErrorId = 'some expected error id'
             Set-Content -Path $testScriptPath -Value "
@@ -224,7 +224,7 @@ InModuleScope Pester {
             $result | Should Match "^Expected: the expression to throw an exception"
             $result | Should -Match "^Expected: the expression to throw an exception"
         }
-        
+
         It 'returns false if the actual message and error id are not the same as the expected message and error id' {
             $unexpectedErrorMessage = 'unexpected'
             $unexpectedErrorId = 'unexpected error id'
@@ -245,7 +245,7 @@ InModuleScope Pester {
             $result | Should Match "^Expected: the expression to throw an exception with message {$expectedErrorMessage} and error id {$expectedErrorId}, an exception was raised, message was {$unexpectedErrorMessage} and error id was {$unexpectedErrorId}`n    from $([RegEx]::Escape($testScriptPath)):\d+ char:\d+"
             $result | Should -Match "^Expected: the expression to throw an exception with message {$expectedErrorMessage} and error id {$expectedErrorId}, an exception was raised, message was {$unexpectedErrorMessage} and error id was {$unexpectedErrorId}`n    from $([RegEx]::Escape($testScriptPath)):\d+ char:\d+"
         }
-        
+
         It 'returns false if the actual message is not the same as the expected message when the actual error id and expected error id match' {
             $unexpectedErrorMessage = 'unexpected'
             $expectedErrorMessage = 'some expected message'
@@ -265,7 +265,7 @@ InModuleScope Pester {
             $result | Should Match "^Expected: the expression to throw an exception with message {$expectedErrorMessage} and error id {$expectedErrorId}, an exception was raised, message was {$unexpectedErrorMessage} and error id was {$expectedErrorId}`n    from $([RegEx]::Escape($testScriptPath)):\d+ char:\d+"
             $result | Should -Match "^Expected: the expression to throw an exception with message {$expectedErrorMessage} and error id {$expectedErrorId}, an exception was raised, message was {$unexpectedErrorMessage} and error id was {$expectedErrorId}`n    from $([RegEx]::Escape($testScriptPath)):\d+ char:\d+"
         }
-        
+
         It 'returns false if the actual error id is not the same as the expected error id when the actual message and expected message match' {
             $unexpectedErrorId = 'unexpected error id'
             $expectedErrorMessage = 'some expected message'
@@ -324,7 +324,7 @@ InModuleScope Pester {
             $result.FailureMessage | Should Match "^Expected: the expression not to throw an exception with error id {$expectedErrorId}, an exception was raised, error id was {$expectedErrorId}`n    from $([RegEx]::Escape($testScriptPath)):\d+ char:\d+"
             $result.FailureMessage | Should -Match "^Expected: the expression not to throw an exception with error id {$expectedErrorId}, an exception was raised, error id was {$expectedErrorId}`n    from $([RegEx]::Escape($testScriptPath)):\d+ char:\d+"
         }
-        
+
         It 'returns false if the actual message or actual error id is the same as the expected message or expected error id' {
             $expectedErrorMessage = 'some expected message'
             $expectedErrorId = 'some expected error id'

--- a/Functions/Assertions/PesterThrow.Tests.ps1
+++ b/Functions/Assertions/PesterThrow.Tests.ps1
@@ -199,7 +199,7 @@ InModuleScope Pester {
                     `$null
                 )
                 throw `$errorRecord
-            "  
+            "
 
             PesterThrow { & $testScriptPath } -ErrorId $expectedErrorId > $null
             $result = PesterThrowFailureMessage $null -ExpectedErrorId $expectedErrorId
@@ -217,7 +217,7 @@ InModuleScope Pester {
                     `$null
                 )
                 throw `$errorRecord
-            "  
+            "
 
             PesterThrow { & $testScriptPath } -ErrorId $expectedErrorId > $null
             $result = PesterThrowFailureMessage $null -ErrorId $expectedErrorId
@@ -318,7 +318,7 @@ InModuleScope Pester {
                     `$null
                 )
                 throw `$errorRecord
-            "  
+            "
 
             $result = PesterThrow { & $testScriptPath } -ErrorId $expectedErrorId -Negate
             $result.FailureMessage | Should Match "^Expected: the expression not to throw an exception with error id {$expectedErrorId}, an exception was raised, error id was {$expectedErrorId}`n    from $([RegEx]::Escape($testScriptPath)):\d+ char:\d+"
@@ -336,7 +336,7 @@ InModuleScope Pester {
                     `$null
                 )
                 throw `$errorRecord
-            "  
+            "
 
             $result = PesterThrow { & $testScriptPath } $expectedErrorMessage -ErrorId $expectedErrorId -Negate
             $result.FailureMessage | Should Match "^Expected: the expression not to throw an exception with message {$expectedErrorMessage} and error id {$expectedErrorId}, an exception was raised, message was {$expectedErrorMessage} and error id was {$expectedErrorId}`n    from $([RegEx]::Escape($testScriptPath)):\d+ char:\d+"

--- a/Functions/Assertions/PesterThrow.Tests.ps1
+++ b/Functions/Assertions/PesterThrow.Tests.ps1
@@ -29,6 +29,110 @@ InModuleScope Pester {
             { throw 'expected error' } | Should Throw 'error'
             { throw 'expected error' } | Should -Throw 'error'
         }
+        
+        It "returns true if the statement throws an exception and the actual fully-qualified error id matches the expected error id" {
+            $expectedErrorId = "expected error id"
+            $ScriptBlock = {
+                $errorRecord = New-Object System.Management.Automation.ErrorRecord(
+                    (New-Object Exception),
+                    $expectedErrorId,
+                    'OperationStopped',
+                    $null
+                )
+                throw $errorRecord
+            }
+          
+            # This syntax only. Not supported by Legacy.
+            $ScriptBlock | Should -Throw -ErrorId $expectedErrorId
+        }
+        
+        It "returns false if the statement throws an exception and the actual fully-qualified error id does not match the expected error id" {
+            $unexpectedErrorId = "unexpected error id"
+            $expectedErrorId = "some expected error id"
+            # Likely a known artefact. There's an edge case that breaks the Contains-based comparison.
+            # $unexpectedErrorId = "unexpected error id"
+            # $expectedErrorId = "expected error id"
+            
+            $ScriptBlock = {
+                $errorRecord = New-Object System.Management.Automation.ErrorRecord(
+                    (New-Object Exception),
+                    $unexpectedErrorId,
+                    'OperationStopped',
+                    $null
+                )
+                throw $errorRecord
+            }
+          
+            $ScriptBlock | Should -Not -Throw -ErrorId $expectedErrorId
+        }
+        
+        It "returns true if the statement throws an exception and the actual error text and the fully-qualified error id match the expected error text and error id" {
+            $expectedErrorMessage = "expected error message"
+            $expectedErrorId = "some expected error id"
+            $ScriptBlock = {
+                $errorRecord = New-Object System.Management.Automation.ErrorRecord(
+                    (New-Object Exception $expectedErrorMessage),
+                    $expectedErrorId,
+                    'OperationStopped',
+                    $null
+                )
+                throw $errorRecord
+            }
+          
+            $ScriptBlock | Should -Throw $expectedErrorMessage -ErrorId $expectedErrorId
+        }
+        
+        It "returns false if the statement throws an exception and the actual error text and fully-qualified error id do not match the expected error text and error id" {
+            $unexpectedErrorMessage = "unexpected error message"
+            $unexpectedErrorId = "unexpected error id"
+            $expectedErrorMessage = "some expected error message"
+            $expectedErrorId = "some expected error id"
+            $ScriptBlock = {
+                $errorRecord = New-Object System.Management.Automation.ErrorRecord(
+                    (New-Object Exception $unexpectedErrorMessage),
+                    $unexpectedErrorId,
+                    'OperationStopped',
+                    $null
+                )
+                throw $errorRecord
+            }
+          
+            $ScriptBlock | Should -Not -Throw $expectedErrorMessage -ErrorId $expectedErrorId
+        }
+        
+        It "returns false if the statement throws an exception and the actual fully-qualified error id does not match the expected error id when the actual error text does match the expected error text" {
+            $unexpectedErrorId = "unexpected error id"
+            $expectedErrorMessage = "some expected error message"
+            $expectedErrorId = "some expected error id"
+            $ScriptBlock = {
+                $errorRecord = New-Object System.Management.Automation.ErrorRecord(
+                    (New-Object Exception $expectedErrorMessage),
+                    $unexpectedErrorId,
+                    'OperationStopped',
+                    $null
+                )
+                throw $errorRecord
+            }
+          
+            $ScriptBlock | Should -Not -Throw $expectedErrorMessage -ErrorId $expectedErrorId
+        }
+        
+        It "returns false if the statement throws an exception and the actual error text does not match the expected error text when the actual error id does match the expected error id" {
+            $unexpectedErrorMessage = "unexpected error message"
+            $expectedErrorMessage = "some expected error message"
+            $expectedErrorId = "some expected error id"
+            $ScriptBlock = {
+                $errorRecord = New-Object System.Management.Automation.ErrorRecord(
+                    (New-Object Exception $unexpectedErrorMessage),
+                    $expectedErrorId,
+                    'OperationStopped',
+                    $null
+                )
+                throw $errorRecord
+            }
+          
+            $ScriptBlock | Should -Not -Throw $expectedErrorMessage -ErrorId $expectedErrorId
+        }
     }
 
     Describe "Get-DoMessagesMatch" {
@@ -83,11 +187,110 @@ InModuleScope Pester {
             $result | Should Be 'Expected: the expression to throw an exception'
             $result | Should -Be 'Expected: the expression to throw an exception'
         }
+        
+        It 'returns false if the actual error id is not the same as the expected error id' {
+            $unexpectedErrorId = 'unexpected error id'
+            $expectedErrorId = 'some expected error id'
+            Set-Content -Path $testScriptPath -Value "
+                `$errorRecord = New-Object System.Management.Automation.ErrorRecord(
+                    (New-Object Exception),
+                    '$unexpectedErrorId',
+                    'OperationStopped',
+                    `$null
+                )
+                throw `$errorRecord
+            "  
+
+            PesterThrow { & $testScriptPath } -ErrorId $expectedErrorId > $null
+            $result = PesterThrowFailureMessage $null -ExpectedErrorId $expectedErrorId
+            $result | Should Match "^Expected: the expression to throw an exception with error id {$expectedErrorId}, an exception was raised, error id was {$unexpectedErrorId}`n    from $([RegEx]::Escape($testScriptPath)):\d+ char:\d+"
+            $result | Should -Match "^Expected: the expression to throw an exception with error id {$expectedErrorId}, an exception was raised, error id was {$unexpectedErrorId}`n    from $([RegEx]::Escape($testScriptPath)):\d+ char:\d+"
+        }
+        
+        It 'returns true if the actual error id is the same as the expected error id' {
+            $expectedErrorId = 'some expected error id'
+            Set-Content -Path $testScriptPath -Value "
+                `$errorRecord = New-Object System.Management.Automation.ErrorRecord(
+                    (New-Object Exception),
+                    '$expectedErrorId',
+                    'OperationStopped',
+                    `$null
+                )
+                throw `$errorRecord
+            "  
+
+            PesterThrow { & $testScriptPath } -ErrorId $expectedErrorId > $null
+            $result = PesterThrowFailureMessage $null -ErrorId $expectedErrorId
+            $result | Should Match "^Expected: the expression to throw an exception"
+            $result | Should -Match "^Expected: the expression to throw an exception"
+        }
+        
+        It 'returns false if the actual message and error id are not the same as the expected message and error id' {
+            $unexpectedErrorMessage = 'unexpected'
+            $unexpectedErrorId = 'unexpected error id'
+            $expectedErrorMessage = 'some expected message'
+            $expectedErrorId = 'some expected error id'
+            Set-Content -Path $testScriptPath -Value "
+                `$errorRecord = New-Object System.Management.Automation.ErrorRecord(
+                    (New-Object Exception '$unexpectedErrorMessage'),
+                    '$unexpectedErrorId',
+                    'OperationStopped',
+                    `$null
+                )
+                throw `$errorRecord
+            "
+
+            PesterThrow { & $testScriptPath } $expectedErrorMessage > $null
+            $result = PesterThrowFailureMessage $null $expectedErrorMessage $expectedErrorId
+            $result | Should Match "^Expected: the expression to throw an exception with message {$expectedErrorMessage} and error id {$expectedErrorId}, an exception was raised, message was {$unexpectedErrorMessage} and error id was {$unexpectedErrorId}`n    from $([RegEx]::Escape($testScriptPath)):\d+ char:\d+"
+            $result | Should -Match "^Expected: the expression to throw an exception with message {$expectedErrorMessage} and error id {$expectedErrorId}, an exception was raised, message was {$unexpectedErrorMessage} and error id was {$unexpectedErrorId}`n    from $([RegEx]::Escape($testScriptPath)):\d+ char:\d+"
+        }
+        
+        It 'returns false if the actual message is not the same as the expected message when the actual error id and expected error id match' {
+            $unexpectedErrorMessage = 'unexpected'
+            $expectedErrorMessage = 'some expected message'
+            $expectedErrorId = 'some expected error id'
+            Set-Content -Path $testScriptPath -Value "
+                `$errorRecord = New-Object System.Management.Automation.ErrorRecord(
+                    (New-Object Exception '$unexpectedErrorMessage'),
+                    '$expectedErrorId',
+                    'OperationStopped',
+                    `$null
+                )
+                throw `$errorRecord
+            "
+
+            PesterThrow { & $testScriptPath } $expectedErrorMessage > $null
+            $result = PesterThrowFailureMessage $null $expectedErrorMessage $expectedErrorId
+            $result | Should Match "^Expected: the expression to throw an exception with message {$expectedErrorMessage} and error id {$expectedErrorId}, an exception was raised, message was {$unexpectedErrorMessage} and error id was {$expectedErrorId}`n    from $([RegEx]::Escape($testScriptPath)):\d+ char:\d+"
+            $result | Should -Match "^Expected: the expression to throw an exception with message {$expectedErrorMessage} and error id {$expectedErrorId}, an exception was raised, message was {$unexpectedErrorMessage} and error id was {$expectedErrorId}`n    from $([RegEx]::Escape($testScriptPath)):\d+ char:\d+"
+        }
+        
+        It 'returns false if the actual error id is not the same as the expected error id when the actual message and expected message match' {
+            $unexpectedErrorId = 'unexpected error id'
+            $expectedErrorMessage = 'some expected message'
+            $expectedErrorId = 'some expected error id'
+            Set-Content -Path $testScriptPath -Value "
+                `$errorRecord = New-Object System.Management.Automation.ErrorRecord(
+                    (New-Object Exception '$expectedErrorMessage'),
+                    '$unexpectedErrorId',
+                    'OperationStopped',
+                    `$null
+                )
+                throw `$errorRecord
+            "
+
+            PesterThrow { & $testScriptPath } $expectedErrorMessage > $null
+            $result = PesterThrowFailureMessage $null $expectedErrorMessage $expectedErrorId
+            $result | Should Match "^Expected: the expression to throw an exception with message {$expectedErrorMessage} and error id {$expectedErrorId}, an exception was raised, message was {$expectedErrorMessage} and error id was {$unexpectedErrorId}`n    from $([RegEx]::Escape($testScriptPath)):\d+ char:\d+"
+            $result | Should -Match "^Expected: the expression to throw an exception with message {$expectedErrorMessage} and error id {$expectedErrorId}, an exception was raised, message was {$expectedErrorMessage} and error id was {$unexpectedErrorId}`n    from $([RegEx]::Escape($testScriptPath)):\d+ char:\d+"
+        }
     }
 
     Describe 'NotPesterThrowFailureMessage' {
         $testScriptPath = Join-Path $TestDrive.FullName test.ps1
 
+        # Shouldn't this test be using -Negate?
         It 'returns false if the actual message is not the same as the expected message' {
             $unexpectedErrorMessage = 'unexpected'
             $expectedErrorMessage = 'some expected message'
@@ -103,6 +306,41 @@ InModuleScope Pester {
             $result = PesterThrow { & $testScriptPath } -Negate
             $result.FailureMessage | Should Match "^Expected: the expression not to throw an exception. Message was {error message}`n    from $([RegEx]::Escape($testScriptPath)):\d+ char:\d+"
             $result.FailureMessage | Should -Match "^Expected: the expression not to throw an exception. Message was {error message}`n    from $([RegEx]::Escape($testScriptPath)):\d+ char:\d+"
+        }
+
+        It 'returns false if the actual error id is the same as the expected error id' {
+            $expectedErrorId = 'some expected error id'
+            Set-Content -Path $testScriptPath -Value "
+                `$errorRecord = New-Object System.Management.Automation.ErrorRecord(
+                    (New-Object Exception),
+                    '$expectedErrorId',
+                    'OperationStopped',
+                    `$null
+                )
+                throw `$errorRecord
+            "  
+
+            $result = PesterThrow { & $testScriptPath } -ErrorId $expectedErrorId -Negate
+            $result.FailureMessage | Should Match "^Expected: the expression not to throw an exception with error id {$expectedErrorId}, an exception was raised, error id was {$expectedErrorId}`n    from $([RegEx]::Escape($testScriptPath)):\d+ char:\d+"
+            $result.FailureMessage | Should -Match "^Expected: the expression not to throw an exception with error id {$expectedErrorId}, an exception was raised, error id was {$expectedErrorId}`n    from $([RegEx]::Escape($testScriptPath)):\d+ char:\d+"
+        }
+        
+        It 'returns false if the actual message or actual error id is the same as the expected message or expected error id' {
+            $expectedErrorMessage = 'some expected message'
+            $expectedErrorId = 'some expected error id'
+            Set-Content -Path $testScriptPath -Value "
+                `$errorRecord = New-Object System.Management.Automation.ErrorRecord(
+                    (New-Object Exception '$expectedErrorMessage'),
+                    '$expectedErrorId',
+                    'OperationStopped',
+                    `$null
+                )
+                throw `$errorRecord
+            "  
+
+            $result = PesterThrow { & $testScriptPath } $expectedErrorMessage -ErrorId $expectedErrorId -Negate
+            $result.FailureMessage | Should Match "^Expected: the expression not to throw an exception with message {$expectedErrorMessage} and error id {$expectedErrorId}, an exception was raised, message was {$expectedErrorMessage} and error id was {$expectedErrorId}`n    from $([RegEx]::Escape($testScriptPath)):\d+ char:\d+"
+            $result.FailureMessage | Should -Match "^Expected: the expression not to throw an exception with message {$expectedErrorMessage} and error id {$expectedErrorId}, an exception was raised, message was {$expectedErrorMessage} and error id was {$expectedErrorId}`n    from $([RegEx]::Escape($testScriptPath)):\d+ char:\d+"
         }
     }
 }

--- a/Functions/Assertions/PesterThrow.ps1
+++ b/Functions/Assertions/PesterThrow.ps1
@@ -60,13 +60,16 @@ function PesterThrowFailureMessage($ActualValue, $ExpectedMessage, $ExpectedErro
     $StringBuilder = Microsoft.PowerShell.Utility\New-Object System.Text.StringBuilder
     $null = $StringBuilder.Append('Expected: the expression to throw an exception')
 
-    if ($ExpectedMessage -or $ExpectedErrorId) {
+    if ($ExpectedMessage -or $ExpectedErrorId)
+    {
         $null = $StringBuilder.Append(' with ')
-        $Expected = switch ($null) {
+        $Expected = switch ($null)
+        {
             { $ExpectedMessage } { 'message {{{0}}}' -f $ExpectedMessage }
             { $ExpectedErrorId } { 'error id {{{0}}}' -f $ExpectedErrorId }
         }
-        $Actual = switch ($null) {
+        $Actual = switch ($null)
+        {
             { $ExpectedMessage } { 'message was {{{0}}}' -f $ActualExceptionMessage }
             { $ExpectedErrorId } { 'error id was {{{0}}}' -f $ActualErrorId }
         }
@@ -85,13 +88,16 @@ function NotPesterThrowFailureMessage($ActualValue, $ExpectedMessage, $ExpectedE
     $StringBuilder = New-Object System.Text.StringBuilder
     $null = $StringBuilder.Append('Expected: the expression not to throw an exception')
 
-    if ($ExpectedMessage -or $ExpectedErrorId) {
+    if ($ExpectedMessage -or $ExpectedErrorId)
+    {
         $null = $StringBuilder.Append(' with ')
-        $Expected = switch ($null) {
+        $Expected = switch ($null)
+        {
             { $ExpectedMessage } { 'message {{{0}}}' -f $ExpectedMessage }
             { $ExpectedErrorId } { 'error id {{{0}}}' -f $ExpectedErrorId }
         }
-        $Actual = switch ($null) {
+        $Actual = switch ($null)
+        {
             { $ExpectedMessage } { 'message was {{{0}}}' -f $ActualExceptionMessage }
             { $ExpectedErrorId } { 'error id was {{{0}}}' -f $ActualErrorId }
         }
@@ -101,7 +107,9 @@ function NotPesterThrowFailureMessage($ActualValue, $ExpectedMessage, $ExpectedE
             ($Actual -join ' and '),
             ($ActualExceptionLine  -replace "`n","`n    ")
         ))
-    } else {
+    }
+    else
+    {
       $null = $StringBuilder.Append((". Message was {{{0}}}`n    {1}" -f $ActualExceptionMessage, ($ActualExceptionLine -replace "`n","`n    ")))
     }
 

--- a/Functions/Assertions/PesterThrow.ps1
+++ b/Functions/Assertions/PesterThrow.ps1
@@ -57,18 +57,18 @@ function Get-ExceptionLineInfo($info) {
 }
 
 function PesterThrowFailureMessage($ActualValue, $ExpectedMessage, $ExpectedErrorId) {
-    $StringBuilder = New-Object System.Text.StringBuilder
+    $StringBuilder = Microsoft.PowerShell.Utility\New-Object System.Text.StringBuilder
     $null = $StringBuilder.Append('Expected: the expression to throw an exception')
-    
+
     if ($ExpectedMessage -or $ExpectedErrorId) {
         $null = $StringBuilder.Append(' with ')
         $Expected = switch ($null) {
-          { $ExpectedMessage } { 'message {{{0}}}' -f $ExpectedMessage }
-          { $ExpectedErrorId } { 'error id {{{0}}}' -f $ExpectedErrorId }
+            { $ExpectedMessage } { 'message {{{0}}}' -f $ExpectedMessage }
+            { $ExpectedErrorId } { 'error id {{{0}}}' -f $ExpectedErrorId }
         }
         $Actual = switch ($null) {
-          { $ExpectedMessage } { 'message was {{{0}}}' -f $ActualExceptionMessage }
-          { $ExpectedErrorId } { 'error id was {{{0}}}' -f $ActualErrorId }
+            { $ExpectedMessage } { 'message was {{{0}}}' -f $ActualExceptionMessage }
+            { $ExpectedErrorId } { 'error id was {{{0}}}' -f $ActualErrorId }
         }
         $null = $StringBuilder.Append(("{0}, an exception was {1}raised, {2}`n    {3}" -f
             ($Expected -join ' and '),
@@ -77,23 +77,23 @@ function PesterThrowFailureMessage($ActualValue, $ExpectedMessage, $ExpectedErro
             ($ActualExceptionLine  -replace "`n","`n    ")
         ))
     }
-    
-    return $StringBuilder.ToString() 
+
+    return $StringBuilder.ToString()
 }
 
 function NotPesterThrowFailureMessage($ActualValue, $ExpectedMessage, $ExpectedErrorId) {
     $StringBuilder = New-Object System.Text.StringBuilder
     $null = $StringBuilder.Append('Expected: the expression not to throw an exception')
-    
+
     if ($ExpectedMessage -or $ExpectedErrorId) {
         $null = $StringBuilder.Append(' with ')
         $Expected = switch ($null) {
-          { $ExpectedMessage } { 'message {{{0}}}' -f $ExpectedMessage }
-          { $ExpectedErrorId } { 'error id {{{0}}}' -f $ExpectedErrorId }
+            { $ExpectedMessage } { 'message {{{0}}}' -f $ExpectedMessage }
+            { $ExpectedErrorId } { 'error id {{{0}}}' -f $ExpectedErrorId }
         }
         $Actual = switch ($null) {
-          { $ExpectedMessage } { 'message was {{{0}}}' -f $ActualExceptionMessage }
-          { $ExpectedErrorId } { 'error id was {{{0}}}' -f $ActualErrorId }
+            { $ExpectedMessage } { 'message was {{{0}}}' -f $ActualExceptionMessage }
+            { $ExpectedErrorId } { 'error id was {{{0}}}' -f $ActualErrorId }
         }
         $null = $StringBuilder.Append(("{0}, an exception was {1}raised, {2}`n    {3}" -f
             ($Expected -join ' and '),
@@ -104,7 +104,7 @@ function NotPesterThrowFailureMessage($ActualValue, $ExpectedMessage, $ExpectedE
     } else {
       $null = $StringBuilder.Append((". Message was {{{0}}}`n    {1}" -f $ActualExceptionMessage, ($ActualExceptionLine -replace "`n","`n    ")))
     }
-    
+
     return $StringBuilder.ToString()
 }
 


### PR DESCRIPTION
Speculative support for ErrorId handling in PesterThrow.
Significant increase in complexity of generated messages from PesterThrow, switched to StringBuilder for greater control.
Extended tests to verify backward compatibility and added features.