### PR TITLE
Fix #655

### DIFF
--- a/Functions/Context.ps1
+++ b/Functions/Context.ps1
@@ -75,11 +75,10 @@ about_TestDrive
     finally
     {
         Invoke-TestGroupTeardownBlocks -Scope $pester.Scope
+        Clear-SetupAndTeardown
+        Clear-TestDrive -Exclude ($TestDriveContent | & $SafeCommands['Select-Object'] -ExpandProperty FullName)
+        Exit-MockScope
+        $Pester.LeaveContext()
     }
-
-    Clear-SetupAndTeardown
-    Clear-TestDrive -Exclude ($TestDriveContent | & $SafeCommands['Select-Object'] -ExpandProperty FullName)
-    Exit-MockScope
-    $Pester.LeaveContext()
 }
 

--- a/Functions/Describe.ps1
+++ b/Functions/Describe.ps1
@@ -113,11 +113,10 @@ about_TestDrive
     {
         Invoke-TestGroupTeardownBlocks -Scope $pester.Scope
         if ($testDriveAdded) { Remove-TestDrive }
+        Clear-SetupAndTeardown
+        Exit-MockScope
+        $Pester.LeaveDescribe()
     }
-
-    Clear-SetupAndTeardown
-    Exit-MockScope
-    $Pester.LeaveDescribe()
 }
 
 function Assert-DescribeInProgress

--- a/Functions/It.ps1
+++ b/Functions/It.ps1
@@ -231,62 +231,66 @@ function Invoke-Test
 
     $Pester.EnterTest($Name)
 
-    if ($Skip)
+    try
     {
-        $Pester.AddTestResult($Name, "Skipped", $null)
-    }
-    elseif ($Pending)
-    {
-        $Pester.AddTestResult($Name, "Pending", $null)
-    }
-    else
-    {
-        & $SafeCommands['Write-Progress'] -Activity "Running test '$Name'" -Status Processing
-
-        $errorRecord = $null
-        try
+        if ($Skip)
         {
-            Invoke-TestCaseSetupBlocks
-
-            do
-            {
-                $null = & $ScriptBlock @Parameters
-            } until ($true)
+            $Pester.AddTestResult($Name, "Skipped", $null)
         }
-        catch
+        elseif ($Pending)
         {
-            $errorRecord = $_
+            $Pester.AddTestResult($Name, "Pending", $null)
         }
-        finally
+        else
         {
-            #guarantee that the teardown action will run and prevent it from failing the whole suite
+            & $SafeCommands['Write-Progress'] -Activity "Running test '$Name'" -Status Processing
+
+            $errorRecord = $null
             try
             {
-                if (-not ($Skip -or $Pending))
+                Invoke-TestCaseSetupBlocks
+
+                do
                 {
-                    Invoke-TestCaseTeardownBlocks
-                }
+                    $null = & $ScriptBlock @Parameters
+                } until ($true)
             }
             catch
             {
                 $errorRecord = $_
             }
+            finally
+            {
+                #guarantee that the teardown action will run and prevent it from failing the whole suite
+                try
+                {
+                    if (-not ($Skip -or $Pending))
+                    {
+                        Invoke-TestCaseTeardownBlocks
+                    }
+                }
+                catch
+                {
+                    $errorRecord = $_
+                }
+            }
+
+            $result = Get-PesterResult -ErrorRecord $errorRecord
+            $orderedParameters = Get-OrderedParameterDictionary -ScriptBlock $ScriptBlock -Dictionary $Parameters
+            $Pester.AddTestResult( $result.name, $result.Result, $null, $result.FailureMessage, $result.StackTrace, $ParameterizedSuiteName, $orderedParameters, $result.ErrorRecord )
+            & $SafeCommands['Write-Progress'] -Activity "Running test '$Name'" -Completed -Status Processing
         }
-
-
-        $result = Get-PesterResult -ErrorRecord $errorRecord
-        $orderedParameters = Get-OrderedParameterDictionary -ScriptBlock $ScriptBlock -Dictionary $Parameters
-        $Pester.AddTestResult( $result.name, $result.Result, $null, $result.FailureMessage, $result.StackTrace, $ParameterizedSuiteName, $orderedParameters, $result.ErrorRecord )
-        & $SafeCommands['Write-Progress'] -Activity "Running test '$Name'" -Completed -Status Processing
+    }
+    finally
+    {
+        Exit-MockScope
+        $Pester.LeaveTest()
     }
 
     if ($null -ne $OutputScriptBlock)
     {
         $Pester.testresult[-1] | & $OutputScriptBlock
     }
-
-    Exit-MockScope
-    $Pester.LeaveTest()
 }
 
 function Get-PesterResult {


### PR DESCRIPTION
Moved some additional cleanup code into `finally` blocks to ensure it executes if control+C is pressed during test run.  (Not having `$pester.ExitTest()` / etc run was messing with execution of AfterAll blocks, and cleanup of mocks / testdrive was being skipped as well.)