### PR TITLE
Should: Use Generic.List[PSObject] instead of ArrayList for $inputArray

### DIFF
--- a/Functions/Assertions/Should.ps1
+++ b/Functions/Assertions/Should.ps1
@@ -96,7 +96,7 @@ function Should {
 
     begin
     {
-        $inputArray = New-Object System.Collections.ArrayList
+        $inputArray = New-Object System.Collections.Generic.List[PSObject]
 
         if ($PSCmdlet.ParameterSetName -eq 'Legacy')
         {
@@ -111,7 +111,7 @@ function Should {
 
     process
     {
-        $null = $inputArray.Add($ActualValue)
+        $inputArray.Add($ActualValue)
     }
 
     end


### PR DESCRIPTION
<!--

Thank you for contributing to Pester!

Before you continue, please review the article [Contributing to Pester](https://github.com/pester/Pester/wiki/Contributing-to-Pester) and [Development rules - technical](https://github.com/pester/Pester/wiki/Developement-rules---technical).

Our continues integration system doesn't send any notifications about failed tests. Please return to the opened pull request (after ~60 minutes) to check if is everything OK.

-->

## 1. General summary of the pull request

Refactor code slightly in `Should` command. [Documentation for ArrayList](https://docs.microsoft.com/en-us/dotnet/api/system.collections.arraylist?view=netframework-4.7.2#remarks) explicitly states that Generic.List[T] should be used instead:

> We don't recommend that you use the ArrayList class for new development. Instead, we recommend that you use the generic List&lt;T&gt; class.

This allows us to drop the `$null =` output-swallowing construct for part of the function, as `List[T]` does not emit output on `.Add()`.

Additionally, typing the List with `[PSObject]` avoids some extremely edge case problems that can occur with reboxing PSObjects that have instance members attached (such as those added via `Add-Member`).