### PR TITLE
WIP: Fix #1124 pester does not print doc strings or data tables

### DIFF
--- a/Examples/Gherkin/Gherkin-ScenarioData.feature
+++ b/Examples/Gherkin/Gherkin-ScenarioData.feature
@@ -1,0 +1,38 @@
+Feature: Pester displays scenario data in the console
+
+  Scenario: Pester outputs the DocString content when writing Pester step results
+
+    Given the following DocString:
+      """
+      This is an example Gherkin DocString
+      that should be displayed underneath the
+      step definition when the step is
+      printed to the console during the test run.
+      """
+     When this scenario is run
+     Then the DocString is displayed in the console
+
+  Scenario: Pester outputs step definition table content when writing Pester step results
+
+    Given a square data table:
+      | fruit  | vegetable       |
+      | apple  | cucumber        |
+      | banana | brussel sprouts |
+    And a rectangular data table:
+      | x | y | result |
+      | 1 | 1 | 2      |
+      | 2 | 2 | 4      |
+    And a single column data table:
+      | PropNames                                   |
+      | ModuleVersion                               |
+      | GUID                                        |
+      | Author                                      |
+      | CompanyName                                 |
+      | Copyright                                   |
+      | Description                                 |
+      | PrivateData.PSData.ProjectUri               |
+      | PrivateData.PSData.RequireLicenseAcceptance |
+      | PrivateData.PSData.ReleaseNotes             |
+      | PrivateData.PSData.Tags                     |
+    When this scenario is run
+    Then the tables are displayed correctly in the console

--- a/Examples/Gherkin/ScenarioData.Steps.ps1
+++ b/Examples/Gherkin/ScenarioData.Steps.ps1
@@ -1,0 +1,12 @@
+Given "the following DocString:?" {
+    param([string]$DocString)
+
+    $DocString | Should -Not -BeNull
+}
+
+When "this scenario is run" { }
+
+Then "the DocString is displayed in the console" { }
+
+GherkinStep "a (square|rectangular|single column) data table:?" { param($table) }
+Then "the tables are displayed correctly in the console" { }

--- a/Functions/Gherkin.Tests.ps1
+++ b/Functions/Gherkin.Tests.ps1
@@ -676,5 +676,40 @@ Describe "A generated NUnit report" -Tag Gherkin {
         Get-XmlInnerText "($scenario5Examples3cStepsXPath)[2]/reason/message" | Should -Be "Could not find implementation for step!"
         Get-XmlInnerText "($scenario5Examples3cStepsXPath)[3]/reason/message" | Should -Be "Could not find implementation for step!"
     }
+}
 
+Describe "Tables and DocStrings are displayed in the console" -Tag Gherkin {
+    # Calling this in a job so we don't monkey with the active pester state that's already running
+    $job = Start-Job -ArgumentList $scriptRoot -ScriptBlock {
+        param ($scriptRoot)
+        Get-Module Pester | Remove-Module -Force
+        Import-Module $scriptRoot\Pester.psd1 -Force
+
+        New-Object psobject -Property @{
+            Results = Invoke-Gherkin (Join-Path $scriptRoot Examples\Gherkin\Gherkin-ScenarioData.feature) -PassThru -Show None
+        }
+
+        InModuleScope Pester {
+            $Feature, $Background, $Scenarios = Import-GherkinFeature -Path (Join-Path $scriptRoot Examples\Gherkin\Gherkin-ScenarioData.feature)
+            $Scenarios | ForEach-Object { @{ Scenario = $_.Name; Steps = @($_.Steps | ForEach-Object { "{0} {1}" -f $_.Keyword, $_.Text }) } }
+        }
+    }
+
+    $gherkin, $ScenarioSteps = $job | Wait-Job | Receive-Job
+    Remove-Job $job
+
+    It 'Should show Step Definition DocStrings' {
+        $gherkin.Results.TestResult[0].Name | Should -Be $ScenarioSteps[0].Steps[0]
+    }
+
+
+    It 'Should show Step Definition Tables' {
+        $SquareTable = $ScenarioSteps[1].Steps[0]
+        $RectangularTable = $ScenarioSteps[1].Steps[1]
+        $SingleColumnTable = $ScenarioSteps[1].Steps[2]
+
+        $gherkin.Results.TestResult[($ScenarioSteps[0].Steps.Count)].Name | Should -Be $SquareTable
+        $gherkin.Results.TestResult[($ScenarioSteps[0].Steps.Count + 1)].Name | Should -Be $RectangularTable
+        $gherkin.Results.TestResult[($ScenarioSteps[0].Steps.Count + 2)].Name | Should -Be $SingleColumnTable
+    }
 }

