### PR TITLE
Fix #1149: Correctly report number of found step files

### DIFF
--- a/Functions/Gherkin.ps1
+++ b/Functions/Gherkin.ps1
@@ -346,7 +346,9 @@ function Import-GherkinSteps {
         $Script:GherkinHooks.Clear()
     }
     process {
-        foreach ($StepFile in & $SafeCommands["Get-ChildItem"] $StepPath -Filter "*.?teps.ps1" -Include "*.[sS]teps.ps1" -Recurse) {
+        $StepFiles = & $SafeCommands["Get-ChildItem"] $StepPath -Filter "*.?teps.ps1" -Include "*.[sS]teps.ps1" -Recurse
+
+        foreach ($StepFile in $StepFiles) {
             $invokeTestScript = {
                 [CmdletBinding()]
                 param (


### PR DESCRIPTION
## 1. General summary of the pull request

Fixes #1149

It appears that at one point, there was a variable named $StepFiles and
it was used to report how many step files from which step definitions
were loaded when displaying Verbose output. At some later time,
$StepFiles was removed and inlined into the foreach loop.

This commit restores the $StepFiles intermediate variable so that the
proper verbose output is displayed.
