### PR TITLE
Add support for JaCoCo XML code coverage reports.

### DIFF
--- a/Functions/Coverage.Tests.ps1
+++ b/Functions/Coverage.Tests.ps1
@@ -78,7 +78,7 @@ InModuleScope Pester {
                 $jaCoCoReportXml = $jaCoCoReportXml -replace 'start="[0-9]*"','start=""'
                 $jaCoCoReportXml = $jaCoCoReportXml -replace 'dump="[0-9]*"','dump=""'
                 $jaCoCoReportXml = $jaCoCoReportXml -replace '\n',''
-                $jaCoCoReportXml | should be '<?xml version="1.0" encoding="UTF-8" standalone="no"?><!DOCTYPE report PUBLIC "-//JACOCO//DTD Report 1.0//EN" "report.dtd"><report name="Pester (date)"><sessioninfo id="this" start="" dump=""/><counter type="INSTRUCTION" missed="1" covered="6"/><counter type="LINE" missed="1" covered="6"/><counter type="METHOD" missed="1" covered="3"/><counter type="CLASS" missed="0" covered="1"/></report>'
+                $jaCoCoReportXml | should be '<?xml version="1.0" encoding="UTF-8" standalone="no"?><!DOCTYPE report PUBLIC "-//JACOCO//DTD Report 1.0//EN" "report.dtd"><report name="Pester (date)"><sessioninfo id="this" start="" dump="" /><counter type="INSTRUCTION" missed="1" covered="6" /><counter type="LINE" missed="1" covered="6" /><counter type="METHOD" missed="1" covered="3" /><counter type="CLASS" missed="0" covered="1" /></report>'
             }
             Exit-CoverageAnalysis -PesterState $testState
         }
@@ -231,35 +231,7 @@ InModuleScope Pester {
             Exit-CoverageAnalysis -PesterState $testState
         }
     }
