### PR TITLE
Add better tests for OS and temp

### DIFF
--- a/Functions/Environment.Tests.ps1
+++ b/Functions/Environment.Tests.ps1
@@ -1,0 +1,103 @@
+InModuleScope -ModuleName Pester {
+    Describe 'Get-PowerShellVersion' {
+        Mock Get-Variable
+        It 'Returns value of $PSVersionTable.PsVersion.Major' {
+            Mock Get-Variable -ParameterFilter { $Name -eq 'PSVersionTable' -and $ValueOnly } -MockWIth {
+                @{ PSVersion = [Version]'1.0.0' }
+            }
+
+            Get-PowerShellVersion | Should -Be 1
+        }
+    }
+
+    Describe "Get-OperatingSystem" {
+        Mock Get-Variable
+        Context "Windows with PowerShell 5 and lower" {
+            It "Returns 'Windows' when PowerShell version is lower than 6" {
+                Mock Get-PowerShellVersion { 5 }
+
+                Get-OperatingSystem | Should -Be 'Windows'
+            }
+        }
+
+        Context "Windows with PowerShell 6 and higher" {
+            Mock Get-Variable -ParameterFilter { $Name -eq 'IsWindows' -and $ValueOnly } -MockWith { $true }
+            Mock Get-Variable -ParameterFilter { $Name -eq 'IsLinux' -and $ValueOnly } -MockWith { $false }
+            Mock Get-Variable -ParameterFilter { $Name -eq 'IsOSX' -and $ValueOnly } -MockWith { $false }
+            Mock Get-PowerShellVersion { 6 }
+
+            $os = Get-OperatingSystem
+            It "Returns 'Windows' when `$IsWindows is `$true and powershell version is 6 or higher" {
+                $os | Should -Be 'Windows'
+            }
+
+            It "Uses Get-Variable to retreive IsWindows" {
+                # IsWindows is a constant and cannot be overwritten, so check that we are using
+                # Get-Variable to access its value, which allows us to mock it easily without
+                # depending on the OS
+
+                Assert-MockCalled Get-Variable -ParameterFilter { $Name -eq 'IsWindows' -and ($ValueOnly) } -Exactly 1
+            }
+        }
+
+        Context "Linux with PowerShell 6 and higher" {
+            Mock Get-Variable -ParameterFilter { $Name -eq 'IsWindows' -and $ValueOnly } -MockWith { $false }
+            Mock Get-Variable -ParameterFilter { $Name -eq 'IsLinux' -and $ValueOnly } -MockWith { $true }
+            Mock Get-Variable -ParameterFilter { $Name -eq 'IsOSX' -and $ValueOnly } -MockWith { $false }
+            Mock Get-PowerShellVersion { 6 }
+
+            $os = Get-OperatingSystem
+            It "Returns 'Linux' when `$IsLinux is `$true and powershell version is 6 or higher" {
+                $os | Should -Be 'Linux'
+            }
+
+            It "Uses Get-Variable to retreive IsLinux" {
+                Assert-MockCalled Get-Variable -ParameterFilter { $Name -eq 'IsLinux' -and $ValueOnly } -Exactly 1
+            }
+        }
+
+        Context "OSx with PowerShell 6 and higher" {
+            Mock Get-Variable -ParameterFilter { $Name -eq 'IsWindows' -and $ValueOnly } -MockWith { $false }
+            Mock Get-Variable -ParameterFilter { $Name -eq 'IsLinux' -and $ValueOnly } -MockWith { $false }
+            Mock Get-Variable -ParameterFilter { $Name -eq 'IsOSX' -and $ValueOnly } -MockWith { $true }
+            Mock Get-PowerShellVersion { 6 }
+
+            $os = Get-OperatingSystem
+            It "Returns 'OSX' when `$IsOSX is `$true and powershell version is 6 or higher" {
+                $os | Should -Be 'OSX'
+            }
+
+            It "Uses Get-Variable to retreive IsOSX" {
+                Assert-MockCalled Get-Variable -ParameterFilter { $Name -eq 'IsOSX' -and $ValueOnly } -Exactly 1
+            }
+        }
+    }
+
+
+    Describe 'Get-TempDirectory' {
+        It 'returns the correct temp directory for Windows' {
+            Mock 'Get-OperatingSystem' {
+                'Windows'
+            }
+            $expected = $env:TEMP = "C:\temp"
+
+            $temp = Get-TempDirectory
+            $temp | Should -Not -BeNullOrEmpty
+            $temp | Should -Be $expected
+        }
+
+        It "returns '/tmp' directory for MacOS" {
+            Mock 'Get-OperatingSystem' {
+                'MacOS'
+            }
+            Get-TempDirectory | Should -Be '/tmp'
+        }
+
+        It "returns '/tmp' directory for Linux" {
+            Mock 'Get-OperatingSystem' {
+                'Linux'
+            }
+            Get-TempDirectory | Should -Be '/tmp'
+        }
+    }
+}

