### PR TITLE
Modify Should Throw to use dot-source operator

### DIFF
--- a/Functions/Assertions/PesterThrow.Tests.ps1
+++ b/Functions/Assertions/PesterThrow.Tests.ps1
@@ -95,3 +95,16 @@ InModuleScope Pester {
         }
     }
 }
+
+Describe 'Should Throw - Scope test' {
+    # This test can't be placed into an "InModuleScope Pester" block, because the whole internal Pester
+    # call stack becomes part of the chain between the test script and the script block that's passed
+    # to "Should Not Throw".  This isn't a problem for any other InModuleScope situation; just when
+    # Pester is testing itself.
+
+    It 'Dot-sources the script block' {
+        $result = 'Set in It scope'
+        { $result = 'Set in Should scope' } | Should Not Throw
+        $result | Should Be 'Set in Should scope'
+    }
+}

--- a/Functions/Assertions/PesterThrow.ps1
+++ b/Functions/Assertions/PesterThrow.ps1
@@ -9,8 +9,12 @@ function PesterThrow([scriptblock] $script, $expectedErrorMessage) {
     $Script:ActualExceptionWasThrown = $false
 
     try {
-        # Redirect to $null so script output does not enter the pipeline
-        & $script > $null
+        # Assign to $null so script output does not enter the pipeline
+        # Script block is dot-sourced so callers may do things like this:
+        # { $result = Do-Something } | Should Not Throw
+        # $result | Should Be 'Successful output test'
+
+        $null = . $script
     } catch {
         $Script:ActualExceptionWasThrown = $true
         $Script:ActualExceptionMessage = $_.Exception.Message


### PR DESCRIPTION
Right now, if one wants to both verify whether or not a command throws an exception _and_ test its output at the same time, the code requires a bit of a workaround:

``` posh
It 'Tests something' {
    $hash = @{}
    { $hash['Result'] = Do-Something } | Should Not Throw
    $hash['Result'] | Should Be 'Some successful output'
}
```

By making the `Should Throw` command dot-source the script block, any variable assignments inside that block will persist out in the scope of the `It` block, allowing for a cleaner approach:

``` posh
It 'Tests something' {
    { $result = Do-Something } | Should Not Throw
    $result | Should Be 'Some successful output'
}
```
