### PR TITLE
make ArraysAreEqual safer

### DIFF
--- a/Functions/Assertions/Be.Tests.ps1
+++ b/Functions/Assertions/Be.Tests.ps1
@@ -96,7 +96,7 @@ InModuleScope Pester {
             $a2 = @($a1,2)
             $a1[0] = $a2
 
-            { $a1 | Should be $a2 } | Should throw 'reached recursion depth limit'
+            { $a1 | Should be $a2 } | Should throw 'recursion depth limit'
         }
     }
 

--- a/Functions/Assertions/Be.Tests.ps1
+++ b/Functions/Assertions/Be.Tests.ps1
@@ -85,7 +85,7 @@ InModuleScope Pester {
             {abc} | Should -CEQ "abc"
         }
 
-         It 'Does not overflow on IEnumerable' {
+        It 'Does not overflow on IEnumerable' {
             # see https://github.com/pester/Pester/issues/785
             $doc = [xml]'<?xml version="1.0" encoding="UTF-8" standalone="no" ?><root></root>'
             $doc | Should be $doc

--- a/Functions/Assertions/Be.Tests.ps1
+++ b/Functions/Assertions/Be.Tests.ps1
@@ -85,10 +85,18 @@ InModuleScope Pester {
             {abc} | Should -CEQ "abc"
         }
 
-        It 'Does not overflow on IEnumerable' {
+        It 'Does not overflow on cyclic object graph' {
             # see https://github.com/pester/Pester/issues/785
             $doc = [xml]'<?xml version="1.0" encoding="UTF-8" standalone="no" ?><root></root>'
             $doc | Should be $doc
+        }
+
+        Context 'recursion limit' {
+            Mock IsIList { $true }
+            It 'throws exception when self-imposed recursion limit is reached' {
+                $doc = [xml]''
+                { $doc | Should be $doc } | Should throw 'reached recursion depth limit'
+            }
         }
     }
 

--- a/Functions/Assertions/Be.Tests.ps1
+++ b/Functions/Assertions/Be.Tests.ps1
@@ -91,14 +91,12 @@ InModuleScope Pester {
             $doc | Should be $doc
         }
 
-        Context 'recursion limit' {
-            It 'throws exception when self-imposed recursion limit is reached' {
-                $a1 = @(0,1)
-                $a2 = @($a1,2)
-                $a1[0] = $a2
+        It 'throws exception when self-imposed recursion limit is reached' {
+            $a1 = @(0,1)
+            $a2 = @($a1,2)
+            $a1[0] = $a2
 
-                { $a1 | Should be $a2 } | Should throw 'reached recursion depth limit'
-            }
+            { $a1 | Should be $a2 } | Should throw 'reached recursion depth limit'
         }
     }
 

--- a/Functions/Assertions/Be.Tests.ps1
+++ b/Functions/Assertions/Be.Tests.ps1
@@ -92,10 +92,12 @@ InModuleScope Pester {
         }
 
         Context 'recursion limit' {
-            Mock IsIList { $true }
             It 'throws exception when self-imposed recursion limit is reached' {
-                $doc = [xml]'<?xml version="1.0" encoding="UTF-8" standalone="no" ?><root></root>'
-                { $doc | Should be $doc } | Should throw 'reached recursion depth limit'
+                $a1 = @(0,1)
+                $a2 = @($a1,2)
+                $a1[0] = $a2
+
+                { $a1 | Should be $a2 } | Should throw 'reached recursion depth limit'
             }
         }
     }

--- a/Functions/Assertions/Be.Tests.ps1
+++ b/Functions/Assertions/Be.Tests.ps1
@@ -85,7 +85,7 @@ InModuleScope Pester {
             {abc} | Should -CEQ "abc"
         }
 
-        It 'Does not overflow on cyclic object graph' {
+         It 'Does not overflow on IEnumerable' {
             # see https://github.com/pester/Pester/issues/785
             $doc = [xml]'<?xml version="1.0" encoding="UTF-8" standalone="no" ?><root></root>'
             $doc | Should be $doc

--- a/Functions/Assertions/Be.Tests.ps1
+++ b/Functions/Assertions/Be.Tests.ps1
@@ -94,7 +94,7 @@ InModuleScope Pester {
         Context 'recursion limit' {
             Mock IsIList { $true }
             It 'throws exception when self-imposed recursion limit is reached' {
-                $doc = [xml]''
+                $doc = [xml]'<?xml version="1.0" encoding="UTF-8" standalone="no" ?><root></root>'
                 { $doc | Should be $doc } | Should throw 'reached recursion depth limit'
             }
         }

--- a/Functions/Assertions/Be.ps1
+++ b/Functions/Assertions/Be.ps1
@@ -243,6 +243,8 @@ function IsArray
 {
     param ([object] $InputObject)
 
+    # Changing this could cause infinite recursion in ArraysAreEqual.
+    # see https://github.com/pester/Pester/issues/785#issuecomment-322794011
     return $InputObject -is [Array]
 }
 

--- a/Functions/Assertions/Be.ps1
+++ b/Functions/Assertions/Be.ps1
@@ -181,7 +181,7 @@ function ArraysAreEqual
         [switch] $CaseSensitive,
         [int] $RecursionLimit = 100
     )
-    if ( -not $recursionDepth ) # PowerShell 2 workaround
+    if ( -not (Get-Variable recursionDepth -ea SilentlyContinue) ) # PowerShell 2 workaround
     {
         $recursionDepth = 1
     }

--- a/Functions/Assertions/Be.ps1
+++ b/Functions/Assertions/Be.ps1
@@ -181,7 +181,7 @@ function ArraysAreEqual
         [switch] $CaseSensitive,
         [int] $RecursionLimit = 100
     )
-    if ( -not (Get-Variable recursionDepth -ea SilentlyContinue) ) # PowerShell 2 workaround
+    if ( -not (Get-Variable recursionDepth*) ) # PowerShell 2 workaround
     {
         $recursionDepth = 1
     }

--- a/Functions/Assertions/Be.ps1
+++ b/Functions/Assertions/Be.ps1
@@ -178,8 +178,14 @@ function ArraysAreEqual
     param (
         [object[]] $First,
         [object[]] $Second,
-        [switch] $CaseSensitive
+        [switch] $CaseSensitive,
+        [int] $RecursionLimit = 100
     )
+    $recursionDepth++
+    if ( $recursionDepth -gt $RecursionLimit )
+    {
+        throw "reached recursion depth limit of $RecursionLimit when comparing arrays $First and $Second"
+    }
 
     # Do not remove the subexpression @() operators in the following two lines; doing so can cause a
     # silly error in PowerShell v3.  (Null Reference exception from the PowerShell engine in a
@@ -196,7 +202,7 @@ function ArraysAreEqual
 
     for ($i = 0; $i -lt $First.Count; $i++)
     {
-        if ((IsCollection $First[$i]) -or (IsCollection $Second[$i]))
+        if ((IsIList $First[$i]) -or (IsIList $Second[$i]))
         {
             if (-not (ArraysAreEqual -First $First[$i] -Second $Second[$i] -CaseSensitive:$CaseSensitive))
             {
@@ -231,11 +237,11 @@ function ArrayOrSingleElementIsNullOrEmpty
     return $null -eq $Array -or $Array.Count -eq 0 -or ($Array.Count -eq 1 -and $null -eq $Array[0])
 }
 
-function IsCollection
+function IsIList
 {
     param ([object] $InputObject)
 
-    return $InputObject -is [Array]
+    return [bool]$InputObject.GetType().GetInterface('IList')
 }
 
 function ReplaceValueInArray

--- a/Functions/Assertions/Be.ps1
+++ b/Functions/Assertions/Be.ps1
@@ -179,17 +179,14 @@ function ArraysAreEqual
         [object[]] $First,
         [object[]] $Second,
         [switch] $CaseSensitive,
+        [int] $RecursionDepth = 0,
         [int] $RecursionLimit = 100
     )
-    if ( -not (Get-Variable recursionDepth*) ) # PowerShell 2 workaround
-    {
-        $recursionDepth = 1
-    }
     $recursionDepth++
 
     if ( $recursionDepth -gt $RecursionLimit )
     {
-        throw "reached recursion depth limit of $RecursionLimit when comparing arrays $First and $Second"
+        throw "Reached the recursion depth limit of $RecursionLimit when comparing arrays $First and $Second.  Is one of your arrays cyclic?"
     }
 
     # Do not remove the subexpression @() operators in the following two lines; doing so can cause a
@@ -209,7 +206,7 @@ function ArraysAreEqual
     {
         if ((IsArray $First[$i]) -or (IsArray $Second[$i]))
         {
-            if (-not (ArraysAreEqual -First $First[$i] -Second $Second[$i] -CaseSensitive:$CaseSensitive))
+            if (-not (ArraysAreEqual -First $First[$i] -Second $Second[$i] -CaseSensitive:$CaseSensitive -RecursionDepth $RecursionDepth))
             {
                 return $false
             }

--- a/Functions/Assertions/Be.ps1
+++ b/Functions/Assertions/Be.ps1
@@ -207,7 +207,7 @@ function ArraysAreEqual
 
     for ($i = 0; $i -lt $First.Count; $i++)
     {
-        if ((IsIList $First[$i]) -or (IsIList $Second[$i]))
+        if ((IsArray $First[$i]) -or (IsArray $Second[$i]))
         {
             if (-not (ArraysAreEqual -First $First[$i] -Second $Second[$i] -CaseSensitive:$CaseSensitive))
             {
@@ -242,11 +242,11 @@ function ArrayOrSingleElementIsNullOrEmpty
     return $null -eq $Array -or $Array.Count -eq 0 -or ($Array.Count -eq 1 -and $null -eq $Array[0])
 }
 
-function IsIList
+function IsArray
 {
     param ([object] $InputObject)
 
-    return [bool]$InputObject.GetType().GetInterface('IList')
+    return $InputObject -is [Array]
 }
 
 function ReplaceValueInArray

--- a/Functions/Assertions/Be.ps1
+++ b/Functions/Assertions/Be.ps1
@@ -181,7 +181,12 @@ function ArraysAreEqual
         [switch] $CaseSensitive,
         [int] $RecursionLimit = 100
     )
+    if ( -not $recursionDepth ) # PowerShell 2 workaround
+    {
+        $recursionDepth = 1
+    }
     $recursionDepth++
+
     if ( $recursionDepth -gt $RecursionLimit )
     {
         throw "reached recursion depth limit of $RecursionLimit when comparing arrays $First and $Second"

--- a/Functions/Assertions/Be.ps1
+++ b/Functions/Assertions/Be.ps1
@@ -182,11 +182,11 @@ function ArraysAreEqual
         [int] $RecursionDepth = 0,
         [int] $RecursionLimit = 100
     )
-    $recursionDepth++
+    $RecursionDepth++
 
-    if ( $recursionDepth -gt $RecursionLimit )
+    if ($RecursionDepth -gt $RecursionLimit)
     {
-        throw "Reached the recursion depth limit of $RecursionLimit when comparing arrays $First and $Second.  Is one of your arrays cyclic?"
+        throw "Reached the recursion depth limit of $RecursionLimit when comparing arrays $First and $Second. Is one of your arrays cyclic?"
     }
 
     # Do not remove the subexpression @() operators in the following two lines; doing so can cause a
@@ -206,7 +206,7 @@ function ArraysAreEqual
     {
         if ((IsArray $First[$i]) -or (IsArray $Second[$i]))
         {
-            if (-not (ArraysAreEqual -First $First[$i] -Second $Second[$i] -CaseSensitive:$CaseSensitive -RecursionDepth $RecursionDepth))
+            if (-not (ArraysAreEqual -First $First[$i] -Second $Second[$i] -CaseSensitive:$CaseSensitive -RecursionDepth $RecursionDepth -RecursionLimit $RecursionLimit))
             {
                 return $false
             }


### PR DESCRIPTION
self-limit recursion depth to cause fast(er) failure in case cyclic object graphs are encountered
rename IsCollection to IsArray