### PR TITLE
New-MarkdownHelp - Fix #720

### DIFF
--- a/Docs/AfterAll.md
+++ b/Docs/AfterAll.md
@@ -1,0 +1,44 @@
+---
+external help file: Pester-help.xml
+online version: 
+schema: 2.0.0
+---
+
+# AfterAll
+
+## SYNOPSIS
+Defines a series of steps to perform at the end of every It block within
+the current Context or Describe block.
+
+## SYNTAX
+
+```
+AfterAll
+```
+
+## DESCRIPTION
+BeforeEach, AfterEach, BeforeAll, and AfterAll are unique in that they apply
+to the entire Context or Describe block, regardless of the order of the
+statements in the Context or Describe.
+
+## EXAMPLES
+
+### Example 1
+```
+PS C:\> {{ Add example code here }}
+```
+
+{{ Add example description here }}
+
+## PARAMETERS
+
+## INPUTS
+
+## OUTPUTS
+
+## NOTES
+
+## RELATED LINKS
+
+[about_BeforeEach_AfterEach]()
+

--- a/Docs/AfterEach.md
+++ b/Docs/AfterEach.md
@@ -1,0 +1,47 @@
+---
+external help file: Pester-help.xml
+online version: 
+schema: 2.0.0
+---
+
+# AfterEach
+
+## SYNOPSIS
+Defines a series of steps to perform at the end of every It block within
+the current Context or Describe block.
+
+## SYNTAX
+
+```
+AfterEach
+```
+
+## DESCRIPTION
+BeforeEach, AfterEach, BeforeAll, and AfterAll are unique in that they apply
+to the entire Context or Describe block, regardless of the order of the
+statements in the Context or Describe. 
+For a full description of this
+behavior, as well as how multiple BeforeEach or AfterEach blocks interact
+with each other, please refer to the about_BeforeEach_AfterEach help file.
+
+## EXAMPLES
+
+### Example 1
+```
+PS C:\> {{ Add example code here }}
+```
+
+{{ Add example description here }}
+
+## PARAMETERS
+
+## INPUTS
+
+## OUTPUTS
+
+## NOTES
+
+## RELATED LINKS
+
+[about_BeforeEach_AfterEach]()
+

--- a/Docs/AfterEachFeature.md
+++ b/Docs/AfterEachFeature.md
@@ -1,0 +1,83 @@
+---
+external help file: Pester-help.xml
+online version: 
+schema: 2.0.0
+---
+
+# AfterEachFeature
+
+## SYNOPSIS
+Defines a ScriptBlock hook to run at the very end of a test run
+
+## SYNTAX
+
+### All (Default)
+```
+AfterEachFeature [-Script] <ScriptBlock>
+```
+
+### Tags
+```
+AfterEachFeature [-Tags] <String[]> [-Script] <ScriptBlock>
+```
+
+## DESCRIPTION
+AfterEachFeature hooks are run after each feature that is in (or above) the folder where the hook is defined.
+
+This is a convenience method, provided because unlike traditional RSpec Pester,
+there is not a simple test script where you can put setup and clean up.
+
+## EXAMPLES
+
+### Example 1
+```
+PS C:\> {{ Add example code here }}
+```
+
+{{ Add example description here }}
+
+## PARAMETERS
+
+### -Tags
+Optional tags.
+If set, this hook only runs for features with matching tags
+
+```yaml
+Type: String[]
+Parameter Sets: Tags
+Aliases: 
+
+Required: True
+Position: 1
+Default value: @()
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Script
+The ScriptBlock to run for the hook
+
+```yaml
+Type: ScriptBlock
+Parameter Sets: (All)
+Aliases: 
+
+Required: True
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+## INPUTS
+
+## OUTPUTS
+
+## NOTES
+
+## RELATED LINKS
+
+[BeforeEachFeature
+BeforeEachScenario
+AfterEachScenario]()
+

--- a/Docs/AfterEachScenario.md
+++ b/Docs/AfterEachScenario.md
@@ -1,0 +1,83 @@
+---
+external help file: Pester-help.xml
+online version: 
+schema: 2.0.0
+---
+
+# AfterEachScenario
+
+## SYNOPSIS
+Defines a ScriptBlock hook to run after each scenario to set up the test environment
+
+## SYNTAX
+
+### All (Default)
+```
+AfterEachScenario [-Script] <ScriptBlock>
+```
+
+### Tags
+```
+AfterEachScenario [-Tags] <String[]> [-Script] <ScriptBlock>
+```
+
+## DESCRIPTION
+AfterEachScenario hooks are run after each Scenario that is in (or above) the folder where the hook is defined.
+
+This is a convenience method, provided because unlike traditional RSpec Pester,
+there is not a simple test script where you can put setup and clean up.
+
+## EXAMPLES
+
+### Example 1
+```
+PS C:\> {{ Add example code here }}
+```
+
+{{ Add example description here }}
+
+## PARAMETERS
+
+### -Tags
+Optional tags.
+If set, this hook only runs for features with matching tags
+
+```yaml
+Type: String[]
+Parameter Sets: Tags
+Aliases: 
+
+Required: True
+Position: 1
+Default value: @()
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Script
+The ScriptBlock to run for the hook
+
+```yaml
+Type: ScriptBlock
+Parameter Sets: (All)
+Aliases: 
+
+Required: True
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+## INPUTS
+
+## OUTPUTS
+
+## NOTES
+
+## RELATED LINKS
+
+[BeforeEachFeature
+BeforeEachScenario
+AfterEachScenario]()
+

