### PR TITLE
Changing Environment checking for IsMacOS to IsOSX to enable using Pester on OS X.

### DIFF
--- a/Functions/Environment.ps1
+++ b/Functions/Environment.ps1
@@ -15,7 +15,7 @@ function GetPesterOs
     {
         'Windows'
     }
-    elseif (Get-Variable -Name 'IsMacOS' -ErrorAction 'SilentlyContinue' -ValueOnly )
+    elseif (Get-Variable -Name 'IsOSX' -ErrorAction 'SilentlyContinue' -ValueOnly )
     {
         'macOS'
     }


### PR DESCRIPTION
Potential fix for https://github.com/pester/Pester/issues/1011 and changes the (probably old) name of the operating system fingerprinting variable referenced from IsMacOS to IsOSX.