### PR TITLE
Formatted About topics

### DIFF
--- a/en-US/about_BeforeEach_AfterEach.help.txt
+++ b/en-US/about_BeforeEach_AfterEach.help.txt
@@ -1,73 +1,88 @@
-BeforeEach, AfterEach, BeforeAll, and AfterAll
--------------------------------
+TOPIC
+    about_BeforeEach_AfterEach
 
-The BeforeEach and AfterEach commands allow you to define setup and teardown tasks that are
-performed at the beginning and end of every It block. This can eliminate duplication of code
-in test scripts, ensure that each test is performed on a pristine state regardless of their
-order, and perform any necessary clean-up tasks after each test.
+SHORT DESCRIPTION
+    Describes the BeforeEach and AfterEach commands, which run a set of commands that you specify
+    before or after every It block.
 
-BeforeEach and AfterEach blocks may be defined inside of any Describe or Context. If they
-are present in both a Context and its parent Describe, BeforeEach blocks in the Describe scope
-are executed first, followed by BeforeEach blocks in the Context scope. AfterEach blocks are
-the reverse of this, with the Context  AfterEach blocks executing before Describe.
+LONG DESCRIPTION
+    The the BeforeEach and AfterEach commands in the Pester module let you define setup and teardown
+    tasks that are performed at the beginning and end of every It block. This can eliminate duplication of code
+    in test scripts, ensure that each test is performed on a pristine state regardless of their
+    order, and perform any necessary clean-up tasks after each test.
 
-The script blocks assigned to BeforeEach and AfterEach are dot-sourced in the Context or Describe
-which contains the current It statement, so you don't have to worry about the scope of variable
-assignments. Any variables that are assigned values within a BeforeEach block can be used inside
-the body of the It block.
+    BeforeEach and AfterEach blocks may be defined inside of any Describe or Context. If they
+    are present in both a Context and its parent Describe, BeforeEach blocks in the Describe scope
+    are executed first, followed by BeforeEach blocks in the Context scope. AfterEach blocks are
+    the reverse of this, with the Context  AfterEach blocks executing before Describe.
 
-BeforeAll and AfterAll are used the same way as BeforeEach and AfterEach, except that they are
-executed at the beginning and end of their containing Describe or Context block.  This is
-essentially syntactic sugar for the following arrangement of code:
+    The script blocks assigned to BeforeEach and AfterEach are dot-sourced in the Context or Describe
+    which contains the current It statement, so you don't have to worry about the scope of variable
+    assignments. Any variables that are assigned values within a BeforeEach block can be used inside
+    the body of the It block.
 
-Describe 'Something' {
-    try
-    {
-        <BeforeAll Code Here>
+    BeforeAll and AfterAll are used the same way as BeforeEach and AfterEach, except that they are
+    executed at the beginning and end of their containing Describe or Context block.  This is
+    essentially syntactic sugar for the following arrangement of code:
 
-        <Describe Body>
-    }
-    finally
-    {
-        <AfterAll Code Here>
-    }
-}
+      Describe 'Something' {
+        try
+        {
+            <BeforeAll Code Here>
 
-Note about syntax and placement
--------------------------------
+            <Describe Body>
+        }
+        finally
+        {
+            <AfterAll Code Here>
+        }
+      }
 
-Unlike most of the commands in a Pester script, BeforeEach, AfterEach, BeforeAll and AfterAll blocks
-apply to the entire Describe or Context scope in which they are defined, regardless of the order of
-commands inside the Describe or Context. In other words, even if an It block appears before BeforeEach
-or AfterEach in the tests file, the BeforeEach and AfterEach will still be executed.  Likewise, BeforeAll
-code will be executed at the beginning of a Context or Describe block regardless of where it is found,
-and AfterAll code will execute at the end of the Context or Describe.
+    
+  SYNTAX AND PLACEMENT
+    Unlike most of the commands in a Pester script, BeforeEach, AfterEach, BeforeAll and AfterAll blocks
+    apply to the entire Describe or Context scope in which they are defined, regardless of the order of
+    commands inside the Describe or Context. In other words, even if an It block appears before BeforeEach
+    or AfterEach in the tests file, the BeforeEach and AfterEach will still be executed.  Likewise, BeforeAll
+    code will be executed at the beginning of a Context or Describe block regardless of where it is found,
+    and AfterAll code will execute at the end of the Context or Describe.
 
