### PR TITLE
Fix assertion naming constraints to accept single word

### DIFF
--- a/Pester.psm1
+++ b/Pester.psm1
@@ -16,6 +16,30 @@ $script:AssertionOperators = New-Object 'Collections.Generic.Dictionary[string,o
 $script:AssertionAliases = New-Object 'Collections.Generic.Dictionary[string,object]'([StringComparer]::InvariantCultureIgnoreCase)
 $script:AssertionDynamicParams = New-Object System.Management.Automation.RuntimeDefinedParameterDictionary
 
+function Test-NullOrWhiteSpace {
+    param ([string]$String)
+
+    $String -match "^\s*$" 
+}
+
+function Assert-ValidAssertionName 
+{ 
+    param([string]$Name)
+    if ($Name -notmatch '^\S+$') 
+    {
+        throw "Assertion name '$name' is invalid, assertion name must be a single word."
+    }
+}
+
+function Assert-ValidAssertionAlias 
+{ 
+    param([string]$Alias)
+    if ($Alias -notmatch '^\S+$')
+    {
+        throw "Assertion alias '$string' is invalid, assertion alias must be a single word."
+    }
+}
+
 function Add-AssertionOperator
 {
     [CmdletBinding()]
@@ -48,9 +72,9 @@ function Add-AssertionOperator
 
     $script:AssertionOperators[$Name] = $entry
 
-    foreach ($string in $Alias)
+    foreach ($string in $Alias | where { -not (Test-NullOrWhiteSpace $_)})
     {
-        if ($string -notmatch '\S') { continue }
+        Assert-ValidAssertionAlias -Alias $string
         $script:AssertionAliases[$string] = $Name
     }
 
@@ -63,9 +87,9 @@ function Assert-AssertionOperatorNameIsUnique
         [string[]] $Name
     )
 
-    foreach ($string in $name)
+    foreach ($string in $name | where { -not (Test-NullOrWhiteSpace $_)})
     {
-        if ($string -notmatch '\S') { continue }
+        Assert-ValidAssertionName -Name $string
 
         if ($script:AssertionOperators.ContainsKey($string))
         {
@@ -95,9 +119,9 @@ function Add-AssertionDynamicParameterSet
 
     $attributeCollection = New-Object Collections.ObjectModel.Collection[Attribute]
     $null = $attributeCollection.Add($attribute)
-
-    if ($AssertionEntry.Alias -match '\S')
-    {
+    if (-not (Test-NullOrWhiteSpace $AssertionEntry.Alias))
+    {    
+        Assert-ValidAssertionAlias -Alias $AssertionEntry.Alias
         $attribute = New-Object System.Management.Automation.AliasAttribute($AssertionEntry.Alias)
         $attributeCollection.Add($attribute)
     }


### PR DESCRIPTION
Assertion name and alias checking does two non complementary checks that allow aliases such as `E Q`. 

```powershell
$string = "A A B"
if ( $string -notmatch '\S')  { "invalid" }
if ( $string -match '\S' )    { "valid" }

#outputs: "valid" becuase string contains at least one non-whitespace character
```

So I changed the name checking to skip empty settings and throw on invalid names to notify us about incorrect configuration.

(btw there is one more check `$unresolvedPath -notmatch '\S'` that also does not seem to be doing what it's error message says)

