### PR TITLE
add tests and use .get_Keys() instead of .Keys [V3Maintenance]

### DIFF
--- a/Functions/Mock.Tests.ps1
+++ b/Functions/Mock.Tests.ps1
@@ -1707,20 +1707,23 @@ Describe 'Globbing characters in command name' {
 }
 
 Describe 'Naming conflicts in mocked functions' {
-    function Sample {
-        param(
-            [string]
-            ${Metadata}
-        )
+    Context 'parameter named Metadata' {
+        function Sample { param( [string] ${Metadata} ) }
+        function Wrapper { Sample -Metadata 'test' }
+
+        Mock Sample { 'mocked' }
+        It 'Works with commands with parameter named Metadata' {
+            Wrapper | Should Be 'mocked'
+        }
     }
+    Context 'parameter named Keys' {
+        function g { [CmdletBinding()] param($Keys,$H) }
+        function Wrapper { g -Keys 'value' }
 
-    function Wrapper {
-        Sample -Metadata 'test'
-    }
-
-    Mock -CommandName Sample { 'mocked' }
-
-    It 'Works with commands that contain variables named Metadata' {
-        Wrapper | Should Be 'mocked'
+        Mock g { $Keys }
+        It 'Works with command with parameter named Keys' {
+            $r = Wrapper
+            $r | Should be 'value'
+        }
     }
 }

--- a/Functions/Mock.ps1
+++ b/Functions/Mock.ps1
@@ -1132,7 +1132,7 @@ function Get-ParamBlockFromBoundParameters
         [System.Management.Automation.CommandMetadata] $Metadata
     )
 
-    $params = foreach ($paramName in $BoundParameters.Keys)
+    $params = foreach ($paramName in $BoundParameters.get_Keys())
     {
         if (IsCommonParameter -Name $paramName -Metadata $Metadata)
         {


### PR DESCRIPTION
add test 'Works with command with parameter named Keys' to 'Naming conflicts in mocked functions'
use $BoundParameters.get_Keys() instead of $BoundParameters.Keys in Get-ParamBlockFromBoundParameters
fix #776