### PR TITLE
Adding support for both forward and back slashes in some paths

### DIFF
--- a/Functions/Coverage.Tests.ps1
+++ b/Functions/Coverage.Tests.ps1
@@ -226,20 +226,23 @@ InModuleScope Pester {
 
     Describe 'Stripping common parent paths' {
         $paths = @(
-            'C:\Common\Folder\UniqueSubfolder1\File.ps1'
-            'C:\Common\Folder\UniqueSubfolder2\File2.ps1'
-            'C:\Common\Folder\UniqueSubfolder3\File3.ps1'
+            Normalize-Path 'C:\Common\Folder\UniqueSubfolder1/File.ps1'
+            Normalize-Path 'C:\Common\Folder\UniqueSubfolder2/File2.ps1'
+            Normalize-Path 'C:\Common\Folder\UniqueSubfolder3/File3.ps1'
         )
 
         $commonPath = Get-CommonParentPath -Path $paths
+        $expectedCommonPath = Normalize-Path 'C:\Common/Folder'
 
         It 'Identifies the correct parent path' {
-            $commonPath | Should Be 'C:\Common\Folder'
+            $commonPath | Should Be $expectedCommonPath
         }
 
+        $expectedRelativePath = Normalize-Path 'UniqueSubfolder1/File.ps1'
+        $relativePath = Get-RelativePath -Path $paths[0] -RelativeTo $commonPath
+
         It 'Strips the common path correctly' {
-            Get-RelativePath -Path $paths[0] -RelativeTo $commonPath |
-            Should Be 'UniqueSubfolder1\File.ps1'
+            $relativePath | Should Be $expectedRelativePath
         }
     }
 


### PR DESCRIPTION
PowerShell allows for paths to be written `like\this` or `like/this`, regardless of what the underlying file system wants.  Some of our code was a bit fragile if forward slashes were used; added some normalization code.