### PR TITLE
Should BeLikeExactly fix

### DIFF
--- a/Functions/Assertions/BeLikeExactly.ps1
+++ b/Functions/Assertions/BeLikeExactly.ps1
@@ -3,11 +3,11 @@ function PesterBeLikeExactly($value, $expectedMatch) {
     return ($value -clike $expectedMatch)
 }
 
-function PesterBeLikeFailureMessage($value, $expectedMatch) {
+function PesterBeLikeExactlyFailureMessage($value, $expectedMatch) {
     return "Expected: {$value} to be exactly like the wildcard {$expectedMatch}"
 }
 
-function NotPesterBeLikeFailureMessage($value, $expectedMatch) {
+function NotPesterBeLikeExactlyFailureMessage($value, $expectedMatch) {
     return "Expected: ${value} to not be exactly like the wildcard ${expectedMatch}"
 }
 

--- a/Functions/Assertions/Should.Tests.ps1
+++ b/Functions/Assertions/Should.Tests.ps1
@@ -158,5 +158,23 @@ InModuleScope Pester {
             }
         }
 
+        It 'All failure message functions are present' {
+            $assertionFunctions = Get-Command -CommandType Function -Module Pester |
+                                  Select-Object -ExpandProperty Name |
+                                  Where-Object { $_ -like 'Pester*' -and $_ -notlike '*FailureMessage' }
+
+            $missingFunctions = @(
+                foreach ($assertionFunction in $assertionFunctions)
+                {
+                    $positiveFailureMessage = "${assertionFunction}FailureMessage"
+                    $negativeFailureMessage = "Not${assertionFunction}FailureMessage"
+
+                    if (-not (Test-Path function:$positiveFailureMessage)) { $positiveFailureMessage }
+                    if (-not (Test-Path function:$negativeFailureMessage)) { $negativeFailureMessage }
+                }
+            )
+
+            [string]$missingFunctions | Should BeNullOrEmpty
+        }
     }
 }


### PR DESCRIPTION
Function names were wrong for the failure messages on Should BeLikeExactly.  This was causing incorrect output for BeLike, and a CommandNotFound error if a BeLikeExactly assertion failed.