### PR TITLE
Run all tests under Set-StrictMode set to Latest

### DIFF
--- a/Dependencies/Format/Format.Tests.ps1
+++ b/Dependencies/Format/Format.Tests.ps1
@@ -1,3 +1,5 @@
+Set-StrictMode -Version Latest
+
 $here = $MyInvocation.MyCommand.Path | Split-Path
 Get-Module Axiom,Format | Remove-Module
 Import-Module $here\..\Axiom\Axiom.psm1 -ErrorAction 'stop' -DisableNameChecking

--- a/Dependencies/TypeClass/TypeClass.Tests.ps1
+++ b/Dependencies/TypeClass/TypeClass.Tests.ps1
@@ -1,3 +1,5 @@
+Set-StrictMode -Version Latest
+
 $here = $MyInvocation.MyCommand.Path | Split-Path
 Import-Module $here/TypeClass.psm1 -DisableNameChecking
 

--- a/Pester.Tests.ps1
+++ b/Pester.Tests.ps1
@@ -376,6 +376,7 @@ Describe 'Set-StrictMode for all tests files' {
         Get-ChildItem $pesterRoot\* -Include *.Tests.ps1
         Get-ChildItem (Join-Path $pesterRoot 'en-US') -Include *.Tests.ps1 -Recurse
         Get-ChildItem (Join-Path $pesterRoot 'Functions') -Include *.Tests.ps1 -Recurse
+        Get-ChildItem (Join-Path $pesterRoot 'Dependencies') -Include *.Tests.ps1 -Recurse
     )
 
     It 'Pester tests files start with explicit declaration of StrictMode set to Latest' {


### PR DESCRIPTION
Tests for Pester itself are run under CI with the Set-StrictMode set to Latest.

Lack of this declaration for tests in the Dependencies folder causes that some tests fail only under CI not when they are run locally.

The related  [issue](https://github.com/pester/Pester/pull/972#issuecomment-387561125).