### PR TITLE
Don't export the function Invoke-GherkinStep

### DIFF
--- a/Pester.psm1
+++ b/Pester.psm1
@@ -1155,5 +1155,5 @@ Throw "This command has been renamed to 'Assert-VerifiableMock' (without the 's'
 & $script:SafeCommands['Export-ModuleMember'] BeforeEach, AfterEach, BeforeAll, AfterAll
 & $script:SafeCommands['Export-ModuleMember'] Get-MockDynamicParameter, Set-DynamicParameterVariable
 & $script:SafeCommands['Export-ModuleMember'] SafeGetCommand, New-PesterOption
-& $script:SafeCommands['Export-ModuleMember'] Invoke-Gherkin, Invoke-GherkinStep, BeforeEachFeature, BeforeEachScenario, AfterEachFeature, AfterEachScenario, GherkinStep -Alias Given, When, Then, And, But
+& $script:SafeCommands['Export-ModuleMember'] Invoke-Gherkin, Find-GherkinStep, BeforeEachFeature, BeforeEachScenario, AfterEachFeature, AfterEachScenario, GherkinStep -Alias Given, When, Then, And, But
 & $script:SafeCommands['Export-ModuleMember'] New-MockObject, Add-AssertionOperator

--- a/Pester.psm1
+++ b/Pester.psm1
@@ -1155,5 +1155,5 @@ Throw "This command has been renamed to 'Assert-VerifiableMock' (without the 's'
 & $script:SafeCommands['Export-ModuleMember'] BeforeEach, AfterEach, BeforeAll, AfterAll
 & $script:SafeCommands['Export-ModuleMember'] Get-MockDynamicParameter, Set-DynamicParameterVariable
 & $script:SafeCommands['Export-ModuleMember'] SafeGetCommand, New-PesterOption
-& $script:SafeCommands['Export-ModuleMember'] Invoke-Gherkin, Invoke-GherkinStep, Find-GherkinStep, BeforeEachFeature, BeforeEachScenario, AfterEachFeature, AfterEachScenario, GherkinStep -Alias Given, When, Then, And, But
+& $script:SafeCommands['Export-ModuleMember'] Invoke-Gherkin, Invoke-GherkinStep, BeforeEachFeature, BeforeEachScenario, AfterEachFeature, AfterEachScenario, GherkinStep -Alias Given, When, Then, And, But
 & $script:SafeCommands['Export-ModuleMember'] New-MockObject, Add-AssertionOperator


### PR DESCRIPTION
Based on the @Jaykul [comment](https://github.com/pester/Pester/issues/808#issuecomment-338449227) the function Invoke-GherkinStep don't need to be exported from Pester.

Update
In the initial version, I proposed to don't export the function Find-GherkinStep what was my mistake