### PR TITLE
Fix GitHub issue template by using the -ListAvailable option on Get-Module when Pester is not already loaded

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -8,7 +8,7 @@ Operating System, Pester version and PowerShell version:
 
 ```powershell
 $bugReport = &{
-    $p = get-module pester
+    $p = Get-Module -ListAvailable Pester
     "Pester version     : " + $p.Version + " " + $p.Path
     "PowerShell version : " + $PSVersionTable.PSVersion
     "OS version         : " + [System.Environment]::OSVersion.VersionString


### PR DESCRIPTION
PowerShell does lazy loading, i.e. if `Invoke-Pester` has not been executed yet, then `Get-Module Pester` does not return anything. Therefore the `-ListAvailable` option has to be used when executing the command in a new shell.