--- a/Docs/Assert-MockCalled.md
+++ b/Docs/Assert-MockCalled.md
@@ -1,0 +1,277 @@
+---
+external help file: Pester-help.xml
+online version: 
+schema: 2.0.0
+---
+
+# Assert-MockCalled
+
+## SYNOPSIS
+Checks if a Mocked command has been called a certain number of times
+and throws an exception if it has not.
+
+## SYNTAX
+
+### ParameterFilter (Default)
+```
+Assert-MockCalled [-CommandName] <String> [[-Times] <Int32>] [[-ParameterFilter] <ScriptBlock>]
+ [[-ModuleName] <String>] [[-Scope] <String>] [-Exactly]
+```
+
+### ExclusiveFilter
+```
+Assert-MockCalled [-CommandName] <String> [[-Times] <Int32>] -ExclusiveFilter <ScriptBlock>
+ [[-ModuleName] <String>] [[-Scope] <String>] [-Exactly]
+```
+
+## DESCRIPTION
+This command verifies that a mocked command has been called a certain number
+of times. 
+If the call history of the mocked command does not match the parameters
+passed to Assert-MockCalled, Assert-MockCalled will throw an exception.
+
+## EXAMPLES
+
+### -------------------------- EXAMPLE 1 --------------------------
+```
+Mock Set-Content {}
+```
+
+{...
+Some Code ...}
+
+C:\PS\>Assert-MockCalled Set-Content
+
+This will throw an exception and cause the test to fail if Set-Content is not called in Some Code.
+
+### -------------------------- EXAMPLE 2 --------------------------
+```
+Mock Set-Content -parameterFilter {$path.StartsWith("$env:temp\")}
+```
+
+{...
+Some Code ...}
+
+C:\PS\>Assert-MockCalled Set-Content 2 { $path -eq "$env:temp\test.txt" }
+
+This will throw an exception if some code calls Set-Content on $path=$env:temp\test.txt less than 2 times
+
+### -------------------------- EXAMPLE 3 --------------------------
+```
+Mock Set-Content {}
+```
+
+{...
+Some Code ...}
+
+C:\PS\>Assert-MockCalled Set-Content 0
+
+This will throw an exception if some code calls Set-Content at all
+
+### -------------------------- EXAMPLE 4 --------------------------
+```
+Mock Set-Content {}
+```
+
+{...
+Some Code ...}
+
+C:\PS\>Assert-MockCalled Set-Content -Exactly 2
+
+This will throw an exception if some code does not call Set-Content Exactly two times.
+
+### -------------------------- EXAMPLE 5 --------------------------
+```
+Describe 'Assert-MockCalled Scope behavior' {
+```
+
+Mock Set-Content { }
+
+    It 'Calls Set-Content at least once in the It block' {
+        {...
+Some Code ...}
+
+        Assert-MockCalled Set-Content -Exactly 0 -Scope It
+    }
+}
+
+Checks for calls only within the current It block.
+
+### -------------------------- EXAMPLE 6 --------------------------
+```
+Describe 'Describe' {
+```
+
+Mock -ModuleName SomeModule Set-Content { }
+
+    {...
+Some Code ...}
+
+    It 'Calls Set-Content at least once in the Describe block' {
+        Assert-MockCalled -ModuleName SomeModule Set-Content
+    }
+}
+
+Checks for calls to the mock within the SomeModule module. 
+Note that both the Mock
+and Assert-MockCalled commands use the same module name.
+
+### -------------------------- EXAMPLE 7 --------------------------
+```
+Assert-MockCalled Get-ChildItem -ExclusiveFilter { $Path -eq 'C:\' }
+```
+
+Checks to make sure that Get-ChildItem was called at least one time with
+the -Path parameter set to 'C:\', and that it was not called at all with
+the -Path parameter set to any other value.
+
+## PARAMETERS
+
+### -CommandName
+The mocked command whose call history should be checked.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases: 
+
+Required: True
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Times
+The number of times that the mock must be called to avoid an exception
+from throwing.
+
+```yaml
+Type: Int32
+Parameter Sets: (All)
+Aliases: 
+
+Required: False
+Position: 2
+Default value: 1
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ParameterFilter
+An optional filter to qualify wich calls should be counted.
+Only those
+calls to the mock whose parameters cause this filter to return true
+will be counted.
+
+```yaml
+Type: ScriptBlock
+Parameter Sets: ParameterFilter
+Aliases: 
+
+Required: False
+Position: 3
+Default value: {$True}
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ExclusiveFilter
+Like ParameterFilter, except when you use ExclusiveFilter, and there
+were any calls to the mocked command which do not match the filter,
+an exception will be thrown. 
+This is a convenient way to avoid needing
+to have two calls to Assert-MockCalled like this:
+
+Assert-MockCalled SomeCommand -Times 1 -ParameterFilter { $something -eq $true }
+Assert-MockCalled SomeCommand -Times 0 -ParameterFilter { $something -ne $true }
+
+```yaml
+Type: ScriptBlock
+Parameter Sets: ExclusiveFilter
+Aliases: 
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ModuleName
+The module where the mock being checked was injected. 
+This is optional,
+and must match the ModuleName that was used when setting up the Mock.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases: 
+
+Required: False
+Position: 4
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Scope
+An optional parameter specifying the Pester scope in which to check for
+calls to the mocked command. 
+By default, Assert-MockCalled will find
+all calls to the mocked command in the current Context block (if present),
+or the current Describe block (if there is no active Context.)  Valid
+values are Describe, Context and It.
+If you use a scope of Describe or
+Context, the command will identify all calls to the mocked command in the
+current Describe / Context block, as well as all child scopes of that block.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases: 
+
+Required: False
+Position: 5
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Exactly
+If this switch is present, the number specified in Times must match
+exactly the number of times the mock has been called.
+Otherwise it
+must match "at least" the number of times specified. 
+If the value
+passed to the Times parameter is zero, the Exactly switch is implied.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: 
+
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+## INPUTS
+
+## OUTPUTS
+
+## NOTES
+The parameter filter passed to Assert-MockCalled does not necessarily have to match the parameter filter
+(if any) which was used to create the Mock. 
+Assert-MockCalled will find any entry in the command history
+which matches its parameter filter, regardless of how the Mock was created. 
+However, if any calls to the
+mocked command are made which did not match any mock's parameter filter (resulting in the original command
+being executed instead of a mock), these calls to the original command are not tracked in the call history.
+In other words, Assert-MockCalled can only be used to check for calls to the mocked implementation, not
+to the original.
+
+## RELATED LINKS
+

--- a/Docs/Assert-VerifiableMocks.md
+++ b/Docs/Assert-VerifiableMocks.md
@@ -1,0 +1,64 @@
+---
+external help file: Pester-help.xml
+online version: 
+schema: 2.0.0
+---
+
+# Assert-VerifiableMocks
+
+## SYNOPSIS
+Checks if any Verifiable Mock has not been invoked.
+If so, this will throw an exception.
+
+## SYNTAX
+
+```
+Assert-VerifiableMocks
+```
+
+## DESCRIPTION
+This can be used in tandem with the -Verifiable switch of the Mock
+function.
+Mock can be used to mock the behavior of an existing command
+and optionally take a -Verifiable switch.
+When Assert-VerifiableMocks
+is called, it checks to see if any Mock marked Verifiable has not been
+invoked.
+If any mocks have been found that specified -Verifiable and
+have not been invoked, an exception will be thrown.
+
+## EXAMPLES
+
+### -------------------------- EXAMPLE 1 --------------------------
+```
+Mock Set-Content {} -Verifiable -ParameterFilter {$Path -eq "some_path" -and $Value -eq "Expected Value"}
+```
+
+{ ...some code that never calls Set-Content some_path -Value "Expected Value"...
+}
+
+Assert-VerifiableMocks
+
+This will throw an exception and cause the test to fail.
+
+### -------------------------- EXAMPLE 2 --------------------------
+```
+Mock Set-Content {} -Verifiable -ParameterFilter {$Path -eq "some_path" -and $Value -eq "Expected Value"}
+```
+
+Set-Content some_path -Value "Expected Value"
+
+Assert-VerifiableMocks
+
+This will not throw an exception because the mock was invoked.
+
+## PARAMETERS
+
+## INPUTS
+
+## OUTPUTS
+
+## NOTES
+
+## RELATED LINKS
+

--- a/Docs/BeforeAll.md
+++ b/Docs/BeforeAll.md
@@ -1,0 +1,44 @@
+---
+external help file: Pester-help.xml
+online version: 
+schema: 2.0.0
+---
+
+# BeforeAll
+
+## SYNOPSIS
+Defines a series of steps to perform at the beginning of the current Context
+or Describe block.
+
+## SYNTAX
+
+```
+BeforeAll
+```
+
+## DESCRIPTION
+BeforeEach, AfterEach, BeforeAll, and AfterAll are unique in that they apply
+to the entire Context or Describe block, regardless of the order of the
+statements in the Context or Describe.
+
+## EXAMPLES
+
+### Example 1
+```
+PS C:\> {{ Add example code here }}
+```
+
+{{ Add example description here }}
+
+## PARAMETERS
+
+## INPUTS
+
+## OUTPUTS
+
+## NOTES
+
+## RELATED LINKS
+
+[about_BeforeEach_AfterEach]()
+

--- a/Docs/BeforeEach.md
+++ b/Docs/BeforeEach.md
@@ -1,0 +1,47 @@
+---
+external help file: Pester-help.xml
+online version: 
+schema: 2.0.0
+---
+
+# BeforeEach
+
+## SYNOPSIS
+Defines a series of steps to perform at the beginning of every It block within
+the current Context or Describe block.
+
+## SYNTAX
+
+```
+BeforeEach
+```
+
+## DESCRIPTION
+BeforeEach, AfterEach, BeforeAll, and AfterAll are unique in that they apply
+to the entire Context or Describe block, regardless of the order of the
+statements in the Context or Describe. 
+For a full description of this
+behavior, as well as how multiple BeforeEach or AfterEach blocks interact
+with each other, please refer to the about_BeforeEach_AfterEach help file.
+
+## EXAMPLES
+
+### Example 1
+```
+PS C:\> {{ Add example code here }}
+```
+
+{{ Add example description here }}
+
+## PARAMETERS
+
+## INPUTS
+
+## OUTPUTS
+
+## NOTES
+
+## RELATED LINKS
+
+[about_BeforeEach_AfterEach]()
+

--- a/Docs/BeforeEachFeature.md
+++ b/Docs/BeforeEachFeature.md
@@ -1,0 +1,83 @@
+---
+external help file: Pester-help.xml
+online version: 
+schema: 2.0.0
+---
+
+# BeforeEachFeature
+
+## SYNOPSIS
+Defines a ScriptBlock hook to run before each feature to set up the test environment
+
+## SYNTAX
+
+### All (Default)
+```
+BeforeEachFeature [-Script] <ScriptBlock>
+```
+
+### Tags
+```
+BeforeEachFeature [-Tags] <String[]> [-Script] <ScriptBlock>
+```
+
+## DESCRIPTION
+BeforeEachFeature hooks are run before each feature that is in (or above) the folder where the hook is defined.
+
+This is a convenience method, provided because unlike traditional RSpec Pester,
+there is not a simple test script where you can put setup and clean up.
+
+## EXAMPLES
+
+### Example 1
+```
+PS C:\> {{ Add example code here }}
+```
+
+{{ Add example description here }}
+
+## PARAMETERS
+
+### -Tags
+Optional tags.
+If set, this hook only runs for features with matching tags
+
+```yaml
+Type: String[]
+Parameter Sets: Tags
+Aliases: 
+
+Required: True
+Position: 1
+Default value: @()
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Script
+The ScriptBlock to run for the hook
+
+```yaml
+Type: ScriptBlock
+Parameter Sets: (All)
+Aliases: 
+
+Required: True
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+## INPUTS
+
+## OUTPUTS
+
+## NOTES
+
+## RELATED LINKS
+
+[AfterEachFeature
+BeforeEachScenario
+AfterEachScenario]()
+

--- a/Docs/BeforeEachScenario.md
+++ b/Docs/BeforeEachScenario.md
@@ -1,0 +1,85 @@
+---
+external help file: Pester-help.xml
+online version: 
+schema: 2.0.0
+---
+
+# BeforeEachScenario
+
+## SYNOPSIS
+Defines a ScriptBlock hook to run before each scenario to set up the test environment
+
+## SYNTAX
+
+### All (Default)
+```
+BeforeEachScenario [-Script] <ScriptBlock>
+```
+
+### Tags
+```
+BeforeEachScenario [-Tags] <String[]> [-Script] <ScriptBlock>
+```
+
+## DESCRIPTION
+BeforeEachScenario hooks are run before each scenario that is in (or above) the folder where the hook is defined.
+
+You should not normally need this, because it overlaps significantly with the "Background" feature in the gherkin language.
+
+This is a convenience method, provided because unlike traditional RSpec Pester,
+there is not a simple test script where you can put setup and clean up.
+
+## EXAMPLES
+
+### Example 1
+```
+PS C:\> {{ Add example code here }}
+```
+
+{{ Add example description here }}
+
+## PARAMETERS
+
+### -Tags
+Optional tags.
+If set, this hook only runs for features with matching tags
+
+```yaml
+Type: String[]
+Parameter Sets: Tags
+Aliases: 
+
+Required: True
+Position: 1
+Default value: @()
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Script
+The ScriptBlock to run for the hook
+
+```yaml
+Type: ScriptBlock
+Parameter Sets: (All)
+Aliases: 
+
+Required: True
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+## INPUTS
+
+## OUTPUTS
+
+## NOTES
+
+## RELATED LINKS
+
+[AfterEachFeature
+BeforeEachScenario
+AfterEachScenario]()
+

--- a/Docs/Context.md
+++ b/Docs/Context.md
@@ -1,0 +1,118 @@
+---
+external help file: Pester-help.xml
+online version: 
+schema: 2.0.0
+---
+
+# Context
+
+## SYNOPSIS
+Provides logical grouping of It blocks within a single Describe block.
+
+## SYNTAX
+
+```
+Context [-Name] <String> [-Tag <Object>] [[-Fixture] <ScriptBlock>]
+```
+
+## DESCRIPTION
+Provides logical grouping of It blocks within a single Describe block.
+Any Mocks defined inside a Context are removed at the end of the Context scope,
+as are any files or folders added to the TestDrive during the Context block's
+execution.
+Any BeforeEach or AfterEach blocks defined inside a Context also only
+apply to tests within that Context .
+
+## EXAMPLES
+
+### -------------------------- EXAMPLE 1 --------------------------
+```
+function Add-Numbers($a, $b) {
+```
+
+return $a + $b
+}
+
+Describe "Add-Numbers" {
+
+    Context "when root does not exist" {
+         It "..." { ...
+}
+    }
+
+    Context "when root does exist" {
+        It "..." { ...
+}
+        It "..." { ...
+}
+        It "..." { ...
+}
+    }
+}
+
+## PARAMETERS
+
+### -Name
+The name of the Context.
+This is a phrase describing a set of tests within a describe.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases: 
+
+Required: True
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Tag
+{{Fill Tag Description}}
+
+```yaml
+Type: Object
+Parameter Sets: (All)
+Aliases: Tags
+
+Required: False
+Position: Named
+Default value: @()
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Fixture
+Script that is executed.
+This may include setup specific to the context
+and one or more It blocks that validate the expected outcomes.
+
+```yaml
+Type: ScriptBlock
+Parameter Sets: (All)
+Aliases: 
+
+Required: False
+Position: 2
+Default value: $(Throw "No test script block is provided. (Have you put the open curly brace on the next line?)")
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+## INPUTS
+
+## OUTPUTS
+
+## NOTES
+
+## RELATED LINKS
+
+[Describe
+It
+BeforeEach
+AfterEach
+about_Should
+about_Mocking
+about_TestDrive]()
+

--- a/Docs/Describe.md
+++ b/Docs/Describe.md
@@ -1,0 +1,145 @@
+---
+external help file: Pester-help.xml
+online version: 
+schema: 2.0.0
+---
+
+# Describe
+
+## SYNOPSIS
+Creates a logical group of tests.
+
+## SYNTAX
+
+```
+Describe [-Name] <String> [-Tag <String[]>] [[-Fixture] <ScriptBlock>] [-CommandUsed <String>]
+```
+
+## DESCRIPTION
+Creates a logical group of tests. 
+All Mocks and TestDrive contents
+defined within a Describe block are scoped to that Describe; they
+will no longer be present when the Describe block exits. 
+A Describe
+block may contain any number of Context and It blocks.
+
+## EXAMPLES
+
+### -------------------------- EXAMPLE 1 --------------------------
+```
+function Add-Numbers($a, $b) {
+```
+
+return $a + $b
+}
+
+Describe "Add-Numbers" {
+    It "adds positive numbers" {
+        $sum = Add-Numbers 2 3
+        $sum | Should Be 5
+    }
+
+    It "adds negative numbers" {
+        $sum = Add-Numbers (-2) (-2)
+        $sum | Should Be (-4)
+    }
+
+    It "adds one negative number to positive number" {
+        $sum = Add-Numbers (-2) 2
+        $sum | Should Be 0
+    }
+
+    It "concatenates strings if given strings" {
+        $sum = Add-Numbers two three
+        $sum | Should Be "twothree"
+    }
+}
+
+## PARAMETERS
+
+### -Name
+The name of the test group.
+This is often an expressive phrase describing
+the scenario being tested.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases: 
+
+Required: True
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Tag
+Optional parameter containing an array of strings. 
+When calling Invoke-Pester,
+it is possible to specify a -Tag parameter which will only execute Describe blocks
+containing the same Tag.
+
+```yaml
+Type: String[]
+Parameter Sets: (All)
+Aliases: Tags
+
+Required: False
+Position: Named
+Default value: @()
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Fixture
+The actual test script.
+If you are following the AAA pattern (Arrange-Act-Assert),
+this typically holds the arrange and act sections.
+The Asserts will also lie
+in this block but are typically nested each in its own It block.
+Assertions are
+typically performed by the Should command within the It blocks.
+
+```yaml
+Type: ScriptBlock
+Parameter Sets: (All)
+Aliases: 
+
+Required: False
+Position: 2
+Default value: $(Throw "No test script block is provided. (Have you put the open curly brace on the next line?)")
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -CommandUsed
+{{Fill CommandUsed Description}}
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases: 
+
+Required: False
+Position: Named
+Default value: Describe
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+## INPUTS
+
+## OUTPUTS
+
+## NOTES
+
+## RELATED LINKS
+
+[It
+Context
+Invoke-Pester
+about_Should
+about_Mocking
+about_TestDrive]()
+

--- a/Docs/Find-GherkinStep.md
+++ b/Docs/Find-GherkinStep.md
@@ -1,0 +1,74 @@
+---
+external help file: Pester-help.xml
+online version: 
+schema: 2.0.0
+---
+
+# Find-GherkinStep
+
+## SYNOPSIS
+{{Fill in the Synopsis}}
+
+## SYNTAX
+
+```
+Find-GherkinStep [[-Step] <String>] [[-BasePath] <String>]
+```
+
+## DESCRIPTION
+{{Fill in the Description}}
+
+## EXAMPLES
+
+### Example 1
+```
+PS C:\> {{ Add example code here }}
+```
+
+{{ Add example description here }}
+
+## PARAMETERS
+
+### -BasePath
+{{Fill BasePath Description}}
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases: 
+
+Required: False
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Step
+{{Fill Step Description}}
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases: 
+
+Required: False
+Position: 0
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+## INPUTS
+
+### None
+
+
+## OUTPUTS
+
+### System.Object
+
+## NOTES
+
+## RELATED LINKS
+

--- a/Docs/Get-MockDynamicParameters.md
+++ b/Docs/Get-MockDynamicParameters.md
@@ -1,0 +1,122 @@
+---
+external help file: Pester-help.xml
+online version: 
+schema: 2.0.0
+---
+
+# Get-MockDynamicParameters
+
+## SYNOPSIS
+This command is used by Pester's Mocking framework. 
+You do not need to call it directly.
+
+## SYNTAX
+
+### Cmdlet
+```
+Get-MockDynamicParameters -CmdletName <String> [-Parameters <IDictionary>] [-Cmdlet <Object>]
+```
+
+### Function
+```
+Get-MockDynamicParameters -FunctionName <String> [-ModuleName <String>] [-Parameters <IDictionary>]
+ [-Cmdlet <Object>]
+```
+
+## DESCRIPTION
+{{Fill in the Description}}
+
+## EXAMPLES
+
+### Example 1
+```
+PS C:\> {{ Add example code here }}
+```
+
+{{ Add example description here }}
+
+## PARAMETERS
+
+### -CmdletName
+{{Fill CmdletName Description}}
+
+```yaml
+Type: String
+Parameter Sets: Cmdlet
+Aliases: 
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -FunctionName
+{{Fill FunctionName Description}}
+
+```yaml
+Type: String
+Parameter Sets: Function
+Aliases: 
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ModuleName
+{{Fill ModuleName Description}}
+
+```yaml
+Type: String
+Parameter Sets: Function
+Aliases: 
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Parameters
+{{Fill Parameters Description}}
+
+```yaml
+Type: IDictionary
+Parameter Sets: (All)
+Aliases: 
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Cmdlet
+{{Fill Cmdlet Description}}
+
+```yaml
+Type: Object
+Parameter Sets: (All)
+Aliases: 
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+## INPUTS
+
+## OUTPUTS
+
+## NOTES
+
+## RELATED LINKS
+

--- a/Docs/Get-TestDriveItem.md
+++ b/Docs/Get-TestDriveItem.md
@@ -1,0 +1,70 @@
+---
+external help file: Pester-help.xml
+online version: https://github.com/pester/Pester/wiki/TestDrive
+about_TestDrive
+schema: 2.0.0
+---
+
+# Get-TestDriveItem
+
+## SYNOPSIS
+The Get-TestDriveItem cmdlet gets the item in Pester test drive.
+
+## SYNTAX
+
+```
+Get-TestDriveItem [[-Path] <String>]
+```
+
+## DESCRIPTION
+The Get-TestDriveItem cmdlet gets the item in Pester test drive.
+It does not
+get the contents of the item at the location unless you use a wildcard
+character (*) to request all the contents of the item.
+
+The function Get-TestDriveItem is deprecated since Pester v.
+4.0
+and will be deleted in the next major version of Pester.
+
+## EXAMPLES
+
+### Example 1
+```
+PS C:\> {{ Add example code here }}
+```
+
+{{ Add example description here }}
+
+## PARAMETERS
+
+### -Path
+Specifies the path to an item.
+The path need to be relative to TestDrive:.
+This cmdlet gets the item at the specified location.
+Wildcards are permitted.
+This parameter is required, but the parameter name ("Path") is optional.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases: 
+
+Required: False
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+## INPUTS
+
+## OUTPUTS
+
+## NOTES
+
+## RELATED LINKS
+
+[https://github.com/pester/Pester/wiki/TestDrive
+about_TestDrive](https://github.com/pester/Pester/wiki/TestDrive
+about_TestDrive)
+

--- a/Docs/GherkinStep.md
+++ b/Docs/GherkinStep.md
@@ -1,0 +1,78 @@
+---
+external help file: Pester-help.xml
+online version: 
+schema: 2.0.0
+---
+
+# GherkinStep
+
+## SYNOPSIS
+A step in a test, also known as a Given, When, or Then
+
+## SYNTAX
+
+```
+GherkinStep [-Name] <String> [-Test] <ScriptBlock>
+```
+
+## DESCRIPTION
+Pester doesn't technically distinguish between the three kinds of steps.
+However, we strongly recommend that you do!
+These words were carefully selected to convey meaning which is crucial to get you into the BDD mindset.
+
+In BDD, we drive development by not first stating the requirements, and then defining steps which can be executed in a manner that is similar to unit tests.
+
+## EXAMPLES
+
+### Example 1
+```
+PS C:\> {{ Add example code here }}
+```
+
+{{ Add example description here }}
+
+## PARAMETERS
+
+### -Name
+The name of a gherkin step is actually a regular expression, from which capturing groups are cast and passed to the parameters in the ScriptBlock
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases: 
+
+Required: True
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Test
+The ScriptBlock which defines this step.
+May accept parameters from regular expression capturing groups (named or not), or from tables or multiline strings.
+
+```yaml
+Type: ScriptBlock
+Parameter Sets: (All)
+Aliases: 
+
+Required: True
+Position: 2
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+## INPUTS
+
+## OUTPUTS
+
+## NOTES
+
+## RELATED LINKS
+
+[about_gherkin
+Invoke-GherkinStep
+https://sites.google.com/site/unclebobconsultingllc/the-truth-about-bdd]()
+

--- a/Docs/In.md
+++ b/Docs/In.md
@@ -1,0 +1,73 @@
+---
+external help file: Pester-help.xml
+online version: 
+schema: 2.0.0
+---
+
+# In
+
+## SYNOPSIS
+A convenience function that executes a script from a specified path.
+
+## SYNTAX
+
+```
+In [[-path] <Object>] [[-execute] <ScriptBlock>]
+```
+
+## DESCRIPTION
+Before the script block passed to the execute parameter is invoked,
+the current location is set to the path specified.
+Once the script
+block has been executed, the location will be reset to the location
+the script was in prior to calling In.
+
+## EXAMPLES
+
+### Example 1
+```
+PS C:\> {{ Add example code here }}
+```
+
+{{ Add example description here }}
+
+## PARAMETERS
+
+### -path
+The path that the execute block will be executed in.
+
+```yaml
+Type: Object
+Parameter Sets: (All)
+Aliases: 
+
+Required: False
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -execute
+The script to be executed in the path provided.
+
+```yaml
+Type: ScriptBlock
+Parameter Sets: (All)
+Aliases: 
+
+Required: False
+Position: 2
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+## INPUTS
+
+## OUTPUTS
+
+## NOTES
+
+## RELATED LINKS
+

--- a/Docs/InModuleScope.md
+++ b/Docs/InModuleScope.md
@@ -1,0 +1,107 @@
+---
+external help file: Pester-help.xml
+online version: 
+schema: 2.0.0
+---
+
+# InModuleScope
+
+## SYNOPSIS
+Allows you to execute parts of a test script within the
+scope of a PowerShell script module.
+
+## SYNTAX
+
+```
+InModuleScope [-ModuleName] <String> [-ScriptBlock] <ScriptBlock>
+```
+
+## DESCRIPTION
+By injecting some test code into the scope of a PowerShell
+script module, you can use non-exported functions, aliases
+and variables inside that module, to perform unit tests on
+its internal implementation.
+
+InModuleScope may be used anywhere inside a Pester script,
+either inside or outside a Describe block.
+
+## EXAMPLES
+
+### -------------------------- EXAMPLE 1 --------------------------
+```
+# The script module:
+```
+
+function PublicFunction
+{
+    # Does something
+}
+
+function PrivateFunction
+{
+    return $true
+}
+
+Export-ModuleMember -Function PublicFunction
+
+# The test script:
+
+Import-Module MyModule
+
+InModuleScope MyModule {
+    Describe 'Testing MyModule' {
+        It 'Tests the Private function' {
+            PrivateFunction | Should Be $true
+        }
+    }
+}
+
+Normally you would not be able to access "PrivateFunction" from
+the PowerShell session, because the module only exported
+"PublicFunction". 
+Using InModuleScope allowed this call to
+"PrivateFunction" to work successfully.
+
+## PARAMETERS
+
+### -ModuleName
+The name of the module into which the test code should be
+injected.
+This module must already be loaded into the current
+PowerShell session.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases: 
+
+Required: True
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ScriptBlock
+The code to be executed within the script module.
+
+```yaml
+Type: ScriptBlock
+Parameter Sets: (All)
+Aliases: 
+
+Required: True
+Position: 2
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+## INPUTS
+
+## OUTPUTS
+
+## NOTES
+
+## RELATED LINKS
+

--- a/Docs/Invoke-Gherkin.md
+++ b/Docs/Invoke-Gherkin.md
@@ -1,0 +1,330 @@
+---
+external help file: Pester-help.xml
+online version: 
+schema: 2.0.0
+---
+
+# Invoke-Gherkin
+
+## SYNOPSIS
+Invokes Pester to run all tests defined in .feature files
+
+## SYNTAX
+
+### Default (Default)
+```
+Invoke-Gherkin [[-Path] <String>] [[-ScenarioName] <String[]>] [-EnableExit] [[-Tag] <String[]>]
+ [-ExcludeTag <String[]>] [-CodeCoverage <Object[]>] [-Strict] [-OutputFile <String>] [-OutputFormat <String>]
+ [-Quiet] [-PesterOption <Object>] [-Show <OutputTypes>] [-PassThru]
+```
+
+### RetestFailed
+```
+Invoke-Gherkin [-FailedLast] [[-Path] <String>] [[-ScenarioName] <String[]>] [-EnableExit] [[-Tag] <String[]>]
+ [-ExcludeTag <String[]>] [-CodeCoverage <Object[]>] [-Strict] [-OutputFile <String>] [-OutputFormat <String>]
+ [-Quiet] [-PesterOption <Object>] [-Show <OutputTypes>] [-PassThru]
+```
+
+## DESCRIPTION
+Upon calling Invoke-Gherkin, all files that have a name matching *.feature in the current folder (and child folders recursively), will be parsed and executed.
+
+If ScenarioName is specified, only scenarios which match the provided name(s) will be run.
+If FailedLast is specified, only scenarios which failed the previous run will be re-executed.
+
+Optionally, Pester can generate a report of how much code is covered by the tests, and information about any commands which were not executed.
+
+## EXAMPLES
+
+### -------------------------- EXAMPLE 1 --------------------------
+```
+Invoke-Gherkin
+```
+
+This will find all *.feature specifications and execute their tests.
+No exit code will be returned and no log file will be saved.
+
+### -------------------------- EXAMPLE 2 --------------------------
+```
+Invoke-Gherkin -Path ./tests/Utils*
+```
+
+This will run all *.feature specifications under ./Tests that begin with Utils.
+
+### -------------------------- EXAMPLE 3 --------------------------
+```
+Invoke-Gherkin -ScenarioName "Add Numbers"
+```
+
+This will only run the Scenario named "Add Numbers"
+
+### -------------------------- EXAMPLE 4 --------------------------
+```
+Invoke-Gherkin -EnableExit -OutputXml "./artifacts/TestResults.xml"
+```
+
+This runs all tests from the current directory downwards and writes the results according to the NUnit schema to artifatcs/TestResults.xml just below the current directory.
+The test run will return an exit code equal to the number of test failures.
+
+### -------------------------- EXAMPLE 5 --------------------------
+```
+Invoke-Gherkin -CodeCoverage 'ScriptUnderTest.ps1'
+```
+
+Runs all *.feature specifications in the current directory, and generates a coverage report for all commands in the "ScriptUnderTest.ps1" file.
+
+### -------------------------- EXAMPLE 6 --------------------------
+```
+Invoke-Gherkin -CodeCoverage @{ Path = 'ScriptUnderTest.ps1'; Function = 'FunctionUnderTest' }
+```
+
+Runs all *.feature specifications in the current directory, and generates a coverage report for all commands in the "FunctionUnderTest" function in the "ScriptUnderTest.ps1" file.
+
+### -------------------------- EXAMPLE 7 --------------------------
+```
+Invoke-Gherkin -CodeCoverage @{ Path = 'ScriptUnderTest.ps1'; StartLine = 10; EndLine = 20 }
+```
+
+Runs all *.feature specifications in the current directory, and generates a coverage report for all commands on lines 10 through 20 in the "ScriptUnderTest.ps1" file.
+
+## PARAMETERS
+
+### -FailedLast
+Rerun only the scenarios which failed last time
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: RetestFailed
+Aliases: 
+
+Required: True
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Path
+This parameter indicates which feature files should be tested.
+Aliased to 'Script' for compatibility with Pester, but does not support hashtables, since feature files don't take parameters.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases: Script, relative_path
+
+Required: False
+Position: 1
+Default value: $Pwd
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ScenarioName
+When set, invokes testing of scenarios which match this name.
+Aliased to 'Name' and 'TestName' for compatibility with Pester.
+
+```yaml
+Type: String[]
+Parameter Sets: (All)
+Aliases: Name, TestName
+
+Required: False
+Position: 2
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -EnableExit
+Will cause Invoke-Gherkin to exit with a exit code equal to the number of failed tests once all tests have been run.
+Use this to "fail" a build when any tests fail.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: 
+
+Required: False
+Position: 3
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Tag
+Filters Scenarios and Features and runs only the ones tagged with the specified tags.
+
+```yaml
+Type: String[]
+Parameter Sets: (All)
+Aliases: Tags
+
+Required: False
+Position: 5
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ExcludeTag
+Informs Invoke-Pester to not run blocks tagged with the tags specified.
+
+```yaml
+Type: String[]
+Parameter Sets: (All)
+Aliases: 
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -CodeCoverage
+Instructs Pester to generate a code coverage report in addition to running tests. 
+You may pass either hashtables or strings to this parameter.
+If strings are used, they must be paths (wildcards allowed) to source files, and all commands in the files are analyzed for code coverage.
+By passing hashtables instead, you can limit the analysis to specific lines or functions within a file.
+Hashtables must contain a Path key (which can be abbreviated to just "P"), and may contain Function (or "F"), StartLine (or "S"), and EndLine ("E") keys to narrow down the commands to be analyzed.
+If Function is specified, StartLine and EndLine are ignored.
+If only StartLine is defined, the entire script file starting with StartLine is analyzed.
+If only EndLine is present, all lines in the script file up to and including EndLine are analyzed.
+Both Function and Path (as well as simple strings passed instead of hashtables) may contain wildcards.
+
+```yaml
+Type: Object[]
+Parameter Sets: (All)
+Aliases: 
+
+Required: False
+Position: Named
+Default value: @()
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Strict
+Makes Pending and Skipped tests to Failed tests.
+Useful for continuous integration where you need to make sure all tests passed.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: 
+
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -OutputFile
+The path to write a report file to.
+If this path is not provided, no log will be generated.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases: 
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -OutputFormat
+The format for output (LegacyNUnitXml or NUnitXml), defaults to NUnitXml
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases: 
+
+Required: False
+Position: Named
+Default value: NUnitXml
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Quiet
+Disables the output Pester writes to screen.
+No other output is generated unless you specify PassThru, or one of the Output parameters.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: 
+
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -PesterOption
+Sets advanced options for the test execution.
+Enter a PesterOption object,
+such as one that you create by using the New-PesterOption cmdlet, or a hash table
+in which the keys are option names and the values are option values.
+For more information on the options available, see the help for New-PesterOption.
+
+```yaml
+Type: Object
+Parameter Sets: (All)
+Aliases: 
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Show
+This parameter does not affect the PassThru custom object or the XML output that
+is written when you use the Output parameters.
+
+```yaml
+Type: OutputTypes
+Parameter Sets: (All)
+Aliases: 
+Accepted values: None, Default, Passed, Failed, Pending, Skipped, Inconclusive, Describe, Context, Summary, Header, Fails, All
+
+Required: False
+Position: Named
+Default value: All
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -PassThru
+{{Fill PassThru Description}}
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: 
+
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+## INPUTS
+
+## OUTPUTS
+
+## NOTES
+
+## RELATED LINKS
+
+[Invoke-Pester]()
+

--- a/Docs/Invoke-GherkinStep.md
+++ b/Docs/Invoke-GherkinStep.md
@@ -1,0 +1,89 @@
+---
+external help file: Pester-help.xml
+online version: 
+schema: 2.0.0
+---
+
+# Invoke-GherkinStep
+
+## SYNOPSIS
+{{Fill in the Synopsis}}
+
+## SYNTAX
+
+```
+Invoke-GherkinStep [[-Step] <Object>] [-Background] [[-Pester] <Object>]
+```
+
+## DESCRIPTION
+{{Fill in the Description}}
+
+## EXAMPLES
+
+### Example 1
+```
+PS C:\> {{ Add example code here }}
+```
+
+{{ Add example description here }}
+
+## PARAMETERS
+
+### -Background
+{{Fill Background Description}}
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: 
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Pester
+{{Fill Pester Description}}
+
+```yaml
+Type: Object
+Parameter Sets: (All)
+Aliases: 
+
+Required: False
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Step
+{{Fill Step Description}}
+
+```yaml
+Type: Object
+Parameter Sets: (All)
+Aliases: 
+
+Required: False
+Position: 0
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+## INPUTS
+
+### None
+
+
+## OUTPUTS
+
+### System.Object
+
+## NOTES
+
+## RELATED LINKS
+

--- a/Docs/Invoke-Mock.md
+++ b/Docs/Invoke-Mock.md
@@ -1,0 +1,162 @@
+---
+external help file: Pester-help.xml
+online version: 
+schema: 2.0.0
+---
+
+# Invoke-Mock
+
+## SYNOPSIS
+This command is used by Pester's Mocking framework. 
+You do not need to call it directly.
+
+## SYNTAX
+
+```
+Invoke-Mock [-CommandName] <String> [-MockCallState] <Hashtable> [[-ModuleName] <String>]
+ [[-BoundParameters] <Hashtable>] [[-ArgumentList] <Object[]>] [[-CallerSessionState] <Object>]
+ [[-FromBlock] <String>] [[-InputObject] <Object>]
+```
+
+## DESCRIPTION
+{{Fill in the Description}}
+
+## EXAMPLES
+
+### Example 1
+```
+PS C:\> {{ Add example code here }}
+```
+
+{{ Add example description here }}
+
+## PARAMETERS
+
+### -CommandName
+{{Fill CommandName Description}}
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases: 
+
+Required: True
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -MockCallState
+{{Fill MockCallState Description}}
+
+```yaml
+Type: Hashtable
+Parameter Sets: (All)
+Aliases: 
+
+Required: True
+Position: 2
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ModuleName
+{{Fill ModuleName Description}}
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases: 
+
+Required: False
+Position: 3
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -BoundParameters
+{{Fill BoundParameters Description}}
+
+```yaml
+Type: Hashtable
+Parameter Sets: (All)
+Aliases: 
+
+Required: False
+Position: 4
+Default value: @{}
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ArgumentList
+{{Fill ArgumentList Description}}
+
+```yaml
+Type: Object[]
+Parameter Sets: (All)
+Aliases: 
+
+Required: False
+Position: 5
+Default value: @()
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -CallerSessionState
+{{Fill CallerSessionState Description}}
+
+```yaml
+Type: Object
+Parameter Sets: (All)
+Aliases: 
+
+Required: False
+Position: 6
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -FromBlock
+{{Fill FromBlock Description}}
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases: 
+
+Required: False
+Position: 7
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -InputObject
+{{Fill InputObject Description}}
+
+```yaml
+Type: Object
+Parameter Sets: (All)
+Aliases: 
+
+Required: False
+Position: 8
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+## INPUTS
+
+## OUTPUTS
+
+## NOTES
+
+## RELATED LINKS
+

--- a/Docs/Invoke-Pester.md
+++ b/Docs/Invoke-Pester.md
@@ -1,0 +1,544 @@
+---
+external help file: Pester-help.xml
+online version: https://github.com/pester/Pester/wiki/Invoke-Pester
+Describe
+about_Pester
+New-PesterOption
+schema: 2.0.0
+---
+
+# Invoke-Pester
+
+## SYNOPSIS
+Runs Pester tests
+
+## SYNTAX
+
+### Default (Default)
+```
+Invoke-Pester [[-Script] <Object[]>] [[-TestName] <String[]>] [-EnableExit] [[-Tag] <String[]>]
+ [-ExcludeTag <String[]>] [-PassThru] [-CodeCoverage <Object[]>] [-Strict] [-Quiet] [-PesterOption <Object>]
+ [-Show <OutputTypes>]
+```
+
+### NewOutputSet
+```
+Invoke-Pester [[-Script] <Object[]>] [[-TestName] <String[]>] [-EnableExit] [[-Tag] <String[]>]
+ [-ExcludeTag <String[]>] [-PassThru] [-CodeCoverage <Object[]>] [-Strict] -OutputFile <String>
+ [-OutputFormat <String>] [-Quiet] [-PesterOption <Object>] [-Show <OutputTypes>]
+```
+
+## DESCRIPTION
+The Invoke-Pester function runs Pester tests, including *.Tests.ps1 files and
+Pester tests in PowerShell scripts.
+
+You can run scripts that include Pester tests just as you would any other
+Windows PowerShell script, including typing the full path at the command line
+and running in a script editing program.
+Typically, you use Invoke-Pester to run
+all Pester tests in a directory, or to use its many helpful parameters,
+including parameters that generate custom objects or XML files.
+
+By default, Invoke-Pester runs all *.Tests.ps1 files in the current directory
+and all subdirectories recursively.
+You can use its parameters to select tests
+by file name, test name, or tag.
+
+To run Pester tests in scripts that take parameter values, use the Script
+parameter with a hash table value.
+
+Also, by default, Pester tests write test results to the console host, much like
+Write-Host does, but you can use the Quiet parameter to suppress the host
+messages, use the PassThru parameter to generate a custom object
+(PSCustomObject) that contains the test results, use the OutputXml and
+OutputFormat parameters to write the test results to an XML file, and use the
+EnableExit parameter to return an exit code that contains the number of failed
+tests.
+
+You can also use the Strict parameter to fail all pending and skipped tests.
+This feature is ideal for build systems and other processes that require success
+on every test.
+
+To help with test design, Invoke-Pester includes a CodeCoverage parameter that
+lists commands, functions, and lines of code that did not run during test
+execution and returns the code that ran as a percentage of all tested code.
+
+Invoke-Pester, and the Pester module that exports it, are products of an
+open-source project hosted on GitHub.
+To view, comment, or contribute to the
+repository, see https://github.com/Pester.
+
+## EXAMPLES
+
+### -------------------------- EXAMPLE 1 --------------------------
+```
+Invoke-Pester
+```
+
+This command runs all *.Tests.ps1 files in the current directory and its subdirectories.
+
+### -------------------------- EXAMPLE 2 --------------------------
+```
+Invoke-Pester -Script .\Util*
+```
+
+This commands runs all *.Tests.ps1 files in subdirectories with names that begin
+with 'Util' and their subdirectories.
+
+### -------------------------- EXAMPLE 3 --------------------------
+```
+Invoke-Pester -Script D:\MyModule, @{ Path = '.\Tests\Utility\ModuleUnit.Tests.ps1'; Parameters = @{ Name = 'User01' }; Arguments = srvNano16  }
+```
+
+This command runs all *.Tests.ps1 files in D:\MyModule and its subdirectories.
+It also runs the tests in the ModuleUnit.Tests.ps1 file using the following
+parameters: .\Tests\Utility\ModuleUnit.Tests.ps1 srvNano16 -Name User01
+
+### -------------------------- EXAMPLE 4 --------------------------
+```
+Invoke-Pester -TestName "Add Numbers"
+```
+
+This command runs only the tests in the Describe block named "Add Numbers".
+
+### -------------------------- EXAMPLE 5 --------------------------
+```
+$results = Invoke-Pester -Script D:\MyModule -PassThru -Show None
+```
+
+$failed = $results.TestResult | where Result -eq 'Failed'
+
+$failed.Name
+cannot find help for parameter: Force : in Compress-Archive
+help for Force parameter in Compress-Archive has wrong Mandatory value
+help for Compress-Archive has wrong parameter type for Force
+help for Update parameter in Compress-Archive has wrong Mandatory value
+help for DestinationPath parameter in Expand-Archive has wrong Mandatory value
+
+$failed\[0\]
+Describe               : Test help for Compress-Archive in Microsoft.PowerShell.Archive (1.0.0.0)
+Context                : Test parameter help for Compress-Archive
+Name                   : cannot find help for parameter: Force : in Compress-Archive
+Result                 : Failed
+Passed                 : False
+Time                   : 00:00:00.0193083
+FailureMessage         : Expected: value to not be empty
+StackTrace             : at line: 279 in C:\GitHub\PesterTdd\Module.Help.Tests.ps1
+                         279:                     $parameterHelp.Description.Text | Should Not BeNullOrEmpty
+ErrorRecord            : Expected: value to not be empty
+ParameterizedSuiteName :
+Parameters             : {}
+
+This examples uses the PassThru parameter to return a custom object with the
+Pester test results.
+By default, Invoke-Pester writes to the host program, but not
+to the output stream.
+It also uses the Quiet parameter to suppress the host output.
+
+The first command runs Invoke-Pester with the PassThru and Quiet parameters and
+saves the PassThru output in the $results variable.
+
+The second command gets only failing results and saves them in the $failed variable.
+
+The third command gets the names of the failing results.
+The result name is the
+name of the It block that contains the test.
+
+The fourth command uses an array index to get the first failing result.
+The
+property values describe the test, the expected result, the actual result, and
+useful values, including a stack tace.
+
+### -------------------------- EXAMPLE 6 --------------------------
+```
+Invoke-Pester -EnableExit -OutputFile ".\artifacts\TestResults.xml" -OutputFormat NUnitXml
+```
+
+This command runs all tests in the current directory and its subdirectories.
+It
+writes the results to the TestResults.xml file using the NUnitXml schema.
+The
+test returns an exit code equal to the number of test failures.
+
+### -------------------------- EXAMPLE 7 --------------------------
+```
+Invoke-Pester -CodeCoverage 'ScriptUnderTest.ps1'
+```
+
+Runs all *.Tests.ps1 scripts in the current directory, and generates a coverage
+report for all commands in the "ScriptUnderTest.ps1" file.
+
+### -------------------------- EXAMPLE 8 --------------------------
+```
+Invoke-Pester -CodeCoverage @{ Path = 'ScriptUnderTest.ps1'; Function = 'FunctionUnderTest' }
+```
+
+Runs all *.Tests.ps1 scripts in the current directory, and generates a coverage
+report for all commands in the "FunctionUnderTest" function in the "ScriptUnderTest.ps1" file.
+
+### -------------------------- EXAMPLE 9 --------------------------
+```
+Invoke-Pester -CodeCoverage @{ Path = 'ScriptUnderTest.ps1'; StartLine = 10; EndLine = 20 }
+```
+
+Runs all *.Tests.ps1 scripts in the current directory, and generates a coverage
+report for all commands on lines 10 through 20 in the "ScriptUnderTest.ps1" file.
+
+### -------------------------- EXAMPLE 10 --------------------------
+```
+Invoke-Pester -Script C:\Tests -Tag UnitTest, Newest -ExcludeTag Bug
+```
+
+This command runs *.Tests.ps1 files in C:\Tests and its subdirectories.
+In those files, it runs only tests that have UnitTest or Newest tags, unless the test also has a Bug tag.
+
+## PARAMETERS
+
+### -Script
+Specifies the test files that Pester runs.
+You can also use the Script parameter
+to pass parameter names and values to a script that contains Pester tests.
+The
+value of the Script parameter can be a string, a hash table, or a collection
+of hash tables and strings.
+Wildcard characters are supported.
+
+The Script parameter is optional.
+If you omit it, Invoke-Pester runs all
+*.Tests.ps1 files in the local directory and its subdirectories recursively.
+
+To run tests in other files, such as .ps1 files, enter the path and file name of
+the file.
+(The file name is required.
+Name patterns that end in "*.ps1" run only
+*.Tests.ps1 files.)
+
+To run a Pester test with parameter names and/or values, use a hash table as the
+value of the script parameter.
+The keys in the hash table are:
+
+-- Path \[string\] (required): Specifies a test to run.
+The value is a path\file
+   name or name pattern.
+Wildcards are permitted.
+All hash tables in a Script
+   parameter value must have a Path key.
+
+-- Parameters \[hashtable\]: Runs the script with the specified parameters.
+The
+   value is a nested hash table with parameter name and value pairs, such as
+   @{UserName = 'User01'; Id = '28'}.
+
+-- Arguments \[array\]: An array or comma-separated list of parameter values
+   without names, such as 'User01', 28.
+Use this key to pass values to positional
+   parameters.
+
+```yaml
+Type: Object[]
+Parameter Sets: (All)
+Aliases: Path, relative_path
+
+Required: False
+Position: 1
+Default value: .
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -TestName
+Runs only tests in Describe blocks that have the specified name or name pattern.
+Wildcard characters are supported.
+
+If you specify multiple TestName values, Invoke-Pester runs tests that have any
+of the values in the Describe name (it ORs the TestName values).
+
+```yaml
+Type: String[]
+Parameter Sets: (All)
+Aliases: Name
+
+Required: False
+Position: 2
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -EnableExit
+Will cause Invoke-Pester to exit with a exit code equal to the number of failed
+tests once all tests have been run.
+Use this to "fail" a build when any tests fail.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: 
+
+Required: False
+Position: 3
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Tag
+Runs only tests in Describe blocks with the specified Tag parameter values.
+Wildcard characters and Tag values that include spaces or whitespace characters
+are not supported.
+
+When you specify multiple Tag values, Invoke-Pester runs tests that have any
+of the listed tags (it ORs the tags).
+However, when you specify TestName
+and Tag values, Invoke-Pester runs only describe blocks that have one of the
+specified TestName values and one of the specified Tag values.
+
+If you use both Tag and ExcludeTag, ExcludeTag takes precedence.
+
+```yaml
+Type: String[]
+Parameter Sets: (All)
+Aliases: Tags
+
+Required: False
+Position: 5
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ExcludeTag
+Omits tests in Describe blocks with the specified Tag parameter values.
+Wildcard
+characters and Tag values that include spaces or whitespace characters are not
+supported.
+
+When you specify multiple ExcludeTag values, Invoke-Pester omits tests that have
+any of the listed tags (it ORs the tags).
+However, when you specify TestName
+and ExcludeTag values, Invoke-Pester omits only describe blocks that have one
+of the specified TestName values and one of the specified Tag values.
+
+If you use both Tag and ExcludeTag, ExcludeTag takes precedence
+
+```yaml
+Type: String[]
+Parameter Sets: (All)
+Aliases: 
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -PassThru
+Returns a custom object (PSCustomObject) that contains the test results.
+
+By default, Invoke-Pester writes to the host program, not to the output stream (stdout).
+If you try to save the result in a variable, the variable is empty unless you
+use the PassThru parameter.
+
+To suppress the host output, use the Quiet parameter.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: 
+
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -CodeCoverage
+Adds a code coverage report to the Pester tests.
+Takes strings or hash table values.
+
+A code coverage report lists the lines of code that did and did not run during
+a Pester test.
+This report does not tell whether code was tested; only whether
+the code ran during the test.
+
+By default, the code coverage report is written to the host program
+(like Write-Host).
+When you use the PassThru parameter, the custom object
+that Invoke-Pester returns has an additional CodeCoverage property that contains
+a custom object with detailed results of the code coverage test, including lines
+hit, lines missed, and helpful statistics.
+
+However, NUnitXML and LegacyNUnitXML output (OutputXML, OutputFormat) do not include
+any code coverage information, because it's not supported by the schema.
+
+Enter the path to the files of code under test (not the test file).
+Wildcard characters are supported.
+If you omit the path, the default is local
+directory, not the directory specified by the Script parameter.
+
+To run a code coverage test only on selected functions or lines in a script,
+enter a hash table value with the following keys:
+
+-- Path (P)(mandatory) \<string\>.
+Enter one path to the files.
+Wildcard characters
+   are supported, but only one string is permitted.
+
+One of the following: Function or StartLine/EndLine
+
+-- Function (F) \<string\>: Enter the function name.
+Wildcard characters are
+   supported, but only one string is permitted.
+
+-or-
+
+-- StartLine (S): Performs code coverage analysis beginning with the specified
+   line.
+Default is line 1.
+-- EndLine (E): Performs code coverage analysis ending with the specified line.
+   Default is the last line of the script.
+
+```yaml
+Type: Object[]
+Parameter Sets: (All)
+Aliases: 
+
+Required: False
+Position: Named
+Default value: @()
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Strict
+Makes Pending and Skipped tests to Failed tests.
+Useful for continuous
+integration where you need to make sure all tests passed.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: 
+
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -OutputFile
+The path where Invoke-Pester will save formatted test results log file.
+If this path is not provided, no log will be generated.
+
+```yaml
+Type: String
+Parameter Sets: NewOutputSet
+Aliases: 
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -OutputFormat
+The format of output.
+Two formats of output are supported: NUnitXML and
+LegacyNUnitXML.
+
+```yaml
+Type: String
+Parameter Sets: NewOutputSet
+Aliases: 
+
+Required: False
+Position: Named
+Default value: NUnitXml
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Quiet
+{{Fill Quiet Description}}
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: 
+
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -PesterOption
+Sets advanced options for the test execution.
+Enter a PesterOption object,
+such as one that you create by using the New-PesterOption cmdlet, or a hash table
+in which the keys are option names and the values are option values.
+For more information on the options available, see the help for New-PesterOption.
+
+```yaml
+Type: Object
+Parameter Sets: (All)
+Aliases: 
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Show
+Customizes the output Pester writes to the screen.
+Available options are None, Default,
+Passed, Failed, Pending, Skipped, Inconclusive, Describe, Context, Summary, Header, All, Fails.
+
+The options can be combined to define presets.
+Common use cases are:
+
+None - to write no output to the screen.
+All - to write all available information (this is default option).
+Fails - to write everything except Passed (but including Describes etc.).
+
+A common setting is also Failed, Summary, to write only failed tests and test summary.
+
+This parameter does not affect the PassThru custom object or the XML output that
+is written when you use the Output parameters.
+
+```yaml
+Type: OutputTypes
+Parameter Sets: (All)
+Aliases: 
+Accepted values: None, Default, Passed, Failed, Pending, Skipped, Inconclusive, Describe, Context, Summary, Header, Fails, All
+
+Required: False
+Position: Named
+Default value: All
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+## INPUTS
+
+## OUTPUTS
+
+## NOTES
+
+## RELATED LINKS
+
+[https://github.com/pester/Pester/wiki/Invoke-Pester
+Describe
+about_Pester
+New-PesterOption](https://github.com/pester/Pester/wiki/Invoke-Pester
+Describe
+about_Pester
+New-PesterOption)
+

--- a/Docs/It.md
+++ b/Docs/It.md
@@ -1,0 +1,206 @@
+---
+external help file: Pester-help.xml
+online version: 
+schema: 2.0.0
+---
+
+# It
+
+## SYNOPSIS
+Validates the results of a test inside of a Describe block.
+
+## SYNTAX
+
+### Normal (Default)
+```
+It [-name] <String> [[-test] <ScriptBlock>] [-TestCases <IDictionary[]>]
+```
+
+### Pending
+```
+It [-name] <String> [[-test] <ScriptBlock>] [-TestCases <IDictionary[]>] [-Pending]
+```
+
+### Skip
+```
+It [-name] <String> [[-test] <ScriptBlock>] [-TestCases <IDictionary[]>] [-Skip]
+```
+
+## DESCRIPTION
+The It command is intended to be used inside of a Describe or Context Block.
+If you are familiar with the AAA pattern (Arrange-Act-Assert), the body of
+the It block is the appropriate location for an assert.
+The convention is to
+assert a single expectation for each It block.
+The code inside of the It block
+should throw a terminating error if the expectation of the test is not met and
+thus cause the test to fail.
+The name of the It block should expressively state
+the expectation of the test.
+
+In addition to using your own logic to test expectations and throw exceptions,
+you may also use Pester's Should command to perform assertions in plain language.
+
+## EXAMPLES
+
+### -------------------------- EXAMPLE 1 --------------------------
+```
+function Add-Numbers($a, $b) {
+```
+
+return $a + $b
+}
+
+Describe "Add-Numbers" {
+    It "adds positive numbers" {
+        $sum = Add-Numbers 2 3
+        $sum | Should Be 5
+    }
+
+    It "adds negative numbers" {
+        $sum = Add-Numbers (-2) (-2)
+        $sum | Should Be (-4)
+    }
+
+    It "adds one negative number to positive number" {
+        $sum = Add-Numbers (-2) 2
+        $sum | Should Be 0
+    }
+
+    It "concatenates strings if given strings" {
+        $sum = Add-Numbers two three
+        $sum | Should Be "twothree"
+    }
+}
+
+### -------------------------- EXAMPLE 2 --------------------------
+```
+function Add-Numbers($a, $b) {
+```
+
+return $a + $b
+}
+
+Describe "Add-Numbers" {
+    $testCases = @(
+        @{ a = 2;     b = 3;       expectedResult = 5 }
+        @{ a = -2;    b = -2;      expectedResult = -4 }
+        @{ a = -2;    b = 2;       expectedResult = 0 }
+        @{ a = 'two'; b = 'three'; expectedResult = 'twothree' }
+    )
+
+    It 'Correctly adds \<a\> and \<b\> to get \<expectedResult\>' -TestCases $testCases {
+        param ($a, $b, $expectedResult)
+
+        $sum = Add-Numbers $a $b
+        $sum | Should Be $expectedResult
+    }
+}
+
+## PARAMETERS
+
+### -name
+An expressive phrase describing the expected test outcome.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases: 
+
+Required: True
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -test
+The script block that should throw an exception if the
+expectation of the test is not met.If you are following the
+AAA pattern (Arrange-Act-Assert), this typically holds the
+Assert.
+
+```yaml
+Type: ScriptBlock
+Parameter Sets: (All)
+Aliases: 
+
+Required: False
+Position: 2
+Default value: {}
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -TestCases
+Optional array of hashtable (or any IDictionary) objects. 
+If this parameter is used,
+Pester will call the test script block once for each table in the TestCases array,
+splatting the dictionary to the test script block as input. 
+If you want the name of
+the test to appear differently for each test case, you can embed tokens into the Name
+parameter with the syntax 'Adds numbers \<A\> and \<B\>' (assuming you have keys named A and B
+in your TestCases hashtables.)
+
+```yaml
+Type: IDictionary[]
+Parameter Sets: (All)
+Aliases: 
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Pending
+Use this parameter to explicitly mark the test as work-in-progress/not implemented/pending when you
+need to distinguish a test that fails because it is not finished yet from a tests
+that fail as a result of changes being made in the code base.
+An empty test, that is a
+test that contains nothing except whitespace or comments is marked as Pending by default.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: Pending
+Aliases: 
+
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Skip
+Use this parameter to explicitly mark the test to be skipped.
+This is preferable to temporarily
+commenting out a test, because the test remains listed in the output.
+Use the Strict parameter
+of Invoke-Pester to force all skipped tests to fail.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: Skip
+Aliases: Ignore
+
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+## INPUTS
+
+## OUTPUTS
+
+## NOTES
+
+## RELATED LINKS
+
+[Describe
+Context
+about_should]()
+

