### PR TITLE
Fix #991 stack trace and Gherkin output from Pester 4 to match Pester 3

### DIFF
--- a/Functions/Output.Tests.ps1
+++ b/Functions/Output.Tests.ps1
@@ -270,9 +270,7 @@ InModuleScope -ModuleName Pester -ScriptBlock {
                         $r.Trace[0] | Should -be "at f1, $testPath`: line 2"
                         $r.Trace[1] | Should -be "at f2, $testPath`: line 5"
                         $r.Trace[2] | Should -be "at <ScriptBlock>, $testPath`: line 7"
-                        $r.Trace[3] -match 'at <ScriptBlock>, .*/Functions/Output.Tests.ps1: line [0-9]*$' |
-                            Should -be $true
-                        $r.Trace.Count | Should -be 5
+                        $r.Trace.Count | Should -be 4
                     }
                 }
                 else {
@@ -280,9 +278,7 @@ InModuleScope -ModuleName Pester -ScriptBlock {
                         $r.Trace[0] | Should -be "at f1, $testPath`: line 2"
                         $r.Trace[1] | Should -be "at f2, $testPath`: line 5"
                         $r.Trace[2] | Should -be "at <ScriptBlock>, $testPath`: line 7"
-                        $r.Trace[3] -match 'at <ScriptBlock>, .*\\Functions\\Output.Tests.ps1: line [0-9]*$' |
-                            Should -be $true
-                        $r.Trace.Count | Should -be 5
+                        $r.Trace.Count | Should -be 4
                     }
                 }
             }
@@ -326,15 +322,13 @@ InModuleScope -ModuleName Pester -ScriptBlock {
                 if ((GetPesterOS) -ne 'Windows') {
                     It 'produces correct trace line.' {
                         $r.Trace[0] | Should -be "at <ScriptBlock>, $testPath`: line 10"
-                        $r.Trace[1] -match 'at <ScriptBlock>, .*/Functions/Output.Tests.ps1: line [0-9]*$'
-                        $r.Trace.Count | Should -be 3
+                        $r.Trace.Count | Should -be 2
                     }
                 }
                 else {
                     It 'produces correct trace line.' {
                         $r.Trace[0] | Should -be "at <ScriptBlock>, $testPath`: line 10"
-                        $r.Trace[1] -match 'at <ScriptBlock>, .*\\Functions\\Output.Tests.ps1: line [0-9]*$'
-                        $r.Trace.Count | Should -be 3
+                        $r.Trace.Count | Should -be 2
                     }
                 }
             }

--- a/Functions/Output.ps1
+++ b/Functions/Output.ps1
@@ -454,13 +454,16 @@ function ConvertTo-FailureLines
             [String]$pattern1 = '^at (Invoke-Test|Context|Describe|InModuleScope|Invoke-Pester), .*/Functions/.*.ps1: line [0-9]*$'
             [String]$pattern2 = '^at Should<End>, .*/Functions/Assertions/Should.ps1: line [0-9]*$'
             [String]$pattern3 = '^at Assert-MockCalled, .*/Functions/Mock.ps1: line [0-9]*$'
+            [String]$pattern4 = '^at Invoke-Assertion, .*/Functions/.*.ps1: line [0-9]*$'
+            [String]$pattern5 = '^at (<ScriptBlock>|Invoke-Gherkin.*), (<No file>|.*/Functions/.*.ps1): line [0-9]*$'
         }
         Else {
 
             [String]$pattern1 = '^at (Invoke-Test|Context|Describe|InModuleScope|Invoke-Pester), .*\\Functions\\.*.ps1: line [0-9]*$'
             [String]$pattern2 = '^at Should<End>, .*\\Functions\\Assertions\\Should.ps1: line [0-9]*$'
             [String]$pattern3 = '^at Assert-MockCalled, .*\\Functions\\Mock.ps1: line [0-9]*$'
-
+            [String]$pattern4 = '^at Invoke-Assertion, .*\\Functions\\.*.ps1: line [0-9]*$'
+            [String]$pattern5 = '^at (<ScriptBlock>|Invoke-Gherkin.*), (<No file>|.*\\Functions\\.*.ps1): line [0-9]*$'
         }
 
         foreach ( $line in $traceLines )
@@ -475,7 +478,9 @@ function ConvertTo-FailureLines
             & $SafeCommands['Select-Object'] -First $count |
             & $SafeCommands['Where-Object'] {
                 $_ -notmatch $pattern2 -and
-                $_ -notmatch $pattern3
+                $_ -notmatch $pattern3 -and
+                $_ -notmatch $pattern4 -and
+                $_ -notmatch $pattern5
             }
 
         return $lines


### PR DESCRIPTION
Updated tests to pass with the changes. This is because the previous tests were checking for Pester-internal exception line information which should never have been there, which is the bug :-)