### PR TITLE
The test Style rules corrected - branch DevelopmentV4

### DIFF
--- a/Functions/Gherkin.ps1
+++ b/Functions/Gherkin.ps1
@@ -189,9 +189,9 @@ function Invoke-Gherkin {
             Microsoft.PowerShell.Utility\Start-Sleep -Seconds 2
 
             if (!$PSBoundParameters.ContainsKey('Show'))
-    		{
-	    		$Show = [Pester.OutputTypes]::None
-		    }
+            {
+                $Show = [Pester.OutputTypes]::None
+            }
         }
 
         if($PSCmdlet.ParameterSetName -eq "RetestFailed") {

--- a/Functions/Output.ps1
+++ b/Functions/Output.ps1
@@ -225,7 +225,7 @@ function Write-PesterResult {
                     & $SafeCommands['Write-Host'] -ForegroundColor $ReportTheme.Pass "$margin[+] $output " -NoNewLine
                     & $SafeCommands['Write-Host'] -ForegroundColor $ReportTheme.PassTime $humanTime
                     break
-        	    }
+                }
 
                 Failed {
                     & $SafeCommands['Write-Host'] -ForegroundColor $ReportTheme.Fail "$margin[-] $output " -NoNewLine
@@ -240,7 +240,7 @@ function Write-PesterResult {
                         & $SafeCommands['Write-Host'] -ForegroundColor $ReportTheme.Fail $($TestResult.stackTrace -replace '(?m)^',$error_margin)
                     }
                     break
-	            }
+                }
 
                 Skipped {
                     & $SafeCommands['Write-Host'] -ForegroundColor $ReportTheme.Skipped "$margin[!] $output $humanTime"

--- a/Pester.Tests.ps1
+++ b/Pester.Tests.ps1
@@ -119,7 +119,7 @@ Describe 'Style rules' {
     $pesterRoot = (Get-Module Pester).ModuleBase
 
     $files = @(
-        Get-ChildItem $pesterRoot -Include *.ps1,*.psm1
+        Get-ChildItem $pesterRoot\* -Include *.ps1,*.psm1
         Get-ChildItem (Join-Path $pesterRoot 'Functions') -Include *.ps1,*.psm1 -Recurse
     )
 
@@ -132,8 +132,7 @@ Describe 'Style rules' {
 
                 for ($i = 0; $i -lt $lineCount; $i++)
                 {
-                    if ($lines[$i] -match '\s+$')
-                    {
+                    if ($lines[$i] -match '\s+$') {
                         'File: {0}, Line: {1}' -f $file.FullName, ($i + 1)
                     }
                 }
@@ -145,21 +144,39 @@ Describe 'Style rules' {
             throw "The following $($badLines.Count) lines contain trailing whitespace: `r`n`r`n$($badLines -join "`r`n")"
         }
     }
+    It 'Pester source files lines start with a tab character' {
+        $badLines = @(
+            foreach ($file in $files)
+            {
+                $lines = [System.IO.File]::ReadAllLines($file.FullName)
+                $lineCount = $lines.Count
+
+                for ($i = 0; $i -lt $lineCount; $i++)
+                {
+                    if ($lines[$i] -match '^[  ]*\t|^\t|^\t[  ]*') {
+                        'File: {0}, Line: {1}' -f $file.FullName, ($i + 1)
+                    }
+                }
+            }
+        )
+
+        if ($badLines.Count -gt 0)
+        {
+            throw "The following $($badLines.Count) lines start with a tab character: `r`n`r`n$($badLines -join "`r`n")"
+        }
+    }
 
     It 'Pester Source Files all end with a newline' {
         $badFiles = @(
-            foreach ($file in $files)
-            {
+            foreach ($file in $files) {
                 $string = [System.IO.File]::ReadAllText($file.FullName)
-                if ($string.Length -gt 0 -and $string[-1] -ne "`n")
-                {
+                if ($string.Length -gt 0 -and $string[-1] -ne "`n") {
                     $file.FullName
                 }
             }
         )
 
-        if ($badFiles.Count -gt 0)
-        {
+        if ($badFiles.Count -gt 0) {
             throw "The following files do not end with a newline: `r`n`r`n$($badFiles -join "`r`n")"
         }
     }

--- a/Pester.psm1
+++ b/Pester.psm1
@@ -78,7 +78,7 @@ $script:SafeCommands = @{
     'Test-Path'           = Get-Command -Name Test-Path           -Module Microsoft.PowerShell.Management @safeCommandLookupParameters
     'Where-Object'        = Get-Command -Name Where-Object        -Module Microsoft.PowerShell.Core       @safeCommandLookupParameters
     'Write-Error'         = Get-Command -Name Write-Error         -Module Microsoft.PowerShell.Utility    @safeCommandLookupParameters
-	'Write-Host'          = Get-Command -Name Write-Host          -Module Microsoft.PowerShell.Utility    @safeCommandLookupParameters
+    'Write-Host'          = Get-Command -Name Write-Host          -Module Microsoft.PowerShell.Utility    @safeCommandLookupParameters
     'Write-Progress'      = Get-Command -Name Write-Progress      -Module Microsoft.PowerShell.Utility    @safeCommandLookupParameters
     'Write-Verbose'       = Get-Command -Name Write-Verbose       -Module Microsoft.PowerShell.Utility    @safeCommandLookupParameters
     'Write-Warning'       = Get-Command -Name Write-Warning       -Module Microsoft.PowerShell.Utility    @safeCommandLookupParameters
@@ -308,9 +308,9 @@ using System;
 
 namespace Pester
 {
-	[Flags]
-	public enum OutputTypes
-	{
+    [Flags]
+    public enum OutputTypes
+    {
         None = 0,
         Default = 1,
         Passed = 2,
@@ -324,7 +324,7 @@ namespace Pester
         Header = 512,
         All = Default | Passed | Failed | Pending | Skipped | Inconclusive | Describe | Context | Summary | Header,
         Fails = Default | Failed | Pending | Skipped | Inconclusive | Describe | Context | Summary | Header
-	}
+    }
 }
 "@
 
@@ -637,7 +637,9 @@ report for all commands on lines 10 through 20 in the "ScriptUnderTest.ps1" file
 .EXAMPLE
 Invoke-Pester -Script C:\Tests -Tag UnitTest, Newest -ExcludeTag Bug
 
-This command runs *.Tests.ps1 files in C:\Tests and its subdirectories. In those files, it runs only tests that have UnitTest or Newest tags, unless the test also has a Bug tag.
+This command runs *.Tests.ps1 files in C:\Tests and its subdirectories. In those
+files, it runs only tests that have UnitTest or Newest tags, unless the test
+also has a Bug tag.
 
 .LINK
 https://github.com/pester/Pester/wiki/Invoke-Pester

--- a/Pester.psm1
+++ b/Pester.psm1
@@ -705,9 +705,9 @@ New-PesterOption
             & $script:SafeCommands['Start-Sleep'] -Seconds 2
 
             if (!$PSBoundParameters.ContainsKey('Show'))
-    		{
-	    		$Show = [Pester.OutputTypes]::None
-		    }
+            {
+                $Show = [Pester.OutputTypes]::None
+            }
         }
 
         $script:mockTable = @{}

--- a/chocolateyInstall.ps1
+++ b/chocolateyInstall.ps1
@@ -16,7 +16,7 @@ end
     }
 
     Update-Directory -Source $sourceDirectory -Destination $targetDirectory
-    
+
     $binPath = Join-Path -Path $targetDirectory -ChildPath bin
     Install-ChocolateyPath $binPath
 


### PR DESCRIPTION
- after correction ps1, psm1 files in the root Pester directory are checked by 'Style rules' too
- trailing spaces removed, 
- tabs replace with 4 spaces

The related issue #689 