### PR TITLE
Fetching dynamic parameters was broken on Powershell 6 beta versions

### DIFF
--- a/Functions/Mock.ps1
+++ b/Functions/Mock.ps1
@@ -1381,7 +1381,7 @@ function Get-DynamicParametersForCmdlet
         return
     }
 
-    if ($PSVersionTable.PSVersion -ge '5.0.10586.122')
+    if ('5.0.10586.122' -lt $PSVersionTable.PSVersion)
     {
         # Older version of PS required Reflection to do this.  It has run into problems on occasion with certain cmdlets,
         # such as ActiveDirectory and AzureRM, so we'll take advantage of the newer PSv5 engine features if at all possible.

--- a/Functions/Mock.ps1
+++ b/Functions/Mock.ps1
@@ -1381,7 +1381,7 @@ function Get-DynamicParametersForCmdlet
         return
     }
 
-    if ('5.0.10586.122' -lt $PSVersionTable.PSVersion)
+    if ('5.0.10586.122' -le $PSVersionTable.PSVersion)
     {
         # Older version of PS required Reflection to do this.  It has run into problems on occasion with certain cmdlets,
         # such as ActiveDirectory and AzureRM, so we'll take advantage of the newer PSv5 engine features if at all possible.


### PR DESCRIPTION
Attempting to do something like `Mock New-Item {}` on Powershell 6 Beta 5 was failing with this error message;

```
 PSArgumentException: Cannot process argument because the value of argument "version" is not valid. Change the value of the "version" argument and run the operation again.
        PSInvalidCastException: Cannot convert value "5.0.10586.122" to type "System.Management.Automation.SemanticVersion". Error: "Cannot process argument because the value of argument "version" is not valid. Change thevalue of the "version" argument and run the operation again."
        RuntimeException: Could not compare "6.0.0-beta" to "5.0.10586.122". Error: "Cannot convert value "5.0.10586.122" to type "System.Management.Automation.SemanticVersion". Error: "Cannot process argument because thevalue of argument "version" is not valid. Change the value of the "version" argument and run the operation again.""
        CmdletInvocationException: Could not compare "6.0.0-beta" to "5.0.10586.122". Error: "Cannot convert value "5.0.10586.122" to type "System.Management.Automation.SemanticVersion". Error: "Cannot process argument because the value of argument "version" is not valid. Change the value of the "version" argument and run the operation again.""
        ParameterBindingException: Cannot retrieve the dynamic parameters for the cmdlet. Could not compare "6.0.0-beta" to "5.0.10586.122". Error: "Cannot convert value "5.0.10586.122" to type "System.Management.Automation.SemanticVersion". Error: "Cannot process argument because the value of argument "version" is not valid. Change the value of the "version" argument and run the operation again.""
        at generatePaketFiles, /Users/edmundd/Development/PowershellDSC/PSForge/PSForge.psm1: line 439
        at <ScriptBlock>, /Users/edmundd/Development/PowershellDSC/PSForge/PSForge.Tests.ps1: line 198
        at DescribeImpl, /Users/edmundd/Development/PowershellDSC/PSForge/packages/Pester/Functions/Describe.ps1: line 161
        at Describe, /Users/edmundd/Development/PowershellDSC/PSForge/packages/Pester/Functions/Describe.ps1: line 86
        at Context, /Users/edmundd/Development/PowershellDSC/PSForge/packages/Pester/Functions/Context.ps1: line 60
        at <ScriptBlock>, /Users/edmundd/Development/PowershellDSC/PSForge/PSForge.Tests.ps1: line 197
        at DescribeImpl, /Users/edmundd/Development/PowershellDSC/PSForge/packages/Pester/Functions/Describe.ps1: line 161
        at Describe, /Users/edmundd/Development/PowershellDSC/PSForge/packages/Pester/Functions/Describe.ps1: line 86
        at <ScriptBlock>, /Users/edmundd/Development/PowershellDSC/PSForge/PSForge.Tests.ps1: line 189
        at InModuleScope, /Users/edmundd/Development/PowershellDSC/PSForge/packages/Pester/Functions/InModuleScope.ps1: line 84
        at <ScriptBlock>, /Users/edmundd/Development/PowershellDSC/PSForge/PSForge.Tests.ps1: line 4
        at <ScriptBlock>, /Users/edmundd/Development/PowershellDSC/PSForge/packages/Pester/Pester.psm1: line 792
        at Invoke-Pester<End>, /Users/edmundd/Development/PowershellDSC/PSForge/packages/Pester/Pester.psm1: line 807
        at <ScriptBlock>, /Users/edmundd/Development/PowershellDSC/PSForge/ci.ps1: line 24
        at <ScriptBlock>, <No file>: line 1
```

The issue was that Powershell couldn't compare semantic version strings due to the "beta" label in the version of Powershell 6 that I'm using. There is a [blog post](https://info.sapien.com/index.php/scripting/versioning/working-with-semanticversion-in-powershell) that explains the problem and the solution.

The fix is to swap the 2 version strings around when comparing them.


