### PR TITLE
Remove "Than" from GreaterOrEqual and LesOrEqual

### DIFF
--- a/en-US/about_Should.help.txt
+++ b/en-US/about_Should.help.txt
@@ -103,7 +103,7 @@ SHOULD MEMBERS
 
         2 | Should -BeGreaterThan 0
 
-    BeGreaterThanOrEqual
+    BeGreaterOrEqual
         Asserts that a number (or other comparable value) is greater than or equal to an expected value. Uses PowerShell's -ge operator to compare the two values.
 
         2 | Should -BeGreaterOrEqual 0
@@ -114,7 +114,7 @@ SHOULD MEMBERS
 
         1 | Should -BeLessThan 10
 
-    BeLessThanOrEqual
+    BeLessOrEqual
         Asserts that a number (or other comparable value) is lower than, or equal to an expected value. Uses PowerShell's -le operator to compare the two values.
 
         1 | Should -BeLessOrEqual 10


### PR DESCRIPTION
I have updated the Should page with missing parts and found this two typos on this file.
This is part of https://github.com/pester/Pester/issues/960