### PR TITLE
Make Add-AssertionOperator a public function

### DIFF
--- a/Pester.psd1
+++ b/Pester.psd1
@@ -50,6 +50,7 @@ FunctionsToExport = @(
     'SafeGetCommand'
     'New-PesterOption'
 	'New-MockObject'
+    'Add-AssertionOperator'
 
     # Gherkin Support:
     'Invoke-Gherkin'

--- a/Pester.psm1
+++ b/Pester.psm1
@@ -140,7 +140,7 @@ function Assert-ValidAssertionAlias
     }
 }
 
-#<#
+<#
 .SYNOPSIS
     Register an Assertion Operator with Pester
 .DESCRIPTION

--- a/Pester.psm1
+++ b/Pester.psm1
@@ -140,6 +140,51 @@ function Assert-ValidAssertionAlias
     }
 }
 
+#<#
+.SYNOPSIS
+    Register an Assertion Operator with Pester
+.DESCRIPTION
+    This function allows you to create custom Should assertions.
+.EXAMPLE
+    function BeAwesome($ActualValue, [switch] $Negate)
+    {
+
+        [bool] $succeeded = $ActualValue -eq 'Awesome'
+        if ($Negate) { $succeeded = -not $succeeded }
+
+        if (-not $succeeded)
+        {
+            if ($Negate)
+            {
+                $failureMessage = "{$ActualValue} is not Awesome"
+            }
+            else
+            {
+                $failureMessage = "{$ActualValue} is not Awesome"
+            }
+        }
+
+        return New-Object psobject -Property @{
+            Succeeded      = $succeeded
+            FailureMessage = $failureMessage
+        }
+    }
+
+    Add-AssertionOperator -Name  BeAwesome `
+                        -Test  $function:BeAwesome `
+                        -Alias 'BA'
+
+    PS C:\> "bad" | should -BeAwesome
+    {bad} is not Awesome
+.PARAMETER Name
+    The name of the assetion. This will become a Named Parameter of Should.
+.PARAMETER Test
+    The test function. The function must return a PSObject with a [Bool]succeeded and a [string]failureMessage property.
+.PARAMETER Alias
+    A list of aliases for the Named Parameter.
+.PARAMETER SupportsArrayInput
+    Does the test function support the passing an array of values to test.
+#>
 function Add-AssertionOperator
 {
     [CmdletBinding()]

--- a/Pester.psm1
+++ b/Pester.psm1
@@ -1031,4 +1031,4 @@ if ((& $script:SafeCommands['Test-Path'] -Path Variable:\psise) -and
 & $script:SafeCommands['Export-ModuleMember'] Get-MockDynamicParameters, Set-DynamicParameterVariables
 & $script:SafeCommands['Export-ModuleMember'] SafeGetCommand, New-PesterOption
 & $script:SafeCommands['Export-ModuleMember'] Invoke-Gherkin, Invoke-GherkinStep, Find-GherkinStep, BeforeEachFeature, BeforeEachScenario, AfterEachFeature, AfterEachScenario, GherkinStep -Alias Given, When, Then, And, But
-& $script:SafeCommands['Export-ModuleMember'] New-MockObject
+& $script:SafeCommands['Export-ModuleMember'] New-MockObject, Add-AssertionOperator


### PR DESCRIPTION
Allow other modules to extend Pester by making `Add-AssertionOperator` public.