### PR TITLE
Initial fix for #470

### DIFF
--- a/Functions/PesterState.ps1
+++ b/Functions/PesterState.ps1
@@ -6,7 +6,8 @@ function New-PesterState
         [String[]]$TestNameFilter,
         [System.Management.Automation.SessionState]$SessionState,
         [Switch]$Strict,
-        [Switch]$Quiet
+        [Switch]$Quiet,
+        [object]$PesterOption
     )
 
     if ($null -eq $SessionState) { $SessionState = $ExecutionContext.SessionState }
@@ -18,7 +19,8 @@ function New-PesterState
             [String[]]$_testNameFilter,
             [System.Management.Automation.SessionState]$_sessionState,
             [Switch]$Strict,
-            [Switch]$Quiet
+            [Switch]$Quiet,
+            [object]$PesterOption
         )
 
         #public read-only
@@ -49,6 +51,8 @@ function New-PesterState
         $script:SkippedCount = 0
         $script:PendingCount = 0
         $script:InconclusiveCount = 0
+
+        $script:IncludeVSCodeMarker = $PesterOption.IncludeVSCodeMarker
 
         $script:SafeCommands = @{}
 
@@ -210,7 +214,8 @@ function New-PesterState
         "FailedCount",
         "SkippedCount",
         "PendingCount",
-        "InconclusiveCount"
+        "InconclusiveCount",
+        "IncludeVSCodeMarker"
 
         $ExportedFunctions = "EnterContext",
         "LeaveContext",
@@ -221,7 +226,7 @@ function New-PesterState
         "AddTestResult"
 
         & $SafeCommands['Export-ModuleMember'] -Variable $ExportedVariables -function $ExportedFunctions
-    } -ArgumentList $TagFilter, $ExcludeTagFilter, $TestNameFilter, $SessionState, $Strict, $Quiet |
+    } -ArgumentList $TagFilter, $ExcludeTagFilter, $TestNameFilter, $SessionState, $Strict, $Quiet, $PesterOption |
     & $SafeCommands['Add-Member'] -MemberType ScriptProperty -Name Scope -Value {
         if ($this.CurrentTest) { 'It' }
         elseif ($this.CurrentContext)  { 'Context' }
@@ -289,8 +294,19 @@ function Write-PesterResult
             }
             Failed {
                 "$margin[-] $output $humanTime" | Write-Screen -OutputType Failed
-                $TestResult.ErrorRecord |
-                    ConvertTo-FailureLines |
+
+                $failureLines = $TestResult.ErrorRecord | ConvertTo-FailureLines
+
+                if ($Pester.IncludeVSCodeMarker)
+                {
+                    $marker = $failureLines |
+                              & $script:SafeCommands['Select-Object'] -First 1 -ExpandProperty Trace |
+                              & $script:SafeCommands['Select-Object'] -First 1
+
+                    Write-Screen -OutputType Failed $($marker -replace '(?m)^',$error_margin)
+                }
+
+                $failureLines |
                     & $SafeCommands['ForEach-Object'] {$_.Message + $_.Trace} |
                     & $SafeCommands['ForEach-Object'] { Write-Screen -OutputType Failed $($_ -replace '(?m)^',$error_margin) }
             }