-Examples
--------------------------------
 
-Describe 'Testing BeforeEach and AfterEach' {
-    $afterEachVariable = 'AfterEach has not been executed yet'
+  EXAMPLES
+    Describe 'Testing BeforeEach and AfterEach' {
+        $afterEachVariable = 'AfterEach has not been executed yet'
 
-    It 'Demonstrates that BeforeEach may be defined after the It command' {
-        $beforeEachVariable | Should Be 'Set in a describe-scoped BeforeEach'
-        $afterEachVariable  | Should Be 'AfterEach has not been executed yet'
-        $beforeAllVariable  | Should Be 'BeforeAll has been executed'
-    }
+        It 'Demonstrates that BeforeEach may be defined after the It command' {
+            $beforeEachVariable | Should Be 'Set in a describe-scoped BeforeEach'
+            $afterEachVariable  | Should Be 'AfterEach has not been executed yet'
+            $beforeAllVariable  | Should Be 'BeforeAll has been executed'
+        }
 
-    It 'Demonstrates that AfterEach has executed after the end of the first test' {
-        $afterEachVariable | Should Be 'AfterEach has been executed'
-    }
+        It 'Demonstrates that AfterEach has executed after the end of the first test' {
+            $afterEachVariable | Should Be 'AfterEach has been executed'
+        }
 
-    BeforeEach {
-        $beforeEachVariable = 'Set in a describe-scoped BeforeEach'
-    }
+        BeforeEach {
+            $beforeEachVariable = 'Set in a describe-scoped BeforeEach'
+        }
 
-    AfterEach {
-        $afterEachVariable = 'AfterEach has been executed'
-    }
+        AfterEach {
+            $afterEachVariable = 'AfterEach has been executed'
+        }
 
-    BeforeAll {
-        $beforeAllVariable = 'BeforeAll has been executed'
-    }
-}
+        BeforeAll {
+            $beforeAllVariable = 'BeforeAll has been executed'
+        }
+      }
+
+SEE ALSO
+    about_Pester
+    about_Should
+    about_Mocking
+    about_TestDrive
+    about_about_Try_Catch_Finally
+    Describe
+    Context
+    Should
+    It
+    Invoke-Pester

--- a/en-US/about_Mocking.help.txt
+++ b/en-US/about_Mocking.help.txt
@@ -1,22 +1,22 @@
 TOPIC
-	Mocking
+    About_Mocking
 
-SYNOPSIS
-	Pester provides a set of Mocking functions making it easy to fake dependencies 
-	and also to verify behavior. Using these mocking functions can allow you to 
-	"shim" a data layer or mock other complex functions that already have their 
-	own tests.
+SHORT DESCRIPTION
+    Pester provides a set of Mocking functions making it easy to fake dependencies 
+    and also to verify behavior. Using these mocking functions can allow you to 
+    "shim" a data layer or mock other complex functions that already have their 
+    own tests.
 
-DESCRIPTION
-	With the set of Mocking functions that Pester exposes, one can:
+LONG DESCRIPTION
+    With the set of Mocking functions that Pester exposes, one can:
 
-	- Mock the behavior of ANY PowerShell command.
-	- Verify that specific commands were (or were not) called.
-	- Verify the number of times a command was called with a set of specified 
-	 parameters.
+        - Mock the behavior of ANY PowerShell command.
+        - Verify that specific commands were (or were not) called.
+        - Verify the number of times a command was called with a set of specified 
+	  parameters.
 
-MOCKING FUNCTIONS
-	See Get-Help for any of the below functions for more detailed information.
+  MOCKING FUNCTIONS
+  For detailed information about the functions in the Pester module, use Get-Help.
 
 	Mock
 		Mocks the behavior of an existing command with an alternate 
@@ -30,159 +30,160 @@ MOCKING FUNCTIONS
 		Checks if a Mocked command has been called a certain number of times 
 		and throws an exception if it has not.
 
