### PR TITLE
Allow mocking commands with single quote in name or module name

### DIFF
--- a/Functions/Mock.Tests.ps1
+++ b/Functions/Mock.Tests.ps1
@@ -1,4 +1,4 @@
-Set-StrictMode -Version Latest
+﻿Set-StrictMode -Version Latest
 
 function FunctionUnderTest
 {
@@ -1576,6 +1576,24 @@ Describe '$args handling' {
     }
     It 'Cmdlet with Args parameter should be mockable' {
         Invoke-CmdletWithArgs -Args garbage | Should Be mock
+    }
+
+}
+
+Describe 'Single quote in command/module name' {
+
+    New-Module "Module '‘’‚‛" {
+        Function NormalCommandName { 'orig' }
+        New-Item "Function::Command '‘’‚‛" -Value { 'orig' }
+    } | Import-Module
+
+    It 'Command with single quote in module name should be mockable' {
+        Mock NormalCommandName { 'mock' }
+        NormalCommandName | Should Be mock
+    }
+    It 'Command with single quote in name should be mockable' {
+        Mock "Command '‘’‚‛" { 'mock' }
+        & "Command '‘’‚‛" | Should Be mock
     }
 
 }

--- a/Functions/Mock.ps1
+++ b/Functions/Mock.ps1
@@ -1,4 +1,4 @@
-function Mock {
+﻿function Mock {
 
 <#
 .SYNOPSIS
@@ -273,9 +273,16 @@ about_Mocking
             }
         }
 
+        $EscapeSingleQuotedStringContent =
+            if ($global:PSVersionTable.PSVersion.Major -ge 5) {
+                { [System.Management.Automation.Language.CodeGeneration]::EscapeSingleQuotedStringContent($args[0]) }
+            } else {
+                { $args[0] -replace "['‘’‚‛]", '$&$&' }
+            }
+
         $newContent = & $SafeCommands['Get-Content'] function:\MockPrototype
-        $newContent = $newContent -replace '#FUNCTIONNAME#', $CommandName
-        $newContent = $newContent -replace '#MODULENAME#', $ModuleName
+        $newContent = $newContent -replace '#FUNCTIONNAME#', (& $EscapeSingleQuotedStringContent $CommandName)
+        $newContent = $newContent -replace '#MODULENAME#', (& $EscapeSingleQuotedStringContent $ModuleName)
 
         $canCaptureArgs = 'true'
         if ($contextInfo.Command.CommandType -eq 'Cmdlet' -or


### PR DESCRIPTION
Single quote does not properly escaped, when command name and module name values got embedded into `MockPrototype`.