### PR TITLE
Updates to better support Pester on Nano

### DIFF
--- a/Functions/Coverage.Tests.ps1
+++ b/Functions/Coverage.Tests.ps1
@@ -256,11 +256,14 @@ InModuleScope Pester {
 
                 configuration MyTestConfig   # does NOT trigger breakpoint
                 {
+                    # add this line to avoid a warning during test
+                    Import-DscResource -ModuleName PSDesiredStateConfiguration # Triggers breakpoint
                     Node localhost    # Triggers breakpoint
                     {
-                        WindowsFeature XPSViewer   # Triggers breakpoint
+                        Environment MyEnvironmentResource   # Triggers breakpoint
                         {
-                            Name = 'XPS-Viewer'  # does NOT trigger breakpoint
+                            Name = 'PesterTest'  # does NOT trigger breakpoint
+                            Value = 'IsTheBest'  # does NOT trigger breakpoint
                             Ensure = 'Present'   # does NOT trigger breakpoint
                         }
                     }
@@ -282,21 +285,21 @@ InModuleScope Pester {
             Enter-CoverageAnalysis -CodeCoverage "$root\TestScriptWithConfiguration.ps1" -PesterState $testState
 
             It 'Has the proper number of breakpoints defined' {
-                $testState.CommandCoverage.Count | Should Be 7
+                $testState.CommandCoverage.Count | Should Be 8
             }
 
             $null = . "$root\TestScriptWithConfiguration.ps1"
 
             $coverageReport = Get-CoverageReport -PesterState $testState
             It 'Reports the proper number of missed commands before running the configuration' {
-                $coverageReport.MissedCommands.Count | Should Be 4
+                $coverageReport.MissedCommands.Count | Should Be 5
             }
 
             MyTestConfig -OutputPath $root
 
             $coverageReport = Get-CoverageReport -PesterState $testState
             It 'Reports the proper number of missed commands after running the configuration' {
-                $coverageReport.MissedCommands.Count | Should Be 2
+                $coverageReport.MissedCommands.Count | Should Be 3
             }
 
             Exit-CoverageAnalysis -PesterState $testState

--- a/Functions/TestResults.Tests.ps1
+++ b/Functions/TestResults.Tests.ps1
@@ -1,6 +1,16 @@
 Set-StrictMode -Version Latest
 
 InModuleScope Pester {
+    # Don't perform the schema validations unless the Validate method exists
+    # XmlDocument.Validate does not exist on Nano
+    if ( [xml].GetMethods()|?{$_.Name -eq "Validate"} )
+    {
+        $skipValidationTests = $false
+    }
+    else
+    {
+        $skipValidationTests = $true
+    }
     Describe "Write nunit test results (Legacy)" {
         Setup -Dir "Results"
 
@@ -194,7 +204,7 @@ InModuleScope Pester {
             $xmlEnvironment.'machine-name'  | Should Be $env:ComputerName
         }
 
-        it "Should validate test results against the nunit 2.5 schema" {
+        it -skip:$SkipValidationTests "Should validate test results against the nunit 2.5 schema" {
             #create state
             $TestResults = New-PesterState -Path TestDrive:\
             $testResults.EnterDescribe('Describe #1')
@@ -213,7 +223,7 @@ InModuleScope Pester {
             { $xml.Validate({throw $args.Exception }) } | Should Not Throw
         }
 
-        it "handles special characters in block descriptions well -!@#$%^&*()_+`1234567890[];'',./""- " {
+        it -skip:$SkipValidationTests "handles special characters in block descriptions well -!@#$%^&*()_+`1234567890[];'',./""- " {
             #create state
             $TestResults = New-PesterState -Path TestDrive:\
             $testResults.EnterDescribe('Describe -!@#$%^&*()_+`1234567890[];'',./"- #1')
@@ -284,7 +294,7 @@ InModuleScope Pester {
                 }
             }
 
-            it 'Should validate test results against the nunit 2.5 schema' {
+            it -skip:$SkipValidationTests 'Should validate test results against the nunit 2.5 schema' {
                 $schemaPath = (Get-Module -Name Pester).Path | Split-Path | Join-Path -ChildPath "nunit_schema_2.5.xsd"
                 $null = $xmlResult.Schemas.Add($null,$schemaPath)
                 { $xmlResult.Validate({throw $args.Exception }) } | Should Not Throw
@@ -413,7 +423,7 @@ InModuleScope Pester {
             $xmlEnvironment.'machine-name'  | Should Be $env:ComputerName
         }
 
-        it "Should validate test results against the nunit 2.5 schema" {
+        it -skip:$SkipValidationTests "Should validate test results against the nunit 2.5 schema" {
             #create state
             $TestResults = New-PesterState -Path TestDrive:\
             $testResults.EnterDescribe('Describe #1')
@@ -432,7 +442,7 @@ InModuleScope Pester {
             { $xml.Validate({throw $args.Exception }) } | Should Not Throw
         }
 
-        it "handles special characters in block descriptions well -!@#$%^&*()_+`1234567890[];'',./""- " {
+        it -skip:$SkipValidationTests "handles special characters in block descriptions well -!@#$%^&*()_+`1234567890[];'',./""- " {
             #create state
             $TestResults = New-PesterState -Path TestDrive:\
             $testResults.EnterDescribe('Describe -!@#$%^&*()_+`1234567890[];'',./"- #1')
@@ -504,7 +514,7 @@ InModuleScope Pester {
                 $testCase2.Time | Should Be 1
             }
 
-            it 'Should validate test results against the nunit 2.5 schema' {
+            it -skip:$SkipValidationTests 'Should validate test results against the nunit 2.5 schema' {
                 $schemaPath = (Get-Module -Name Pester).Path | Split-Path | Join-Path -ChildPath "nunit_schema_2.5.xsd"
                 $null = $xmlResult.Schemas.Add($null,$schemaPath)
                 { $xmlResult.Validate({throw $args.Exception }) } | Should Not Throw


### PR DESCRIPTION
Update Coverage tests to use a different resource. The WindowsFeature resource
doesn't exist on Nano, but the Environment resource does
Update the TestResult tests to only validate against schema when the Validate
method is available on the system. Nano, for example, doesn't have this method
available because of the differences between Core and Full CLR
