### PR TITLE
Support "Manifest"-type modules in Get-ScriptModule

### DIFF
--- a/Functions/InModuleScope.ps1
+++ b/Functions/InModuleScope.ps1
@@ -125,7 +125,7 @@ function Get-ScriptModule
 
         $actualTypes = $actualTypes -join ', '
 
-        throw "Module '$ModuleName' is not a Script module.  Detected modules of the following types: '$actualTypes'"
+        throw "Module '$ModuleName' is not a Script module.  Detected modules of the following types: '$actualTypes'.    See https://github.com/pester/Pester/wiki/Testing-different-module-types for more information."
     }
 
     return $scriptModules[0]


### PR DESCRIPTION
A fix for https://github.com/pester/Pester/issues/933 to support "Manifest"-type modules (i.e. no RootModule specified in a *.psd1 file).