### PR TITLE
Changed all URLs in PrivateData to HTTPS

### DIFF
--- a/Pester.psd1
+++ b/Pester.psd1
@@ -111,13 +111,13 @@ PrivateData = @{
         Tags = @('powershell','unit_testing','bdd','tdd','mocking')
 
         # The web address of an icon which can be used in galleries to represent this module
-        IconUri = "http://pesterbdd.com/images/Pester.png"
+        IconUri = "https://pesterbdd.com/images/Pester.png"
 
         # The web address of this module's project or support homepage.
         ProjectUri = "https://github.com/Pester/Pester"
 
         # The web address of this module's license. Points to a page that's embeddable and linkable.
-        LicenseUri = "http://www.apache.org/licenses/LICENSE-2.0.html"
+        LicenseUri = "https://www.apache.org/licenses/LICENSE-2.0.html"
 
         # Release notes for this particular version of the module
         # ReleaseNotes = False


### PR DESCRIPTION
Using insecure network communications increases the risk for attacks such as Man in the Middle attacks.
As part of good coding practice, we should default to using https in all URLs unless http is specifically needed.