### PR TITLE
Swap Describe and Context and order correctly with \ as a separator

### DIFF
--- a/Functions/PesterState.ps1
+++ b/Functions/PesterState.ps1
@@ -182,7 +182,11 @@ function New-PesterState
             $describe = ''
             $contexts = [System.Collections.ArrayList]@()
 
-            foreach ($group in $script:TestGroupStack.GetEnumerator())
+            # make a copy of the stack and reverse it
+            $reversedStack = $script:TestGroupStack.ToArray()
+            [array]::Reverse($reversedStack)
+
+            foreach ($group in $reversedStack)
             {
                 if ($group.Hint -eq 'Root' -or $group.Hint -eq 'Script') { continue }
                 if ($describe -eq '')
@@ -195,7 +199,7 @@ function New-PesterState
                 }
             }
 
-            $context = $contexts -join '/'
+            $context = $contexts -join '\'
 
             $script:TestResult += & $SafeCommands['New-Object'] psobject -Property @{
                 Describe               = $describe


### PR DESCRIPTION
Fixed the placement, changed the separator to be `\` which seemed more natural. 

```powershell
'Describe "top" { describe "middle" { context "bottom" { it "whatever" { $true | Should Be $true } } } }' | Out-File -FilePath .\test.ps1
$result = Invoke-Pester -Script .\test.ps1 -PassThru
$result.TestResult
```
```
ErrorRecord            : 
ParameterizedSuiteName : 
Describe               : top
Parameters             : {}
Passed                 : True
Show                   : All
FailureMessage         : 
Time                   : 00:00:00.0974222
Name                   : whatever
Result                 : Passed
Context                : middle\bottom
StackTrace             : 
```

Fixes #751