### PR TITLE
Fix for #1060 - Invoke-Pester -PassThru returns pipeline output from test scripts

### DIFF
--- a/Pester.Tests.ps1
+++ b/Pester.Tests.ps1
@@ -581,7 +581,7 @@ InModuleScope -ModuleName Pester {
 }
 
 
-Describe 'Invoke-Pester -PassThru happy path returns only test results'  {
+Describe 'Invoke-Pester happy path returns only test results'  {
 
     Set-Content -Path "TestDrive:\Invoke-MyFunction.ps1" -Value @'
         function Invoke-MyFunction
@@ -592,14 +592,14 @@ Describe 'Invoke-Pester -PassThru happy path returns only test results'  {
 
     Set-Content -Path "TestDrive:\Invoke-MyFunction.Tests.ps1" -Value @'
         . "TestDrive:\Invoke-MyFunction.ps1";
-        Describe "MyFunction Tests" {
+        Describe "Invoke-MyFunction Tests" {
             It "Should not throw" {
                 Invoke-MyFunction
             }
         }
 '@;
 
-    It "Should swallow test output" {
+    It "Should swallow test output with -PassThru" {
 
         $results = Invoke-Pester -Script "TestDrive:\Invoke-MyFunction.Tests.ps1" -PassThru -Show "None";
 
@@ -615,10 +615,15 @@ Describe 'Invoke-Pester -PassThru happy path returns only test results'  {
 
     }
 
+    It "Should swallow test output without -PassThru" {
+        $results = Invoke-Pester -Script "TestDrive:\Invoke-MyFunction.Tests.ps1" -Show "None";
+        $results | Should -Be $null;
+    }
+
 }
 
 
-Describe 'Invoke-Pester -PassThru swallows pipeline output from system-under-test'  {
+Describe 'Invoke-Pester swallows pipeline output from system-under-test'  {
 
     Set-Content -Path "TestDrive:\Invoke-MyFunction.ps1" -Value @'
         Write-Output "my system-under-test output";
@@ -630,14 +635,14 @@ Describe 'Invoke-Pester -PassThru swallows pipeline output from system-under-tes
 
     Set-Content -Path "TestDrive:\Invoke-MyFunction.Tests.ps1" -Value @'
         . "TestDrive:\Invoke-MyFunction.ps1";
-        Describe "MyFunction Tests" {
+        Describe "Invoke-MyFunction Tests" {
             It "Should not throw" {
                 Invoke-MyFunction
             }
         }
 '@;
 
-    It "Should swallow test output" {
+    It "Should swallow test output with -PassThru" {
 
         $results = Invoke-Pester -Script "TestDrive:\Invoke-MyFunction.Tests.ps1" -PassThru -Show "None";
 
@@ -653,10 +658,15 @@ Describe 'Invoke-Pester -PassThru swallows pipeline output from system-under-tes
 
     }
 
+    It "Should swallow test output without -PassThru" {
+        $results = Invoke-Pester -Script "TestDrive:\Invoke-MyFunction.Tests.ps1" -Show "None";
+        $results | Should -Be $null;
+    }
+
 }
 
 
-Describe 'Invoke-Pester -PassThru swallows pipeline output from test script'  {
+Describe 'Invoke-Pester swallows pipeline output from test script'  {
 
     Set-Content -Path "TestDrive:\Invoke-MyFunction.ps1" -Value @'
         function Invoke-MyFunction
@@ -668,16 +678,16 @@ Describe 'Invoke-Pester -PassThru swallows pipeline output from test script'  {
     Set-Content -Path "TestDrive:\Invoke-MyFunction.Tests.ps1" -Value @'
         . "TestDrive:\Invoke-MyFunction.ps1";
         Write-Output "my test script output";
-        Describe "MyFunction Tests" {
+        Describe "Invoke-MyFunction Tests" {
             It "Should not throw" {
                 Invoke-MyFunction
             }
         }
 '@;
 
-    It "Should swallow test output" {
+    It "Should swallow test output with -PassThru" {
 
-        $results = Invoke-Pester -Script "TestDrive:\Invoke-MyFunction.Tests.ps1" -PassThru;
+        $results = Invoke-Pester -Script "TestDrive:\Invoke-MyFunction.Tests.ps1" -PassThru -Show "None";
 
         # note - the pipe command unrolls enumerable objects, so we have to wrap
         #        results in a sacificial array to retain its original structure
@@ -689,6 +699,11 @@ Describe 'Invoke-Pester -PassThru swallows pipeline output from test script'  {
         # ($results -is [PSCustomObject]) | Should -Be $true;
         # $results.TotalCount | Should -Be 1;
 
+    }
+
+    It "Should swallow test output without -PassThru" {
+        $results = Invoke-Pester -Script "TestDrive:\Invoke-MyFunction.Tests.ps1" -Show "None";
+        $results | Should -Be $null;
     }
 
 }

--- a/Pester.Tests.ps1
+++ b/Pester.Tests.ps1
@@ -604,7 +604,7 @@ Describe 'Invoke-Pester happy path returns only test results'  {
         $results = Invoke-Pester -Script "TestDrive:\Invoke-MyFunction.Tests.ps1" -PassThru -Show "None";
 
         # note - the pipe command unrolls enumerable objects, so we have to wrap
-        #        results in a sacificial array to retain its original structure
+        #        results in a sacrificial array to retain its original structure
         #        when passed to Should
         @(,$results) | Should -BeOfType [PSCustomObject];
         $results.TotalCount | Should -Be 1;
@@ -647,7 +647,7 @@ Describe 'Invoke-Pester swallows pipeline output from system-under-test'  {
         $results = Invoke-Pester -Script "TestDrive:\Invoke-MyFunction.Tests.ps1" -PassThru -Show "None";
 
         # note - the pipe command unrolls enumerable objects, so we have to wrap
-        #        results in a sacificial array to retain its original structure
+        #        results in a sacrificial array to retain its original structure
         #        when passed to Should
         @(,$results) | Should -BeOfType [PSCustomObject];
         $results.TotalCount | Should -Be 1;
@@ -690,7 +690,7 @@ Describe 'Invoke-Pester swallows pipeline output from test script'  {
         $results = Invoke-Pester -Script "TestDrive:\Invoke-MyFunction.Tests.ps1" -PassThru -Show "None";
 
         # note - the pipe command unrolls enumerable objects, so we have to wrap
-        #        results in a sacificial array to retain its original structure
+        #        results in a sacrificial array to retain its original structure
         #        when passed to Should
         @(,$results) | Should -BeOfType [PSCustomObject];
         $results.TotalCount | Should -Be 1;

--- a/Pester.psm1
+++ b/Pester.psm1
@@ -851,7 +851,7 @@ New-PesterOption
                     Write-Describe $testScript.Path -CommandUsed Script
                     do
                     {
-                        & $invokeTestScript -Path $testScript.Path -Arguments $testScript.Arguments -Parameters $testScript.Parameters
+                        $testOutput = & $invokeTestScript -Path $testScript.Path -Arguments $testScript.Arguments -Parameters $testScript.Parameters
                     } until ($true)
                 }
                 catch


### PR DESCRIPTION
Swallow objects that are written to the output pipeline inside test scripts so that they don't get returned by Invoke-Pester when the -PassThru switch is specified.

Also added some tests to validate the new behaviour.