### PR TITLE
Allow assertion operators to be re-registered if they are identical

### DIFF
--- a/Pester.Tests.ps1
+++ b/Pester.Tests.ps1
@@ -328,3 +328,31 @@ InModuleScope Pester {
         }
     }
 }
+Describe 'Assertion operators' {
+    It 'Allows an identical operator to be registered with the same name and scriptblock' {
+        function SameNameAndScript {$true}
+        Add-AssertionOperator -Name SameNameAndScript -Test $function:SameNameAndScript
+
+        { Add-AssertionOperator -Name SameNameAndScript -Test {$true} } | Should -Not -Throw
+    }
+    It 'Allows an identical operator to be registered with the same name and alias multiple times' {
+        function SameNameAndScriptAndAlias {$true}
+        Add-AssertionOperator -Name SameNameAndScriptAndAlias -Test $function:SameNameAndScriptAndAlias -Alias SameAlias
+
+        { Add-AssertionOperator -Name SameNameAndScriptAndAlias -Test {$true} -Alias SameAlias } | Should -Not -Throw
+    }
+    It 'Does not allow an operator with a different scriptblock to use an existing name' {
+        function DifferentScriptBlockA {$true}
+        function DifferentScriptBlockB {$false}
+        Add-AssertionOperator -Name DifferentScriptBlock -Test $function:DifferentScriptBlockA
+
+        { Add-AssertionOperator -Name DifferentScriptBlock -Test $function:DifferentScriptBlockB } | Should -Throw
+    }
+    It 'Does not allow an operator with a different test to use an existing alias' {
+        function DifferentAliasA { $true }
+        function DifferentAliasB { $true }
+        Add-AssertionOperator -Name DifferentAliasA -Test $function:DifferentAliasA -Alias DifferentAliasTest
+
+        { Add-AssertionOperator -Name DifferentAliasB -Test $function:DifferentAliasB -Alias DifferentAliasTest } | Should -Throw
+    }
+}

