### PR TITLE
Fix -FileContentMatch example.

### DIFF
--- a/en-US/about_Should.help.txt
+++ b/en-US/about_Should.help.txt
@@ -151,7 +151,7 @@ SHOULD MEMBERS
 
         Set-Content -Path TestDrive:\file.txt -Value 'I am a file.'
         'TestDrive:\file.txt' | Should -FileContentMatch 'I Am' # Test will pass
-        'TestDrive:\file.txt' | Should -FileContentMatch '^I.*file$' # Test will pass
+        'TestDrive:\file.txt' | Should -FileContentMatch '^I.*file\.$' # Test will pass
 
         'TestDrive:\file.txt' | Should -FileContentMatch 'I Am Not' # Test will fail
 


### PR DESCRIPTION
Fix -FileContentMatch example in about_Should.help.txt file.