### PR TITLE
Use OS independent path for resolve test

### DIFF
--- a/Functions/TestResults.Tests.ps1
+++ b/Functions/TestResults.Tests.ps1
@@ -284,7 +284,10 @@ InModuleScope Pester {
         }
 
         It "Resolves full path correctly" {
-            GetFullPath C:\Windows\System32\notepad.exe | Should Be C:\Windows\System32\notepad.exe
+            $powershellPath = Get-Command 'powershell' | select -ExpandProperty 'Definition'
+            $powershellPath | Should -Not -BeNullOrEmpty
+
+            GetFullPath $powershellPath | Should Be $powershellPath
         }
     }
 }


### PR DESCRIPTION
Used path of powershell instead of hardcoded path to notepad.exe to make it compatible with Linux.