-EXAMPLE
-  function Build ($version) {
-    Write-Host "a build was run for version: $version"
-  }
-
-  function BuildIfChanged {
-    $thisVersion = Get-Version
-    $nextVersion = Get-NextVersion
-    if ($thisVersion -ne $nextVersion) { Build $nextVersion }
-    return $nextVersion
-  }
-
-  $here = Split-Path -Parent $MyInvocation.MyCommand.Path
-  $sut = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -replace '\.Tests\.', '.'
-  . "$here\$sut"
-
-  Describe "BuildIfChanged" {
-    Context "When there are Changes" {
-      Mock Get-Version {return 1.1}
-      Mock Get-NextVersion {return 1.2}
-      Mock Build {} -Verifiable -ParameterFilter {$version -eq 1.2}
-
-      $result = BuildIfChanged
-
-      It "Builds the next version" {
-        Assert-VerifiableMocks
-      }
-      It "returns the next version number" {
-        $result | Should Be 1.2
-      }
-    }
-    Context "When there are no Changes" {
-      Mock Get-Version { return 1.1 }
-      Mock Get-NextVersion { return 1.1 }
-      Mock Build {}
-
-      $result = BuildIfChanged
-
-      It "Should not build the next version" {
-        Assert-MockCalled Build -Times 0 -ParameterFilter {$version -eq 1.1}
-      }
-    }
-  }
-
-MOCKING CALLS TO COMMANDS MADE FROM INSIDE SCRIPT MODULES
-
-Let's say you have code like this inside a script module (.psm1 file):
-
-  function BuildIfChanged {
-    $thisVersion = Get-Version
-    $nextVersion = Get-NextVersion
-    if ($thisVersion -ne $nextVersion) { Build $nextVersion }
-    return $nextVersion
-  }
-
-  function Build ($version) {
-    Write-Host "a build was run for version: $version"
-  }
-
-  # Actual definitions of Get-Version and Get-NextVersion are not shown here,
-  # since we'll just be mocking them anyway. However, the commands do need to
-  # exist in order to be mocked, so we'll stick dummy functions here
-
-  function Get-Version { return 0 }
-  function Get-NextVersion { return 0 }
-
-  Export-ModuleMember -Function BuildIfChanged
-
-You wish to write a unit test for this module which mocks the calls to Get-Version
-and Get-NextVersion from the module's BuildIfChanged command. In older versions of
-Pester, this was not possible. As of version 3.0, there are two ways you can perform
-unit tests of PowerShell script modules. The first is to inject mocks into a module:
-
-For these example, we'll assume that the PSM1 file is named "MyModule.psm1", and that
-it is installed on your PSModulePath.
-
-  Import-Module MyModule
-
-  Describe "BuildIfChanged" {
-    Context "When there are Changes" {
-      Mock -ModuleName MyModule Get-Version { return 1.1 }
-      Mock -ModuleName MyModule Get-NextVersion { return 1.2 }
-
-      # Just for giggles, we'll also mock Write-Host here, to demonstrate that you can
-      # mock calls to commands other than functions defined within the same module.
-      Mock -ModuleName MyModule Write-Host {} -Verifiable -ParameterFilter {
-        $Object -eq 'a build was run for version: 1.2'
-      }
-
-      $result = BuildIfChanged
-
-      It "Builds the next version and calls Write-Host" {
-        Assert-VerifiableMocks
-      }
-
-      It "returns the next version number" {
-        $result | Should Be 1.2
-      }
+  EXAMPLE
+    function Build ($version) {
+        Write-Host "a build was run for version: $version"
     }
 
-    Context "When there are no Changes" {
-      Mock -ModuleName MyModule Get-Version { return 1.1 }
-      Mock -ModuleName MyModule Get-NextVersion { return 1.1 }
-      Mock -ModuleName MyModule Build { }
+    function BuildIfChanged {
+        $thisVersion = Get-Version
+        $nextVersion = Get-NextVersion
+        if ($thisVersion -ne $nextVersion) { Build $nextVersion }
+        return $nextVersion
+    }
 
-      $result = BuildIfChanged
+    $here = Split-Path -Parent $MyInvocation.MyCommand.Path
+    $sut = (Split-Path -Leaf $MyInvocation.MyCommand.Path).Replace(".Tests.", ".")
+    . "$here\$sut"
 
-      It "Should not build the next version" {
-        Assert-MockCalled Build -ModuleName MyModule -Times 0 -ParameterFilter {
-          $version -eq 1.1
+    Describe "BuildIfChanged" {
+      Context "When there are Changes" {
+        Mock Get-Version {return 1.1}
+        Mock Get-NextVersion {return 1.2}
+        Mock Build {} -Verifiable -ParameterFilter {$version -eq 1.2}
+
+        $result = BuildIfChanged
+
+        It "Builds the next version" {
+          Assert-VerifiableMocks
+        }
+        It "returns the next version number" {
+          $result | Should Be 1.2
+        }
+      }
+      Context "When there are no Changes" {
+        Mock Get-Version { return 1.1 }
+        Mock Get-NextVersion { return 1.1 }
+        Mock Build {}
+
+        $result = BuildIfChanged
+
+        It "Should not build the next version" {
+          Assert-MockCalled Build -Times 0 -ParameterFilter {$version -eq 1.1}
         }
       }
     }
-  }
 
-Notice that in this example test script, all calls to Mock and Assert-MockCalled have had the
--ModuleName MyModule parameter added. This tells Pester to inject the mock into the module's scope,
-which causes any calls to those commands from inside the module to execute the mock instead.
 
-When you write your test script this way, you can mock commands that are called by the module's
-internal functions. However, your test script is still limited to accessing the public, exported
-members of the module. If you wanted to write a unit test that calls Build directly, for example,
-it wouldn't work using the above technique. That's where the second approach to script module testing
-comes into play. With Pester 3.0's InModuleScope command, you can cause entire sections of your test
-script to execute inside the targeted script module. This gives you access to non-exported members of
-the module. For example:
+  MOCKING CALLS TO COMMANDS MADE FROM INSIDE SCRIPT MODULES
 
-  Import-Module MyModule
+  Let's say you have code like this inside a script module (.psm1 file):
 
-  Describe "Unit testing the module's internal Build function:" {
-    InModuleScope MyModule {
-      $testVersion = 5.0
-      Mock Write-Host { }
+    function BuildIfChanged {
+      $thisVersion = Get-Version
+      $nextVersion = Get-NextVersion
+      if ($thisVersion -ne $nextVersion) { Build $nextVersion }
+      return $nextVersion
+    }
 
-      Build $testVersion
+    function Build ($version) {
+      Write-Host "a build was run for version: $version"
+    }
 
-      It 'Outputs the correct message' {
-        Assert-MockCalled Write-Host -ParameterFilter {
-          $Object -eq "a build was run for version: $testVersion"
+    # Actual definitions of Get-Version and Get-NextVersion are not shown here,
+    # since we'll just be mocking them anyway. However, the commands do need to
+    # exist in order to be mocked, so we'll stick dummy functions here
+
+    function Get-Version { return 0 }
+    function Get-NextVersion { return 0 }
+
+    Export-ModuleMember -Function BuildIfChanged
+
+  Beginning in Pester 3.0, there are two ways to write a unit test for a module that 
+  mocks the calls to Get-Version and Get-NextVersion from the module's BuildIfChanged 
+  command. The first is to inject mocks into a module:
+
+  In these examples, the PSM1 file, MyModule.psm1 is installed in $env:PSModulePath on
+  the local computer.
+
+    Import-Module MyModule
+
+    Describe "BuildIfChanged" {
+      Context "When there are Changes" {
+        Mock -ModuleName MyModule Get-Version { return 1.1 }
+        Mock -ModuleName MyModule Get-NextVersion { return 1.2 }
+
+        # To demonstrate that you can mock calls to commands other than functions 
+        # defined in the same module, we'll mock a call to Write-Host.
+      
+        Mock -ModuleName MyModule Write-Host {} -Verifiable -ParameterFilter {
+            $Object -eq 'a build was run for version: 1.2'
+        }
+
+        $result = BuildIfChanged
+
+        It "Builds the next version and calls Write-Host" {
+          Assert-VerifiableMocks
+        }
+
+        It "returns the next version number" {
+          $result | Should Be 1.2
+        }
+      }
+
+      Context "When there are no Changes" {
+        Mock -ModuleName MyModule Get-Version { return 1.1 }
+        Mock -ModuleName MyModule Get-NextVersion { return 1.1 }
+        Mock -ModuleName MyModule Build { }
+
+        $result = BuildIfChanged
+
+        It "Should not build the next version" {
+          Assert-MockCalled Build -ModuleName MyModule -Times 0 -ParameterFilter {
+            $version -eq 1.1
+          }
         }
       }
     }
-  }
 
-Notice that when using InModuleScope, you no longer need to specify a -ModuleName parameter when calling
-Mock or Assert-MockCalled for commands within that module. You are also able to directly call the Build
-function, which the module does not export.
+
+  In this sample test script, all calls to Mock and Assert-MockCalled have the
+  -ModuleName MyModule parameter added. This tells Pester to inject the mock into the module scope,
+  which causes any calls to those commands from inside the module to execute the mock instead.
+
+  When you write your test script this way, you can mock commands that are called by the module's
+  internal functions. However, your test script is still limited to accessing the public, exported
+  members of the module. For example, you could not call the Build function directly.
+
+  The InModuleScope command causes entire sections of your test script to execute inside the targeted
+  script module. This gives you access to unexported members of the module. For example:
+
+    Import-Module MyModule
+ 
+    Describe "Unit testing the module's internal Build function:" {
+      InModuleScope MyModule {
+        $testVersion = 5.0
+        Mock Write-Host { }
+
+        Build $testVersion
+
+        It 'Outputs the correct message' {
+          Assert-MockCalled Write-Host -ParameterFilter {
+            $Object -eq "a build was run for version: $testVersion"
+          }
+        }
+      }
+    }
+
+  When using InModuleScope, you no longer need to specify a ModuleName parameter when calling
+  Mock or Assert-MockCalled for commands in the module. You can also directly call the Build
+  function that the module does not export.
 
 SEE ALSO
-	Mock
-	Assert-VerifiableMocks
-	Assert-MockCalled
-    InModuleScope
-	Describe
-	Context
-	It
+  Mock
+  Assert-VerifiableMocks
+  Assert-MockCalled
+  InModuleScope
+  Describe
+  Context
+  It

--- a/en-US/about_Pester.help.txt
+++ b/en-US/about_Pester.help.txt
@@ -1,48 +1,50 @@
 TOPIC
-	Pester
+    Pester
 
-SYNOPSIS
-	Pester is a BDD based test runner for PowerShell.
+SHORT DESCRIPTION
+    Pester is a behavior-driven development (BDD) test framework for Windows PowerShell.
 
-DESCRIPTION
-	Pester provides a framework for running Unit Tests to execute and validate 
-	PowerShell commands. Pester follows a file naming convention for naming 
-	tests to be discovered by pester at test time and a simple set of 
-	functions that expose a Testing DSL for isolating, running, evaluating and 
-	reporting the results of PowerShell commands.
+LONG DESCRIPTION
+    Pester provides a framework for running unit tests to execute and validate 
+    PowerShell commands. Pester follows a file naming convention for naming 
+    tests to be discovered by pester at test time and a simple set of 
+    functions that expose a domain-specific testing language for isolating, 
+    running, evaluating, and reporting the results of PowerShell commands.
 
-	Pester tests can execute any command or script that is accessible to a 
-	pester test file. This can include functions, cmdlets, modules and scripts. 
-	Pester can be run in ad hoc style in a console or it can be integrated into 
-	the Build scripts of a Continuous Integration system.
+    Pester tests can execute any command or script that is accessible to a 
+    Pester test file. This can include functions, cmdlets, modules and scripts. 
+    Pester can be run in ad hoc style in a console or it can be integrated into 
+    the build scripts of a continuous integration system.
 
-	Pester also contains a powerful set of Mocking Functions that allow tests to 
-	mimic and mock the functionality of any command inside of a piece of 
-	PowerShell code being tested. See about_Mocking.
+    Pester also contains a powerful set of mocking functions that allow tests to 
+    mimic and mock the functionality of any command inside a PowerShell script or
+    module being tested. For more information, see about_Mocking.
 
-CREATING A PESTER TEST
-	To start using Pester, you may use the New-Fixture function to scaffold both 
-	a new implementation function and a test function.
+  CREATING A PESTER TEST
+    To start using Pester, you can use the New-Fixture function to create a "scaffold" 
+    files (structure without content) for a new script with a function of the same name
+    and its test file. 
 
-	C:\PS>New-Fixture deploy Clean
+    C:\PS>New-Fixture deploy Clean
+ 
+    Creates two files:
+        ./deploy/Clean.ps1
 
-	Creates two files:
-	./deploy/Clean.ps1
-	function clean {
+          function clean {
 
-	}
+          }
 
-    ./deploy/clean.Tests.ps1
-    $here = Split-Path -Parent $MyInvocation.MyCommand.Path
-    $sut = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -replace '\.Tests\.', '.'
-    . "$here\$sut"
+     ./deploy/clean.Tests.ps1
+         $here = Split-Path -Parent $MyInvocation.MyCommand.Path
+         $sut = (Split-Path -Leaf $MyInvocation.MyCommand.Path).Replace(".Tests.", ".")
+         . "$here\$sut"
 
-    Describe "clean" {
-
-        It "does something useful" {
-            $true | should be $false
-        }
-    }
+      Describe "clean" {
+ 
+          It "does something useful" {
+             $true | should be $false
+          }
+      }
 
     Now you have a skeleton of a clean function with a failing test. Pester 
     considers all files containing *Tests.ps1 to be a test file (see 
@@ -55,13 +57,15 @@ CREATING A PESTER TEST
     comparisons between the values emitted or altered by a test and an expected 
     value (see about_Should). 
 
-RUNNNING A PESTER TEST
-	Once you have some logic that you are ready to test, run the Tests file directly, 
-	usually by pressing F5 in your ISE. 
+  RUNNNING A PESTER TEST
+    When you have some logic that you are ready to test, run the Tests file, 
+    by clicking Run (typically F5) in your script editor. 
 	
-	To run multiple test files, get summary for the test run, to get nUnit compatible XML
-	report or to get PesterResult object use the Invoke-Pester command. You can zero in on 
-	just one test (Describe block) or an entire tree of directories.
+    You can also run the Invoke-Pester function. This is particularly useful when
+    you want to use its parameters, such as to run multiple test files, get a summary of the 
+    test results, get an nUnit-compatible XML report, or to get a custom object (PSCustomObject)
+    of Pester results. You can also use the Invoke-Pester parameters to run a particular test
+    or all tests in a directory recursively.
 
 	function BuildIfChanged {
 		$thisVersion=Get-Version
@@ -71,43 +75,43 @@ RUNNNING A PESTER TEST
 	}
 
 	$here = Split-Path -Parent $MyInvocation.MyCommand.Path
-    $sut = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -replace '\.Tests\.', '.'
-    . "$here\$sut"
+        $sut = (Split-Path -Leaf $MyInvocation.MyCommand.Path).Replace(".Tests.", ".")
+        . "$here\$sut"
 
-    Describe "BuildIfChanged" {
-    	Context "When there are Changes" {
-    		Mock Get-Version {return 1.1}
-    		Mock Get-NextVersion {return 1.2}
-    		Mock Build {} -Verifiable -ParameterFilter {$version -eq 1.2}
+        Describe "BuildIfChanged" {
+            Context "When there are Changes" {
+                Mock Get-Version {return 1.1}
+      	        Mock Get-NextVersion {return 1.2}
+    	        Mock Build {} -Verifiable -ParameterFilter {$version -eq 1.2}
 
-    		$result = BuildIfChanged
+                $result = BuildIfChanged
 
-	        It "Builds the next version" {
+                It "Builds the next version" {
 	            Assert-VerifiableMocks
 	        }
 	        It "returns the next version number" {
 	            $result | Should Be 1.2
 	        }
-        }
-    	Context "When there are no Changes" {
-    		Mock Get-Version -MockWith {return 1.1}
-    		Mock Get-NextVersion -MockWith {return 1.1}
+            }
+    	   Context "When there are no Changes" {
+    	        Mock Get-Version -MockWith {return 1.1}
+    	        Mock Get-NextVersion -MockWith {return 1.1}
     		Mock Build {}
 
-    		$result = BuildIfChanged
+   	        $result = BuildIfChanged
 
-	        It "Should not build the next version" {
+                It "Should not build the next version" {
 	            Assert-MockCalled Build -Times 0 -ParameterFilter{$version -eq 1.1}
 	        }
+            }
         }
-    }
 
 	C:\PS>Invoke-Pester
 
-	This will run all tests recursively from the current directory downwards 
-	and print a report of all failing and passing tests to the console.
+	This will run all tests in the current directory recursively 
+	and write a report of all failing and passing tests to the console.
 
-PESTER AND CONTINUOUS INTEGRATION
+  PESTER AND CONTINUOUS INTEGRATION
 	Pester integrates well with almost any build automation solution. You 
 	could create a MSBuild target that calls Pester's convenience Batch file:
 
@@ -115,14 +119,13 @@ PESTER AND CONTINUOUS INTEGRATION
 	<Exec Command="cmd /c $(baseDir)pester\bin\pester.bat" />
 	</Target>
 
-	This will start a PowerShell session, import the Pester Module and call 
+	This will start a PowerShell session, import the Pester module and call 
 	invoke pester within the current directory. If any test fails, it will 
 	return an exit code equal to the number of failed tests and all test 
-	results will be saved to Test.xml using NUnit's Schema allowing you to 
-	plug these results nicely into most Build systems like CruiseControl, 
-	TeamCity, TFS or Jenkins.
+	results will be saved to Test.xml using the NUnit XML schema allowing you to 
+	use these results into build systems, such as CruiseControl, TeamCity, TFS, or Jenkins.
 
-OTHER EXAMPLES
+  OTHER EXAMPLES
 	Pester's own tests. See all files in the Pester Functions folder 
 	containing *Tests.ps1
 	
@@ -131,11 +134,11 @@ OTHER EXAMPLES
 	functionality.
 
 SEE ALSO
-	about_Mocking
-	Describe
-	Context
-	It
-	New-Fixture
-	Invoke-Pester
-	about_Should
-	about_TestDrive
+    about_Mocking
+    Describe
+    Context
+    It
+    Add-Fixture
+    Invoke-Pester
+    about_Should
+    about_TestDrive

--- a/en-US/about_TestDrive.help.txt
+++ b/en-US/about_TestDrive.help.txt
@@ -1,18 +1,18 @@
 TOPIC
-	TestDrive
+    TestDrive
 
-SYNOPSIS
-	A PSDrive for file activity limited to the scope of a single Describe or 
-	Context block.
+SHORT DESCRIPTION
+    A PSDrive for file activity limited to the scope of a singe Describe or 
+    Context block.
 
-DESCRIPTION	
-	A test may need to work with file operations and validate certain types of 
-	file activities. It is usually desirable not to perform file activity tests 
-	that will produce side effects outside of an individual test. Pester 
-	creates a PSDrive inside the user's temporary drive that is accessible via a 
-	names PSDrive TestDrive:. Pester will remove this drive after the test 
-	completes. You may use this drive to isolate the file operations of your 
-	test to a temporary store.
+LONG DESCRIPTION	
+    A test may need to work with file operations and validate certain types of 
+    file activities. It is usually desirable not to perform file activity tests 
+    that will produce side effects outside of an individual test. Pester 
+    creates a PSDrive inside the user's temporary drive that is accessible via a 
+    names PSDrive TestDrive:. Pester will remove this drive after the test 
+    completes. You may use this drive to isolate the file operations of your 
+    test to a temporary store.
 
 EXAMPLE
 	function Add-Footer($path, $footer) {
@@ -34,7 +34,7 @@ EXAMPLE
 	be removed.
 
 SEE ALSO
-	Context
-	Describe
-	It
-	about_Should
+    Context
+    Describe
+    It
+    about_Should

--- a/en-US/about_should.help.txt
+++ b/en-US/about_should.help.txt
@@ -1,25 +1,24 @@
 TOPIC
-	Should
+    about_Should
 
-SYNOPSIS
-	Provides assertion convenience methods for comparing objects and throwing 
-	test failures when test expectations fail.
+SHORT DESCRIPTION
+    Provides assertion convenience methods for comparing objects and throwing 
+    test failures when test expectations fail.
 
-DESCRIPTION
-	Should is an Extension of System.Object and can be used as a native type 
-	inside Describe blocks. The various Should member methods can be invoked 
-	directly from an object being compared. It is typically used in individual 
-	It blocks to verify the results of an expectation. The Should method is 
-	typically called from the "actual" object being compared and takes the 
-	"expected" object as a parameter. Should includes several members that 
-	perform various comparisons of objects and will throw a PesterFailure when 
-	the objects do not evaluate to be comparable.
+LONG DESCRIPTION
+    Should is an Extension of System.Object and can be used as a native type 
+    inside Describe blocks. The various Should member methods can be invoked 
+    directly from an object being compared. It is typically used in individual 
+    It blocks to verify the results of an expectation. The Should method is 
+    typically called from the "actual" object being compared and takes the 
+    expected" object as a parameter. Should includes several members that 
+    perform various comparisons of objects and will throw a PesterFailure when 
+    the objects do not evaluate to be comparable.
 
-SHOULD MEMBERS
-
-	Be
-		Compares one object with another for equality and throws if the two 
-		objects are not the same.
+  SHOULD MEMBERS
+    Be
+        Compares one object with another for equality and throws if the two 
+        objects are not the same.
 
         $actual="Actual value"
         $actual | Should Be "actual value" # Test will pass
@@ -31,22 +30,6 @@ SHOULD MEMBERS
         $actual="Actual value"
         $actual | Should BeExactly "Actual value" # Test will pass
         $actual | Should BeExactly "actual value" # Test will fail
-        
-    BeLike
-        Users a wildcard to compare two objects. The comparision is not case sensitive.
-        
-        "I am a value" | Should BeLike "*value"  # Test will pass
-        "I am a value" | Should BeLike "value"  # Test will fail
-        
-        Tip: use [Management.Automation.WildcardPattern]::Escape() to escape wildcard-characters.
-        
-    BeLikeExactly
-        Users a wildcard to compare two objects. The comparision is case sensitive.
-        
-        "I am a value" | Should BeLike "*value"  # Test will pass
-        "I am a value" | Should BeLike "*VALUE"  # Test will fail
-        
-        Tip: use [Management.Automation.WildcardPattern]::Escape() to escape wildcard-characters.
         
     BeGreaterThan
         Asserts that a number is greater than an expected value. Uses PowerShell's -gt operator to compare the two values.
@@ -107,7 +90,7 @@ SHOULD MEMBERS
         "I am a value" | Should MatchExactly "I Am" # Test will fail
 
     Throw
-        Checks if an exception was thrown in the input ScriptBlock.
+        Checks if an exception was thrown. Enclose input in a script block.
 
         { foo } | Should Throw # Test will pass
         { $foo = 1 } | Should Throw # Test will fail
@@ -126,7 +109,7 @@ SHOULD MEMBERS
         @()   | Should BeNullOrEmpty # Test will pass
         ""    | Should BeNullOrEmpty # Test will pass
 
-USING SHOULD IN A TEST
+  USING SHOULD IN A TEST
 
 	function Add-Numbers($a, $b) {
 	    return $a + $b
@@ -143,6 +126,6 @@ USING SHOULD IN A TEST
 	This test will fail since 3 will not be equal to the sum of 2 and 3.
 
 SEE ALSO
-	Describe
-    Context
-	It
+  Describe
+  Context
+  It


### PR DESCRIPTION
Applied standard formatting rules to Pester About topics. Among other things, this allows the About topics to be included in post-processing tools that look for standard elements in these otherwise unstructured text files.

I also corrected just a few grammatical errors. Really, just a few.