### PR TITLE
Show-PesterAssertion to improve parameter discovery

### DIFF
--- a/Functions/Assertions/Should.ps1
+++ b/Functions/Assertions/Should.ps1
@@ -58,16 +58,21 @@ function New-ShouldErrorRecord ([string] $Message, [string] $File, [string] $Lin
 function Should {
 <#
     .SYNOPSIS
-    Should is a keyword what is used to define an assertion inside It block.
+    Should is Pester's keyword to execute assertions.
 
     .DESCRIPTION
-    Should is a keyword what is used to define an assertion inside the It block.
-    Should provides assertion methods for verify assertion e.g. comparing objects.
-    If assertion is not met the test fails and an exception is throwed up.
+    Should is used inside an It block to trigger an assertion.
 
-    Should can be used more than once in the It block if more than one assertion
-    need to be verified. Each Should keywords need to be located in a new line.
-    Test will be passed only when all assertion will be met (logical conjuction).
+    Should provides various assertion methods to compare values, objects, etc.
+    If the values are not identical, the test fails, and an exception is thrown.
+
+    To view Should examples and the available assertion parameters,
+    `Get-Help about_Should` or `Show-PesterAssertion`
+
+    .NOTES
+    Should may be used multiple times inside a single It block.
+
+    Each Should keyword needs to be located on a new line.
 
     .LINK
     about_Should

--- a/Functions/Show-PesterAssertion.ps1
+++ b/Functions/Show-PesterAssertion.ps1
@@ -8,7 +8,10 @@ function Show-PesterAssertion {
     This limits the user's ability to discover the available assertions.
 
     Show-PesterAssertion is a basic attempt to provide that information.
+    It displays the parameters, categories, and examples made available
+    to help you craft the tests you need.
 
+    .NOTES
     This command parses the about_Should help file to provide a summarized view.
     It is highly dependent on proper formatting to return accurate results.
 
@@ -26,6 +29,7 @@ function Show-PesterAssertion {
 
     .LINK
     https://github.com/Pester/Pester
+    about_Should
     #>
     [CmdletBinding()]
     param (

--- a/Functions/Show-PesterAssertion.ps1
+++ b/Functions/Show-PesterAssertion.ps1
@@ -67,12 +67,15 @@ function Show-PesterAssertion {
             Write-Verbose "Break on $i"
     
             # Return the current object before we overwrite it
-            # $Category should match or be empty; same with $Assertion
-            If (($Category -eq $ObjectCategory -or -not $Category) -and ($Assertion -like $CurrentAssertion -or -not $Assertion)) {
+            If ($Assertion -eq $CurrentAssertion) {
+                # If $Assertion was specified, return the text only
+                $text
+            } ElseIf (($Category -eq $ObjectCategory -or -not $Category) -and -not $Assertion) {
+                # If $Category was specified, or neither were, return an object
                 [PSCustomObject]@{
-                    Assertion = $CurrentAssertion
-                    Category  = $ObjectCategory
-                    Text      = $text
+                    Name     = $CurrentAssertion
+                    Category = $ObjectCategory
+                    Text     = $text
                 }
             }
         

--- a/Functions/Show-PesterAssertion.ps1
+++ b/Functions/Show-PesterAssertion.ps1
@@ -1,5 +1,31 @@
 function Show-PesterAssertion {
     <#
+    .SYNOPSIS
+    Display the assertions available for use with Should.
+
+    .DESCRIPTION
+    Pester uses dynamic parameters to populate Should arguments.
+    This limits the user's ability to discover the available assertions.
+
+    Show-PesterAssertion is a basic attempt to provide that information.
+
+    This command parses the about_Should help file to provide a summarized view.
+    It is highly dependent on proper formatting to return accurate results.
+
+    .EXAMPLE
+    Show-PesterAssertion
+    Return the Name, Category, and Text (examples) of available Should parameters.
+
+    .EXAMPLE
+    Show-PesterAssertion -Category Collection
+    Return objects containing more info on the available collection assertions.
+
+    .EXAMPLE
+    Show-PesterAssertion -Assertion Match
+    Return only the multi-line text example of the Match assertion.
+
+    .LINK
+    https://github.com/Pester/Pester
     #>
     [CmdletBinding()]
     param (

--- a/Functions/Show-PesterAssertion.ps1
+++ b/Functions/Show-PesterAssertion.ps1
@@ -1,0 +1,103 @@
+function Show-PesterAssertion {
+    <#
+    #>
+    [CmdletBinding()]
+    param (
+        [ValidateSet(
+            'General',
+            'Text',
+            'Comparison',
+            'Collection',
+            'File',
+            'Exceptions',
+            'Negative',
+            'Because'
+        )]
+        [string]$Category,
+
+        [ValidateSet(
+            'Be', 
+            'Because', 
+            'BeExactly', 
+            'BeFalse', 
+            'BeGreaterOrEqual', 
+            'BeGreaterThan', 
+            'BeIn', 
+            'BeLessOrEqual', 
+            'BeLessThan', 
+            'BeLike', 
+            'BeLikeExactly', 
+            'BeNullOrEmpty', 
+            'BeOfType, HaveType', 
+            'BeTrue', 
+            'Contain', 
+            'Exist', 
+            'FileContentMatch', 
+            'FileContentMatchExactly', 
+            'FileContentMatchMultiline', 
+            'HaveCount', 
+            'Match', 
+            'MatchExactly', 
+            'Not', 
+            'Throw'
+        )]
+        [string]$Assertion
+    )
+
+    $help = (Get-Content -Path $PSScriptRoot\..\en-US\about_Should.help.txt) -Split [Environment]::NewLine
+    Write-Verbose "about_Should line count is $($help.Count)"
+
+    $IgnoreTopLevel = 'TOPIC|DESCRIPTION|ALSO'
+    $IgnoreAssertions = 'USING SHOULD IN A TEST'
+
+    $text = [System.Collections.Generic.List[string]]::new()
+
+    for ($i = 0; $i -lt $help.Count; $i++) {
+        $line = $help[$i]
+    
+        If ($line -match '^\S') {
+            $TopLevel = $line
+        }
+    
+        If ($TopLevel -match $IgnoreTopLevel) {
+            continue
+        }
+    
+        If ($CurrentAssertion -and $line -match '^\s{4}\S') {
+            Write-Verbose "Break on $i"
+    
+            # Return the current object before we overwrite it
+            # $Category should match or be empty; same with $Assertion
+            If (($Category -eq $ObjectCategory -or -not $Category) -and ($Assertion -like $CurrentAssertion -or -not $Assertion)) {
+                [PSCustomObject]@{
+                    Assertion = $CurrentAssertion
+                    Category  = $ObjectCategory
+                    Text      = $text
+                }
+            }
+        
+            If ($cat -notin $IgnoreAssertions) {
+                # Reset the list to empty for the next assertion's text
+                $text = [System.Collections.Generic.List[string]]::new()
+            } Else {
+                # Assumes all the $IgnoreAssertions are at the end of the file
+                # So we can exit the for loop and be done
+                break
+            }
+        } ElseIf ($CurrentAssertion -and $cat -notin $IgnoreAssertions) {
+            [void]$text.Add($line.Trim())
+        }
+        
+        If ($line -match "^\s{4}\S.*$" -and $cat -notin $IgnoreAssertions) {
+            Write-Verbose "Assertion on $i - $line"
+            $CurrentAssertion = $line.Trim()
+            # Lock in the next object's category. $cat might change by then
+            $ObjectCategory = $cat
+        }
+    
+        If ($line -match "^\s{2}\S.*$") {
+            Write-Verbose "Category on $i - $line"
+            $cat = $line.Trim()
+        }
+    } #for
+}

--- a/Pester.psd1
+++ b/Pester.psd1
@@ -52,6 +52,7 @@ FunctionsToExport = @(
     'New-PesterOption'
     'New-MockObject'
     'Add-AssertionOperator'
+    'Show-PesterAssertion'
 
     # Gherkin Support:
     'Invoke-Gherkin'

--- a/Pester.psm1
+++ b/Pester.psm1
@@ -1190,4 +1190,4 @@ Throw "This command has been renamed to 'Assert-VerifiableMock' (without the 's'
 & $script:SafeCommands['Export-ModuleMember'] Get-MockDynamicParameter, Set-DynamicParameterVariable
 & $script:SafeCommands['Export-ModuleMember'] SafeGetCommand, New-PesterOption
 & $script:SafeCommands['Export-ModuleMember'] Invoke-Gherkin, Find-GherkinStep, BeforeEachFeature, BeforeEachScenario, AfterEachFeature, AfterEachScenario, GherkinStep -Alias Given, When, Then, And, But
-& $script:SafeCommands['Export-ModuleMember'] New-MockObject, Add-AssertionOperator
+& $script:SafeCommands['Export-ModuleMember'] New-MockObject, Add-AssertionOperator, Show-PesterAssertion

--- a/en-US/about_Should.help.txt
+++ b/en-US/about_Should.help.txt
@@ -73,7 +73,6 @@ SHOULD MEMBERS
         $actual | Should -BeLike "not actual *" # Test will fail
 
     BeLikeExactly
-
         Asserts that the actual value matches a wildcard pattern using PowerShell's -like operator.  This comparison is case-sensitive.
 
         $actual="Actual value"
@@ -198,20 +197,29 @@ SHOULD MEMBERS
 
         Get-Process -Name "process" -ErrorAction Stop | Should -Throw # Should pass, but the exception thrown by Get-Process causes the test to fail.
 
-  NEGATIVE ASSERTIONS
-    Any of the Should operators described above can be negated by using the word "Not" before the operator.  For example:
+  NEGATIVE
+    Not
+        Any of the Should operators described above can be negated by using the word "Not" before the operator.  For example:
 
-    'one' | Should -Not -Be 'Two'
-    { Get-Item $env:SystemRoot } | Should -Not -Throw
+        'one' | Should -Not -Be 'Two'
+        { Get-Item $env:SystemRoot } | Should -Not -Throw
+
+  BECAUSE
+    Because
+        Every built in assertion allows you to specify -Because parameter, to give more meaning to your tests.
+
+        function Get-Group { $null }
+        $groups = 1..10 | Get-Group -Size 3
+        $groups | Should -HaveCount 4 -Because "because 10 items are split into three groups with 3 members and one extra group with 1 member"
+
+        Which fails with: "Expected a collection with size {4}, because 10 items are split into three groups with 3 members and one extra group with 1 member, but got collection with size {1} [].
 
   USING SHOULD IN A TEST
-
     function Add-Numbers($a, $b) {
         return $a + $b
     }
 
     Describe "Add-Numbers" {
-
         It "adds positive numbers" {
             $sum = Add-Numbers 2 3
             $sum | Should -Be 3
@@ -219,15 +227,6 @@ SHOULD MEMBERS
     }
 
     This test will fail since 3 will not be equal to the sum of 2 and 3.
-
-  BECAUSE
-    Every built in assertion allows you to specify -Because parameter, to give more meaning to your tests.
-
-    function Get-Group { $null }
-    $groups = 1..10 | Get-Group -Size 3
-    $groups | Should -HaveCount 4 -Because "because 10 items are split into three groups with 3 members and one extra group with 1 member"
-
-    Which fails with: "Expected a collection with size {4}, because 10 items are split into three groups with 3 members and one extra group with 1 member, but got collection with size {1} [].
 
 SEE ALSO
   Describe


### PR DESCRIPTION
This PR would add a new function, `Show-PesterAssertion`, in an attempt to improve discoverability of Should parameter assertions. All it does is parse `about_Should.help.txt` to return options in a summarized format for users.

Resolves #878. Headed over there now to post a few more technical details, and to further explain the pros and cons of solving the problem this way.

My feelings will definitely not be hurt if you reject this PR. 🙂 If you'd like to move forward with it, I'm happy to write up some unit tests for the function. It felt extra ridiculous to work on the tests for this ahead of time.