--- a/Docs/Mock.md
+++ b/Docs/Mock.md
@@ -1,0 +1,280 @@
+---
+external help file: Pester-help.xml
+online version: 
+schema: 2.0.0
+---
+
+# Mock
+
+## SYNOPSIS
+Mocks the behavior of an existing command with an alternate
+implementation.
+
+## SYNTAX
+
+```
+Mock [[-CommandName] <String>] [[-MockWith] <ScriptBlock>] [-Verifiable] [[-ParameterFilter] <ScriptBlock>]
+ [[-ModuleName] <String>]
+```
+
+## DESCRIPTION
+This creates new behavior for any existing command within the scope of a
+Describe or Context block.
+The function allows you to specify a script block
+that will become the command's new behavior.
+
+Optionally, you may create a Parameter Filter which will examine the
+parameters passed to the mocked command and will invoke the mocked
+behavior only if the values of the parameter values pass the filter.
+If
+they do not, the original command implementation will be invoked instead
+of a mock.
+
+You may create multiple mocks for the same command, each using a different
+ParameterFilter.
+ParameterFilters will be evaluated in reverse order of
+their creation.
+The last one created will be the first to be evaluated.
+The mock of the first filter to pass will be used.
+The exception to this
+rule are Mocks with no filters.
+They will always be evaluated last since
+they will act as a "catch all" mock.
+
+Mocks can be marked Verifiable.
+If so, the Assert-VerifiableMocks command
+can be used to check if all Verifiable mocks were actually called.
+If any
+verifiable mock is not called, Assert-VerifiableMocks will throw an
+exception and indicate all mocks not called.
+
+If you wish to mock commands that are called from inside a script module,
+you can do so by using the -ModuleName parameter to the Mock command.
+This
+injects the mock into the specified module.
+If you do not specify a
+module name, the mock will be created in the same scope as the test script.
+You may mock the same command multiple times, in different scopes, as needed.
+Each module's mock maintains a separate call history and verified status.
+
+## EXAMPLES
+
+### -------------------------- EXAMPLE 1 --------------------------
+```
+Mock Get-ChildItem { return @{FullName = "A_File.TXT"} }
+```
+
+Using this Mock, all calls to Get-ChildItem will return a hashtable with a
+FullName property returning "A_File.TXT"
+
+### -------------------------- EXAMPLE 2 --------------------------
+```
+Mock Get-ChildItem { return @{FullName = "A_File.TXT"} } -ParameterFilter { $Path -and $Path.StartsWith($env:temp) }
+```
+
+This Mock will only be applied to Get-ChildItem calls within the user's temp directory.
+
+### -------------------------- EXAMPLE 3 --------------------------
+```
+Mock Set-Content {} -Verifiable -ParameterFilter { $Path -eq "some_path" -and $Value -eq "Expected Value" }
+```
+
+When this mock is used, if the Mock is never invoked and Assert-VerifiableMocks is called, an exception will be thrown.
+The command behavior will do nothing since the ScriptBlock is empty.
+
+### -------------------------- EXAMPLE 4 --------------------------
+```
+Mock Get-ChildItem { return @{FullName = "A_File.TXT"} } -ParameterFilter { $Path -and $Path.StartsWith($env:temp\1) }
+```
+
+Mock Get-ChildItem { return @{FullName = "B_File.TXT"} } -ParameterFilter { $Path -and $Path.StartsWith($env:temp\2) }
+Mock Get-ChildItem { return @{FullName = "C_File.TXT"} } -ParameterFilter { $Path -and $Path.StartsWith($env:temp\3) }
+
+Multiple mocks of the same command may be used.
+The parameter filter determines which is invoked.
+Here, if Get-ChildItem is called on the "2" directory of the temp folder, then B_File.txt will be returned.
+
+### -------------------------- EXAMPLE 5 --------------------------
+```
+Mock Get-ChildItem { return @{FullName="B_File.TXT"} } -ParameterFilter { $Path -eq "$env:temp\me" }
+```
+
+Mock Get-ChildItem { return @{FullName="A_File.TXT"} } -ParameterFilter { $Path -and $Path.StartsWith($env:temp) }
+
+Get-ChildItem $env:temp\me
+
+Here, both mocks could apply since both filters will pass.
+A_File.TXT will be returned because it was the most recent Mock created.
+
+### -------------------------- EXAMPLE 6 --------------------------
+```
+Mock Get-ChildItem { return @{FullName = "B_File.TXT"} } -ParameterFilter { $Path -eq "$env:temp\me" }
+```
+
+Mock Get-ChildItem { return @{FullName = "A_File.TXT"} }
+
+Get-ChildItem c:\windows
+
+Here, A_File.TXT will be returned.
+Since no filter was specified, it will apply to any call to Get-ChildItem that does not pass another filter.
+
+### -------------------------- EXAMPLE 7 --------------------------
+```
+Mock Get-ChildItem { return @{FullName = "B_File.TXT"} } -ParameterFilter { $Path -eq "$env:temp\me" }
+```
+
+Mock Get-ChildItem { return @{FullName = "A_File.TXT"} }
+
+Get-ChildItem $env:temp\me
+
+Here, B_File.TXT will be returned.
+Even though the filterless mock was created more recently.
+This illustrates that filterless Mocks are always evaluated last regardless of their creation order.
+
+### -------------------------- EXAMPLE 8 --------------------------
+```
+Mock Get-ChildItem { return @{FullName = "A_File.TXT"} } -ModuleName MyTestModule
+```
+
+Using this Mock, all calls to Get-ChildItem from within the MyTestModule module
+will return a hashtable with a FullName property returning "A_File.TXT"
+
+### -------------------------- EXAMPLE 9 --------------------------
+```
+Get-Module -Name ModuleMockExample | Remove-Module
+```
+
+New-Module -Name ModuleMockExample  -ScriptBlock {
+    function Hidden { "Internal Module Function" }
+    function Exported { Hidden }
+
+    Export-ModuleMember -Function Exported
+} | Import-Module -Force
+
+Describe "ModuleMockExample" {
+
+    It "Hidden function is not directly accessible outside the module" {
+        { Hidden } | Should Throw
+    }
+
+    It "Original Hidden function is called" {
+        Exported | Should Be "Internal Module Function"
+    }
+
+    It "Hidden is replaced with our implementation" {
+        Mock Hidden { "Mocked" } -ModuleName ModuleMockExample
+        Exported | Should Be "Mocked"
+    }
+}
+
+This example shows how calls to commands made from inside a module can be
+mocked by using the -ModuleName parameter.
+
+## PARAMETERS
+
+### -CommandName
+The name of the command to be mocked.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases: 
+
+Required: False
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -MockWith
+A ScriptBlock specifying the behavior that will be used to mock CommandName.
+The default is an empty ScriptBlock.
+NOTE: Do not specify param or dynamicparam blocks in this script block.
+These will be injected automatically based on the signature of the command
+being mocked, and the MockWith script block can contain references to the
+mocked commands parameter variables.
+
+```yaml
+Type: ScriptBlock
+Parameter Sets: (All)
+Aliases: 
+
+Required: False
+Position: 2
+Default value: {}
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Verifiable
+When this is set, the mock will be checked when Assert-VerifiableMocks is
+called.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: 
+
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ParameterFilter
+An optional filter to limit mocking behavior only to usages of
+CommandName where the values of the parameters passed to the command
+pass the filter.
+
+This ScriptBlock must return a boolean value.
+See examples for usage.
+
+```yaml
+Type: ScriptBlock
+Parameter Sets: (All)
+Aliases: 
+
+Required: False
+Position: 3
+Default value: {$True}
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ModuleName
+Optional string specifying the name of the module where this command
+is to be mocked. 
+This should be a module that _calls_ the mocked
+command; it doesn't necessarily have to be the same module which
+originally implemented the command.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases: 
+
+Required: False
+Position: 4
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+## INPUTS
+
+## OUTPUTS
+
+## NOTES
+
+## RELATED LINKS
+
+[Assert-MockCalled
+Assert-VerifiableMocks
+Describe
+Context
+It
+about_Should
+about_Mocking]()
+

