### PR TITLE
use full command name instead of alias

### DIFF
--- a/Dependencies/TypeClass/TypeClass.Tests.ps1
+++ b/Dependencies/TypeClass/TypeClass.Tests.ps1
@@ -162,7 +162,7 @@ Describe "Is-Collection" {
         @{ Value = @{} }
         @{ Value = @{ Name = 'Jakub' } }
 
-        @{ Value = (ps -Name Idle) }
+        @{ Value = (Get-Process -Name Idle) }
         @{ Value = New-Object -TypeName Diagnostics.Process }
     ) {
         param($Value)

--- a/Dependencies/TypeClass/TypeClass.Tests.ps1
+++ b/Dependencies/TypeClass/TypeClass.Tests.ps1
@@ -143,8 +143,6 @@ Describe "Is-Collection" {
     }
 
     It "Given an object '<value>' of type '<type>' that is not a collection it returns `$false" -TestCases @(
-        @{ Value = $null }
-
         @{ Value = [char] 'a' }
         @{ Value = "a" }
 

--- a/Dependencies/TypeClass/TypeClass.Tests.ps1
+++ b/Dependencies/TypeClass/TypeClass.Tests.ps1
@@ -64,7 +64,7 @@ Describe "Is-ScriptBlock" {
     It "Given a scriptblock '{<value>}' it returns `$true" -TestCases @(
         @{ Value = {} },
         @{ Value = {abc} },
-        @{ Value = { Get-Process -Name Idle } }
+        @{ Value = { Get-Process } }
     ) {
         param ($Value)
         Is-ScriptBlock -Value $Value | Verify-True
@@ -138,6 +138,10 @@ Describe "Is-Collection" {
         Is-Collection -Value $Value | Verify-True
     }
 
+    It "Given `$null it returns `$false" {
+        Is-Collection -Value $null | Verify-False
+    }
+
     It "Given an object '<value>' of type '<type>' that is not a collection it returns `$false" -TestCases @(
         @{ Value = $null }
 
@@ -162,10 +166,11 @@ Describe "Is-Collection" {
         @{ Value = @{} }
         @{ Value = @{ Name = 'Jakub' } }
 
-        @{ Value = (Get-Process -Name Idle) }
+        @{ Value = (Get-Process -Id $PID) }
         @{ Value = New-Object -TypeName Diagnostics.Process }
     ) {
         param($Value)
+        Verify-NotNull $Value
         Is-Collection -Value $Value | Verify-False
     }
 }


### PR DESCRIPTION
Fix #1030

The test was using `ps` alias which I assume does not exist on Linux to avoid yet another `curl` fiasco. The test did not fail because the result was `$null` which is not a collection, which is what we expected.