--- a/Functions/Gherkin.ps1
+++ b/Functions/Gherkin.ps1
@@ -134,6 +134,10 @@ function Invoke-Gherkin {
             This parameter does not affect the PassThru custom object or the XML output that
             is written when you use the Output parameters.
 
+        .PARAMETER HideStepData
+            Controls whether or not Step Definition tables or DocStrings are printed to the console
+            during the test run.
+
         .PARAMETER PassThru
             Returns a custom object (PSCustomObject) that contains the test results.
             By default, Invoke-Gherkin writes to the host program, not to the output stream (stdout).
@@ -218,6 +222,8 @@ function Invoke-Gherkin {
 
         [Pester.OutputTypes]$Show = 'All',
 
+        [Switch]$HideStepData,
+
         [switch]$PassThru
     )
     begin {
@@ -282,7 +288,7 @@ function Invoke-Gherkin {
         Enter-CoverageAnalysis -CodeCoverage $CodeCoverage -PesterState $pester
 
         foreach ($FeatureFile in & $SafeCommands["Get-ChildItem"] $Path -Filter "*.feature" -Recurse ) {
-            Invoke-GherkinFeature $FeatureFile -Pester $pester
+            Invoke-GherkinFeature $FeatureFile -Pester $pester -HideStepData:$HideStepData
         }
 
         # Remove all the steps
@@ -378,9 +384,14 @@ function Import-GherkinFeature {
 
         .PARAMETER Pester
             Internal Pester object. For internal use only
+
+        .PARAMETER HideStepData
+            Controls whether or not Step Definition text includes DocStrings or Tables.
+            If this parameter is set, then DocStrings or tables will not be appended to
+            Step Definition text and will not be output to the console.
     #>
     [CmdletBinding()]
-    param($Path, [PSObject]$Pester)
+    param($Path, [PSObject]$Pester, [Switch]$HideStepData)
     $Background = $null
 
     $parser = & $SafeCommands["New-Object"] Gherkin.Parser
@@ -443,8 +454,58 @@ function Import-GherkinFeature {
                     & $SafeCommands["New-Object"] Gherkin.Ast.Scenario $ExampleSet.Tags, $Scenario.Location, $Scenario.Keyword.Trim(), $ScenarioName, $Scenario.Description, $Steps | Convert-Tags $Scenario.Tags
                 }
             }
-        } else {
+        } elseif ($HideStepData) {
             $Scenario
+        } else {
+            $Steps = foreach ($Step in $Scenario.Steps) {
+                [string]$StepText = $Step.Text
+                if ($Step.Argument -is [Gherkin.Ast.DocString]) {
+                    $StepText += "$([Environment]::NewLine)  `"`"`"$([Environment]::NewLine) $(foreach ($str in ($Step.Argument.Content -split [Environment]::NewLine)) { " $str$([Environment]::NewLine)" })  `"`"`""
+                }
+                if ($Step.Argument -is [Gherkin.Ast.DataTable]) {
+                    $table = $Step.Argument.Rows |
+                        & $SafeCommands['ForEach-Object'] { ,@($_ |
+                        & $SafeCommands['Select-Object'] -ExpandProperty Cells |
+                        & $SafeCommands['Select-Object'] -ExpandProperty Value) }
+
+                    if ($Step.Argument.Rows[0].Cells.Length -gt 1) {
+                        $transposedTable = for ($i = $table[0].Length - 1; $i -ge 0; $i--) {
+                            ,@(for ($j = 0; $j -lt $table.Length; $j++) {
+                                $table[$j][$i]
+                            })
+                        }
+
+                        [Array]::Reverse($transposedTable)
+                        $cellWidths = $transposedTable |
+                            & $SafeCommands['ForEach-Object'] { $_ |
+                            & $SafeCommands['Measure-Object'] -Property Length -Maximum |
+                            & $SafeCommands['Select-Object'] -ExpandProperty Maximum }
+                    } else {
+                        $cellWidths = @($table |
+                            & $SafeCommands['ForEach-Object'] { $_ } |
+                            & $SafeCommands['Measure-Object'] -Property Length -Maximum |
+                            & $SafeCommands['Select-Object'] -ExpandProperty Maximum)
+                    }
+
+                    $tableText = ""
+                    foreach ($row in $Step.Argument.Rows) {
+                        $rowText = "  |"
+                        for ($j = 0; $j -lt $row.Cells.Length; $j++) {
+                            $rowText += " {0,$(-$cellWidths[$j])} |" -f $row.Cells[$j].Value
+                        }
+
+                        $tableText += "$([Environment]::NewLine)$rowText"
+                    }
+
+                    $StepText += "$($tableText.TrimEnd())"
+                }
+                if ($StepText -ne $Step.Text) {
+                    & $SafeCommands["New-Object"] Gherkin.Ast.Step $Step.Location, $Step.Keyword.Trim(), $StepText, $Step.Argument
+                } else {
+                    $Step
+                }
+            }
+            & $SafeCommands["New-Object"] Gherkin.Ast.Scenario $null, $Scenario.Location, $Scenario.Keyword.Trim(), $Scenario.Name, $Scenario.Description, $Steps | Convert-Tags $Scenario.Tags
         }
     }
     )