--- a/Docs/New-Fixture.md
+++ b/Docs/New-Fixture.md
@@ -1,0 +1,115 @@
+---
+external help file: Pester-help.xml
+online version: 
+schema: 2.0.0
+---
+
+# New-Fixture
+
+## SYNOPSIS
+This function generates two scripts, one that defines a function
+and another one that contains its tests.
+
+## SYNTAX
+
+```
+New-Fixture [[-Path] <String>] [-Name] <String>
+```
+
+## DESCRIPTION
+This function generates two scripts, one that defines a function
+and another one that contains its tests.
+The files are by default
+placed in the current directory and are called and populated as such:
+
+
+The script defining the function: .\Clean.ps1:
+
+function Clean {
+
+}
+
+The script containing the example test .\Clean.Tests.ps1:
+
+$here = Split-Path -Parent $MyInvocation.MyCommand.Path
+$sut = (Split-Path -Leaf $MyInvocation.MyCommand.Path).Replace(".Tests.", ".")
+.
+"$here\$sut"
+
+Describe "Clean" {
+
+    It "does something useful" {
+        $false | Should Be $true
+    }
+}
+
+## EXAMPLES
+
+### -------------------------- EXAMPLE 1 --------------------------
+```
+New-Fixture -Name Clean
+```
+
+Creates the scripts in the current directory.
+
+### -------------------------- EXAMPLE 2 --------------------------
+```
+New-Fixture C:\Projects\Cleaner Clean
+```
+
+Creates the scripts in the C:\Projects\Cleaner directory.
+
+### -------------------------- EXAMPLE 3 --------------------------
+```
+New-Fixture Cleaner Clean
+```
+
+Creates a new folder named Cleaner in the current directory and creates the scripts in it.
+
+## PARAMETERS
+
+### -Path
+Defines path where the test and the function should be created, you can use full or relative path.
+If the parameter is not specified the scripts are created in the current directory.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases: 
+
+Required: False
+Position: 1
+Default value: $PWD
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Name
+Defines the name of the function and the name of the test to be created.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases: 
+
+Required: True
+Position: 2
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+## INPUTS
+
+## OUTPUTS
+
+## NOTES
+
+## RELATED LINKS
+
+[Describe
+Context
+It
+about_Pester
+about_Should]()
+

