### PR TITLE
Fix for #1119 in single column tables in Gherkin feature files

### DIFF
--- a/Functions/Gherkin.Tests.ps1
+++ b/Functions/Gherkin.Tests.ps1
@@ -182,7 +182,7 @@ Scenario: The test data should be converted properly
 
                 # resolve the full name to the temporary feature file because gherkin doesn't support PSDrive paths
                 $testDrive = (Get-PSDrive -Name "TestDrive").Root
-                $featureFile = Join-Path -Path $testDrive -ChildPath "singlecolumn.feature"
+                $featureFile = Join-Path -Path $testDrive -ChildPath "multicolumn.feature"
 
                 # write the temporary feature file that we're going to parse
                 Set-Content -Path $featureFile -Value @'

--- a/Functions/Gherkin.Tests.ps1
+++ b/Functions/Gherkin.Tests.ps1
@@ -169,6 +169,7 @@ Scenario: The test data should be converted properly
                 $actualTable.Length | Should -Be $expectedTable.Length;
                 for( $i = 0; $i -lt $expectedTable.Length; $i++ )
                 {
+                    $expectedTable[$i].Keys.Length | Should -Be $actualTable[$i].Keys.Length;
                     foreach( $key in $expectedTable[$i].Keys )
                     {
                         $key | Should -BeIn $actualTable[$i].Keys;
@@ -219,6 +220,7 @@ Scenario: The test data should be converted properly
                 $actualTable.Length | Should -Be $expectedTable.Length;
                 for( $i = 0; $i -lt $expectedTable.Length; $i++ )
                 {
+                    $expectedTable[$i].Keys.Length | Should -Be $actualTable[$i].Keys.Length;
                     foreach( $key in $expectedTable[$i].Keys )
                     {
                         $key | Should -BeIn $actualTable[$i].Keys;

--- a/Functions/Gherkin.Tests.ps1
+++ b/Functions/Gherkin.Tests.ps1
@@ -124,7 +124,7 @@ Describe "Mocking works in Gherkin" -Tag Gherkin {
 
 InModuleScope "Pester" {
 
-    Describe "Get-StepParameters" {
+    Describe "Get-StepParameters" -Tag Gherkin {
 
         Context "Converts data in feature file steps" {
 

--- a/Functions/Gherkin.Tests.ps1
+++ b/Functions/Gherkin.Tests.ps1
@@ -169,7 +169,7 @@ Scenario: The test data should be converted properly
                 $actualTable.Length | Should -Be $expectedTable.Length;
                 for( $i = 0; $i -lt $expectedTable.Length; $i++ )
                 {
-                    $expectedTable[$i].Keys.Length | Should -Be $actualTable[$i].Keys.Length;
+                    $expectedTable[$i].Keys.Count | Should -Be $actualTable[$i].Keys.Count;
                     foreach( $key in $expectedTable[$i].Keys )
                     {
                         $key | Should -BeIn $actualTable[$i].Keys;
@@ -220,7 +220,7 @@ Scenario: The test data should be converted properly
                 $actualTable.Length | Should -Be $expectedTable.Length;
                 for( $i = 0; $i -lt $expectedTable.Length; $i++ )
                 {
-                    $expectedTable[$i].Keys.Length | Should -Be $actualTable[$i].Keys.Length;
+                    $expectedTable[$i].Keys.Count | Should -Be $actualTable[$i].Keys.Count;
                     foreach( $key in $expectedTable[$i].Keys )
                     {
                         $key | Should -BeIn $actualTable[$i].Keys;

--- a/Functions/Gherkin.ps1
+++ b/Functions/Gherkin.ps1
@@ -406,6 +406,13 @@ function Import-GherkinFeature {
             }
         }
 
+# temporary logging to debug build failures
+write-host ($null -eq $Scenario)
+write-host ($Scenario.GetType().FullName)
+write-host ($Scenario | gm | ft | out-string)
+write-host (gwmi win32_operatingsystem | fl * | out-string)
+write-host ($PSVersionTable | ft | out-string)
+
         if ($Scenario.Examples) {
             foreach ($ExampleSet in $Scenario.Examples) {
                 ${Column Names} = @($ExampleSet.TableHeader.Cells | & $SafeCommands["Select-Object"] -ExpandProperty Value)

--- a/Functions/Gherkin.ps1
+++ b/Functions/Gherkin.ps1
@@ -833,8 +833,8 @@ function ConvertTo-HashTableArray {
             ${Column Names} = @(${InputObject Header}.Cells | & $SafeCommands["Select-Object"] -ExpandProperty Value)
         }
 
-        & $SafeCommands["Write-Verbose"] "Processing $(${InputObject Rows}.Length) Rows"
         if( $null -ne ${InputObject Rows} ) {
+            & $SafeCommands["Write-Verbose"] "Processing $(${InputObject Rows}.Length) Rows"
             foreach (${InputObject row} in ${InputObject Rows}) {
                 ${Pester Result} = @{}
                 for ($n = 0; $n -lt ${Column Names}.Length; $n++) {

--- a/Functions/Gherkin.ps1
+++ b/Functions/Gherkin.ps1
@@ -830,7 +830,7 @@ function ConvertTo-HashTableArray {
         if (!${Column Names}) {
             & $SafeCommands["Write-Verbose"] "Reading Names from Header"
             ${InputObject Header}, ${InputObject Rows} = ${InputObject Rows}
-            ${Column Names} = ${InputObject Header}.Cells | & $SafeCommands["Select-Object"] -ExpandProperty Value
+            ${Column Names} = @(${InputObject Header}.Cells | & $SafeCommands["Select-Object"] -ExpandProperty Value)
         }
 
         & $SafeCommands["Write-Verbose"] "Processing $(${InputObject Rows}.Length) Rows"

--- a/Functions/Gherkin.ps1
+++ b/Functions/Gherkin.ps1
@@ -834,12 +834,14 @@ function ConvertTo-HashTableArray {
         }
 
         & $SafeCommands["Write-Verbose"] "Processing $(${InputObject Rows}.Length) Rows"
-        foreach (${InputObject row} in ${InputObject Rows}) {
-            ${Pester Result} = @{}
-            for ($n = 0; $n -lt ${Column Names}.Length; $n++) {
-                ${Pester Result}.Add(${Column Names}[$n], ${InputObject row}.Cells[$n].Value)
+        if( $null -ne ${InputObject Rows} ) {
+            foreach (${InputObject row} in ${InputObject Rows}) {
+                ${Pester Result} = @{}
+                for ($n = 0; $n -lt ${Column Names}.Length; $n++) {
+                    ${Pester Result}.Add(${Column Names}[$n], ${InputObject row}.Cells[$n].Value)
+                }
+                ${Result Table} += @(${Pester Result})
             }
-            ${Result Table} += @(${Pester Result})
         }
     }
     end {

--- a/Functions/Gherkin.ps1
+++ b/Functions/Gherkin.ps1
@@ -406,16 +406,6 @@ function Import-GherkinFeature {
             }
         }
 
-# temporary logging to debug build failures
-write-host ($null -eq $Scenario)
-write-host ($Scenario.GetType().FullName)
-write-host ($Scenario | gm | ft | out-string)
-if( $null -eq (get-command "gwmi" -ea silentlycontinue))
-{
-    write-host (gwmi win32_operatingsystem | fl * | out-string)
-}
-write-host ($PSVersionTable | ft | out-string)
-
         if ($Scenario.Examples) {
             foreach ($ExampleSet in $Scenario.Examples) {
                 ${Column Names} = @($ExampleSet.TableHeader.Cells | & $SafeCommands["Select-Object"] -ExpandProperty Value)

--- a/Functions/Gherkin.ps1
+++ b/Functions/Gherkin.ps1
@@ -406,7 +406,7 @@ function Import-GherkinFeature {
             }
         }
 
-        if ($Scenario.Examples) {
+        if( $Scenario -is [Gherkin.Ast.ScenarioOutline] ) {
             foreach ($ExampleSet in $Scenario.Examples) {
                 ${Column Names} = @($ExampleSet.TableHeader.Cells | & $SafeCommands["Select-Object"] -ExpandProperty Value)
                 $NamesPattern = "<(?:" + (${Column Names} -join "|") + ")>"

--- a/Functions/Gherkin.ps1
+++ b/Functions/Gherkin.ps1
@@ -410,7 +410,10 @@ function Import-GherkinFeature {
 write-host ($null -eq $Scenario)
 write-host ($Scenario.GetType().FullName)
 write-host ($Scenario | gm | ft | out-string)
-write-host (gwmi win32_operatingsystem | fl * | out-string)
+if( $null -eq (get-command "gwmi" -ea silentlycontinue))
+{
+    write-host (gwmi win32_operatingsystem | fl * | out-string)
+}
 write-host ($PSVersionTable | ft | out-string)
 
         if ($Scenario.Examples) {


### PR DESCRIPTION
Added some tests to reproduce issue #1119, and then applied a fix.

The tests are a bit long and awkward because they have to do a lot of work to arrange the test (write a temporary feature file, use Gherkin to parse it, *then* call the function under test), and I also couldn't find an easy way to compare two arrays of hashtables so the test has to walk the structure piecemeal. Any thoughts welcome about how to improve this.

Cheers,

Mike