### PR TITLE
update SafeCommands to use Get-CimInstance if it exists, then try Get…

### DIFF
--- a/Functions/Context.Tests.ps1
+++ b/Functions/Context.Tests.ps1
@@ -8,7 +8,8 @@ Describe 'Testing Context' {
         $parameter = $command.Parameters['Fixture']
         $parameter | Should Not Be $null
 
-        $attribute = $parameter.Attributes | Where-Object { $_.TypeId -eq [System.Management.Automation.ParameterAttribute] }
+        # Some environments (Nano/CoreClr) don't have all the type extensions
+        $attribute = $parameter.Attributes | Where-Object { $_ -is [System.Management.Automation.ParameterAttribute] }
         $isMandatory = $null -ne $attribute -and $attribute.Mandatory
 
         $isMandatory | Should Be $false

--- a/Functions/Describe.Tests.ps1
+++ b/Functions/Describe.Tests.ps1
@@ -8,7 +8,8 @@ Describe 'Testing Describe' {
         $parameter = $command.Parameters['Fixture']
         $parameter | Should Not Be $null
 
-        $attribute = $parameter.Attributes | Where-Object { $_.TypeId -eq [System.Management.Automation.ParameterAttribute] }
+        # Some environments (Nano/CoreClr) don't have all the type extensions
+        $attribute = $parameter.Attributes | Where-Object { $_ -is [System.Management.Automation.ParameterAttribute] }
         $isMandatory = $null -ne $attribute -and $attribute.Mandatory
 
         $isMandatory | Should Be $false

--- a/Functions/TestResults.ps1
+++ b/Functions/TestResults.ps1
@@ -409,7 +409,22 @@ function Write-NUnitTestCaseAttributes($TestResult, [System.Xml.XmlWriter] $XmlW
     }
 }
 function Get-RunTimeEnvironment() {
-    $osSystemInformation = (& $SafeCommands['Get-WmiObject'] Win32_OperatingSystem)
+    # based on what we found during startup, use the appropriate cmdlet
+    if ( $SafeCommands['Get-CimInstance'] -ne $null )
+    {
+        $osSystemInformation = (& $SafeCommands['Get-CimInstance'] Win32_OperatingSystem)
+    }
+    elseif ( $SafeCommands['Get-WmiObject'] -ne $null )
+    {
+        $osSystemInformation = (& $SafeCommands['Get-WmiObject'] Win32_OperatingSystem)
+    }
+    else
+    {
+        $osSystemInformation = @{
+            Name = "Unknown"
+            Version = "0.0.0.0"
+            }
+    }
     @{
         'nunit-version' = '2.5.8.0'
         'os-version' = $osSystemInformation.Version

--- a/Pester.psm1
+++ b/Pester.psm1
@@ -34,7 +34,6 @@ $script:SafeCommands = @{
     'Get-Module'          = Get-Command -Name Get-Module          -Module Microsoft.PowerShell.Core       -CommandType Cmdlet -ErrorAction Stop
     'Get-PSDrive'         = Get-Command -Name Get-PSDrive         -Module Microsoft.PowerShell.Management -CommandType Cmdlet -ErrorAction Stop
     'Get-Variable'        = Get-Command -Name Get-Variable        -Module Microsoft.PowerShell.Utility    -CommandType Cmdlet -ErrorAction Stop
-    'Get-WmiObject'       = Get-Command -Name Get-WmiObject       -Module Microsoft.PowerShell.Management -CommandType Cmdlet -ErrorAction Stop
     'Group-Object'        = Get-Command -Name Group-Object        -Module Microsoft.PowerShell.Utility    -CommandType Cmdlet -ErrorAction Stop
     'Join-Path'           = Get-Command -Name Join-Path           -Module Microsoft.PowerShell.Management -CommandType Cmdlet -ErrorAction Stop
     'Measure-Object'      = Get-Command -Name Measure-Object      -Module Microsoft.PowerShell.Utility    -CommandType Cmdlet -ErrorAction Stop
@@ -66,6 +65,23 @@ $script:SafeCommands = @{
     'Write-Progress'      = Get-Command -Name Write-Progress      -Module Microsoft.PowerShell.Utility    -CommandType Cmdlet -ErrorAction Stop
     'Write-Verbose'       = Get-Command -Name Write-Verbose       -Module Microsoft.PowerShell.Utility    -CommandType Cmdlet -ErrorAction Stop
     'Write-Warning'       = Get-Command -Name Write-Warning       -Module Microsoft.PowerShell.Utility    -CommandType Cmdlet -ErrorAction Stop
+}
+
+# Not all platforms have Get-WmiObject (Nano)
+# Get-CimInstance is prefered, but we can use Get-WmiObject if it exists
+# Moreover, it shouldn't really be fatal if neither of those cmdlets
+# exist 
+if ( Get-Command -ea SilentlyContinue Get-CimInstance )
+{
+    $script:SafeCommands['Get-CimInstance'] = Get-Command -Name Get-CimInstance -Module CimCmdlets -CommandType Cmdlet -ErrorAction Stop
+}
+elseif ( Get-command -ea SilentlyContinue Get-WmiObject )
+{
+    $script:SafeCommands['Get-WmiObject']   = Get-Command -Name Get-WmiObject   -Module Microsoft.PowerShell.Management -CommandType Cmdlet -ErrorAction Stop
+}
+else
+{
+    Write-Warning "OS Information retrieval is not possible, reports will contain only partial system data"
 }
 
 # little sanity check to make sure we don't blow up a system with a typo up there


### PR DESCRIPTION
…-WmiObject. If neither exist, then warn the user that the test results may not have all the system information. Updated TestResult to try harder to get system information (based on whether Get-CIMInstance or Get-Wmi exists). Also, change a couple of tests to be more portable when it comes to CoreCLR because TypeId does not exist as property on Parameter.