--- a/Docs/New-MockObject.md
+++ b/Docs/New-MockObject.md
@@ -1,0 +1,57 @@
+---
+external help file: Pester-help.xml
+online version: 
+schema: 2.0.0
+---
+
+# New-MockObject
+
+## SYNOPSIS
+This function instantiates a .NET object from a type.
+The assembly for the particular type must be
+loaded.
+
+## SYNTAX
+
+```
+New-MockObject [-Type] <Type>
+```
+
+## DESCRIPTION
+{{Fill in the Description}}
+
+## EXAMPLES
+
+### -------------------------- EXAMPLE 1 --------------------------
+```
+$obj = New-MockObject -Type 'System.Diagnostics.Process'
+```
+
+PS\> $obj.GetType().FullName
+    System.Diagnostics.Process
+
+## PARAMETERS
+
+### -Type
+The .NET type to create an object from.
+
+```yaml
+Type: Type
+Parameter Sets: (All)
+Aliases: 
+
+Required: True
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+## INPUTS
+
+## OUTPUTS
+
+## NOTES
+
+## RELATED LINKS
+

--- a/Docs/New-PesterOption.md
+++ b/Docs/New-PesterOption.md
@@ -1,0 +1,78 @@
+---
+external help file: Pester-help.xml
+online version: 
+schema: 2.0.0
+---
+
+# New-PesterOption
+
+## SYNOPSIS
+Creates an object that contains advanced options for Invoke-Pester
+
+## SYNTAX
+
+```
+New-PesterOption [-IncludeVSCodeMarker] [[-TestSuiteName] <String>]
+```
+
+## DESCRIPTION
+{{Fill in the Description}}
+
+## EXAMPLES
+
+### Example 1
+```
+PS C:\> {{ Add example code here }}
+```
+
+{{ Add example description here }}
+
+## PARAMETERS
+
+### -IncludeVSCodeMarker
+When this switch is set, an extra line of output will be written to the console for test failures, making it easier
+for VSCode's parser to provide highlighting / tooltips on the line where the error occurred.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: 
+
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -TestSuiteName
+When generating NUnit XML output, this controls the name assigned to the root "test-suite" element. 
+Defaults to "Pester".
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases: 
+
+Required: False
+Position: 1
+Default value: Pester
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+## INPUTS
+
+### None
+You cannot pipe input to this command.
+
+## OUTPUTS
+
+### System.Management.Automation.PSObject
+
+## NOTES
+
+## RELATED LINKS
+
+[Invoke-Pester]()
+

--- a/Docs/Pester.md
+++ b/Docs/Pester.md
@@ -1,0 +1,109 @@
+---
+Module Name: Pester
+Module Guid: a699dea5-2c73-4616-a270-1f7abb777e71
+Download Help Link: {{Please enter FwLink manually}}
+Help Version: {{Please enter version of help manually (X.X.X.X) format}}
+Locale: en-US
+---
+
+# Pester Module
+## Description
+{{Manually Enter Description Here}}
+
+## Pester Cmdlets
+### [AfterAll](AfterAll.md)
+{{Manually Enter AfterAll Description Here}}
+
+### [AfterEach](AfterEach.md)
+{{Manually Enter AfterEach Description Here}}
+
+### [AfterEachFeature](AfterEachFeature.md)
+{{Manually Enter AfterEachFeature Description Here}}
+
+### [AfterEachScenario](AfterEachScenario.md)
+{{Manually Enter AfterEachScenario Description Here}}
+
+### [Assert-MockCalled](Assert-MockCalled.md)
+{{Manually Enter Assert-MockCalled Description Here}}
+
+### [Assert-VerifiableMocks](Assert-VerifiableMocks.md)
+{{Manually Enter Assert-VerifiableMocks Description Here}}
+
+### [BeforeAll](BeforeAll.md)
+{{Manually Enter BeforeAll Description Here}}
+
+### [BeforeEach](BeforeEach.md)
+{{Manually Enter BeforeEach Description Here}}
+
+### [BeforeEachFeature](BeforeEachFeature.md)
+{{Manually Enter BeforeEachFeature Description Here}}
+
+### [BeforeEachScenario](BeforeEachScenario.md)
+{{Manually Enter BeforeEachScenario Description Here}}
+
+### [Context](Context.md)
+{{Manually Enter Context Description Here}}
+
+### [Describe](Describe.md)
+{{Manually Enter Describe Description Here}}
+
+### [Find-GherkinStep](Find-GherkinStep.md)
+{{Manually Enter Find-GherkinStep Description Here}}
+
+### [Get-MockDynamicParameters](Get-MockDynamicParameters.md)
+{{Manually Enter Get-MockDynamicParameters Description Here}}
+
+### [Get-TestDriveItem](Get-TestDriveItem.md)
+{{Manually Enter Get-TestDriveItem Description Here}}
+
+### [GherkinStep](GherkinStep.md)
+{{Manually Enter GherkinStep Description Here}}
+
+### [In](In.md)
+{{Manually Enter In Description Here}}
+
+### [InModuleScope](InModuleScope.md)
+{{Manually Enter InModuleScope Description Here}}
+
+### [Invoke-Gherkin](Invoke-Gherkin.md)
+{{Manually Enter Invoke-Gherkin Description Here}}
+
+### [Invoke-GherkinStep](Invoke-GherkinStep.md)
+{{Manually Enter Invoke-GherkinStep Description Here}}
+
+### [Invoke-Mock](Invoke-Mock.md)
+{{Manually Enter Invoke-Mock Description Here}}
+
+### [Invoke-Pester](Invoke-Pester.md)
+{{Manually Enter Invoke-Pester Description Here}}
+
+### [It](It.md)
+{{Manually Enter It Description Here}}
+
+### [Mock](Mock.md)
+{{Manually Enter Mock Description Here}}
+
+### [New-Fixture](New-Fixture.md)
+{{Manually Enter New-Fixture Description Here}}
+
+### [New-MockObject](New-MockObject.md)
+{{Manually Enter New-MockObject Description Here}}
+
+### [New-PesterOption](New-PesterOption.md)
+{{Manually Enter New-PesterOption Description Here}}
+
+### [SafeGetCommand](SafeGetCommand.md)
+{{Manually Enter SafeGetCommand Description Here}}
+
+### [Set-DynamicParameterVariables](Set-DynamicParameterVariables.md)
+{{Manually Enter Set-DynamicParameterVariables Description Here}}
+
+### [Set-TestInconclusive](Set-TestInconclusive.md)
+{{Manually Enter Set-TestInconclusive Description Here}}
+
+### [Setup](Setup.md)
+{{Manually Enter Setup Description Here}}
+
+### [Should](Should.md)
+{{Manually Enter Should Description Here}}
+

--- a/Docs/SafeGetCommand.md
+++ b/Docs/SafeGetCommand.md
@@ -1,0 +1,40 @@
+---
+external help file: Pester-help.xml
+online version: 
+schema: 2.0.0
+---
+
+# SafeGetCommand
+
+## SYNOPSIS
+This command is used by Pester's Mocking framework. 
+You do not need to call it directly.
+
+## SYNTAX
+
+```
+SafeGetCommand
+```
+
+## DESCRIPTION
+{{Fill in the Description}}
+
+## EXAMPLES
+
+### Example 1
+```
+PS C:\> {{ Add example code here }}
+```
+
+{{ Add example description here }}
+
+## PARAMETERS
+
+## INPUTS
+
+## OUTPUTS
+
+## NOTES
+
+## RELATED LINKS
+

--- a/Docs/Set-DynamicParameterVariables.md
+++ b/Docs/Set-DynamicParameterVariables.md
@@ -1,0 +1,86 @@
+---
+external help file: Pester-help.xml
+online version: 
+schema: 2.0.0
+---
+
+# Set-DynamicParameterVariables
+
+## SYNOPSIS
+This command is used by Pester's Mocking framework. 
+You do not need to call it directly.
+
+## SYNTAX
+
+```
+Set-DynamicParameterVariables [-SessionState] <SessionState> [[-Parameters] <Hashtable>]
+ [[-Metadata] <CommandMetadata>]
+```
+
+## DESCRIPTION
+{{Fill in the Description}}
+
+## EXAMPLES
+
+### Example 1
+```
+PS C:\> {{ Add example code here }}
+```
+
+{{ Add example description here }}
+
+## PARAMETERS
+
+### -SessionState
+{{Fill SessionState Description}}
+
+```yaml
+Type: SessionState
+Parameter Sets: (All)
+Aliases: 
+
+Required: True
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Parameters
+{{Fill Parameters Description}}
+
+```yaml
+Type: Hashtable
+Parameter Sets: (All)
+Aliases: 
+
+Required: False
+Position: 2
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Metadata
+{{Fill Metadata Description}}
+
+```yaml
+Type: CommandMetadata
+Parameter Sets: (All)
+Aliases: 
+
+Required: False
+Position: 3
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+## INPUTS
+
+## OUTPUTS
+
+## NOTES
+
+## RELATED LINKS
+