@@ -464,7 +525,8 @@ function Invoke-GherkinFeature {
         [Parameter(Mandatory = $True, Position = 0, ValueFromPipelineByPropertyName = $True)]
         [IO.FileInfo]$FeatureFile,
 
-        [PSObject]$Pester
+        [PSObject]$Pester,
+        [Switch]$HideStepData
     )
     # Make sure broken tests don't leave you in space:
     $CWD = [Environment]::CurrentDirectory
@@ -474,7 +536,7 @@ function Invoke-GherkinFeature {
     try {
         $Parent = & $SafeCommands["Split-Path"] $FeatureFile.FullName
         Import-GherkinSteps -StepPath $Parent -Pester $pester
-        $Feature, $Background, $Scenarios = Import-GherkinFeature -Path $FeatureFile.FullName -Pester $Pester
+        $Feature, $Background, $Scenarios = Import-GherkinFeature -Path $FeatureFile.FullName -Pester $Pester -HideStepData:$HideStepData
     } catch [Gherkin.ParserException] {
         & $SafeCommands["Write-Error"] -Exception $_.Exception -Message "Skipped '$($FeatureFile.FullName)' because of parser error.`n$(($_.Exception.Errors | & $SafeCommands["Select-Object"] -Expand Message) -join "`n`n")"
         continue
@@ -709,7 +771,8 @@ function Invoke-GherkinStep {
         #  Pick the match with the least grouping wildcards in it...
         $StepCommand = $(
             foreach ($StepCommand in $Script:GherkinSteps.Keys) {
-                if ($Step.Text -match "^${StepCommand}$") {
+                $StepText = $Step.Text -split [Environment]::NewLine | & $SafeCommands["Select-Object"] -First 1
+                if ($StepText -match "^${StepCommand}$") {
                     $StepCommand | & $SafeCommands["Add-Member"] -MemberType NoteProperty -Name MatchCount -Value $Matches.Count -PassThru
                 }
             }
@@ -739,9 +802,6 @@ function Invoke-GherkinStep {
                 # Invoke-GherkinHook BeforeStep $Step.Text $Step.Tags
 
                 if ($NamedArguments.Count) {
-                    if ($NamedArguments.ContainsKey("Table")) {
-                        $DisplayText += "..."
-                    }
                     $ScriptBlock = { . $Script:GherkinSteps.$StepCommand @NamedArguments @Parameters }
                 } else {
                     $ScriptBlock = { . $Script:GherkinSteps.$StepCommand @Parameters }

--- a/Functions/Output.ps1
+++ b/Functions/Output.ps1
@@ -245,14 +245,28 @@ function Write-PesterResult {
             switch ($TestResult.Result)
             {
                 Passed {
-                    & $SafeCommands['Write-Host'] -ForegroundColor $ReportTheme.Pass "$margin[+] $output" -NoNewLine
-                    & $SafeCommands['Write-Host'] -ForegroundColor $ReportTheme.PassTime " $humanTime"
+                    $outputLines = $output -split [Environment]::NewLine
+                    for ($n = 0; $n -lt $outputLines.Length; $n++) {
+                        if ($n) {
+                            & $SafeCommands['Write-Host'] -ForegroundColor $ReportTheme.Pass "$margin$margin$($outputLines[$n])"
+                        } else {
+                            & $SafeCommands['Write-Host'] -ForegroundColor $ReportTheme.Pass "$margin[+] $($outputLines[0]) " -NoNewLine
+                            & $SafeCommands['Write-Host'] -ForegroundColor $ReportTheme.PassTime $humanTime
+                        }
+                    }
                     break
                 }
 
                 Failed {
-                    & $SafeCommands['Write-Host'] -ForegroundColor $ReportTheme.Fail "$margin[-] $output" -NoNewLine
-                    & $SafeCommands['Write-Host'] -ForegroundColor $ReportTheme.FailTime " $humanTime"
+                    $outputLines = $output -split [Environment]::NewLine
+                    for ($n = 0; $n -lt $outputLines.Length; $n++) {
+                        if ($n) {
+                            & $SafeCommands['Write-Host'] -ForegroundColor $ReportTheme.Fail "$margin$margin$($outputLines[$n])"
+                        } else {
+                            & $SafeCommands['Write-Host'] -ForegroundColor $ReportTheme.Fail "$margin[-] $($outputLines[0]) " -NoNewLine
+                            & $SafeCommands['Write-Host'] -ForegroundColor $ReportTheme.FailTime $humanTime
+                        }
+                    }
 
                     if($pester.IncludeVSCodeMarker) {
                         & $SafeCommands['Write-Host'] -ForegroundColor $ReportTheme.Fail $($TestResult.StackTrace -replace '(?m)^',$error_margin)
@@ -269,25 +283,50 @@ function Write-PesterResult {
 
                 Skipped {
                     $because = if ($testresult.ErrorRecord.TargetObject.Data.Because) { ", because $($testresult.ErrorRecord.TargetObject.Data.Because)"} else { $null }
-                    & $SafeCommands['Write-Host'] -ForegroundColor $ReportTheme.Skipped "$margin[!] $output" -NoNewLine
-                    & $SafeCommands['Write-Host'] -ForegroundColor $ReportTheme.Skipped ", is skipped$because" -NoNewLine
-                    & $SafeCommands['Write-Host'] -ForegroundColor $ReportTheme.SkippedTime " $humanTime"
+                    $outputLines = $output -split [Environment]::NewLine
+                    for ($n = 0; $n -lt $outputLines.Length; $n++) {
+                        if ($n) {
+                            & $SafeCommands['Write-Host'] -ForegroundColor $ReportTheme.Skipped "$margin$margin$($outputLines[$n])"
+                            & $SafeCommands['Write-Host'] -ForegroundColor $ReportTheme.Skipped ", is skipped$because" -NoNewLine
+                        } else {
+                            & $SafeCommands['Write-Host'] -ForegroundColor $ReportTheme.Skipped "$margin[!] $($outputLines[0]) " -NoNewLine
+                            & $SafeCommands['Write-Host'] -ForegroundColor $ReportTheme.SkippedTime $humanTime
+                        }
+                    }
                     break
                 }
 
                 Pending {
                     $because = if ($testresult.ErrorRecord.TargetObject.Data.Because) { ", because $($testresult.ErrorRecord.TargetObject.Data.Because)"} else { $null }
-                    & $SafeCommands['Write-Host'] -ForegroundColor $ReportTheme.Pending "$margin[?] $output" -NoNewLine
-                    & $SafeCommands['Write-Host'] -ForegroundColor $ReportTheme.Pending ", is pending$because" -NoNewLine
-                    & $SafeCommands['Write-Host'] -ForegroundColor $ReportTheme.PendingTime " $humanTime"
+                    $outputLines = $output -split [Environment]::NewLine
+                    for ($n = 0; $n -lt $outputLines.Length; $n++) {
+                        if ($n) {
+                            & $SafeCommands['Write-Host'] -ForegroundColor $ReportTheme.Pending "$margin$margin$($outputLines[$n])"
+                            & $SafeCommands['Write-Host'] -ForegroundColor $ReportTheme.Pending ", is pending$because" -NoNewLine
+                        } else {
+                            & $SafeCommands['Write-Host'] -ForegroundColor $ReportTheme.Pending "$margin[?] $($outputLines[0]) " -NoNewLine
+                            & $SafeCommands['Write-Host'] -ForegroundColor $ReportTheme.PendingTime $humanTime
+                        }
+                    }
                     break
                 }
 
                 Inconclusive {
                     $because = if ($testresult.ErrorRecord.TargetObject.Data.Because) { ", because $($testresult.ErrorRecord.TargetObject.Data.Because)"} else { $null }
-                    & $SafeCommands['Write-Host'] -ForegroundColor $ReportTheme.Inconclusive "$margin[?] $output" -NoNewLine
-                    & $SafeCommands['Write-Host'] -ForegroundColor $ReportTheme.Inconclusive ", is inconclusive$because" -NoNewLine
-                    & $SafeCommands['Write-Host'] -ForegroundColor $ReportTheme.InconclusiveTime " $humanTime"
+                    $outputLines = $output -split [Environment]::NewLine
+                    for ($n = 0; $n -lt $outputLines.Length; $n++) {
+                        if ($n) {
+                            & $SafeCommands['Write-Host'] -ForegroundColor $ReportTheme.Inconclusive "$margin$margin$($outputLines[$n])"
+                            & $SafeCommands['Write-Host'] -ForegroundColor $ReportTheme.Inconclusive ", is inconclusive$because" -NoNewLine
+                        } else {
+                            & $SafeCommands['Write-Host'] -ForegroundColor $ReportTheme.Inconclusive "$margin[?] $($outputLines[0]) " -NoNewLine
+                            & $SafeCommands['Write-Host'] -ForegroundColor $ReportTheme.InconclusiveTime $humanTime
+                        }
+                    }
+
+                    if ($testresult.FailureMessage) {
+                        & $SafeCommands['Write-Host'] -ForegroundColor $ReportTheme.Inconclusive $($TestResult.failureMessage -replace '(?m)^',$error_margin)
+                    }
 
                     break
                 }


### PR DESCRIPTION
## 1. General summary of the pull request

Fixes #1124.

For Gherkin Step Definitions which have DocString or DataTable data, this data is now printed to the console by default. A new switch parameter has been added to `Invoke-Gherkin` called `HideStepData` which controls whether or not DocString/DataTable data is printed to the console: when enabled, this data is not printed. The default is for the data to be printed.
