### PR TITLE
Make an attempt to get environment information for non-Windows platforms

### DIFF
--- a/Functions/TestResults.ps1
+++ b/Functions/TestResults.ps1
@@ -454,7 +454,7 @@ function Get-RunTimeEnvironment() {
             }
             if ( $SafeCommands['id'] -ne $null )
             {
-                $userName = & $SafeCommands['id']
+                $userName = & $SafeCommands['id'] -un
             }
         }
         catch {

--- a/Functions/TestResults.ps1
+++ b/Functions/TestResults.ps1
@@ -429,6 +429,8 @@ function Write-NUnitTestCaseAttributes($TestResult, [System.Xml.XmlWriter] $XmlW
 }
 function Get-RunTimeEnvironment() {
     # based on what we found during startup, use the appropriate cmdlet
+    $computerName = $env:ComputerName
+    $userName = $env:Username
     if ( $SafeCommands['Get-CimInstance'] -ne $null )
     {
         $osSystemInformation = (& $SafeCommands['Get-CimInstance'] Win32_OperatingSystem)
@@ -436,6 +438,28 @@ function Get-RunTimeEnvironment() {
     elseif ( $SafeCommands['Get-WmiObject'] -ne $null )
     {
         $osSystemInformation = (& $SafeCommands['Get-WmiObject'] Win32_OperatingSystem)
+    }
+    elseif ( $IsMacOS -or $IsLinux )
+    {
+        $osSystemInformation = @{
+            Name = "Unknown"
+            Version = "0.0.0.0"
+            }
+        try {
+            if ( $SafeCommands['uname'] -ne $null )
+            {
+                $osSystemInformation.Version = & $SafeCommands['uname'] -r
+                $osSystemInformation.Name = & $SafeCommands['uname'] -s
+                $computerName = & $SafeCommands['uname'] -n
+            }
+            if ( $SafeCommands['id'] -ne $null )
+            {
+                $userName = & $SafeCommands['id']
+            }
+        }
+        catch {
+            # well, we tried
+        }
     }
     else
     {
@@ -461,8 +485,8 @@ function Get-RunTimeEnvironment() {
         'os-version' = $osSystemInformation.Version
         platform = $osSystemInformation.Name
         cwd = (& $SafeCommands['Get-Location']).Path #run path
-        'machine-name' = $env:ComputerName
-        user = $env:Username
+        'machine-name' = $computerName
+        user = $username
         'user-domain' = $env:userDomain
         'clr-version' = $CLrVersion
     }

--- a/Pester.Tests.ps1
+++ b/Pester.Tests.ps1
@@ -124,7 +124,8 @@ if ($PSVersionTable.PSVersion.Major -ge 3)
 
             # These commands are conditionally added to the safeCommands table due to Nano / Core versus PSv2 compatibility; one will always
             # be missing, and can be ignored.
-            $missingSafeCommands = $missingSafeCommands | Where { @('Get-WmiObject', 'Get-CimInstance') -notcontains $_ }
+            # Also add the two possible commands uname and id which would be found on non-Windows platforms
+            $missingSafeCommands = $missingSafeCommands | Where { @('Get-WmiObject', 'Get-CimInstance','uname','id') -notcontains $_ }
 
             It 'The SafeCommands table contains all commands that are called from the module' {
                 $missingSafeCommands | Should -Be $null

--- a/Pester.psm1
+++ b/Pester.psm1
@@ -100,6 +100,14 @@ elseif ( Get-command -ea SilentlyContinue Get-WmiObject )
 {
     $script:SafeCommands['Get-WmiObject']   = Get-Command -Name Get-WmiObject   -Module Microsoft.PowerShell.Management @safeCommandLookupParameters
 }
+elseif ( Get-Command -ea SilentlyContinue uname -Type Application )
+{
+    $script:SafeCommands['uname'] = Get-Command -Name uname -Type Application
+    if ( Get-Command -ea SilentlyContinue id -Type Application )
+    {
+        $script:SafeCommands['id'] = Get-Command -Name id -Type Application
+    }
+}
 else
 {
     Write-Warning "OS Information retrieval is not possible, reports will contain only partial system data"


### PR DESCRIPTION
I'm definitely missing environment information when running Pester in our CI on Non-Windows platforms. I would love if the logs had that information. This is an attempt at providing that information with tools that will probably be there. I'm using `uname` and `id` to provide that info. If those tools aren't there, we won't be any worse off, but if they are there, then we can provide the test environment pretty well.