### PR TITLE
Check scope of Set-Variable to resolve #1107

### DIFF
--- a/Functions/Mock.ps1
+++ b/Functions/Mock.ps1
@@ -1007,6 +1007,13 @@ function Invoke-Mock {
 
                 Set-ScriptBlockScope -ScriptBlock $scriptBlock -SessionState $state
 
+                <#
+                    In order to mock Set-Variable correctly we need to scope outside of the Mock
+                #>
+                if( ($mock.OriginalCommand -like "Set-Variable") -and ($MockCallState['BeginBoundParameters'].Keys -notcontains "Scope") ){
+                    $MockCallState['BeginBoundParameters'].Add( "Scope", "Global")
+                }
+
                 & $scriptBlock -Command $mock.OriginalCommand `
                                -ArgumentList $MockCallState['BeginArgumentList'] `
                                -BoundParameters $MockCallState['BeginBoundParameters'] `

--- a/Functions/Mock.ps1
+++ b/Functions/Mock.ps1
@@ -1010,8 +1010,15 @@ function Invoke-Mock {
                 <#
                     In order to mock Set-Variable correctly we need to scope outside of the Mock
                 #>
-                if( ($mock.OriginalCommand -like "Set-Variable") -and ($MockCallState['BeginBoundParameters'].Keys -notcontains "Scope") ){
-                    $MockCallState['BeginBoundParameters'].Add( "Scope", "Global")
+                if( $mock.OriginalCommand -like "Set-Variable" ){
+                    if ($MockCallState['BeginBoundParameters'].Keys -notcontains "Scope") {
+                        $MockCallState['BeginBoundParameters'].Add( "Scope", 2)
+                        Write-Host -Object "No Scope Defined" -ForegroundColor Yellow
+                    }
+                    elseif($MockCallState['BeginBoundParameters'].Scope -match "\d"){
+                        $MockCallState['BeginBoundParameters'].Scope = 2
+                        Write-Host -Object "Scope defined" -ForegroundColor Yellow
+                    }
                 }
 
                 & $scriptBlock -Command $mock.OriginalCommand `

--- a/Functions/Mock.ps1
+++ b/Functions/Mock.ps1
@@ -1013,11 +1013,9 @@ function Invoke-Mock {
                 if( $mock.OriginalCommand -like "Set-Variable" ){
                     if ($MockCallState['BeginBoundParameters'].Keys -notcontains "Scope") {
                         $MockCallState['BeginBoundParameters'].Add( "Scope", 2)
-                        Write-Host -Object "No Scope Defined" -ForegroundColor Yellow
                     }
                     elseif($MockCallState['BeginBoundParameters'].Scope -match "\d"){
                         $MockCallState['BeginBoundParameters'].Scope = 2
-                        Write-Host -Object "Scope defined" -ForegroundColor Yellow
                     }
                 }
 


### PR DESCRIPTION
## 1. General summary of the pull request
Very small change to Invoke-Mock. Added a change to Set-Variable mocking to include a scope parameter of Global. This is intended to resolve #1107 
<!--

Please provide a descriptive title of the pull request in the field 'Title' too.

Please provide us information on how your pull request improves Pester or what fixes.

If your pull request integrate Pester with another system (e.g. a continues integration product) please provide instruction how the updated code can be tested.

If your pull request resolves the issue reported previously, please mention it by using `#<issue_number>` syntax.

Please remember about update [the Pester wiki](https://github.com/pester/Pester/wiki) too.

-->