### PR TITLE
Fix using [ScriptBlock]::Create with InModuleScope.

### DIFF
--- a/Functions/InModuleScope.Tests.ps1
+++ b/Functions/InModuleScope.Tests.ps1
@@ -40,13 +40,15 @@ Describe "Executing test code inside a module" {
         }
     }
 
-    It "Can use ScriptBlock inside the module scope" {
-        $ScriptBlockOne = { Write-Output "I am a ScriptBlockOne" }
-        $ScriptBlockTwoString = 'Write-Output "I am a ScriptBlockTwo"'
-        $ScriptBlockTwo = [ScriptBlock]::Create($ScriptBlockTwoString)
+    It "Can execute bound ScriptBlock inside the module scope" {
+        $ScriptBlock = { Write-Output "I am a bound ScriptBlock" }
+        InModuleScope TestModule $ScriptBlock | Should -BeExactly "I am a bound ScriptBlock"
+    }
 
-        InModuleScope TestModule $ScriptBlockOne | Should -BeExactly "I am a ScriptBlockOne"
-        InModuleScope TestModule $ScriptBlockTwo | Should -BeExactly "I am a ScriptBlockTwo"
+    It "Can execute unbound ScriptBlock inside the module scope" {
+        $ScriptBlockString = 'Write-Output "I am an unbound ScriptBlock"'
+        $ScriptBlock = [ScriptBlock]::Create($ScriptBlockString)
+        InModuleScope TestModule $ScriptBlock | Should -BeExactly "I am an unbound ScriptBlock"
     }
 
     Remove-Module TestModule -Force

--- a/Functions/InModuleScope.Tests.ps1
+++ b/Functions/InModuleScope.Tests.ps1
@@ -40,6 +40,15 @@ Describe "Executing test code inside a module" {
         }
     }
 
+    It "Can use ScriptBlock inside the module scope" {
+        $ScriptBlockOne = { Write-Output "I am a ScriptBlockOne" }
+        $ScriptBlockTwoString = 'Write-Output "I am a ScriptBlockTwo"'
+        $ScriptBlockTwo = [ScriptBlock]::Create($ScriptBlockTwoString)
+
+        InModuleScope TestModule $ScriptBlockOne | Should -BeExactly "I am a ScriptBlockOne"
+        InModuleScope TestModule $ScriptBlockTwo | Should -BeExactly "I am a ScriptBlockTwo"
+    }
+
     Remove-Module TestModule -Force
 }
 

--- a/Pester.psm1
+++ b/Pester.psm1
@@ -1066,6 +1066,7 @@ function Set-ScriptBlockScope
         $SessionState,
 
         [Parameter(Mandatory = $true, ParameterSetName = 'FromSessionStateInternal')]
+        [AllowNull()]
         $SessionStateInternal
     )
 


### PR DESCRIPTION
## 1. General summary of the pull request

We use **ScriptBlock** with **InModuleScope**.

Now we can use it like this:

```powershell
Describe "{}" {
    $ScriptBlock = {Write-Output -InputObject 'This is a ScriptBlock'}
    Import-Module -Name PowerShellGet
    InModuleScope -ModuleName PowerShellGet -ScriptBlock $ScriptBlock
}
```

the result is:
```powershell
Describing {}
```

But if we need to construct ScriptBlock dynamicly by using **[ScriptBlock]::Create** method
```powershell
Describe "[ScriptBlock]::Create" {
    $ScriptBlockText = "Write-Output -InputObject 'This is a ScriptBlock'"
    $ScriptBlock = [ScriptBlock]::Create($ScriptBlockText)
    Import-Module -Name PowerShellGet
    InModuleScope -ModuleName PowerShellGet -ScriptBlock $ScriptBlock
}
```

the result will be:

```powershell
Describing [ScriptBlock]::Create
  [-] Error occurred in Describe block 49ms
    ParameterBindingValidationException: Cannot bind argument to parameter 'SessionStateInternal' because it is null.
```

This is because, when InModuleScope function gets **$originalScriptBlockScope** of the ScriptBlock
https://github.com/pester/Pester/blob/5a53c46bc7704726e97ad747647dc711652edb96/Functions/InModuleScope.ps1#L74
the result will be $null.

It seems, that ScriptBlock created with Create method doesn't have **SessionStateInternal** property.
For example this code returns null:
```powershell
$ScriptBlockText = "Write-Output -InputObject 'This is a ScriptBlock'"
$ScriptBlock = [ScriptBlock]::Create($ScriptBlockText)
$flags = [System.Reflection.BindingFlags]'Instance,NonPublic'
[scriptblock].GetProperty('SessionStateInternal', $flags).GetValue($ScriptBlock, $null)
```

So, when InModuleScope function tries to return the **$originalScriptBlockScope** to the ScriptBlock
https://github.com/pester/Pester/blob/5a53c46bc7704726e97ad747647dc711652edb96/Functions/InModuleScope.ps1#L90
the **Set-ScriptBlockScope** throws an error, because **-SessionStateInternal** parameter cannot be null.

This PS allows **-SessionStateInternal** parameter to accept null, so that ScriptBlock will have its original SessionStateInternal back, even if it is $null.


<!--

Thank you for contributing to Pester!

Before you continue, please review the article [Contributing to Pester](https://github.com/pester/Pester/wiki/Contributing-to-Pester) and [Development rules - technical](https://github.com/pester/Pester/wiki/Developement-rules---technical).

Our continues integration system doesn't send any notifications about failed tests. Please return to the opened pull request (after ~60 minutes) to check if is everything OK.

-->


<!--

Please provide a descriptive title of the pull request in the field 'Title' too.

Please provide us information on how your pull request improves Pester or what fixes.

If your pull request integrate Pester with another system (e.g. a continues integration product) please provide instruction how the updated code can be tested.

If your pull request resolves the issue reported previously, please mention it by using `#<issue_number>` syntax.

Please remember about update [the Pester wiki](https://github.com/pester/Pester/wiki) too.

-->