-    Describe 'Testing DTD Validator' {
-        Context 'Custom documents' {
-            $jaCoCoReplortXml = '<?xml version="1.0" encoding="UTF-8" standalone="no"?><!DOCTYPE report PUBLIC "-//JACOCO//DTD Report 1.0//EN" "report.dtd"><report name="Pester (date)"><sessioninfo id="this" start="" dump=""/><counter type="INSTRUCTION" missed="1" covered="6"/><counter type="LINE" missed="1" covered="6"/><counter type="METHOD" missed="1" covered="3"/><counter type="CLASS" missed="0" covered="1"/></report>'
-            It 'Dtd Validator on normal document' {
-                Test-DtdSchema $jaCoCoReplortXml | should be $true,""
-            }
-            It 'Provided invalid XML' {
-                $jaCoCoReplortXml = $jaCoCoReplortXml -replace "/>","/>`n"
-                $jaCoCoReplortXml = $jaCoCoReplortXml -replace "CLASS","CLASS2"
-                $expectedErrorTest = "Validation error in XML string on line 5, position 10: 'CLASS2' is not in the enumeration list.`n"
-                $expectedErrorTest += '<counter type="CLASS2" missed="0" covered="1"/>' + "`n"
-                $expectedErrorTest += "---------^"
-                Test-DtdSchema $jaCoCoReplortXml | should be $false,$expectedErrorTest
-            }
-            It 'Provided missing DTD' {
-                # this causes an underlying error which is not easy to understand, as the exception will not should the right stack trace.
-                # Therefore an extra try catch has been added in the Test-DtdSchema function that wraps the exception. Therefore we test that the Test-DtdSchema is part of the stack trace.
-                $jaCoCoReplortXml = '<?xml version="1.0" encoding="UTF-8" standalone="no"?><!DOCTYPE report PUBLIC "-//JACOCO//DTD Report 1.0//EN" "report2.dtd"><report/>'
-                try{
-                    Test-DtdSchema $jaCoCoReplortXml
-                    $true | should be $false
-                }
-                catch{
-                    $_.Exception.Message | Should BeLike 'Exception calling "Read" with "0" argument(s): "Could not find file*'
-                    $_.ScriptStackTrace | Should BeLike 'At Test-DtdSchema*'
-                }
-            }
-        }
-    }
+
     Describe 'Stripping common parent paths' {
         $paths = @(
             Normalize-Path 'C:\Common\Folder\UniqueSubfolder1/File.ps1'

--- a/Functions/Coverage.ps1
+++ b/Functions/Coverage.ps1
@@ -600,67 +600,35 @@ function Get-JaCoCoReportXml {
     [long]$totalFiles = $CoverageReport.NumberOfFilesAnalyzed
     [long]$hitFiles = ($CoverageReport.HitCommands | ForEach-Object {$_.File} | Select-Object -uniq ).Count
     [long]$missedFiles = $totalFiles - $hitFiles
-    $jaCoCoReport += "<?xml version=""1.0"" encoding=""UTF-8"" standalone=""no""?>`n"
-    $jaCoCoReport += "<!DOCTYPE report PUBLIC ""-//JACOCO//DTD Report 1.0//EN"" ""report.dtd"">`n"
+
     $now = & $SafeCommands['Get-Date']
-    $jaCoCoReport +=  "<report name=""Pester ($now)"">`n"
     $nineteenseventy = & $SafeCommands['Get-Date'] -Date "01/01/1970"
     [long]$endTime =  [math]::Floor((new-timespan -start $nineteenseventy -end $now).TotalSeconds * 1000)
     [long]$startTime = [math]::Floor($endTime - $PesterState.Time.TotalSeconds*1000)
-    $jaCoCoReport += "<sessioninfo id=""this"" start=""$startTime"" dump=""$endTime""/>`n"
-    $jaCoCoReport += "<counter type=""INSTRUCTION"" missed=""$($CoverageReport.MissedCommands.Count)"" covered=""$($CoverageReport.HitCommands.Count)""/>`n"
-    $jaCoCoReport += "<counter type=""LINE"" missed=""$missedLines"" covered=""$hitLines""/>`n"
-    $jaCoCoReport += "<counter type=""METHOD"" missed=""$missedFunctions"" covered=""$hitFunctions""/>`n"
-    $jaCoCoReport += "<counter type=""CLASS"" missed=""$missedFiles"" covered=""$hitFiles""/>`n"
+
+    # the JaCoCo xml format without the doctype, as the XML stuff does not like DTD's.
+    $jaCoCoReport += "<?xml version=""1.0"" encoding=""UTF-8"" standalone=""no""?>`n"
+    $jaCoCoReport += "<report name="""">`n"
+    $jaCoCoReport += "<sessioninfo id=""this"" start="""" dump="""" />`n"
+    $jaCoCoReport += "<counter type=""INSTRUCTION"" missed="""" covered=""""/>`n"
+    $jaCoCoReport += "<counter type=""LINE"" missed="""" covered=""""/>`n"
+    $jaCoCoReport += "<counter type=""METHOD"" missed="""" covered=""""/>`n"
+    $jaCoCoReport += "<counter type=""CLASS"" missed="""" covered=""""/>`n"
     $jaCoCoReport += "</report>"
-    return $jaCocoReport
+
+    [xml] $jaCoCoReportXml = $jaCoCoReport
+    $jaCoCoReportXml.report.name = "Pester ($now)"
+    $jaCoCoReportXml.report.sessioninfo.start=$startTime.ToString()
+    $jaCoCoReportXml.report.sessioninfo.dump=$endTime.ToString()
+    $jaCoCoReportXml.report.counter[0].missed = $CoverageReport.MissedCommands.Count.ToString()
+    $jaCoCoReportXml.report.counter[0].covered = $CoverageReport.HitCommands.Count.ToString()
+    $jaCoCoReportXml.report.counter[1].missed = $missedLines.ToString()
+    $jaCoCoReportXml.report.counter[1].covered = $hitLines.ToString()
+    $jaCoCoReportXml.report.counter[2].missed = $missedFunctions.ToString()
+    $jaCoCoReportXml.report.counter[2].covered = $hitFunctions.ToString()
+    $jaCoCoReportXml.report.counter[3].missed = $missedFiles.ToString()
+    $jaCoCoReportXml.report.counter[3].covered = $hitFiles.ToString()
+    # There is no pretty way to insert the Doctype, as microsoft has deprecated the DTD stuff.
+    $jaCoCoReportDocType = "<!DOCTYPE report PUBLIC ""-//JACOCO//DTD Report 1.0//EN"" ""report.dtd"">`n"
+    return $jaCocoReportXml.OuterXml.Insert(54, $jaCoCoReportDocType)
 }
-
-function Test-DtdSchema {
-    [CmdletBinding()]
-    param(
-        [Parameter(Mandatory = $true)]
-        [ValidateNotNullOrEmpty()]
-        $XmlString
-    )
-
-    # Create delegate for handling/reporting errors
-    [System.Xml.Schema.ValidationEventHandler] $onValidationError = {
-        param($sender,[System.Xml.Schema.ValidationEventArgs]$eventArgs)
-        # Interestingly the linting tool can't see it is a global, but this variable is used to track if there are errors in the XML file.
-        $global:isValid = $false;
-        $errorText = "Validation error in XML string on line $($eventArgs.Exception.LineNumber), position $($eventArgs.Exception.LinePosition): $($eventArgs.Message)`n"
-        # Get the line where the validation error occurred
-        $errorText +=  "$($global:XmlFilePath.Split(""`n"")[$eventArgs.Exception.LineNumber-1])`n"
-        # Add an arrow to point at the place in the line where the validation error occurred
-        $errorText += "^".PadLeft($eventArgs.Exception.LinePosition,"-")
-        $global:errorText += $errorText
-    }
-
-    # Set while loop flag
-    $global:isValid = $true
-    $global:errorText = ""
-    $global:XmlFilePath = $XmlString
-    # Instantiate ValidatingReader and set ValidationType
-    $XmlValidatingReader = & $SafeCommands['New-Object'] -TypeName System.Xml.XmlValidatingReader($XmlString, [System.Xml.XmlNodeType]::Document, $null)
-    $XmlValidatingReader.ValidationType = [System.Xml.ValidationType]::DTD;
-
-    # Add handler to Validating Reader
-    $XmlValidatingReader.add_ValidationEventHandler($onValidationError)
-
-    # Validate file
-    try {
-        while ($XmlValidatingReader.Read()) {}
-    }
-    catch  {
-        throw [System.Exception] $_.Exception
-    }
-    finally {
-        # Close handles
-        $XmlValidatingReader.Close()
-    }
-
-    # Output whether the document is valid or invalid.
-    return $global:isValid,$global:errorText
-}
-

--- a/Pester.psm1
+++ b/Pester.psm1
@@ -802,6 +802,7 @@ New-PesterOption
         }
 
         Set-PesterStatistics
+        
         if (& $script:SafeCommands['Get-Variable'] -Name OutputFile -ValueOnly -ErrorAction $script:IgnoreErrorPreference) {
             Export-PesterResults -PesterState $pester -Path $OutputFile -Format $OutputFormat
         }

--- a/Pester.psm1
+++ b/Pester.psm1
@@ -787,11 +787,12 @@ New-PesterOption
             Write-CoverageReport -CoverageReport $coverageReport
             if (& $script:SafeCommands['Get-Variable'] -Name CodeCoverageOutputFile -ValueOnly -ErrorAction $script:IgnoreErrorPreference) {
                 $jaCoCoReport = Get-JaCoCoReportXml -PesterState $pester -CoverageReport $coverageReport
-                if (Test-DtdSchema $jaCoCoReport){
+                $isValid,$errorText = Test-DtdSchema $jaCoCoReport
+                if ($isValid){
                     $jaCoCoReport | & $SafeCommands['Out-File'] $CodeCoverageOutputFile -Encoding utf8
                 }
                 else {
-                    throw "Unable to create valid XML for JaCoCo report."
+                    throw "Unable to create valid XML for JaCoCo report. `n$errorText"
                 }
             }
             Exit-CoverageAnalysis -PesterState $pester

--- a/Pester.psm1
+++ b/Pester.psm1
@@ -58,6 +58,7 @@ $script:SafeCommands = @{
     'New-PSDrive'         = Get-Command -Name New-PSDrive         -Module Microsoft.PowerShell.Management @safeCommandLookupParameters
     'New-Variable'        = Get-Command -Name New-Variable        -Module Microsoft.PowerShell.Utility    @safeCommandLookupParameters
     'Out-Host'            = Get-Command -Name Out-Host            -Module $outHostModule                  @safeCommandLookupParameters
+    'Out-File'            = Get-Command -Name Out-File            -Module Microsoft.PowerShell.Utility    @safeCommandLookupParameters
     'Out-Null'            = Get-Command -Name Out-Null            -Module $outNullModule                  @safeCommandLookupParameters
     'Out-String'          = Get-Command -Name Out-String          -Module Microsoft.PowerShell.Utility    @safeCommandLookupParameters
     'Pop-Location'        = Get-Command -Name Pop-Location        -Module Microsoft.PowerShell.Management @safeCommandLookupParameters
@@ -507,6 +508,14 @@ One of the following: Function or StartLine/EndLine
 -- EndLine (E): Performs code coverage analysis ending with the specified line.
    Default is the last line of the script.
 
+.PARAMETER CodeCoverageOutputFile
+The path where Invoke-Pester will save formatted code coverage results file in JaCoCo format.
+
+The path must include the location and name of the folder and file name with
+the xml extension.
+
+If this path is not provided, no xml file will be generated.
+
 
 .PARAMETER Strict
 Makes Pending and Skipped tests to Failed tests. Useful for continuous
@@ -628,6 +637,13 @@ Invoke-Pester -CodeCoverage @{ Path = 'ScriptUnderTest.ps1'; Function = 'Functio
 Runs all *.Tests.ps1 scripts in the current directory, and generates a coverage
 report for all commands in the "FunctionUnderTest" function in the "ScriptUnderTest.ps1" file.
 
+ .EXAMPLE
+Invoke-Pester -CodeCoverage 'ScriptUnderTest.ps1' -CodeCoverageOutputFile '.\artifacts\TestOutput.xml'
+
+Runs all *.Tests.ps1 scripts in the current directory, and generates a coverage
+report for all commands in the "ScriptUnderTest.ps1" file, and writes the coverage report to TestOutput.xml
+file using the JaCoCo XML Report DTD.
+
 .EXAMPLE
 Invoke-Pester -CodeCoverage @{ Path = 'ScriptUnderTest.ps1'; StartLine = 10; EndLine = 20 }
 
@@ -670,6 +686,8 @@ New-PesterOption
         [switch]$PassThru,
 
         [object[]] $CodeCoverage = @(),
+
+        [string] $CodeCoverageOutputFile,
 
         [Switch]$Strict,
 
@@ -767,6 +785,15 @@ New-PesterOption
             $pester | Write-PesterReport
             $coverageReport = Get-CoverageReport -PesterState $pester
             Write-CoverageReport -CoverageReport $coverageReport
+            if (& $script:SafeCommands['Get-Variable'] -Name CodeCoverageOutputFile -ValueOnly -ErrorAction $script:IgnoreErrorPreference) {
+                $jaCoCoReport = Get-JaCoCoReportXml -PesterState $pester -CoverageReport $coverageReport
+                if (Test-DtdSchema $jaCoCoReport){
+                    $jaCoCoReport | & $SafeCommands['Out-File'] $CodeCoverageOutputFile -Encoding utf8
+                }
+                else {
+                    throw "Unable to create valid XML for JaCoCo report."
+                }
+            }
             Exit-CoverageAnalysis -PesterState $pester
         }
         finally
@@ -775,7 +802,6 @@ New-PesterOption
         }
 
         Set-PesterStatistics
-
         if (& $script:SafeCommands['Get-Variable'] -Name OutputFile -ValueOnly -ErrorAction $script:IgnoreErrorPreference) {
             Export-PesterResults -PesterState $pester -Path $OutputFile -Format $OutputFormat
         }

--- a/Pester.psm1
+++ b/Pester.psm1
@@ -802,7 +802,7 @@ New-PesterOption
         }
 
         Set-PesterStatistics
-        
+
         if (& $script:SafeCommands['Get-Variable'] -Name OutputFile -ValueOnly -ErrorAction $script:IgnoreErrorPreference) {
             Export-PesterResults -PesterState $pester -Path $OutputFile -Format $OutputFormat
         }

--- a/Pester.psm1
+++ b/Pester.psm1
@@ -787,13 +787,7 @@ New-PesterOption
             Write-CoverageReport -CoverageReport $coverageReport
             if (& $script:SafeCommands['Get-Variable'] -Name CodeCoverageOutputFile -ValueOnly -ErrorAction $script:IgnoreErrorPreference) {
                 $jaCoCoReport = Get-JaCoCoReportXml -PesterState $pester -CoverageReport $coverageReport
-                $isValid,$errorText = Test-DtdSchema $jaCoCoReport
-                if ($isValid){
-                    $jaCoCoReport | & $SafeCommands['Out-File'] $CodeCoverageOutputFile -Encoding utf8
-                }
-                else {
-                    throw "Unable to create valid XML for JaCoCo report. `n$errorText"
-                }
+                $jaCoCoReport | & $SafeCommands['Out-File'] $CodeCoverageOutputFile -Encoding utf8
             }
             Exit-CoverageAnalysis -PesterState $pester
         }

--- a/report.dtd
+++ b/report.dtd
@@ -1,0 +1,84 @@
+<!-- 
+   Copyright (c) 2009, 2017 Mountainminds GmbH & Co. KG and Contributors
+   All rights reserved. This program and the accompanying materials
+   are made available under the terms of the Eclipse Public License v1.0
+   which accompanies this distribution, and is available at
+   http://www.eclipse.org/legal/epl-v10.html
+     
+   Contributors:
+      Brock Janiczak - initial API and implementation
+      Marc R. Hoffmann - generalized report structure, line info, documentation
+      
+   $Id: $
+-->
+
+<!-- This DTD describes the JaCoCo XML report format. It is identified by the
+     following identifiers:
+
+        PUBID  = "-//JACOCO//DTD report 1.0//EN"
+        SYSTEM = "report.dtd"
+-->
+
+<!-- report root node -->
+<!ELEMENT report (sessioninfo*, (group* | package*), counter*)>
+  <!ATTLIST report name CDATA #REQUIRED>
+
+<!-- information about a session which contributed execution data -->
+<!ELEMENT sessioninfo EMPTY>
+  <!-- session id -->
+  <!ATTLIST sessioninfo id CDATA #REQUIRED>
+  <!-- start time stamp -->
+  <!ATTLIST sessioninfo start CDATA #REQUIRED>
+  <!-- dump time stamp -->
+  <!ATTLIST sessioninfo dump CDATA #REQUIRED>
+
+<!-- representation of a group -->
+<!ELEMENT group ((group* | package*), counter*)>
+  <!-- group name -->
+  <!ATTLIST group name CDATA #REQUIRED>
+
+<!-- representation of a package -->
+<!ELEMENT package ((class | sourcefile)*, counter*)>
+  <!-- package name in VM notation -->
+  <!ATTLIST package name CDATA #REQUIRED>
+
+<!-- representation of a class -->
+<!ELEMENT class (method*, counter*)>
+  <!-- fully qualified VM name -->
+  <!ATTLIST class name CDATA #REQUIRED>
+
+<!-- representation of a method -->
+<!ELEMENT method (counter*)>
+  <!-- method name -->
+  <!ATTLIST method name CDATA #REQUIRED>
+  <!-- method descriptor -->
+  <!ATTLIST method desc CDATA #REQUIRED>
+  <!-- first source line number of this method -->
+  <!ATTLIST method line CDATA #IMPLIED>
+  
+<!-- representation of a source file -->
+<!ELEMENT sourcefile (line*, counter*)>
+  <!-- local source file name -->
+  <!ATTLIST sourcefile name CDATA #REQUIRED>
+
+<!-- representation of a source line -->
+<!ELEMENT line EMPTY>
+  <!-- line number -->
+  <!ATTLIST line nr CDATA #REQUIRED>
+  <!-- number of missed instructions -->
+  <!ATTLIST line mi CDATA #IMPLIED>
+  <!-- number of covered instructions -->
+  <!ATTLIST line ci CDATA #IMPLIED>
+  <!-- number of missed branches -->
+  <!ATTLIST line mb CDATA #IMPLIED>
+  <!-- number of covered branches -->
+  <!ATTLIST line cb CDATA #IMPLIED>
+
+<!-- coverage data counter for different metrics -->
+<!ELEMENT counter EMPTY>
+  <!-- metric type -->
+  <!ATTLIST counter type (INSTRUCTION|BRANCH|LINE|COMPLEXITY|METHOD|CLASS) #REQUIRED>
+  <!-- number of missed items -->
+  <!ATTLIST counter missed CDATA #REQUIRED>
+  <!-- number of covered items -->
+  <!ATTLIST counter covered CDATA #REQUIRED>


### PR DESCRIPTION
I have added a parameter called CodeCoverageOutputFile, which will make Pester write the summarised code coverage results in a JaCoCo formatted XML file to the path specified. This XML file is compatible with the VSTS/TFS Code Coverage overview:
![image](https://cloud.githubusercontent.com/assets/28932826/26468451/ca1aac58-4196-11e7-88b6-1fd42f282436.png)