--- a/Functions/Environment.ps1
+++ b/Functions/Environment.ps1
@@ -1,0 +1,42 @@
+function Get-PowerShellVersion
+{
+    # accessing the value indirectly so it can be mocked
+    (Get-Variable 'PSVersionTable' -ValueOnly).PsVersion.Major
+}
+
+function Get-OperatingSystem
+{
+    # Prior to v6, PowerShell was solely on Windows. In v6, the $IsWindows variable was introduced.
+    if ((Get-PowerShellVersion) -lt 6)
+    {
+        'Windows'
+    }
+    elseif (Get-Variable -Name 'IsWindows' -ErrorAction 'SilentlyContinue' -ValueOnly )
+    {
+        'Windows'
+    }
+    elseif (Get-Variable -Name 'IsOSX' -ErrorAction 'SilentlyContinue' -ValueOnly )
+    {
+        'OSX'
+    }
+    elseif (Get-Variable -Name 'IsLinux' -ErrorAction 'SilentlyContinue' -ValueOnly )
+    {
+        'Linux'
+    }
+    else
+    {
+        throw "Unsupported Operating system!"
+    }
+}
+
+function Get-TempDirectory
+{
+    if ((Get-OperatingSystem) -eq 'Windows')
+    {
+        $env:TEMP
+    }
+    else
+    {
+        '/tmp'
+    }
+}

--- a/Pester.Tests.ps1
+++ b/Pester.Tests.ps1
@@ -284,36 +284,4 @@ InModuleScope Pester {
             }
         }
     }
-
-    describe 'Get-OperatingSystem' {
-
-        it 'returns Windows' {
-
-            Get-OperatingSystem | should be 'Windows'
-        }
-    }
-
-    describe 'Get-TempDirectory' {
-
-        it 'returns the correct temp directory for Windows' {
-            mock 'Get-OperatingSystem' {
-                'Windows'
-            }
-            Get-TempDirectory | should be $env:TEMP
-        }
-
-        it 'returns the correct temp directory for MacOS' {
-            mock 'Get-OperatingSystem' {
-                'MacOS'
-            }
-            Get-TempDirectory | should be '/tmp'
-        }
-
-        it 'returns the correct temp directory for Linux' {
-            mock 'Get-OperatingSystem' {
-                'Linux'
-            }
-            Get-TempDirectory | should be '/tmp'
-        }
-    }
 }

--- a/Pester.psm1
+++ b/Pester.psm1
@@ -935,40 +935,6 @@ function Get-ScriptBlockScope
     [scriptblock].GetProperty('SessionStateInternal', $flags).GetValue($ScriptBlock, $null)
 }
 
-function Get-OperatingSystem
-{
-    [CmdletBinding()]
-    param()
-
-    ## Prior to v6, PowerShell was solely Windows. In v6, the $IsWindows var was introduced.
-    if ($PSVersionTable.PSVersion.Major -lt 6 -or $IsWindows)
-    {
-        'Windows'
-    }
-    elseif ($IsOSX)
-    {
-        'OSX'
-    }
-    elseif ($IsLinux)
-    {
-        'Linux'
-    }
-}
-
-function Get-TempDirectory
-{
-    [CmdletBinding()]
-    param()
-
-    if ((Get-OperatingSystem) -eq 'Windows')
-    {
-        $env:TEMP
-    }
-    else
-    {
-        '/tmp'
-    }
-}
 
 function SafeGetCommand
 {


### PR DESCRIPTION
I am trying to make Pester work on Linux (namely the microsoft/powershell docker container), so I am taking it from the most obvious failing tests like the one that checked that Get-OS returns Windows. I added tests in a way that is able to run on any operating system, I am probably doing too much work there, but I wanted to think about different approaches. 

One thing I am not sure about is how would I test with functions that are in the safe command table? I can't mock those.