### PR TITLE
Don't run Pester version tests on forks

### DIFF
--- a/Pester.Tests.ps1
+++ b/Pester.Tests.ps1
@@ -44,41 +44,41 @@ Describe -Tags 'VersionChecks' "Pester manifest and changelog" {
             $script:tagVersion                  | Should -Not -BeNullOrEmpty
             $script:tagVersionShort -as [Version]    | Should -Not -BeNullOrEmpty
         }
-    }
 
-    It "has valid release notes in the manifest" {
-        $script:manifest.PrivateData.PSData.ReleaseNotes | Should -Be "https://github.com/pester/Pester/releases/tag/$script:tagVersion"
+        It "has valid release notes in the manifest" -skip:$skipVersionTest {
+            $script:manifest.PrivateData.PSData.ReleaseNotes | Should -Be "https://github.com/pester/Pester/releases/tag/$script:tagVersion"
+        }
+
+        It "tag and changelog versions are the same" -skip:$skipVersionTest {
+
+            foreach ($line in (Get-Content $changeLogPath))
+            {
+                if ($line -match "^\s*##\s+(?<Version>.*?)\s")
+                {
+                    $script:changelogVersion = $matches.Version
+                    $script:changelogVersionShort = $script:changelogVersion -replace "-.*$", ''
+                    break
+                }
+            }
+
+            $script:changelogVersion      | Should -Be $script:tagVersion
+            $script:changelogVersionShort | Should -Be $script:tagVersionShort
+        }
+
+        It "tag and changelog versions are the same" -skip:$skipVersionTest {
+            $script:changelogVersion | Should -Be $script:tagVersion
+        }
+
+        It "all short versions are the same" -skip:$skipVersionTest {
+            $script:changelogVersionShort -as [Version] | Should -Be ( $script:manifest.Version -as [Version] )
+            $script:manifest.Version -as [Version] | Should -Be ( $script:tagVersionShort -as [Version] )
+        }
     }
 
     It "has valid pre-release suffix in manifest (empty for stable version)" {
         # might be empty or null, as well as the tagPrerelase. we need empty string to eq $null but not to eq any other value
         $prereleaseFromManifest = $script:manifest.PrivateData.PSData.Prerelease | where {$_}
         $prereleaseFromManifest | Should -Be $script:tagPrerelease
-    }
-
-    It "tag and changelog versions are the same" {
-
-        foreach ($line in (Get-Content $changeLogPath))
-        {
-            if ($line -match "^\s*##\s+(?<Version>.*?)\s")
-            {
-                $script:changelogVersion = $matches.Version
-                $script:changelogVersionShort = $script:changelogVersion -replace "-.*$", ''
-                break
-            }
-        }
-
-        $script:changelogVersion      | Should -Be $script:tagVersion
-        $script:changelogVersionShort | Should -Be $script:tagVersionShort
-    }
-
-    It "tag and changelog versions are the same" {
-        $script:changelogVersion | Should -Be $script:tagVersion
-    }
-
-    It "all short versions are the same" -skip:$skipVersionTest {
-        $script:changelogVersionShort -as [Version] | Should -Be ( $script:manifest.Version -as [Version] )
-        $script:manifest.Version -as [Version] | Should -Be ( $script:tagVersionShort -as [Version] )
     }
 }
 


### PR DESCRIPTION
## 1. General summary of the pull request

I had a PR build fail due to an unrelated unit test failing. But, just
to be sure, I checked out my branch locally and ran the entire test
suite starting at the root.

Lo and behold, I had some failing tests--but all due to ensuring that
the correct module manifest version is being found. I also found that at
least one test was skipped if the git remote did not contain 'github.com/Pester/'.

It seems to me that the other tests in the same area of the suite which
also check module versioning information should also not run if the
current git repository is a fork.

This commit moves those tests inside the `if` statement which checks
whether or not the current git repository is the official Pester
repository, or whether or not it's a fork.

After this change, the test suite ran to completion with no failures.