### PR TITLE
Fixes #697 - Mocking a Dummy Function with a Pipeline in two consequitive Context

### DIFF
--- a/Functions/Mock.Tests.ps1
+++ b/Functions/Mock.Tests.ps1
@@ -75,21 +75,6 @@ function PipelineInputFunction {
     }
 }
 
-Describe "When calling Mock on existing function" {
-    Mock FunctionUnderTest { return "I am the mock test that was passed $param1"}
-
-    $result = FunctionUnderTest "boundArg"
-
-    It "Should rename function under test" {
-        $renamed = (Test-Path function:PesterIsMocking_FunctionUnderTest)
-        $renamed | Should Be $true
-    }
-
-    It "Should Invoke the mocked script" {
-        $result | Should Be "I am the mock test that was passed boundArg"
-    }
-}
-
 Describe "When the caller mocks a command Pester uses internally" {
     Mock Write-Host { }
 
@@ -282,7 +267,7 @@ Describe "When calling Mock on existing cmdlet to handle pipelined input" {
 Describe "When calling Mock on existing cmdlet with Common params" {
     Mock CommonParamFunction
 
-    $result=[string](Get-Content function:\CommonParamFunction)
+    $result=[string](Get-Command CommonParamFunction).ResolvedCommand.ScriptBlock
 
     It "Should strip verbose" {
         $result.contains("`${Verbose}") | Should Be $false

--- a/Functions/Mock.Tests.ps1
+++ b/Functions/Mock.Tests.ps1
@@ -267,7 +267,7 @@ Describe "When calling Mock on existing cmdlet to handle pipelined input" {
 Describe "When calling Mock on existing cmdlet with Common params" {
     Mock CommonParamFunction
 
-    $result=[string](Get-Command CommonParamFunction).ResolvedCommand.ScriptBlock
+    $result=[string](Get-Alias CommonParamFunction).ResolvedCommand.ScriptBlock
 
     It "Should strip verbose" {
         $result.contains("`${Verbose}") | Should Be $false

--- a/Functions/Mock.Tests.ps1
+++ b/Functions/Mock.Tests.ps1
@@ -1734,3 +1734,32 @@ Describe 'Passing unbound script blocks as mocks' {
         TestMe | Should -Be Mocked
     }
 }
+
+Describe "Restoring original commands when mock scopes exit" {
+    function a (){}
+    Context "first context" {
+        Mock a { "mock" }
+
+        # Deliberately not using "Should Exist" here because that executes in
+        # Pester's module scope, where function:\a does not exist
+        It "original function exists" {
+            $function:a | Should -Not -Be $null
+        }
+
+        It "passes in first context" {
+            a | Should Be "mock"
+        }
+    }
+
+    Context "second context" {
+        Mock a { "mock" }
+
+        It "original function exists" {
+            $function:a | Should -Not -Be $null
+        }
+
+        It "passes in second context" {
+            a | Should Be "mock"
+        }
+    }
+}


### PR DESCRIPTION
In the past we've been renaming functions back and forth when mocking an existing function. Apparently we've been lucky that this worked at all, because when we rename the function back, we can wind up modifying its scope.

This PR changes the approach: we never modify the original command, even if it's a function. Instead, we create an alias with the same name (which takes precedence anyway), and point that alias to our mock's bootstrap function that can exist under any name. (Using GUIDs to ensure uniqueness.) When we delete the alias, the original unmocked version of the command goes back to being in effect without any tampering on Pester's part.

Fixes #697