### PR TITLE
Mocking cmdlet without positional parameters

### DIFF
--- a/Functions/Mock.ps1
+++ b/Functions/Mock.ps1
@@ -227,6 +227,13 @@ about_Mocking
             }
 
             $cmdletBinding = [Management.Automation.ProxyCommand]::GetCmdletBindingAttribute($metadata)
+            if ($global:PSVersionTable.PSVersion.Major -ge 3 -and $contextInfo.Command.CommandType -eq 'Cmdlet') {
+                if ($cmdletBinding -ne '[CmdletBinding()]') {
+                    $cmdletBinding = $cmdletBinding.Insert($cmdletBinding.Length-2, ',')
+                }
+                $cmdletBinding = $cmdletBinding.Insert($cmdletBinding.Length-2, 'PositionalBinding=$false')
+            }
+
             $paramBlock    = [Management.Automation.ProxyCommand]::GetParamBlock($metadata)
 
             if ($contextInfo.Command.CommandType -eq 'Cmdlet')


### PR DESCRIPTION
If advanced function does not specify any positional parameters, then PowerShell make all function parameters to be positional implicitly. This is not true for cmdlets. So that, mock of cmdlet can have different parameter binding behavior compared to original cmdlet. In v3+ you can disable implicit positional parameter binding behavior by specifying `PositionalBinding=$false` in `CmdletBinding` attribute.