### PR TITLE
Fix tags filter warning

### DIFF
--- a/Functions/Describe.Tests.ps1
+++ b/Functions/Describe.Tests.ps1
@@ -92,10 +92,6 @@ InModuleScope Pester {
         Context 'Test Name Filter' {
             $testState = New-PesterState -Path $TestDrive -TestNameFilter '*One*', 'Test Two'
 
-            # This is necessary for now, Describe code assumes that filters should only apply at a stack depth of
-            # "2".  ("1" being the Tests.ps1 script that's active.)
-            $testState.EnterTestGroup('Mocked Script', 'Script')
-
             $testBlock = { MockMe }
 
             $cases = @(
@@ -122,10 +118,6 @@ InModuleScope Pester {
         Context 'Tags Filter' {
             $filter = 'Unit', 'Integ*'
             $testState = New-PesterState -Path $TestDrive -TagFilter $filter
-
-            # This is necessary for now, Describe code assumes that filters should only apply at a stack depth of
-            # "2".  ("1" being the Tests.ps1 script that's active.)
-            $testState.EnterTestGroup('Mocked Script', 'Script')
 
             $testBlock = { MockMe }
 
@@ -161,10 +153,6 @@ InModuleScope Pester {
         Context 'Exclude Tags Filter' {
             $filter = 'Unit', 'Integ*'
             $testState = New-PesterState -Path $TestDrive -ExcludeTagFilter $filter
-
-            # This is necessary for now, Describe code assumes that filters should only apply at a stack depth of
-            # "2".  ("1" being the Tests.ps1 script that's active.)
-            $testState.EnterTestGroup('Mocked Script', 'Script')
 
             $testBlock = { MockMe }
 

--- a/Functions/Describe.ps1
+++ b/Functions/Describe.ps1
@@ -110,7 +110,8 @@ function DescribeImpl {
 
     Assert-DescribeInProgress -CommandName $CommandUsed
 
-    if ($Pester.TestGroupStack.Count -eq 2)
+    if (($Pester.RunningViaInvokePester -and $Pester.TestGroupStack.Count -eq 2) -or
+        (-not $Pester.RunningViaInvokePester -and $Pester.TestGroupStack.Count -eq 1))
     {
         if ($Pester.TestNameFilter -and $Name) {
             if (-not (Contain-AnyStringLike -Filter $Pester.TestNameFilter -Collection $Name)) {

--- a/Functions/PesterState.ps1
+++ b/Functions/PesterState.ps1
@@ -7,7 +7,8 @@ function New-PesterState
         [System.Management.Automation.SessionState]$SessionState,
         [Switch]$Strict,
         [Pester.OutputTypes]$Show = 'All',
-        [object]$PesterOption
+        [object]$PesterOption,
+        [Switch]$RunningViaInvokePester
     )
 
     if ($null -eq $SessionState) { $SessionState = $ExecutionContext.SessionState }
@@ -28,7 +29,7 @@ function New-PesterState
         }
     }
 
-    & $SafeCommands['New-Module'] -Name Pester -AsCustomObject -ArgumentList $TagFilter, $ExcludeTagFilter, $TestNameFilter, $SessionState, $Strict, $Show, $PesterOption -ScriptBlock {
+    & $SafeCommands['New-Module'] -Name Pester -AsCustomObject -ArgumentList $TagFilter, $ExcludeTagFilter, $TestNameFilter, $SessionState, $Strict, $Show, $PesterOption, $RunningViaInvokePester -ScriptBlock {
         param (
             [String[]]$_tagFilter,
             [String[]]$_excludeTagFilter,
@@ -36,7 +37,8 @@ function New-PesterState
             [System.Management.Automation.SessionState]$_sessionState,
             [Switch]$Strict,
             [Pester.OutputTypes]$Show,
-            [object]$PesterOption
+            [object]$PesterOption,
+            [Switch]$RunningViaInvokePester
         )
 
         #public read-only
@@ -64,6 +66,7 @@ function New-PesterState
 
         $script:IncludeVSCodeMarker = $PesterOption.IncludeVSCodeMarker
         $script:TestSuiteName       = $PesterOption.TestSuiteName
+        $script:RunningViaInvokePester = $RunningViaInvokePester
 
         $script:SafeCommands = @{}
 
@@ -343,7 +346,8 @@ function New-PesterState
         "TestActions",
         "TestGroupStack",
         "TestSuiteName",
-        "InTest"
+        "InTest",
+        "RunningViaInvokePester"
 
         $ExportedFunctions = "EnterTestGroup",
                              "LeaveTestGroup",

--- a/Pester.psm1
+++ b/Pester.psm1
@@ -820,7 +820,7 @@ New-PesterOption
 
         $script:mockTable = @{}
         Remove-MockFunctionsAndAliases
-        $pester = New-PesterState -TestNameFilter $TestName -TagFilter ($Tag -split "\s") -ExcludeTagFilter ($ExcludeTag -split "\s") -SessionState $PSCmdlet.SessionState -Strict:$Strict -Show:$Show -PesterOption $PesterOption
+        $pester = New-PesterState -TestNameFilter $TestName -TagFilter ($Tag -split "\s") -ExcludeTagFilter ($ExcludeTag -split "\s") -SessionState $PSCmdlet.SessionState -Strict:$Strict -Show:$Show -PesterOption $PesterOption -RunningViaInvokePester
 
         try
         {


### PR DESCRIPTION
Fixes tag warning that appears when we run directly from an editor because the test stack in that case is smaller than 2 and we were only looking at the stack size to determine how deep we are in the structure. This fix adds a flag to the Pester state that determines if we are running directly or via Invoke-Pester by using a switch when we instantiate state directly in Invoke-Pester and no switch when we instantiate in Describe.

Fix #1066