### PR TITLE
Make paths to be provider qualified

### DIFF
--- a/Functions/Assertions/Exist.Tests.ps1
+++ b/Functions/Assertions/Exist.Tests.ps1
@@ -15,10 +15,10 @@ InModuleScope Pester {
             "TestDrive:\``[test``].txt"  | Should Exist
         }
 
-        It 'returns correct result for function drive' {
+        It 'returns correct result for function provider' {
             function f1 {}
 
-            'function:f1' | Should Exist
+            'function::f1' | Should Exist
         }
 
         It 'returns correct result for env drive' {

--- a/Functions/Assertions/Should.Tests.ps1
+++ b/Functions/Assertions/Should.Tests.ps1
@@ -141,8 +141,8 @@ InModuleScope Pester {
             $assertionFunctions = @("PesterBe", "PesterThrow", "PesterBeNullOrEmpty", "PesterExist",
                 "PesterMatch", "PesterContain")
             $assertionFunctions | % {
-                "function:$($_)FailureMessage" | Should Exist
-                "function:Not$($_)FailureMessage" | Should Exist
+                "function::$($_)FailureMessage" | Should Exist
+                "function::Not$($_)FailureMessage" | Should Exist
             }
         }
 

--- a/Functions/GlobalMock-A.Tests.ps1
+++ b/Functions/GlobalMock-A.Tests.ps1
@@ -4,9 +4,9 @@
 
 $functionName = '01c1a57716fe4005ac1a7bf216f38ad0'
 
-if (Test-Path Function:\$functionName)
+if (Test-Path Function::$functionName)
 {
-    Remove-Item Function:\$functionName -Force -ErrorAction Stop
+    Remove-Item Function::$functionName -Force -ErrorAction Stop
 }
 
 function global:01c1a57716fe4005ac1a7bf216f38ad0

--- a/Functions/GlobalMock-B.Tests.ps1
+++ b/Functions/GlobalMock-B.Tests.ps1
@@ -8,7 +8,7 @@ try
 {
     Describe 'Mocking Global Functions - Part Two' {
         It 'Restored the global function properly' {
-            $globalFunctionExists = Test-Path Function:\global:$functionName
+            $globalFunctionExists = Test-Path Function::global:$functionName
             $globalFunctionExists | Should Be $true
             & $functionName | Should Be 'Original Function'
         }
@@ -16,8 +16,8 @@ try
 }
 finally
 {
-    if (Test-Path Function:\$functionName)
+    if (Test-Path Function::$functionName)
     {
-        Remove-Item Function:\$functionName -Force
+        Remove-Item Function::$functionName -Force
     }
 }

--- a/Functions/InModuleScope.Tests.ps1
+++ b/Functions/InModuleScope.Tests.ps1
@@ -14,7 +14,7 @@ Describe "Module scope separation" {
         # TODO : come up with a better way of verifying that only the desired commands from the Pester
         # module are visible to the SUT.
 
-        (Get-Item function:\Get-PesterResult -ErrorAction SilentlyContinue) | Should Be $null
+        (Get-Item function::Get-PesterResult -ErrorAction SilentlyContinue) | Should Be $null
     }
 }
 

--- a/Functions/It.Tests.ps1
+++ b/Functions/It.Tests.ps1
@@ -183,7 +183,7 @@ InModuleScope Pester {
 $thisScriptRegex = [regex]::Escape($MyInvocation.MyCommand.Path)
 
 Describe 'Get-PesterResult' {
-    $getPesterResult = InModuleScope Pester { ${function:Get-PesterResult} }
+    $getPesterResult = InModuleScope Pester { & $SafeCommands['Get-Content'] function::Get-PesterResult }
 
     Context 'failed tests in Tests file' {
         #the $script scriptblock below is used as a position marker to determine

--- a/Functions/It.ps1
+++ b/Functions/It.ps1
@@ -114,7 +114,7 @@ about_should
         [Switch] $Skip
     )
 
-    ItImpl -Pester $pester -OutputScriptBlock ${function:Write-PesterResult} @PSBoundParameters
+    ItImpl -Pester $pester -OutputScriptBlock (& $SafeCommands['Get-Content'] function::Write-PesterResult) @PSBoundParameters
 }
 
 function ItImpl
@@ -390,13 +390,13 @@ function Get-ParameterDictionary
 
     try
     {
-        & $SafeCommands['Set-Content'] function:\$guid $ScriptBlock
+        & $SafeCommands['Set-Content'] function::$guid $ScriptBlock
         $metadata = [System.Management.Automation.CommandMetadata](& $SafeCommands['Get-Command'] -Name $guid -CommandType Function)
 
         return $metadata.Parameters
     }
     finally
     {
-        if (& $SafeCommands['Test-Path'] function:\$guid) { & $SafeCommands['Remove-Item'] function:\$guid }
+        if (& $SafeCommands['Test-Path'] function::$guid) { & $SafeCommands['Remove-Item'] function::$guid }
     }
 }

--- a/Functions/Mock.Tests.ps1
+++ b/Functions/Mock.Tests.ps1
@@ -81,7 +81,7 @@ Describe "When calling Mock on existing function" {
     $result = FunctionUnderTest "boundArg"
 
     It "Should rename function under test" {
-        $renamed = (Test-Path function:PesterIsMocking_FunctionUnderTest)
+        $renamed = (Test-Path function::PesterIsMocking_FunctionUnderTest)
         $renamed | Should Be $true
     }
 
@@ -282,7 +282,7 @@ Describe "When calling Mock on existing cmdlet to handle pipelined input" {
 Describe "When calling Mock on existing cmdlet with Common params" {
     Mock CommonParamFunction
 
-    $result=[string](Get-Content function:\CommonParamFunction)
+    $result=[string](Get-Content function::CommonParamFunction)
 
     It "Should strip verbose" {
         $result.contains("`${Verbose}") | Should Be $false
@@ -1494,7 +1494,7 @@ Describe 'After a mock goes out of scope' {
 
 Describe 'Assert-MockCalled with Aliases' {
     AfterEach {
-        if (Test-Path alias:PesterTF) { Remove-Item Alias:PesterTF }
+        if (Test-Path alias::PesterTF) { Remove-Item Alias::PesterTF }
     }
 
     It 'Allows calls to Assert-MockCalled to use both aliases and the original command name' {

--- a/Functions/Mock.ps1
+++ b/Functions/Mock.ps1
@@ -287,7 +287,7 @@ about_Mocking
                 { $args[0] -replace "['‘’‚‛]", '$&$&' }
             }
 
-        $newContent = & $SafeCommands['Get-Content'] function:\MockPrototype
+        $newContent = & $SafeCommands['Get-Content'] function::MockPrototype
         $newContent = $newContent -replace '#FUNCTIONNAME#', (& $EscapeSingleQuotedStringContent $CommandName)
         $newContent = $newContent -replace '#MODULENAME#', (& $EscapeSingleQuotedStringContent $ModuleName)
 
@@ -344,16 +344,16 @@ about_Mocking
             {
                 param ( [string] $CommandName )
 
-                if ($ExecutionContext.InvokeProvider.Item.Exists("Function:\$CommandName"))
+                if ($ExecutionContext.InvokeProvider.Item.Exists("Function::$CommandName"))
                 {
-                    $ExecutionContext.InvokeProvider.Item.Rename("Function:\$CommandName", "script:PesterIsMocking_$CommandName", $true)
+                    $ExecutionContext.InvokeProvider.Item.Rename("Function::$CommandName", "script:PesterIsMocking_$CommandName", $true)
                 }
             }
 
             $null = Invoke-InMockScope -SessionState $mock.SessionState -ScriptBlock $scriptBlock -ArgumentList $CommandName
         }
 
-        $scriptBlock = { $ExecutionContext.InvokeProvider.Item.Set("Function:\script:$($args[0])", $args[1], $true, $true) }
+        $scriptBlock = { $ExecutionContext.InvokeProvider.Item.New('Function::',"script:$($args[0])", 'function', $args[1], $true) }
         $null = Invoke-InMockScope -SessionState $mock.SessionState -ScriptBlock $scriptBlock -ArgumentList $CommandName, $mockScript
 
         if ($mock.OriginalCommand.ModuleName)
@@ -710,15 +710,15 @@ function Exit-MockScope {
             [string] $Alias
         )
 
-        $ExecutionContext.InvokeProvider.Item.Remove("Function:\$CommandName", $false, $true, $true)
-        if ($ExecutionContext.InvokeProvider.Item.Exists("Function:\PesterIsMocking_$CommandName", $true, $true))
+        $ExecutionContext.InvokeProvider.Item.Remove("Function::$CommandName", $false, $true, $true)
+        if ($ExecutionContext.InvokeProvider.Item.Exists("Function::PesterIsMocking_$CommandName", $true, $true))
         {
-            $ExecutionContext.InvokeProvider.Item.Rename("Function:\PesterIsMocking_$CommandName", "$Scope$CommandName", $true)
+            $ExecutionContext.InvokeProvider.Item.Rename("Function::PesterIsMocking_$CommandName", "$Scope$CommandName", $true)
         }
 
-        if ($Alias -and $ExecutionContext.InvokeProvider.Item.Exists("Alias:$Alias", $true, $true))
+        if ($Alias -and $ExecutionContext.InvokeProvider.Item.Exists("Alias::$Alias", $true, $true))
         {
-            $ExecutionContext.InvokeProvider.Item.Remove("Alias:$Alias", $false, $true, $true)
+            $ExecutionContext.InvokeProvider.Item.Remove("Alias::$Alias", $false, $true, $true)
         }
     }
 
@@ -766,13 +766,13 @@ function Validate-Command([string]$CommandName, [string]$ModuleName) {
 
         if ($null -ne $command -and $command.CommandType -eq 'Function')
         {
-            if ($ExecutionContext.InvokeProvider.Item.Exists("function:\global:$($command.Name)") -and
-                (& $getContentCommand "function:\global:$($command.Name)" -ErrorAction Stop) -eq $command.ScriptBlock)
+            if ($ExecutionContext.InvokeProvider.Item.Exists("function::global:$($command.Name)") -and
+                (& $getContentCommand "function::global:$($command.Name)" -ErrorAction Stop) -eq $command.ScriptBlock)
             {
                 $properties['Scope'] = 'global:'
             }
-            elseif ($ExecutionContext.InvokeProvider.Item.Exists("function:\script:$($command.Name)") -and
-                    (& $getContentCommand "function:\script:$($command.Name)" -ErrorAction Stop) -eq $command.ScriptBlock)
+            elseif ($ExecutionContext.InvokeProvider.Item.Exists("function::script:$($command.Name)") -and
+                    (& $getContentCommand "function::script:$($command.Name)" -ErrorAction Stop) -eq $command.ScriptBlock)
             {
                 $properties['Scope'] = 'script:'
             }


### PR DESCRIPTION
This change make Pester work even if someone remove build-in PowerShell drives: `Remove-PSDrive Alias,Function`. It seems, that `configuration` keyword in PowerShell is not happy if `function` drive is not exists. So the test involve it fails if you actually remove `function` drive, but other tests pass successfully.