@@ -322,7 +338,7 @@ function ConvertTo-FailureLines
         $ErrorRecord
     )
     process {
-        $lines = @{
+        $lines = & $script:SafeCommands['New-Object'] psobject -Property @{
             Message = @()
             Trace = @()
         }

--- a/Functions/PesterState.ps1
+++ b/Functions/PesterState.ps1
@@ -11,7 +11,22 @@ function New-PesterState
     )
 
     if ($null -eq $SessionState) { $SessionState = $ExecutionContext.SessionState }
-    if ($null -eq $PesterOption) { $PesterOption = New-PesterOption }
+
+    if ($null -eq $PesterOption)
+    {
+        $PesterOption = New-PesterOption
+    }
+    elseif ($PesterOption -is [System.Collections.IDictionary])
+    {
+        try
+        {
+            $PesterOption = New-PesterOption @PesterOption
+        }
+        catch
+        {
+            throw
+        }
+    }
 
     & $SafeCommands['New-Module'] -Name Pester -AsCustomObject -ScriptBlock {
         param (

--- a/Functions/PesterState.ps1
+++ b/Functions/PesterState.ps1
@@ -11,6 +11,7 @@ function New-PesterState
     )
 
     if ($null -eq $SessionState) { $SessionState = $ExecutionContext.SessionState }
+    if ($null -eq $PesterOption) { $PesterOption = New-PesterOption }
 
     & $SafeCommands['New-Module'] -Name Pester -AsCustomObject -ScriptBlock {
         param (

--- a/Pester.psd1
+++ b/Pester.psd1
@@ -47,7 +47,8 @@ FunctionsToExport = @(
     'Get-MockDynamicParameters',
     'Set-DynamicParameterVariables',
     'Set-TestInconclusive',
-    'SafeGetCommand'
+    'SafeGetCommand',
+    'New-PesterOption'
 )
 
 # # Cmdlets to export from this module

--- a/Pester.psm1
+++ b/Pester.psm1
@@ -155,6 +155,10 @@ Makes Pending and Skipped tests to Failed tests. Useful for continuous integrati
 .PARAMETER Quiet
 Disables the output Pester writes to screen. No other output is generated unless you specify PassThru, or one of the Output parameters.
 
+.PARAMETER PesterOption
+Sets advanced options for the session.  Enter a PesterOption object, such as one that you create by using the New-PSPesterOption cmdlet, or a hash table in which the keys are session option names and the values are session option values.
+For more information on the options available, see the help for New-PesterOption.
+
 .Example
 Invoke-Pester
 
@@ -203,6 +207,7 @@ Runs all *.Tests.ps1 scripts in the current directory, and generates a coverage 
 .LINK
 Describe
 about_pester
+New-PesterOption
 
 #>
     [CmdletBinding(DefaultParameterSetName = 'LegacyOutputXml')]
@@ -329,6 +334,21 @@ about_pester
 
 function New-PesterOption
 {
+<#
+.SYNOPSIS
+   Creates an object that contains advanced options for Invoke-Pester
+.PARAMETER IncludeVSCodeMarker
+   When this switch is set, an extra line of output will be written to the console for test failures, making it easier
+   for VSCode's parser to provide highlighting / tooltips on the line where the error occurred.
+.INPUTS
+   None
+   You cannot pipe input to this command.
+.OUTPUTS
+   System.Management.Automation.PSObject
+.LINK
+   Invoke-Pester
+#>
+
     [CmdletBinding()]
     param (
         [switch] $IncludeVSCodeMarker

--- a/Pester.psm1
+++ b/Pester.psm1
@@ -242,7 +242,7 @@ about_pester
 
         [Switch]$Quiet,
 
-        [object]$PesterOption = (New-PesterOption)
+        [object]$PesterOption
     )
 
     if ($PSBoundParameters.ContainsKey('OutputXml'))

--- a/Pester.psm1
+++ b/Pester.psm1
@@ -240,7 +240,9 @@ about_pester
         [ValidateSet('LegacyNUnitXml', 'NUnitXml')]
         [string] $OutputFormat,
 
-        [Switch]$Quiet
+        [Switch]$Quiet,
+
+        [object]$PesterOption = (New-PesterOption)
     )
 
     if ($PSBoundParameters.ContainsKey('OutputXml'))
@@ -255,7 +257,7 @@ about_pester
 
     $script:mockTable = @{}
 
-    $pester = New-PesterState -TestNameFilter $TestName -TagFilter ($Tag -split "\s") -ExcludeTagFilter ($ExcludeTag -split "\s") -SessionState $PSCmdlet.SessionState -Strict:$Strict -Quiet:$Quiet
+    $pester = New-PesterState -TestNameFilter $TestName -TagFilter ($Tag -split "\s") -ExcludeTagFilter ($ExcludeTag -split "\s") -SessionState $PSCmdlet.SessionState -Strict:$Strict -Quiet:$Quiet -PesterOption $PesterOption
     Enter-CoverageAnalysis -CodeCoverage $CodeCoverage -PesterState $pester
 
     Write-Screen "`r`n`r`n`r`n`r`n"
@@ -323,6 +325,18 @@ about_pester
     }
 
     if ($EnableExit) { Exit-WithCode -FailedCount $pester.FailedCount }
+}
+
+function New-PesterOption
+{
+    [CmdletBinding()]
+    param (
+        [switch] $IncludeVSCodeMarker
+    )
+
+    return & $script:SafeCommands['New-Object'] psobject -Property @{
+        IncludeVSCodeMarker = [bool]$IncludeVSCodeMarker
+    }
 }
 
 function ResolveTestScripts
@@ -474,4 +488,4 @@ if ((& $script:SafeCommands['Test-Path'] -Path Variable:\psise) -and
 & $script:SafeCommands['Export-ModuleMember'] New-Fixture, Get-TestDriveItem, Should, Invoke-Pester, Setup, InModuleScope, Invoke-Mock
 & $script:SafeCommands['Export-ModuleMember'] BeforeEach, AfterEach, BeforeAll, AfterAll
 & $script:SafeCommands['Export-ModuleMember'] Get-MockDynamicParameters, Set-DynamicParameterVariables
-& $script:SafeCommands['Export-ModuleMember'] SafeGetCommand
+& $script:SafeCommands['Export-ModuleMember'] SafeGetCommand, New-PesterOption


### PR DESCRIPTION
@rkeithhill , start with this and let me know what you think.  This was just about the quickest and laziest way I could implement this, just to get the ball rolling.  If the new option is specified, the first line of the stack trace gets output in between the failed test header line and the error message.  We can tweak this as needed.  Here's how the usage works (same as you'd expect with New-PSSessionOption / etc):

```posh
$option = New-PesterOption -IncludeVSCodeMarker
Invoke-Pester -PesterOption $option
```
