### PR TITLE
Take only the first instance of the id and uname utilities.

### DIFF
--- a/Pester.psm1
+++ b/Pester.psm1
@@ -102,10 +102,10 @@ elseif ( Get-command -ea SilentlyContinue Get-WmiObject )
 }
 elseif ( Get-Command -ea SilentlyContinue uname -Type Application )
 {
-    $script:SafeCommands['uname'] = Get-Command -Name uname -Type Application
+    $script:SafeCommands['uname'] = Get-Command -Name uname -Type Application | Select-Object -First 1
     if ( Get-Command -ea SilentlyContinue id -Type Application )
     {
-        $script:SafeCommands['id'] = Get-Command -Name id -Type Application
+        $script:SafeCommands['id'] = Get-Command -Name id -Type Application | Select-Object -First 1
     }
 }
 else


### PR DESCRIPTION

## 1. General summary of the pull request

Some *nix's have symbolic links such as /bin -> /usr/bin which cause Get-Command to retrieve multiple instances. This causes the module to not load on those systems.

The ubuntu* releases don't seem to do this, but CentOS, for example, has `/bin` as a symlink to `/usr/bin` which causes the problem.