--- a/Pester.Tests.ps1
+++ b/Pester.Tests.ps1
@@ -329,26 +329,26 @@ InModuleScope Pester {
     }
 }
 Describe 'Assertion operators' {
-    It 'Allows an identical operator to be registered with the same name and scriptblock' {
+    It 'Allows an operator with an identical name and test to be re-registered' {
         function SameNameAndScript {$true}
         Add-AssertionOperator -Name SameNameAndScript -Test $function:SameNameAndScript
 
         { Add-AssertionOperator -Name SameNameAndScript -Test {$true} } | Should -Not -Throw
     }
-    It 'Allows an identical operator to be registered with the same name and alias multiple times' {
+    It 'Allows an operator with an identical name, test, and alias to be re-registered' {
         function SameNameAndScriptAndAlias {$true}
         Add-AssertionOperator -Name SameNameAndScriptAndAlias -Test $function:SameNameAndScriptAndAlias -Alias SameAlias
 
         { Add-AssertionOperator -Name SameNameAndScriptAndAlias -Test {$true} -Alias SameAlias } | Should -Not -Throw
     }
-    It 'Does not allow an operator with a different scriptblock to use an existing name' {
+    It 'Does not allow an operator with a different test to be registered using an existing name' {
         function DifferentScriptBlockA {$true}
         function DifferentScriptBlockB {$false}
         Add-AssertionOperator -Name DifferentScriptBlock -Test $function:DifferentScriptBlockA
 
         { Add-AssertionOperator -Name DifferentScriptBlock -Test $function:DifferentScriptBlockB } | Should -Throw
     }
-    It 'Does not allow an operator with a different test to use an existing alias' {
+    It 'Does not allow an operator with a different test to be registered using an existing alias' {
         function DifferentAliasA { $true }
         function DifferentAliasB { $true }
         Add-AssertionOperator -Name DifferentAliasA -Test $function:DifferentAliasA -Alias DifferentAliasTest

--- a/Pester.psm1
+++ b/Pester.psm1
@@ -245,11 +245,13 @@ function Test-AssertionOperatorIsDuplicate
         $Operator.SupportsArrayInput -eq $existing.SupportsArrayInput -and
         $Operator.Test.ToString() -eq $existing.Test.ToString()
 
-    # Test Alias
-    foreach ($string in $Operator.Alias | Where { -not (Test-NullOrWhiteSpace $_)})
-    {
-        if (-not $existing.Alias -contains $string) {
-            $isDuplicate = $false
+    # Test Aliases
+    if ($Operator.Aliases) {
+        foreach ($string in $Operator.Alias | Where { -not (Test-NullOrWhiteSpace $_)})
+        {
+            if ($existing.Alias -and (-not $existing.Alias -contains $string)) {
+                $isDuplicate = $false
+            }
         }
     }
 

--- a/Pester.psm1
+++ b/Pester.psm1
@@ -246,7 +246,7 @@ function Test-AssertionOperatorIsDuplicate
         $Operator.Test.ToString() -eq $existing.Test.ToString()
 
     # Test Aliases
-    if ($Operator.Aliases) {
+    if ($Operator.Alias) {
         foreach ($string in $Operator.Alias | Where { -not (Test-NullOrWhiteSpace $_)})
         {
             if ($existing.Alias -and (-not $existing.Alias -contains $string)) {

--- a/Pester.psm1
+++ b/Pester.psm1
@@ -235,27 +235,17 @@ function Add-AssertionOperator
 function Test-AssertionOperatorIsDuplicate
 {
     param (
-        [object] $Operator
+        [psobject] $Operator
     )
 
     $existing = $script:AssertionOperators[$Operator.Name]
+    if (-not $existing) { return $false }
 
-    # Test SupportsArrayObject and scriptblock (as string) are identical
-    $isDuplicate = $existing -and
-        $Operator.SupportsArrayInput -eq $existing.SupportsArrayInput -and
-        $Operator.Test.ToString() -eq $existing.Test.ToString()
+    return $Operator.SupportsArrayInput -eq $existing.SupportsArrayInput -and
+           $Operator.Test.ToString() -eq $existing.Test.ToString() -and
+           ($Operator.Alias -eq $null -or
+           -not (Compare-Object $Operator.Alias $existing.Alias))
 
-    # Test Aliases
-    if ($Operator.Alias) {
-        foreach ($string in $Operator.Alias | Where { -not (Test-NullOrWhiteSpace $_)})
-        {
-            if ($existing.Alias -and (-not $existing.Alias -contains $string)) {
-                $isDuplicate = $false
-            }
-        }
-    }
-
-    return $isDuplicate
 }
 function Assert-AssertionOperatorNameIsUnique
 {

--- a/Pester.psm1
+++ b/Pester.psm1
@@ -235,7 +235,7 @@ function Add-AssertionOperator
 function Test-AssertionOperatorIsDuplicate
 {
     param (
-        [psobject] $Operator
+        [object] $Operator
     )
 
     $existing = $script:AssertionOperators[$Operator.Name]

--- a/Pester.psm1
+++ b/Pester.psm1
@@ -198,7 +198,8 @@ function Add-AssertionOperator
         [scriptblock] $Test,
 
         [ValidateNotNullOrEmpty()]
-        [string[]] $Alias,
+        [AllowEmptyCollection()]
+        [string[]] $Alias = @(),
 
         [switch] $SupportsArrayInput
     )
@@ -243,9 +244,7 @@ function Test-AssertionOperatorIsDuplicate
 
     return $Operator.SupportsArrayInput -eq $existing.SupportsArrayInput -and
            $Operator.Test.ToString() -eq $existing.Test.ToString() -and
-           ($Operator.Alias -eq $null -or
-           -not (Compare-Object $Operator.Alias $existing.Alias))
-
+           -not (Compare-Object $Operator.Alias $existing.Alias)
 }
 function Assert-AssertionOperatorNameIsUnique
 {


### PR DESCRIPTION
Fixes #891.

I feel it's a bit redundant to have both `Test-AssertionOperatorIsDuplicate` *and* `Assert-AssertionOperatorNameIsUnique` but I didn't want to tear up and refactor _too_ much. Let me know what you think.