### PR TITLE
Allow assertions with multiple aliases

### DIFF
--- a/Pester.Tests.ps1
+++ b/Pester.Tests.ps1
@@ -353,6 +353,10 @@ Describe 'Assertion operators' {
 
         { Add-AssertionOperator -Name SameNameAndScriptAndAlias -Test {$true} -Alias SameAlias } | Should -Not -Throw
     }
+    It 'Allows an operator to be registered with multiple aliases' {
+        function MultipleAlias {$true}
+        Add-AssertionOperator -Name MultipleAlias -Test $Function:MultipleAlias -Alias mult, multiple
+    }
     It 'Does not allow an operator with a different test to be registered using an existing name' {
         function DifferentScriptBlockA {$true}
         function DifferentScriptBlockB {$false}

--- a/Pester.Tests.ps1
+++ b/Pester.Tests.ps1
@@ -356,6 +356,8 @@ Describe 'Assertion operators' {
     It 'Allows an operator to be registered with multiple aliases' {
         function MultipleAlias {$true}
         Add-AssertionOperator -Name MultipleAlias -Test $Function:MultipleAlias -Alias mult, multiple
+        
+        {Add-AssertionOperator -Name MultipleAlias -Test $Function:MultipleAlias -Alias mult, multiple} | Should -Not -Throw
     }
     It 'Does not allow an operator with a different test to be registered using an existing name' {
         function DifferentScriptBlockA {$true}

--- a/Pester.psm1
+++ b/Pester.psm1
@@ -145,7 +145,7 @@ function Assert-ValidAssertionName
 
 function Assert-ValidAssertionAlias
 {
-    param([string]$Alias)
+    param([string[]]$Alias)
     if ($Alias -notmatch '^\S+$')
     {
         throw "Assertion alias '$string' is invalid, assertion alias must be a single word."


### PR DESCRIPTION
`Add-AssertionOperator` intends to allow multiple aliases [[see here](https://github.com/pester/Pester/blob/517f40c90f013e3d042d8845c68444c4c8728eb2/Pester.psm1#L212)], but a bug with a private validation function prevents that behavior.

This PR is a bugfix for `Assert-ValidAssertionAlias`, and adds one test to ensure future adherence.