### PR TITLE
Fix Assert-VerifiableMocks silently does not report anything if 'Verifiable' is spelled wrong on one mock

### DIFF
--- a/Functions/Assertions/Set-TestInconclusive.ps1
+++ b/Functions/Assertions/Set-TestInconclusive.ps1
@@ -51,6 +51,7 @@ function Set-TestInconclusive {
     .LINK
     https://github.com/pester/Pester/wiki/Set%E2%80%90TestInconclusive
 #>
+    [CmdletBinding()]
     param (
         [string] $Message
     )

--- a/Functions/In.ps1
+++ b/Functions/In.ps1
@@ -16,11 +16,11 @@ The path that the execute block will be executed in.
 The script to be executed in the path provided.
 
 #>
-
-param(
-    $path,
-    [ScriptBlock] $execute
-)
+    [CmdletBinding()]
+    param(
+        $path,
+        [ScriptBlock] $execute
+    )
     Assert-DescribeInProgress -CommandName In
 
     $old_pwd = $pwd

--- a/Functions/Mock.ps1
+++ b/Functions/Mock.ps1
@@ -154,7 +154,7 @@ It
 about_Should
 about_Mocking
 #>
-
+    [CmdletBinding()]
     param(
         [string]$CommandName,
         [ScriptBlock]$MockWith={},
@@ -405,6 +405,7 @@ Assert-VerifiableMocks
 This will not throw an exception because the mock was invoked.
 
 #>
+    [CmdletBinding()]param()
     Assert-DescribeInProgress -CommandName Assert-VerifiableMocks
 
     $unVerified=@{}

--- a/Functions/SetupTeardown.ps1
+++ b/Functions/SetupTeardown.ps1
@@ -15,6 +15,15 @@ function BeforeEach
 .LINK
     about_BeforeEach_AfterEach
 #>
+    [CmdletBinding()]
+    param
+    (
+        # the scriptblock to execute
+        [Parameter(Mandatory = $true,
+                   Position = 1)]
+        [Scriptblock]
+        $Scriptblock
+    )
     Assert-DescribeInProgress -CommandName BeforeEach
 }
 
@@ -35,6 +44,15 @@ function AfterEach
 .LINK
     about_BeforeEach_AfterEach
 #>
+    [CmdletBinding()]
+    param
+    (
+        # the scriptblock to execute
+        [Parameter(Mandatory = $true,
+                   Position = 1)]
+        [Scriptblock]
+        $Scriptblock
+    )
     Assert-DescribeInProgress -CommandName AfterEach
 }
 
@@ -53,6 +71,15 @@ function BeforeAll
 .LINK
     about_BeforeEach_AfterEach
 #>
+    [CmdletBinding()]
+    param
+    (
+        # the scriptblock to execute
+        [Parameter(Mandatory = $true,
+                   Position = 1)]
+        [Scriptblock]
+        $Scriptblock
+    )
     Assert-DescribeInProgress -CommandName BeforeAll
 }
 
@@ -71,6 +98,15 @@ function AfterAll
 .LINK
     about_BeforeEach_AfterEach
 #>
+    [CmdletBinding()]
+    param
+    (
+        # the scriptblock to execute
+        [Parameter(Mandatory = $true,
+                   Position = 1)]
+        [Scriptblock]
+        $Scriptblock
+    )
     Assert-DescribeInProgress -CommandName AfterAll
 }
 

--- a/Functions/TestDrive.ps1
+++ b/Functions/TestDrive.ps1
@@ -130,7 +130,10 @@ function Remove-TestDrive {
 }
 
 function Setup {
-    #included for backwards compatibility
+    <#
+        .SYNOPSIS
+        This command is included in the Pester Mocking framework for backwards compatibility.  You do not need to call it directly.
+    #>
     param(
     [switch]$Dir,
     [switch]$File,

--- a/Pester.Tests.ps1
+++ b/Pester.Tests.ps1
@@ -116,16 +116,17 @@ if ($PSVersionTable.PSVersion.Major -ge 3)
 }
 
 Describe 'Public API' {
-    It 'all non-deprecated public commands use CmdletBinding' {
+    It 'all non-deprecated, non-internal public commands use CmdletBinding' {
         $r = Get-Command -Module Pester |
         ? { -not $_.CmdletBinding } |
-        % Name |
+        ? { $_.CommandType -ne 'Alias' } | # Get-Command outputs aliases in PowerShell 2
+        % { $_.Name } |
         ? {
-            $_ -notin @(
+            @(
                 'Get-TestDriveItem' # deprecated in 4.0
                 'SafeGetCommand' # Pester internal
                 'Setup' # deprecated
-            )
+            ) -notcontains $_
         }
         $r | Should beNullOrEmpty
     }

--- a/Pester.Tests.ps1
+++ b/Pester.Tests.ps1
@@ -115,6 +115,22 @@ if ($PSVersionTable.PSVersion.Major -ge 3)
     }
 }
 
+Describe 'Public API' {
+    It 'all non-deprecated public commands use CmdletBinding' {
+        $r = Get-Command -Module Pester |
+        ? { -not $_.CmdletBinding } |
+        % Name |
+        ? {
+            $_ -notin @(
+                'Get-TestDriveItem' # deprecated in 4.0
+                'SafeGetCommand' # Pester internal
+                'Setup' # deprecated
+            )
+        }
+        $r | Should beNullOrEmpty
+    }
+}
+
 Describe 'Style rules' {
     $pesterRoot = (Get-Module Pester).ModuleBase
 

--- a/Pester.Tests.ps1
+++ b/Pester.Tests.ps1
@@ -118,8 +118,8 @@ if ($PSVersionTable.PSVersion.Major -ge 3)
 Describe 'Public API' {
     It 'all non-deprecated, non-internal public commands use CmdletBinding' {
         $r = Get-Command -Module Pester |
-        ? { -not $_.CmdletBinding } |
         ? { $_.CommandType -ne 'Alias' } | # Get-Command outputs aliases in PowerShell 2
+        ? { -not $_.CmdletBinding } |
         % { $_.Name } |
         ? {
             @(


### PR DESCRIPTION
This PR resolves #781 by doing the following:

* add tests that assert that all non-deprecated, non-internal, public Pester commands use CmdletBinding
* add `[CmdletBinding()]` to the signature of those commands that were missing it
* fix the comment-based help synopsis for `Setup` to make identifying public vs. Pester-internal more consistent