### PR TITLE
Make Should Throw case insensitive

### DIFF
--- a/Functions/Assertions/PesterThrow.Tests.ps1
+++ b/Functions/Assertions/PesterThrow.Tests.ps1
@@ -18,6 +18,13 @@ InModuleScope Pester {
             { throw $expectedErrorMessage } | Should -Throw $expectedErrorMessage
         }
 
+        It "returns true if the statement throws an exception and the actual error text matches the expected error text (case insensitive)" {
+            $expectedErrorMessage = "expected error message"
+            $errorMessage = $expectedErrorMessage.ToUpperInvariant()
+            { throw $errorMessage } | Should Throw $expectedErrorMessage
+            { throw $errorMessage } | Should -Throw $expectedErrorMessage
+        }
+
         It "returns false if the statement throws an exception and the actual error does not match the expected error text" {
             $unexpectedErrorMessage = "unexpected error message"
             $expectedErrorMessage = "some expected error message"
@@ -154,7 +161,7 @@ InModuleScope Pester {
         It "returns true if the actual message is the same as the expected message" {
             $expectedErrorMessage = "expected"
             $actualErrorMessage = "expected"
-            $result = Get-DoMessagesMatch $actualErrorMessage $expectedErrorMessage
+            $result = Get-DoValuesMatch $actualErrorMessage $expectedErrorMessage
             $result | Should Be $True
             $result | Should -Be $True
         }
@@ -162,21 +169,33 @@ InModuleScope Pester {
         It "returns false if the actual message is not the same as the expected message" {
             $expectedErrorMessage = "some expected message"
             $actualErrorMessage = "unexpected"
-            $result = Get-DoMessagesMatch $actualErrorMessage $expectedErrorMessage
+            $result = Get-DoValuesMatch $actualErrorMessage $expectedErrorMessage
             $result | Should Be $False
             $result | Should -Be $False
         }
 
-        It "returns false is there's no expectation" {
-            $result = Get-DoMessagesMatch "" ""
-            $result | Should Be $False
-            $result | Should -Be $False
+        It "returns true is there's no expectation" {
+            $result = Get-DoValuesMatch "any error message" #expectation is null
+            $result | Should Be $True
+            $result | Should -Be $True
+        }
+
+        It "returns true if the message is empty and the expectation is empty" {
+            $result = Get-DoValuesMatch "" ""
+            $result | Should Be $True
+            $result | Should -Be $True
+        }
+
+        It "returns true if the message is empty and there is no expectation" {
+            $result = Get-DoValuesMatch "" #expectation is null
+            $result | Should Be $True
+            $result | Should -Be $True
         }
 
         It "returns true if the expected error is contained in the actual message" {
             $actualErrorMessage = "this is a long error message"
             $expectedText = "long error"
-            $result = Get-DoMessagesMatch $actualErrorMessage $expectedText
+            $result = Get-DoValuesMatch $actualErrorMessage $expectedText
             $result | Should Be $True
             $result | Should -Be $True
         }

--- a/Functions/Assertions/PesterThrow.ps1
+++ b/Functions/Assertions/PesterThrow.ps1
@@ -23,8 +23,8 @@ function PesterThrow([scriptblock] $ActualValue, $ExpectedMessage, $ErrorId, [sw
     [bool] $succeeded = $false
 
     if ($ActualExceptionWasThrown) {
-        $succeeded = (Get-DoMessagesMatch $script:ActualExceptionMessage $ExpectedMessage) -and
-                     (Get-DoMessagesMatch $script:ActualErrorId $ExpectedErrorId)
+        $succeeded = (Get-DoValuesMatch $script:ActualExceptionMessage $ExpectedMessage) -and
+                     (Get-DoValuesMatch $script:ActualErrorId $ExpectedErrorId)
     }
 
     if ($Negate) { $succeeded = -not $succeeded }
@@ -49,9 +49,11 @@ function PesterThrow([scriptblock] $ActualValue, $ExpectedMessage, $ErrorId, [sw
     }
 }
 
-function Get-DoMessagesMatch($ActualValue, $ExpectedMessage, $ExpectedErrorId) {
-    if ($ExpectedMessage -eq "") { return $false }
-    return $ActualValue.Contains($ExpectedMessage)
+function Get-DoValuesMatch($ActualValue, $ExpectedValue) {
+    #user did not specify any message filter, so any message matches
+    if ($null -eq $ExpectedValue ) { return $true }
+
+    return $ActualValue.ToString().IndexOf($ExpectedValue, [System.StringComparison]::InvariantCultureIgnoreCase) -ge 0
 }
 
 function Get-ExceptionLineInfo($info) {


### PR DESCRIPTION
I replaced the original Contains with IndexOf and a $null check, becuase
Contains returns $True for $null input. The $null in this context means
that users did not specify any expected message and hence all messages
should pass the Get-DoMessagesMatch filter.

There was also a test case which made sure that empty string expectation
returns $False. I removed that case, because it complicates the
contract, and no one is likely using it as it would always fail the
assertion. Instead replaced it with cases that ensure that empty-string
error message will match empty-string expectation.

I also removed the $ExpectedErrorId parameter from Get-DoMessagesMatch,
because it was not used. I guess the idea was to implement the logic of
"id and message must both match" inside of the Get-DoMessageMatch
function, but it is implemented elsewhere.

The Get-DoMessagesMatch is renamed to Get-DoValuesMatch, because it does not work with messages only anymore.

This is a breaking change, and so is making the comparison
case-insensitive.

Fixes #577

This is another attempt at #579 Thanks for the inputs there @dlwyatt , but I had to use different approach because I needed contains, and not equals. I could not find any non-synthetic case where the `-like` would fail, but I did not use it anyway. 