### PR TITLE
Fixes #746 - Incorrect Mock call history scopes

### DIFF
--- a/Functions/Describe.Tests.ps1
+++ b/Functions/Describe.Tests.ps1
@@ -24,6 +24,14 @@ InModuleScope Pester {
         function MockMe { param ($Name) }
         Mock MockMe
 
+        BeforeEach {
+            $testState.EnterTest()
+        }
+
+        AfterEach {
+            $testState.LeaveTest()
+        }
+
         Context 'Handling errors in the Fixture' {
             $testState = New-PesterState -Path $TestDrive
 

--- a/Functions/It.ps1
+++ b/Functions/It.ps1
@@ -246,6 +246,7 @@ function Invoke-Test
             $errorRecord = $null
             try
             {
+                $pester.EnterTest()
                 Invoke-TestCaseSetupBlocks
 
                 do
@@ -271,6 +272,8 @@ function Invoke-Test
                 {
                     $errorRecord = $_
                 }
+
+                $pester.LeaveTest()
             }
 
             $result = ConvertTo-PesterResult -ErrorRecord $errorRecord

--- a/Functions/Mock.Tests.ps1
+++ b/Functions/Mock.Tests.ps1
@@ -1735,15 +1735,27 @@ Describe 'Passing unbound script blocks as mocks' {
     }
 }
 
-Describe 'Case sensitive?' {
+Describe 'Assert-MockCalled when mock called outside of It block' {
     function TestMe { 'Original ' }
     mock TestMe { 'Mocked' }
 
     $null = TestMe
 
-    It 'Should work fine' {
-        TestMe | Should -Be Mocked
-        Assert-MockCalled TestMe -Scope It -Exactly -Times 1
-        Assert-MockCalled TestMe -Scope Describe -Exactly -Times 2
+    Context 'Context' {
+        $null = TestMe
+
+        It 'Should log the correct number of calls' {
+            TestMe | Should -Be Mocked
+            Assert-MockCalled TestMe -Scope It -Exactly -Times 1
+            Assert-MockCalled TestMe -Scope Context -Exactly -Times 2
+            Assert-MockCalled TestMe -Scope Describe -Exactly -Times 3
+        }
+
+        It 'Should log the correct number of calls (second test)' {
+            TestMe | Should -Be Mocked
+            Assert-MockCalled TestMe -Scope It -Exactly -Times 1
+            Assert-MockCalled TestMe -Scope Context -Exactly -Times 3
+            Assert-MockCalled TestMe -Scope Describe -Exactly -Times 4        
+        }
     }
 }

--- a/Functions/Mock.Tests.ps1
+++ b/Functions/Mock.Tests.ps1
@@ -1734,3 +1734,15 @@ Describe 'Passing unbound script blocks as mocks' {
         TestMe | Should -Be Mocked
     }
 }
+
+Describe 'Case sensitive?' {
+    function TestMe { 'Original ' }
+    mock TestMe { 'Mocked' }
+
+    $null = TestMe
+
+    It 'Should work fine' {
+        TestMe | Should -Be Mocked
+        Assert-MockCalled TestMe -Scope It -Exactly -Times 1
+    }
+}

--- a/Functions/Mock.Tests.ps1
+++ b/Functions/Mock.Tests.ps1
@@ -1755,7 +1755,7 @@ Describe 'Assert-MockCalled when mock called outside of It block' {
             TestMe | Should -Be Mocked
             Assert-MockCalled TestMe -Scope It -Exactly -Times 1
             Assert-MockCalled TestMe -Scope Context -Exactly -Times 3
-            Assert-MockCalled TestMe -Scope Describe -Exactly -Times 4        
+            Assert-MockCalled TestMe -Scope Describe -Exactly -Times 4
         }
     }
 }

--- a/Functions/Mock.Tests.ps1
+++ b/Functions/Mock.Tests.ps1
@@ -1744,5 +1744,6 @@ Describe 'Case sensitive?' {
     It 'Should work fine' {
         TestMe | Should -Be Mocked
         Assert-MockCalled TestMe -Scope It -Exactly -Times 1
+        Assert-MockCalled TestMe -Scope Describe -Exactly -Times 2
     }
 }

--- a/Functions/Mock.ps1
+++ b/Functions/Mock.ps1
@@ -1103,8 +1103,8 @@ function ExecuteBlock
 
     $Block.Verifiable = $false
 
-    # We set Scope to $null here to indicate the call came from the current Test Case.  It'll get assigned to a test group scope when Exit-MockScope is called.
-    $Mock.CallHistory += @{CommandName = "$ModuleName||$CommandName"; BoundParams = $BoundParameters; Args = $ArgumentList; Scope = $null }
+    $scope = if ($pester.InTest) { $null } else { $pester.CurrentTestGroup }
+    $Mock.CallHistory += @{CommandName = "$ModuleName||$CommandName"; BoundParams = $BoundParameters; Args = $ArgumentList; Scope = $scope }
 
     $scriptBlock = {
         param (

--- a/Functions/PesterState.ps1
+++ b/Functions/PesterState.ps1
@@ -50,6 +50,7 @@ function New-PesterState
         $script:CommandCoverage = @()
         $script:Strict = $Strict
         $script:Show = $Show
+        $script:InTest = $false
 
         $script:TestResult = @()
 
@@ -293,6 +294,21 @@ function New-PesterState
             return $script:TestGroupStack.Peek().AfterAll
         }
 
+        function EnterTest
+        {
+            if ($script:InTest)
+            {
+                throw 'You are already in a test case.'
+            }
+
+            $script:InTest = $true
+        }
+
+        function LeaveTest
+        {
+            $script:InTest = $false
+        }
+
         $ExportedVariables = "TagFilter",
         "ExcludeTagFilter",
         "TestNameFilter",
@@ -311,7 +327,8 @@ function New-PesterState
         "IncludeVSCodeMarker",
         "TestActions",
         "TestGroupStack",
-        "TestSuiteName"
+        "TestSuiteName",
+        "InTest"
 
         $ExportedFunctions = "EnterTestGroup",
                              "LeaveTestGroup",
@@ -320,7 +337,9 @@ function New-PesterState
                              "GetTestCaseSetupBlocks",
                              "GetTestCaseTeardownBlocks",
                              "GetCurrentTestGroupSetupBlocks",
-                             "GetCurrentTestGroupTeardownBlocks"
+                             "GetCurrentTestGroupTeardownBlocks",
+                             "EnterTest",
+                             "LeaveTest"
 
         & $SafeCommands['Export-ModuleMember'] -Variable $ExportedVariables -function $ExportedFunctions
     }  |


### PR DESCRIPTION
Pester internals now track when they are inside an It block, and correctly assign test group scopes to mock calls when this is not the case.

Fixes #746