### PR TITLE
$count was null

### DIFF
--- a/Functions/PesterState.ps1
+++ b/Functions/PesterState.ps1
@@ -397,6 +397,11 @@ function ConvertTo-FailureLines
         ## convert the stack trace
         $traceLines = $ErrorRecord.ScriptStackTrace.Split([Environment]::NewLine, [System.StringSplitOptions]::RemoveEmptyEntries)
 
+        if (-not $traceLines)
+        {
+            $count = 1    
+        } 
+        
         # omit the lines internal to Pester
         foreach ( $line in $traceLines )
         {


### PR DESCRIPTION
$count was $null forcing -First on line 415 to error with a $null param arg. I'm creating the $count variable to ensure $count is always 1.