### PR TITLE
Fix Should Be 

### DIFF
--- a/Functions/Assertions/Be.Tests.ps1
+++ b/Functions/Assertions/Be.Tests.ps1
@@ -72,6 +72,18 @@ InModuleScope Pester {
             $array1 | Should -Not -Be $array3
             $array1 | Should -Not -EQ $array3
         }
+
+        It "returns true if the actual value can be cast to the expected value and they are the same value" {
+            {abc} | Should Be "aBc"
+            {abc} | Should -Be "aBc"
+            {abc} | Should -EQ "aBc"
+        }
+
+        It "returns true if the actual value can be cast to the expected value and they are the same value (case sensitive)" {
+            {abc} | Should BeExactly "abc"
+            {abc} | Should -BeExactly "abc"
+            {abc} | Should -CEQ "abc"
+        }
     }
 
     Describe "PesterBeFailureMessage" {

--- a/Functions/Assertions/Be.ps1
+++ b/Functions/Assertions/Be.ps1
@@ -207,11 +207,11 @@ function ArraysAreEqual
         {
             if ($CaseSensitive)
             {
-                $comparer = { $args[0] -ceq $args[1] }
+                $comparer = { param($Actual, $Expected) $Expected -ceq $Actual }
             }
             else
             {
-                $comparer = { $args[0] -eq $args[1] }
+                $comparer = { param($Actual, $Expected) $Expected -eq $Actual }
             }
 
             if (-not (& $comparer $First[$i] $Second[$i]))


### PR DESCRIPTION
Fix Should be to behave the same way as in 3.4.6 where the expected side determines the type to be used for comparison. 
Fix #703