--- a/Docs/Set-TestInconclusive.md
+++ b/Docs/Set-TestInconclusive.md
@@ -1,0 +1,59 @@
+---
+external help file: Pester-help.xml
+online version: 
+schema: 2.0.0
+---
+
+# Set-TestInconclusive
+
+## SYNOPSIS
+{{Fill in the Synopsis}}
+
+## SYNTAX
+
+```
+Set-TestInconclusive [[-Message] <String>]
+```
+
+## DESCRIPTION
+{{Fill in the Description}}
+
+## EXAMPLES
+
+### Example 1
+```
+PS C:\> {{ Add example code here }}
+```
+
+{{ Add example description here }}
+
+## PARAMETERS
+
+### -Message
+{{Fill Message Description}}
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases: 
+
+Required: False
+Position: 0
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+## INPUTS
+
+### None
+
+
+## OUTPUTS
+
+### System.Object
+
+## NOTES
+
+## RELATED LINKS
+

--- a/Docs/Setup.md
+++ b/Docs/Setup.md
@@ -1,0 +1,119 @@
+---
+external help file: Pester-help.xml
+online version: 
+schema: 2.0.0
+---
+
+# Setup
+
+## SYNOPSIS
+{{Fill in the Synopsis}}
+
+## SYNTAX
+
+```
+Setup [-Dir] [-File] [[-Path] <Object>] [[-Content] <Object>] [-PassThru]
+```
+
+## DESCRIPTION
+{{Fill in the Description}}
+
+## EXAMPLES
+
+### Example 1
+```
+PS C:\> {{ Add example code here }}
+```
+
+{{ Add example description here }}
+
+## PARAMETERS
+
+### -Content
+{{Fill Content Description}}
+
+```yaml
+Type: Object
+Parameter Sets: (All)
+Aliases: 
+
+Required: False
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Dir
+{{Fill Dir Description}}
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: 
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -File
+{{Fill File Description}}
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: 
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -PassThru
+{{Fill PassThru Description}}
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: 
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Path
+{{Fill Path Description}}
+
+```yaml
+Type: Object
+Parameter Sets: (All)
+Aliases: 
+
+Required: False
+Position: 0
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+## INPUTS
+
+### None
+
+
+## OUTPUTS
+
+### System.Object
+
+## NOTES
+
+## RELATED LINKS
+

