### PR TITLE
improvements in TestDrive.ps1

### DIFF
--- a/Functions/TestDrive.ps1
+++ b/Functions/TestDrive.ps1
@@ -1,6 +1,6 @@
 #
 function New-TestDrive ([Switch]$PassThru, [string] $Path) {
-    if ([string]::IsNullOrWhiteSpace($Path))
+    if ($Path -notmatch '\S')
     {
         $directory = New-RandomTempDirectory
     }

--- a/Functions/TestDrive.ps1
+++ b/Functions/TestDrive.ps1
@@ -1,6 +1,6 @@
 #
 function New-TestDrive ([Switch]$PassThru, [string] $Path) {
-    if ($Path -notmatch '\S')
+    if ([string]::IsNullOrWhiteSpace($Path))
     {
         $directory = New-RandomTempDirectory
     }
@@ -8,7 +8,7 @@ function New-TestDrive ([Switch]$PassThru, [string] $Path) {
     {
         if (-not (& $SafeCommands['Test-Path'] -Path $Path))
         {
-            & $SafeCommands['New-Item'] -ItemType Container -Path $Path | & $SafeCommands['Out-Null']
+            $null = & $SafeCommands['New-Item'] -ItemType Container -Path $Path
         }
 
         $directory = & $SafeCommands['Get-Item'] $Path
@@ -19,7 +19,7 @@ function New-TestDrive ([Switch]$PassThru, [string] $Path) {
     #setup the test drive
     if ( -not (& $SafeCommands['Test-Path'] "${DriveName}:\") )
     {
-        & $SafeCommands['New-PSDrive'] -Name $DriveName -PSProvider FileSystem -Root $directory -Scope Global -Description "Pester test drive" | & $SafeCommands['Out-Null']
+        $null = & $SafeCommands['New-PSDrive'] -Name $DriveName -PSProvider FileSystem -Root $directory -Scope Global -Description "Pester test drive"
     }
 
     #publish the global TestDrive variable used in few places within the module
@@ -116,7 +116,7 @@ function Remove-TestDrive {
 
     if ( $Drive )
     {
-        $Drive | & $SafeCommands['Remove-PSDrive'] -Force -ErrorAction $script:IgnoreErrorPreference
+        $Drive | & $SafeCommands['Remove-PSDrive'] -Force #This should fail explicitly as it impacts future pester runs
     }
 
     if (& $SafeCommands['Test-Path'] -Path $Path)


### PR DESCRIPTION
Was debugging an issue where if the temp folder backing TestDrive: gets deleted mid-test-run (some bad DSC temp folder cleanup on our end) where

``` powershell
& $SafeCommands['New-PSDrive'] -Name $DriveName -PSProvider FileSystem -Root $directory -Scope Global -Description "Pester test drive"
```
still gets reached because Test-Path TestDrive:\ returns false, and throws because the TestDrive psdrive still being registered. 
During debugging I found the erroraction ignore on Remove-PSDrive and thought that might be swallowing the error leaving testdrive behind. Turned out not to be the case, but is still a bug regardless in my opinion, unless there was some explicit reasoning for ignoring errors. 

Also removed unnecessary hashtable calls for 'out-null' when $null = is more performant and more explicit, and removed the unnecessary regex checking for non-whitespace when a .net call to [string]::IsNullOrWhiteSpace() is more performant.