### PR TITLE
Fix Has-Flag on Powershell v4 and older

### DIFF
--- a/Pester.psm1
+++ b/Pester.psm1
@@ -143,8 +143,10 @@ function Has-Flag  {
      param
      (
          [Parameter(Mandatory = $true)]
+         [Pester.OutputTypes]
          $Setting,
          [Parameter(Mandatory = $true, ValueFromPipeline=$true)]
+         [Pester.OutputTypes]
          $Value
      )
 


### PR DESCRIPTION
On Powershell v4 and older the Has-Flag does not cast to the Pester.OutputTypes flagged enum automatically as it does on Powershell v5 which prevents Invoke-Pester from running.