--- a/Docs/Should.md
+++ b/Docs/Should.md
@@ -1,0 +1,510 @@
+---
+external help file: Pester-help.xml
+online version: 
+schema: 2.0.0
+---
+
+# Should
+
+## SYNOPSIS
+{{Fill in the Synopsis}}
+
+## SYNTAX
+
+### Legacy (Default)
+```
+Should [[-LegacyArg1] <Object>] [[-LegacyArg2] <Object>] [[-LegacyArg3] <Object>] [-ActualValue <Object>]
+```
+
+### Be
+```
+Should [-ActualValue <Object>] [-Be] [-Not] [[-ExpectedValue] <Object>]
+```
+
+### BeExactly
+```
+Should [-ActualValue <Object>] [-Not] [[-ExpectedValue] <Object>] [-BeExactly]
+```
+
+### BeGreaterThan
+```
+Should [-ActualValue <Object>] [-Not] [[-ExpectedValue] <Object>] [-BeGreaterThan]
+```
+
+### BeIn
+```
+Should [-ActualValue <Object>] [-Not] [[-ExpectedValue] <Object>] [-BeIn]
+```
+
+### BeLessThan
+```
+Should [-ActualValue <Object>] [-Not] [[-ExpectedValue] <Object>] [-BeLessThan]
+```
+
+### BeLike
+```
+Should [-ActualValue <Object>] [-Not] [[-ExpectedValue] <Object>] [-BeLike]
+```
+
+### BeNullOrEmpty
+```
+Should [-ActualValue <Object>] [-Not] [-BeNullOrEmpty]
+```
+
+### BeOfType
+```
+Should [-ActualValue <Object>] [-Not] [-BeOfType] [[-ExpectedType] <Object>]
+```
+
+### Contain
+```
+Should [-ActualValue <Object>] [-Not] [-Contain] [[-ExpectedContent] <Object>]
+```
+
+### ContainExactly
+```
+Should [-ActualValue <Object>] [-Not] [[-ExpectedContent] <Object>] [-ContainExactly]
+```
+
+### ContainMultiline
+```
+Should [-ActualValue <Object>] [-Not] [[-ExpectedContent] <Object>] [-ContainMultiline]
+```
+
+### Exist
+```
+Should [-ActualValue <Object>] [-Not] [-Exist]
+```
+
+### Match
+```
+Should [-ActualValue <Object>] [-Not] [-Match] [[-RegularExpression] <Object>]
+```
+
+### MatchExactly
+```
+Should [-ActualValue <Object>] [-Not] [[-RegularExpression] <Object>] [-MatchExactly]
+```
+
+### Throw
+```
+Should [-ActualValue <Object>] [-Not] [-Throw] [[-ExpectedMessage] <Object>] [[-ErrorId] <Object>]
+```
+
+## DESCRIPTION
+{{Fill in the Description}}
+
+## EXAMPLES
+
+### Example 1
+```
+PS C:\> {{ Add example code here }}
+```
+
+{{ Add example description here }}
+
+## PARAMETERS
+
+### -ActualValue
+{{Fill ActualValue Description}}
+
+```yaml
+Type: Object
+Parameter Sets: (All)
+Aliases: 
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: True (ByValue)
+Accept wildcard characters: False
+```
+
+### -Be
+{{Fill Be Description}}
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: Be
+Aliases: EQ
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -BeExactly
+{{Fill BeExactly Description}}
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: BeExactly
+Aliases: CEQ
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -BeGreaterThan
+{{Fill BeGreaterThan Description}}
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: BeGreaterThan
+Aliases: GT
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -BeIn
+{{Fill BeIn Description}}
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: BeIn
+Aliases: 
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -BeLessThan
+{{Fill BeLessThan Description}}
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: BeLessThan
+Aliases: LT
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -BeLike
+{{Fill BeLike Description}}
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: BeLike
+Aliases: 
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -BeNullOrEmpty
+{{Fill BeNullOrEmpty Description}}
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: BeNullOrEmpty
+Aliases: 
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -BeOfType
+{{Fill BeOfType Description}}
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: BeOfType
+Aliases: 
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Contain
+{{Fill Contain Description}}
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: Contain
+Aliases: 
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ContainExactly
+{{Fill ContainExactly Description}}
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: ContainExactly
+Aliases: 
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ContainMultiline
+{{Fill ContainMultiline Description}}
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: ContainMultiline
+Aliases: 
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ErrorId
+{{Fill ErrorId Description}}
+
+```yaml
+Type: Object
+Parameter Sets: Throw
+Aliases: 
+
+Required: False
+Position: 2
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Exist
+{{Fill Exist Description}}
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: Exist
+Aliases: 
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ExpectedContent
+{{Fill ExpectedContent Description}}
+
+```yaml
+Type: Object
+Parameter Sets: Contain, ContainExactly, ContainMultiline
+Aliases: 
+
+Required: False
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ExpectedMessage
+{{Fill ExpectedMessage Description}}
+
+```yaml
+Type: Object
+Parameter Sets: Throw
+Aliases: 
+
+Required: False
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ExpectedType
+{{Fill ExpectedType Description}}
+
+```yaml
+Type: Object
+Parameter Sets: BeOfType
+Aliases: 
+
+Required: False
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ExpectedValue
+{{Fill ExpectedValue Description}}
+
+```yaml
+Type: Object
+Parameter Sets: Be, BeExactly, BeGreaterThan, BeIn, BeLessThan, BeLike
+Aliases: 
+
+Required: False
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -LegacyArg1
+{{Fill LegacyArg1 Description}}
+
+```yaml
+Type: Object
+Parameter Sets: Legacy
+Aliases: 
+
+Required: False
+Position: 0
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -LegacyArg2
+{{Fill LegacyArg2 Description}}
+
+```yaml
+Type: Object
+Parameter Sets: Legacy
+Aliases: 
+
+Required: False
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -LegacyArg3
+{{Fill LegacyArg3 Description}}
+
+```yaml
+Type: Object
+Parameter Sets: Legacy
+Aliases: 
+
+Required: False
+Position: 2
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Match
+{{Fill Match Description}}
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: Match
+Aliases: 
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -MatchExactly
+{{Fill MatchExactly Description}}
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: MatchExactly
+Aliases: CMATCH
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Not
+{{Fill Not Description}}
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: Be, BeExactly, BeGreaterThan, BeIn, BeLessThan, BeLike, BeNullOrEmpty, BeOfType, Contain, ContainExactly, ContainMultiline, Exist, Match, MatchExactly, Throw
+Aliases: 
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -RegularExpression
+{{Fill RegularExpression Description}}
+
+```yaml
+Type: Object
+Parameter Sets: Match, MatchExactly
+Aliases: 
+
+Required: False
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Throw
+{{Fill Throw Description}}
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: Throw
+Aliases: 
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+## INPUTS
+
+### System.Object
+
+
+## OUTPUTS
+
+### System.Object
+
+## NOTES
+
+## RELATED LINKS
+


### PR DESCRIPTION
Create a branch for PlatyPS help to address #720

Initially, just import `New-MarkdownHelp -Module Pester -OutputFolder Docs -WithModulePage`

I recommend we not merge to DevelopmentV4, but create a branch. Before merging, we should get a `Build` to run PlatyPS on the source markdown to build the xml help, and then retrofit all the functions to reference the xml files instead of having comments...