### PR TITLE
Add commas to summary

### DIFF
--- a/Functions/PesterState.ps1
+++ b/Functions/PesterState.ps1
@@ -427,7 +427,7 @@ function Write-PesterReport
     )
 
     Write-Screen "Tests completed in $(Get-HumanTime $PesterState.Time.TotalSeconds)" -OutputType "Summary"
-    Write-Screen ("Passed: {0} Failed: {1} Skipped: {2} Pending: {3} Inconclusive: {4}" -f
+    Write-Screen ("Passed: {0}, Failed: {1}, Skipped: {2}, Pending: {3}, Inconclusive: {4}" -f
                   $PesterState.PassedCount,
                   $PesterState.FailedCount,
                   $PesterState.SkippedCount,


### PR DESCRIPTION
Add commas to test run summary as requested on Twitter. 
![image](https://cloud.githubusercontent.com/assets/5735905/21907412/c5837ffc-d90f-11e6-9c7e-82d9e13cb3cd.png)

Is this a breaking change? Is anyone using this to do integrations? I hope not, but in case you do, use the `-PassThru` switch of `Invoke-Pester` to get all the information as PSObjects.
