### PR TITLE
Update New-Fixture help and add stripping .ps1 from the Name parameter

### DIFF
--- a/Functions/New-Fixture.Tests.ps1
+++ b/Functions/New-Fixture.Tests.ps1
@@ -69,6 +69,18 @@ Describe "New-Fixture" {
             Join-Path -Path "$path" -ChildPath "$name.ps1" | Should -Exist
             Join-Path -Path "$path" -ChildPath "$name.Tests.ps1" | Should -Exist
         }
+        It "Creates fixture if Path is set to '(pwd)' and Name contains the 'ps1' extension:" {
+            $name = "Relative4-Fixture.ps1"
+            $nameWithoutExtension = $name.Substring(0,$($name.Length)-4)
+            $path = "TestDrive:\"
+
+            Push-Location -Path $path
+            New-Fixture -Name $name -Path (Get-Location) | Out-Null
+            Pop-Location
+
+            Join-Path -Path "$path" -ChildPath "$nameWithoutExtension.ps1" | Should -Exist
+            Join-Path -Path "$path" -ChildPath "$nameWithoutExtension.Tests.ps1" | Should -Exist
+        }
         It "Writes warning if file exists" {
             $name = "Warning-Fixture"
             $path = "TestDrive:\"

--- a/Functions/New-Fixture.ps1
+++ b/Functions/New-Fixture.ps1
@@ -65,19 +65,22 @@ function New-Fixture {
         [Parameter(Mandatory=$true)]
         [String]$Name
     )
+
+    $Name = $Name -ireplace [regex]::Escape('.ps1'), ''
+
     #region File contents
     #keep this formatted as is. the format is output to the file as is, including indentation
-    $scriptCode = "function $name {$([System.Environment]::NewLine)$([System.Environment]::NewLine)}"
+    $scriptCode = "function $Name {$([System.Environment]::NewLine)$([System.Environment]::NewLine)}"
 
     $testCode = '$here = Split-Path -Parent $MyInvocation.MyCommand.Path
-$sut = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -replace ''\.Tests\.'', ''.''
+$sut = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -ireplace [regex]::Escape(''.Tests.''), ''.''
 . "$here\$sut"
 
 Describe "#name#" {
     It "does something useful" {
         $true | Should -Be $false
     }
-}' -replace "#name#",$name
+}' -replace "#name#",$Name
 
     #endregion
 

--- a/Functions/New-Fixture.ps1
+++ b/Functions/New-Fixture.ps1
@@ -19,13 +19,13 @@ function New-Fixture {
     The script containing the example test .\Clean.Tests.ps1:
 
     $here = Split-Path -Parent $MyInvocation.MyCommand.Path
-    $sut = (Split-Path -Leaf $MyInvocation.MyCommand.Path).Replace(".Tests.", ".")
+    $sut = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -replace '\.Tests\.', '.'
     . "$here\$sut"
 
     Describe "Clean" {
 
         It "does something useful" {
-            $false | Should -Be $true
+            $true | Should -Be $false
         }
     }
 
@@ -66,14 +66,14 @@ function New-Fixture {
         [String]$Name
     )
 
-    $Name = $Name -ireplace [regex]::Escape('.ps1'), ''
+    $Name = $Name -replace '.ps1',''
 
     #region File contents
     #keep this formatted as is. the format is output to the file as is, including indentation
     $scriptCode = "function $Name {$([System.Environment]::NewLine)$([System.Environment]::NewLine)}"
 
     $testCode = '$here = Split-Path -Parent $MyInvocation.MyCommand.Path
-$sut = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -ireplace [regex]::Escape(''.Tests.''), ''.''
+$sut = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -replace ''\.Tests\.'', ''.''
 . "$here\$sut"
 
 Describe "#name#" {


### PR DESCRIPTION
Fix #369 

Additionally, the extension 'ps1' will be stripped from a provided name to don't duplicate it