### PR TITLE
WIP: Write properties to NUnit file per testcase

### DIFF
--- a/Functions/TestResults.Tests.ps1
+++ b/Functions/TestResults.Tests.ps1
@@ -33,13 +33,14 @@ InModuleScope Pester {
                 [String]$testFile = "$TestDrive{0}Results{0}Tests.xml" -f [System.IO.Path]::DirectorySeparatorChar
                 Export-NunitReport $testResults $testFile
                 $xmlResult = [xml] (Get-Content $testFile)
-                $xmlTestCase = $xmlResult.SelectNodes("//test-case")
+                write-verbose ($xmlresult.outerxml) -verbose
+                $xmlTestCase = $xmlResult.SelectSingleNode("//test-case")
                 $xmlTestCase.name                   | Should -Be "Mocked Describe.Failed testcase"
                 $xmlTestCase.result                 | Should -Be "Failure"
                 $xmlTestCase.time                   | Should -Be "2.5"
                 $xmlTestCase.failure.message        | Should -Be 'Assert failed: "Expected: Test. But was: Testing"'
                 $xmlTestCase.failure.'stack-trace'  | Should -Be 'at line: 28 in  C:\Pester\Result.Tests.ps1'
-                $xmlTestCase.SelectNodes("//properties/property[@name='Param1']").value | should -be 'test value'
+                $xmlTestCase.SelectSingleNode("//properties/property[@name='Param1']").value | should -be 'test value'
             }
 
             It "should write the test summary" {

--- a/Functions/TestResults.Tests.ps1
+++ b/Functions/TestResults.Tests.ps1
@@ -26,18 +26,20 @@ InModuleScope Pester {
                 $TestResults = New-PesterState -Path TestDrive:\
                 $testResults.EnterTestGroup('Mocked Describe', 'Describe')
                 $time = [TimeSpan]25000000 #2.5 seconds
-                $TestResults.AddTestResult("Failed testcase",'Failed',$time,'Assert failed: "Expected: Test. But was: Testing"','at line: 28 in  C:\Pester\Result.Tests.ps1')
+                try { throw 'message' } catch { $e = $_ }
+                $TestResults.AddTestResult("Failed testcase",'Failed',$time,'Assert failed: "Expected: Test. But was: Testing"','at line: 28 in  C:\Pester\Result.Tests.ps1', "Mocked Describe", @{Param1 = "test value"}, $e)
 
                 #export and validate the file
                 [String]$testFile = "$TestDrive{0}Results{0}Tests.xml" -f [System.IO.Path]::DirectorySeparatorChar
                 Export-NunitReport $testResults $testFile
                 $xmlResult = [xml] (Get-Content $testFile)
-                $xmlTestCase = $xmlResult.'test-results'.'test-suite'.'results'.'test-suite'.'results'.'test-case'
+                $xmlTestCase = $xmlResult.SelectNodes("//test-case")
                 $xmlTestCase.name                   | Should -Be "Mocked Describe.Failed testcase"
                 $xmlTestCase.result                 | Should -Be "Failure"
                 $xmlTestCase.time                   | Should -Be "2.5"
                 $xmlTestCase.failure.message        | Should -Be 'Assert failed: "Expected: Test. But was: Testing"'
                 $xmlTestCase.failure.'stack-trace'  | Should -Be 'at line: 28 in  C:\Pester\Result.Tests.ps1'
+                $xmlTestCase.SelectNodes("//properties/property[@name='Param1']").value | should -be 'test value'
             }
 
             It "should write the test summary" {

--- a/Functions/TestResults.Tests.ps1
+++ b/Functions/TestResults.Tests.ps1
@@ -33,7 +33,6 @@ InModuleScope Pester {
                 [String]$testFile = "$TestDrive{0}Results{0}Tests.xml" -f [System.IO.Path]::DirectorySeparatorChar
                 Export-NunitReport $testResults $testFile
                 $xmlResult = [xml] (Get-Content $testFile)
-                write-verbose ($xmlresult.outerxml) -verbose
                 $xmlTestCase = $xmlResult.SelectSingleNode("//test-case")
                 $xmlTestCase.name                   | Should -Be "Mocked Describe.Failed testcase"
                 $xmlTestCase.result                 | Should -Be "Failure"

--- a/Functions/TestResults.ps1
+++ b/Functions/TestResults.ps1
@@ -418,10 +418,9 @@ function Write-NUnitTestCaseAttributes($TestResult, [System.Xml.XmlWriter] $XmlW
     if($TestResult.Parameters) {
         $XmlWriter.WriteStartElement('properties')
         $TestResult.Parameters.GetEnumerator() | ForEach-Object -Process {
-            trap{}
             $XmlWriter.WriteStartElement("property")
             $XmlWriter.WriteAttributeString("name",$_.Name)
-            $XmlWriter.WriteAttributeString("value", $_.Value)
+            $XmlWriter.WriteAttributeString("value", [string] $_.Value)
             $XmlWriter.WriteEndElement()
         }
         $XmlWriter.WriteEndElement()

--- a/Functions/TestResults.ps1
+++ b/Functions/TestResults.ps1
@@ -417,7 +417,7 @@ function Write-NUnitTestCaseAttributes($TestResult, [System.Xml.XmlWriter] $XmlW
 
     if($TestResult.Parameters) {
         $XmlWriter.WriteStartElement('properties')
-        $TestResult.Parameters.GetEnumerator().Foreach{
+        $TestResult.Parameters.GetEnumerator() | ForEach-Object -Process {
             trap{}
             $XmlWriter.WriteStartElement("property")
             $XmlWriter.WriteAttributeString("name",$_.Name)

--- a/Functions/TestResults.ps1
+++ b/Functions/TestResults.ps1
@@ -405,7 +405,32 @@ function Write-NUnitTestCaseAttributes($TestResult, [System.Xml.XmlWriter] $XmlW
         {
             $XmlWriter.WriteAttributeString('result', 'Inconclusive')
             $XmlWriter.WriteAttributeString('executed', 'True')
+            break
+        }
+        Failed
+        {
+            $XmlWriter.WriteAttributeString('result', 'Failure')
+            $XmlWriter.WriteAttributeString('executed', 'True')
+            break
+        }
+    }
 
+    if($TestResult.Parameters) {
+        $XmlWriter.WriteStartElement('properties')
+        $TestResult.Parameters.GetEnumerator().Foreach{
+            trap{}
+            $XmlWriter.WriteStartElement("property")
+            $XmlWriter.WriteAttributeString("name",$_.Name)
+            $XmlWriter.WriteAttributeString("value", $_.Value)
+            $XmlWriter.WriteEndElement()
+        }
+        $XmlWriter.WriteEndElement()
+    }
+
+    switch ($TestResult.Result)
+    {
+        Inconclusive
+        {
             if ($TestResult.FailureMessage)
             {
                 $XmlWriter.WriteStartElement('reason')
@@ -417,8 +442,6 @@ function Write-NUnitTestCaseAttributes($TestResult, [System.Xml.XmlWriter] $XmlW
         }
         Failed
         {
-            $XmlWriter.WriteAttributeString('result', 'Failure')
-            $XmlWriter.WriteAttributeString('executed', 'True')
             $XmlWriter.WriteStartElement('failure')
             $xmlWriter.WriteElementString('message', $TestResult.FailureMessage)
             $XmlWriter.WriteElementString('stack-trace', $TestResult.StackTrace)
@@ -426,6 +449,7 @@ function Write-NUnitTestCaseAttributes($TestResult, [System.Xml.XmlWriter] $XmlW
             break
         }
     }
+
 }
 function Get-RunTimeEnvironment() {
     # based on what we found during startup, use the appropriate cmdlet


### PR DESCRIPTION
In order to make it easier to review the NUnit test output after the fact. The properties that are passed to the testcase are also written to the output xml