### PR TITLE
Better support of PowerShell classes in coverage

### DIFF
--- a/Functions/Coverage.Tests.ps1
+++ b/Functions/Coverage.Tests.ps1
@@ -6,9 +6,12 @@ InModuleScope Pester {
     Describe 'Code Coverage Analysis' {
         $root = (Get-PSDrive TestDrive).Root
 
-        $null = New-Item -Path $(Join-Path -Path $root -ChildPath TestScript.ps1) -ItemType File -ErrorAction SilentlyContinue
+        $testScriptPath = Join-Path -Path $root -ChildPath TestScript.ps1
+        $testScript2Path = Join-Path -Path $root -ChildPath TestScript2.ps1
 
-        Set-Content -Path $(Join-Path -Path $root -ChildPath TestScript.ps1) -Value @'
+        $null = New-Item -Path $testScriptPath -ItemType File -ErrorAction SilentlyContinue
+
+        Set-Content -Path $testScriptPath -Value @'
             function FunctionOne
             {
                 function NestedFunction
@@ -33,6 +36,14 @@ InModuleScope Pester {
                 'I am function two.  I never get called.'
             }
 
+            FunctionOne
+
+'@
+        # Classes have been introduced in PowerShell 5.0
+        if ($PSVersionTable.PSVersion.Major -ge 5)
+        {
+            Add-Content -Path $testScriptPath -Value @'
+
             class MyClass
             {
                 MyClass()
@@ -51,14 +62,43 @@ InModuleScope Pester {
                 }
             }
 
-            FunctionOne
-            [MyClass]::new().MethodOne()
+            $class = [MyClass]::new()
+            $class.MethodOne()
 
 '@
+        }
+        else
+        {
+            # Before that, let's just create equivalent commands to above class with exact same line numbers
+            Add-Content -Path $testScriptPath -Value @'
 
-        $null = New-Item -Path $(Join-Path -Path $root -ChildPath TestScript2.ps1) -ItemType File -ErrorAction SilentlyContinue
+            #class MyClass
+            #{
+                function MyClass
+                {
+                    'I am the constructor.'
+                }
 
-        Set-Content -Path $(Join-Path -Path $root -ChildPath TestScript2.ps1) -Value @'
+                function MethodOne
+                {
+                    'I am method one.'
+                }
+
+                function MethodTwo
+                {
+                    'I am method two. I never get called.'
+                }
+            #}
+
+            MyClass
+            MethodOne
+
+'@
+        }
+
+        $null = New-Item -Path $testScript2Path -ItemType File -ErrorAction SilentlyContinue
+
+        Set-Content -Path $testScript2Path -Value @'
             'Some {0} file' `
                 -f `
                 'other'
@@ -69,22 +109,22 @@ InModuleScope Pester {
             $testState = New-PesterState -Path $root
 
             # Path deliberately duplicated to make sure the code doesn't produce multiple breakpoints for the same commands
-            Enter-CoverageAnalysis -CodeCoverage "$(Join-Path -Path $root -ChildPath TestScript.ps1)", "$(Join-Path -Path $root -ChildPath TestScript.ps1)", "$(Join-Path -Path $root -ChildPath TestScript2.ps1)" -PesterState $testState
+            Enter-CoverageAnalysis -CodeCoverage $testScriptPath, $testScriptPath, $testScript2Path -PesterState $testState
 
             It 'Has the proper number of breakpoints defined' {
-                $testState.CommandCoverage.Count | Should -Be 16
+                $testState.CommandCoverage.Count | Should -Be 17
             }
 
-            $null = & "$(Join-Path -Path $root -ChildPath TestScript.ps1)"
-            $null = & "$(Join-Path -Path $root -ChildPath TestScript2.ps1)"
+            $null = & $testScriptPath
+            $null = & $testScript2Path
             $coverageReport = Get-CoverageReport -PesterState $testState
 
             It 'Reports the proper number of executed commands' {
-                $coverageReport.NumberOfCommandsExecuted | Should -Be 13
+                $coverageReport.NumberOfCommandsExecuted | Should -Be 14
             }
 
             It 'Reports the proper number of analyzed commands' {
-                $coverageReport.NumberOfCommandsAnalyzed | Should -Be 16
+                $coverageReport.NumberOfCommandsAnalyzed | Should -Be 17
             }
 
             It 'Reports the proper number of analyzed files' {
@@ -102,7 +142,7 @@ InModuleScope Pester {
             }
 
             It 'Reports the proper number of hit commands' {
-                $coverageReport.HitCommands.Count | Should -Be 13
+                $coverageReport.HitCommands.Count | Should -Be 14
             }
 
             It 'Reports the correct hit command' {
@@ -111,14 +151,23 @@ InModuleScope Pester {
 
             It 'Reports the correct class names' {
                 $coverageReport.HitCommands[0].Class | Should -BeNullOrEmpty
-                $coverageReport.HitCommands[8].Class | Should -Be 'MyClass'
-                $coverageReport.MissedCommands[2].Class | Should -Be 'MyClass'
+                # Classes have been introduced in PowerShell 5.0
+                if ($PSVersionTable.PSVersion.Major -ge 5)
+                {
+                    $coverageReport.HitCommands[9].Class | Should -Be 'MyClass'
+                    $coverageReport.MissedCommands[2].Class | Should -Be 'MyClass'
+                }
+                else
+                {
+                    $coverageReport.HitCommands[9].Class | Should -BeNullOrEmpty
+                    $coverageReport.MissedCommands[2].Class | Should -BeNullOrEmpty
+                }
             }
 
             It 'Reports the correct function names' {
                 $coverageReport.HitCommands[0].Function | Should -Be 'NestedFunction'
                 $coverageReport.HitCommands[2].Function | Should -Be 'FunctionOne'
-                $coverageReport.HitCommands[8].Function | Should -Be 'MyClass'
+                $coverageReport.HitCommands[9].Function | Should -Be 'MyClass'
                 $coverageReport.MissedCommands[2].Function | Should -Be 'MethodTwo'
             }
 
@@ -129,7 +178,7 @@ InModuleScope Pester {
                 $jaCoCoReportXml = $jaCoCoReportXml -replace 'dump="[0-9]*"','dump=""'
                 $jaCoCoReportXml = $jaCoCoReportXml -replace "$([System.Environment]::NewLine)",''
                 $jaCoCoReportXml = $jaCoCoReportXml.Replace($root.Replace('\', '/'), '')
-                $jaCoCoReportXml | should -be '<?xml version="1.0" encoding="UTF-8" standalone="no"?><!DOCTYPE report PUBLIC "-//JACOCO//DTD Report 1.1//EN" "report.dtd"><report name="Pester (date)"><sessioninfo id="this" start="" dump="" /><package name="PowerShell"><class name="TestScript.ps1" sourcefilename="/TestScript.ps1"><method name="NestedFunction" desc="()" line="5"><counter type="INSTRUCTION" missed="0" covered="2" /><counter type="LINE" missed="0" covered="2" /><counter type="METHOD" missed="0" covered="1" /></method><method name="FunctionOne" desc="()" line="9"><counter type="INSTRUCTION" missed="1" covered="6" /><counter type="LINE" missed="0" covered="5" /><counter type="METHOD" missed="0" covered="1" /></method><method name="FunctionTwo" desc="()" line="22"><counter type="INSTRUCTION" missed="1" covered="0" /><counter type="LINE" missed="1" covered="0" /><counter type="METHOD" missed="1" covered="0" /></method><method name="MyClass" desc="()" line="29"><counter type="INSTRUCTION" missed="0" covered="1" /><counter type="LINE" missed="0" covered="1" /><counter type="METHOD" missed="0" covered="1" /></method><method name="MethodOne" desc="()" line="34"><counter type="INSTRUCTION" missed="0" covered="1" /><counter type="LINE" missed="0" covered="1" /><counter type="METHOD" missed="0" covered="1" /></method><method name="MethodTwo" desc="()" line="39"><counter type="INSTRUCTION" missed="1" covered="0" /><counter type="LINE" missed="1" covered="0" /><counter type="METHOD" missed="1" covered="0" /></method><method name="&lt;script&gt;" desc="()" line="43"><counter type="INSTRUCTION" missed="0" covered="2" /><counter type="LINE" missed="0" covered="2" /><counter type="METHOD" missed="0" covered="1" /></method><counter type="INSTRUCTION" missed="3" covered="12" /><counter type="LINE" missed="2" covered="11" /><counter type="METHOD" missed="2" covered="5" /><counter type="CLASS" missed="0" covered="1" /></class><class name="TestScript2.ps1" sourcefilename="/TestScript2.ps1"><method name="&lt;script&gt;" desc="()" line="1"><counter type="INSTRUCTION" missed="0" covered="1" /><counter type="LINE" missed="0" covered="1" /><counter type="METHOD" missed="0" covered="1" /></method><counter type="INSTRUCTION" missed="0" covered="1" /><counter type="LINE" missed="0" covered="1" /><counter type="METHOD" missed="0" covered="1" /><counter type="CLASS" missed="0" covered="1" /></class><sourcefile name="/TestScript.ps1"><line nr="5" mi="0" ci="1" /><line nr="6" mi="0" ci="1" /><line nr="9" mi="0" ci="1" /><line nr="11" mi="0" ci="1" /><line nr="12" mi="0" ci="1" /><line nr="15" mi="1" ci="1" /><line nr="17" mi="0" ci="2" /><line nr="22" mi="1" ci="0" /><line nr="29" mi="0" ci="1" /><line nr="34" mi="0" ci="1" /><line nr="39" mi="1" ci="0" /><line nr="43" mi="0" ci="1" /><line nr="44" mi="0" ci="1" /><counter type="INSTRUCTION" missed="3" covered="12" /><counter type="LINE" missed="2" covered="11" /><counter type="METHOD" missed="2" covered="5" /><counter type="CLASS" missed="0" covered="1" /></sourcefile><sourcefile name="/TestScript2.ps1"><line nr="1" mi="0" ci="1" /><counter type="INSTRUCTION" missed="0" covered="1" /><counter type="LINE" missed="0" covered="1" /><counter type="METHOD" missed="0" covered="1" /><counter type="CLASS" missed="0" covered="1" /></sourcefile><counter type="INSTRUCTION" missed="3" covered="13" /><counter type="LINE" missed="2" covered="12" /><counter type="METHOD" missed="2" covered="6" /><counter type="CLASS" missed="0" covered="2" /></package><counter type="INSTRUCTION" missed="3" covered="13" /><counter type="LINE" missed="2" covered="12" /><counter type="METHOD" missed="2" covered="6" /><counter type="CLASS" missed="0" covered="2" /></report>'
+                $jaCoCoReportXml | should -be '<?xml version="1.0" encoding="UTF-8" standalone="no"?><!DOCTYPE report PUBLIC "-//JACOCO//DTD Report 1.1//EN" "report.dtd"><report name="Pester (date)"><sessioninfo id="this" start="" dump="" /><package name="PowerShell"><class name="TestScript.ps1" sourcefilename="/TestScript.ps1"><method name="NestedFunction" desc="()" line="5"><counter type="INSTRUCTION" missed="0" covered="2" /><counter type="LINE" missed="0" covered="2" /><counter type="METHOD" missed="0" covered="1" /></method><method name="FunctionOne" desc="()" line="9"><counter type="INSTRUCTION" missed="1" covered="6" /><counter type="LINE" missed="0" covered="5" /><counter type="METHOD" missed="0" covered="1" /></method><method name="FunctionTwo" desc="()" line="22"><counter type="INSTRUCTION" missed="1" covered="0" /><counter type="LINE" missed="1" covered="0" /><counter type="METHOD" missed="1" covered="0" /></method><method name="&lt;script&gt;" desc="()" line="25"><counter type="INSTRUCTION" missed="0" covered="3" /><counter type="LINE" missed="0" covered="3" /><counter type="METHOD" missed="0" covered="1" /></method><method name="MyClass" desc="()" line="32"><counter type="INSTRUCTION" missed="0" covered="1" /><counter type="LINE" missed="0" covered="1" /><counter type="METHOD" missed="0" covered="1" /></method><method name="MethodOne" desc="()" line="37"><counter type="INSTRUCTION" missed="0" covered="1" /><counter type="LINE" missed="0" covered="1" /><counter type="METHOD" missed="0" covered="1" /></method><method name="MethodTwo" desc="()" line="42"><counter type="INSTRUCTION" missed="1" covered="0" /><counter type="LINE" missed="1" covered="0" /><counter type="METHOD" missed="1" covered="0" /></method><counter type="INSTRUCTION" missed="3" covered="13" /><counter type="LINE" missed="2" covered="12" /><counter type="METHOD" missed="2" covered="5" /><counter type="CLASS" missed="0" covered="1" /></class><class name="TestScript2.ps1" sourcefilename="/TestScript2.ps1"><method name="&lt;script&gt;" desc="()" line="1"><counter type="INSTRUCTION" missed="0" covered="1" /><counter type="LINE" missed="0" covered="1" /><counter type="METHOD" missed="0" covered="1" /></method><counter type="INSTRUCTION" missed="0" covered="1" /><counter type="LINE" missed="0" covered="1" /><counter type="METHOD" missed="0" covered="1" /><counter type="CLASS" missed="0" covered="1" /></class><sourcefile name="/TestScript.ps1"><line nr="5" mi="0" ci="1" /><line nr="6" mi="0" ci="1" /><line nr="9" mi="0" ci="1" /><line nr="11" mi="0" ci="1" /><line nr="12" mi="0" ci="1" /><line nr="15" mi="1" ci="1" /><line nr="17" mi="0" ci="2" /><line nr="22" mi="1" ci="0" /><line nr="25" mi="0" ci="1" /><line nr="32" mi="0" ci="1" /><line nr="37" mi="0" ci="1" /><line nr="42" mi="1" ci="0" /><line nr="46" mi="0" ci="1" /><line nr="47" mi="0" ci="1" /><counter type="INSTRUCTION" missed="3" covered="13" /><counter type="LINE" missed="2" covered="12" /><counter type="METHOD" missed="2" covered="5" /><counter type="CLASS" missed="0" covered="1" /></sourcefile><sourcefile name="/TestScript2.ps1"><line nr="1" mi="0" ci="1" /><counter type="INSTRUCTION" missed="0" covered="1" /><counter type="LINE" missed="0" covered="1" /><counter type="METHOD" missed="0" covered="1" /><counter type="CLASS" missed="0" covered="1" /></sourcefile><counter type="INSTRUCTION" missed="3" covered="14" /><counter type="LINE" missed="2" covered="13" /><counter type="METHOD" missed="2" covered="6" /><counter type="CLASS" missed="0" covered="2" /></package><counter type="INSTRUCTION" missed="3" covered="14" /><counter type="LINE" missed="2" covered="13" /><counter type="METHOD" missed="2" covered="6" /><counter type="CLASS" missed="0" covered="2" /></report>'
             }
 
             It 'Reports the right line numbers' {
@@ -146,47 +195,16 @@ InModuleScope Pester {
             Exit-CoverageAnalysis -PesterState $testState
         }
 
-        Context 'Single class' {
-            $testState = New-PesterState -Path $root
-
-            Enter-CoverageAnalysis -CodeCoverage @{Path = "$(Join-Path -Path $root -ChildPath TestScript.ps1)"; Class = 'MyClass'} -PesterState $testState
-
-            It 'Has the proper number of breakpoints defined' {
-                $testState.CommandCoverage.Count | Should -Be 3
-            }
-
-            $null = & "$(Join-Path -Path $root -ChildPath TestScript.ps1)"
-            $coverageReport = Get-CoverageReport -PesterState $testState
-
-            It 'Reports the proper number of executed commands' {
-                $coverageReport.NumberOfCommandsExecuted | Should -Be 2
-            }
-
-            It 'Reports the proper number of analyzed commands' {
-                $coverageReport.NumberOfCommandsAnalyzed | Should -Be 3
-            }
-
-            It 'Reports the proper number of missed commands' {
-                $coverageReport.MissedCommands.Count | Should -Be 1
-            }
-
-            It 'Reports the proper number of hit commands' {
-                $coverageReport.HitCommands.Count | Should -Be 2
-            }
-
-            Exit-CoverageAnalysis -PesterState $testState
-        }
-
         Context 'Single function with missed commands' {
             $testState = New-PesterState -Path $root
 
-            Enter-CoverageAnalysis -CodeCoverage @{Path = "$(Join-Path -Path $root -ChildPath TestScript.ps1)"; Function = 'FunctionTwo'} -PesterState $testState
+            Enter-CoverageAnalysis -CodeCoverage @{Path = $testScriptPath; Function = 'FunctionTwo'} -PesterState $testState
 
             It 'Has the proper number of breakpoints defined' {
                 $testState.CommandCoverage.Count | Should -Be 1
             }
 
-            $null = & "$(Join-Path -Path $root -ChildPath TestScript.ps1)"
+            $null = & $testScriptPath
             $coverageReport = Get-CoverageReport -PesterState $testState
 
             It 'Reports the proper number of executed commands' {
@@ -215,13 +233,13 @@ InModuleScope Pester {
         Context 'Single function with no missed commands' {
             $testState = New-PesterState -Path $root
 
-            Enter-CoverageAnalysis -CodeCoverage @{Path = "$(Join-Path -Path $root -ChildPath TestScript.ps1)"; Function = 'FunctionOne'} -PesterState $testState
+            Enter-CoverageAnalysis -CodeCoverage @{Path = $testScriptPath; Function = 'FunctionOne'} -PesterState $testState
 
             It 'Has the proper number of breakpoints defined' {
                 $testState.CommandCoverage.Count | Should -Be 9
             }
 
-            $null = & "$(Join-Path -Path $root -ChildPath TestScript.ps1)"
+            $null = & $testScriptPath
             $coverageReport = Get-CoverageReport -PesterState $testState
 
             It 'Reports the proper number of executed commands' {
@@ -250,13 +268,13 @@ InModuleScope Pester {
         Context 'Range of lines' {
             $testState = New-PesterState -Path $root
 
-            Enter-CoverageAnalysis -CodeCoverage @{Path = "$(Join-Path -Path $root -ChildPath TestScript.ps1)"; StartLine = 11; EndLine = 12 } -PesterState $testState
+            Enter-CoverageAnalysis -CodeCoverage @{Path = $testScriptPath; StartLine = 11; EndLine = 12 } -PesterState $testState
 
             It 'Has the proper number of breakpoints defined' {
                 $testState.CommandCoverage.Count | Should -Be 2
             }
 
-            $null = & "$(Join-Path -Path $root -ChildPath TestScript.ps1)"
+            $null = & $testScriptPath
             $coverageReport = Get-CoverageReport -PesterState $testState
 
             It 'Reports the proper number of executed commands' {
@@ -282,37 +300,6 @@ InModuleScope Pester {
             Exit-CoverageAnalysis -PesterState $testState
         }
 
-        Context 'Class wildcard resolution' {
-            $testState = New-PesterState -Path $root
-
-            Enter-CoverageAnalysis -CodeCoverage @{Path = "$(Join-Path -Path $root -ChildPath TestScript.ps1)"; Class = '*'} -PesterState $testState
-
-            It 'Has the proper number of breakpoints defined' {
-                $testState.CommandCoverage.Count | Should -Be 3
-            }
-
-            $null = & "$(Join-Path -Path $root -ChildPath TestScript.ps1)"
-            $coverageReport = Get-CoverageReport -PesterState $testState
-
-            It 'Reports the proper number of executed commands' {
-                $coverageReport.NumberOfCommandsExecuted | Should -Be 2
-            }
-
-            It 'Reports the proper number of analyzed commands' {
-                $coverageReport.NumberOfCommandsAnalyzed | Should -Be 3
-            }
-
-            It 'Reports the proper number of missed commands' {
-                $coverageReport.MissedCommands.Count | Should -Be 1
-            }
-
-            It 'Reports the proper number of hit commands' {
-                $coverageReport.HitCommands.Count | Should -Be 2
-            }
-
-            Exit-CoverageAnalysis -PesterState $testState
-        }
-
         Context 'Function wildcard resolution' {
             $testState = New-PesterState -Path $root
 
@@ -322,7 +309,7 @@ InModuleScope Pester {
                 $testState.CommandCoverage.Count | Should -Be 13
             }
 
-            $null = & "$(Join-Path -Path $root -ChildPath TestScript.ps1)"
+            $null = & $testScriptPath
             $coverageReport = Get-CoverageReport -PesterState $testState
 
             It 'Reports the proper number of executed commands' {
@@ -357,35 +344,134 @@ InModuleScope Pester {
             Exit-CoverageAnalysis -PesterState $testState
         }
 
-        Context 'Class and function filter' {
-            $testState = New-PesterState -Path $root
-
-            Enter-CoverageAnalysis -CodeCoverage @{Path = "$(Join-Path -Path $root -ChildPath TestScript.ps1)"; Class = 'MyClass'; Function = 'MethodTwo'} -PesterState $testState
-
-            It 'Has the proper number of breakpoints defined' {
-                $testState.CommandCoverage.Count | Should -Be 1
+        # Classes have been introduced in PowerShell 5.0
+        if ($PSVersionTable.PSVersion.Major -ge 5)
+        {
+            Context 'Single class' {
+                $testState = New-PesterState -Path $root
+    
+                Enter-CoverageAnalysis -CodeCoverage @{Path = $testScriptPath; Class = 'MyClass'} -PesterState $testState
+    
+                It 'Has the proper number of breakpoints defined' {
+                    $testState.CommandCoverage.Count | Should -Be 3
+                }
+    
+                $null = & $testScriptPath
+                $coverageReport = Get-CoverageReport -PesterState $testState
+    
+                It 'Reports the proper number of executed commands' {
+                    $coverageReport.NumberOfCommandsExecuted | Should -Be 2
+                }
+    
+                It 'Reports the proper number of analyzed commands' {
+                    $coverageReport.NumberOfCommandsAnalyzed | Should -Be 3
+                }
+    
+                It 'Reports the proper number of missed commands' {
+                    $coverageReport.MissedCommands.Count | Should -Be 1
+                }
+    
+                It 'Reports the proper number of hit commands' {
+                    $coverageReport.HitCommands.Count | Should -Be 2
+                }
+    
+                Exit-CoverageAnalysis -PesterState $testState
             }
-
-            $null = & "$(Join-Path -Path $root -ChildPath TestScript.ps1)"
-            $coverageReport = Get-CoverageReport -PesterState $testState
-
-            It 'Reports the proper number of executed commands' {
-                $coverageReport.NumberOfCommandsExecuted | Should -Be 0
+    
+            Context 'Class wildcard resolution' {
+                $testState = New-PesterState -Path $root
+    
+                Enter-CoverageAnalysis -CodeCoverage @{Path = $testScriptPath; Class = '*'} -PesterState $testState
+    
+                It 'Has the proper number of breakpoints defined' {
+                    $testState.CommandCoverage.Count | Should -Be 3
+                }
+    
+                $null = & $testScriptPath
+                $coverageReport = Get-CoverageReport -PesterState $testState
+    
+                It 'Reports the proper number of executed commands' {
+                    $coverageReport.NumberOfCommandsExecuted | Should -Be 2
+                }
+    
+                It 'Reports the proper number of analyzed commands' {
+                    $coverageReport.NumberOfCommandsAnalyzed | Should -Be 3
+                }
+    
+                It 'Reports the proper number of missed commands' {
+                    $coverageReport.MissedCommands.Count | Should -Be 1
+                }
+    
+                It 'Reports the proper number of hit commands' {
+                    $coverageReport.HitCommands.Count | Should -Be 2
+                }
+    
+                Exit-CoverageAnalysis -PesterState $testState
             }
-
-            It 'Reports the proper number of analyzed commands' {
-                $coverageReport.NumberOfCommandsAnalyzed | Should -Be 1
+    
+            Context 'Class and function filter' {
+                $testState = New-PesterState -Path $root
+    
+                Enter-CoverageAnalysis -CodeCoverage @{Path = $testScriptPath; Class = 'MyClass'; Function = 'MethodTwo'} -PesterState $testState
+    
+                It 'Has the proper number of breakpoints defined' {
+                    $testState.CommandCoverage.Count | Should -Be 1
+                }
+    
+                $null = & $testScriptPath
+                $coverageReport = Get-CoverageReport -PesterState $testState
+    
+                It 'Reports the proper number of executed commands' {
+                    $coverageReport.NumberOfCommandsExecuted | Should -Be 0
+                }
+    
+                It 'Reports the proper number of analyzed commands' {
+                    $coverageReport.NumberOfCommandsAnalyzed | Should -Be 1
+                }
+    
+                It 'Reports the proper number of missed commands' {
+                    $coverageReport.MissedCommands.Count | Should -Be 1
+                }
+    
+                It 'Reports the proper number of hit commands' {
+                    $coverageReport.HitCommands.Count | Should -Be 0
+                }
+    
+                Exit-CoverageAnalysis -PesterState $testState
             }
-
-            It 'Reports the proper number of missed commands' {
-                $coverageReport.MissedCommands.Count | Should -Be 1
+        }
+        else
+        {
+            Context 'Single class when not supported' {
+                $testState = New-PesterState -Path $root
+    
+                Enter-CoverageAnalysis -CodeCoverage @{Path = $testScriptPath; Class = 'MyClass'} -PesterState $testState
+    
+                It 'Has the proper number of breakpoints defined' {
+                    $testState.CommandCoverage.Count | Should -Be 0
+                }
+    
+                $null = & $testScriptPath
+                $coverageReport = Get-CoverageReport -PesterState $testState
+    
+                It 'Reports the proper number of executed commands' {
+                    $coverageReport.NumberOfCommandsExecuted | Should -Be 0
+                }
+    
+                It 'Reports the proper number of analyzed commands' {
+                    $coverageReport.NumberOfCommandsAnalyzed | Should -Be 0
+                }
+    
+                It 'Reports the proper number of missed commands' {
+                    $coverageReport.MissedCommands.Count | Should -Be 0
+                }
+    
+                It 'Reports the proper number of hit commands' {
+                    $coverageReport.HitCommands.Count | Should -Be 0
+                }
+    
+                Exit-CoverageAnalysis -PesterState $testState
             }
-
-            It 'Reports the proper number of hit commands' {
-                $coverageReport.HitCommands.Count | Should -Be 0
-            }
-
-            Exit-CoverageAnalysis -PesterState $testState
         }
     }
 

--- a/Functions/Coverage.Tests.ps1
+++ b/Functions/Coverage.Tests.ps1
@@ -33,7 +33,26 @@ InModuleScope Pester {
                 'I am function two.  I never get called.'
             }
 
+            class MyClass
+            {
+                MyClass()
+                {
+                    'I am the constructor.'
+                }
+
+                MethodOne()
+                {
+                    'I am method one.'
+                }
+
+                hidden static MethodTwo()
+                {
+                    'I am method two. I never get called.'
+                }
+            }
+
             FunctionOne
+            [MyClass]::new().MethodOne()
 
 '@
 
@@ -53,7 +72,7 @@ InModuleScope Pester {
             Enter-CoverageAnalysis -CodeCoverage "$(Join-Path -Path $root -ChildPath TestScript.ps1)", "$(Join-Path -Path $root -ChildPath TestScript.ps1)", "$(Join-Path -Path $root -ChildPath TestScript2.ps1)" -PesterState $testState
 
             It 'Has the proper number of breakpoints defined' {
-                $testState.CommandCoverage.Count | Should -Be 12
+                $testState.CommandCoverage.Count | Should -Be 16
             }
 
             $null = & "$(Join-Path -Path $root -ChildPath TestScript.ps1)"
@@ -61,11 +80,11 @@ InModuleScope Pester {
             $coverageReport = Get-CoverageReport -PesterState $testState
 
             It 'Reports the proper number of executed commands' {
-                $coverageReport.NumberOfCommandsExecuted | Should -Be 10
+                $coverageReport.NumberOfCommandsExecuted | Should -Be 13
             }
 
             It 'Reports the proper number of analyzed commands' {
-                $coverageReport.NumberOfCommandsAnalyzed | Should -Be 12
+                $coverageReport.NumberOfCommandsAnalyzed | Should -Be 16
             }
 
             It 'Reports the proper number of analyzed files' {
@@ -73,20 +92,34 @@ InModuleScope Pester {
             }
 
             It 'Reports the proper number of missed commands' {
-                $coverageReport.MissedCommands.Count | Should -Be 2
+                $coverageReport.MissedCommands.Count | Should -Be 3
             }
 
             It 'Reports the correct missed command' {
                 $coverageReport.MissedCommands[0].Command | Should -Be "'I cannot get called.'"
                 $coverageReport.MissedCommands[1].Command | Should -Be "'I am function two.  I never get called.'"
+                $coverageReport.MissedCommands[2].Command | Should -Be "'I am method two. I never get called.'"
             }
 
             It 'Reports the proper number of hit commands' {
-                $coverageReport.HitCommands.Count | Should -Be 10
+                $coverageReport.HitCommands.Count | Should -Be 13
             }
 
             It 'Reports the correct hit command' {
                 $coverageReport.HitCommands[0].Command | Should -Be "'I am the nested function.'"
+            }
+
+            It 'Reports the correct class names' {
+                $coverageReport.HitCommands[0].Class | Should -BeNullOrEmpty
+                $coverageReport.HitCommands[8].Class | Should -Be 'MyClass'
+                $coverageReport.MissedCommands[2].Class | Should -Be 'MyClass'
+            }
+
+            It 'Reports the correct function names' {
+                $coverageReport.HitCommands[0].Function | Should -Be 'NestedFunction'
+                $coverageReport.HitCommands[2].Function | Should -Be 'FunctionOne'
+                $coverageReport.HitCommands[8].Function | Should -Be 'MyClass'
+                $coverageReport.MissedCommands[2].Function | Should -Be 'MethodTwo'
             }
 
             It 'JaCoCo report must be correct'{
@@ -96,7 +129,7 @@ InModuleScope Pester {
                 $jaCoCoReportXml = $jaCoCoReportXml -replace 'dump="[0-9]*"','dump=""'
                 $jaCoCoReportXml = $jaCoCoReportXml -replace "$([System.Environment]::NewLine)",''
                 $jaCoCoReportXml = $jaCoCoReportXml.Replace($root.Replace('\', '/'), '')
-                $jaCoCoReportXml | should -be '<?xml version="1.0" encoding="UTF-8" standalone="no"?><!DOCTYPE report PUBLIC "-//JACOCO//DTD Report 1.1//EN" "report.dtd"><report name="Pester (date)"><sessioninfo id="this" start="" dump="" /><package name="PowerShell"><class name="TestScript.ps1" sourcefilename="/TestScript.ps1"><method name="NestedFunction" desc="()" line="5"><counter type="INSTRUCTION" missed="0" covered="2" /><counter type="LINE" missed="0" covered="2" /><counter type="METHOD" missed="0" covered="1" /></method><method name="FunctionOne" desc="()" line="9"><counter type="INSTRUCTION" missed="1" covered="6" /><counter type="LINE" missed="0" covered="5" /><counter type="METHOD" missed="0" covered="1" /></method><method name="FunctionTwo" desc="()" line="22"><counter type="INSTRUCTION" missed="1" covered="0" /><counter type="LINE" missed="1" covered="0" /><counter type="METHOD" missed="1" covered="0" /></method><method name="&lt;script&gt;" desc="()" line="25"><counter type="INSTRUCTION" missed="0" covered="1" /><counter type="LINE" missed="0" covered="1" /><counter type="METHOD" missed="0" covered="1" /></method><counter type="INSTRUCTION" missed="2" covered="9" /><counter type="LINE" missed="1" covered="8" /><counter type="METHOD" missed="1" covered="3" /><counter type="CLASS" missed="0" covered="1" /></class><class name="TestScript2.ps1" sourcefilename="/TestScript2.ps1"><method name="&lt;script&gt;" desc="()" line="1"><counter type="INSTRUCTION" missed="0" covered="1" /><counter type="LINE" missed="0" covered="1" /><counter type="METHOD" missed="0" covered="1" /></method><counter type="INSTRUCTION" missed="0" covered="1" /><counter type="LINE" missed="0" covered="1" /><counter type="METHOD" missed="0" covered="1" /><counter type="CLASS" missed="0" covered="1" /></class><sourcefile name="/TestScript.ps1"><line nr="5" mi="0" ci="1" /><line nr="6" mi="0" ci="1" /><line nr="9" mi="0" ci="1" /><line nr="11" mi="0" ci="1" /><line nr="12" mi="0" ci="1" /><line nr="15" mi="1" ci="1" /><line nr="17" mi="0" ci="2" /><line nr="22" mi="1" ci="0" /><line nr="25" mi="0" ci="1" /><counter type="INSTRUCTION" missed="2" covered="9" /><counter type="LINE" missed="1" covered="8" /><counter type="METHOD" missed="1" covered="3" /><counter type="CLASS" missed="0" covered="1" /></sourcefile><sourcefile name="/TestScript2.ps1"><line nr="1" mi="0" ci="1" /><counter type="INSTRUCTION" missed="0" covered="1" /><counter type="LINE" missed="0" covered="1" /><counter type="METHOD" missed="0" covered="1" /><counter type="CLASS" missed="0" covered="1" /></sourcefile><counter type="INSTRUCTION" missed="2" covered="10" /><counter type="LINE" missed="1" covered="9" /><counter type="METHOD" missed="1" covered="4" /><counter type="CLASS" missed="0" covered="2" /></package><counter type="INSTRUCTION" missed="2" covered="10" /><counter type="LINE" missed="1" covered="9" /><counter type="METHOD" missed="1" covered="4" /><counter type="CLASS" missed="0" covered="2" /></report>'
+                $jaCoCoReportXml | should -be '<?xml version="1.0" encoding="UTF-8" standalone="no"?><!DOCTYPE report PUBLIC "-//JACOCO//DTD Report 1.1//EN" "report.dtd"><report name="Pester (date)"><sessioninfo id="this" start="" dump="" /><package name="PowerShell"><class name="TestScript.ps1" sourcefilename="/TestScript.ps1"><method name="NestedFunction" desc="()" line="5"><counter type="INSTRUCTION" missed="0" covered="2" /><counter type="LINE" missed="0" covered="2" /><counter type="METHOD" missed="0" covered="1" /></method><method name="FunctionOne" desc="()" line="9"><counter type="INSTRUCTION" missed="1" covered="6" /><counter type="LINE" missed="0" covered="5" /><counter type="METHOD" missed="0" covered="1" /></method><method name="FunctionTwo" desc="()" line="22"><counter type="INSTRUCTION" missed="1" covered="0" /><counter type="LINE" missed="1" covered="0" /><counter type="METHOD" missed="1" covered="0" /></method><method name="MyClass" desc="()" line="29"><counter type="INSTRUCTION" missed="0" covered="1" /><counter type="LINE" missed="0" covered="1" /><counter type="METHOD" missed="0" covered="1" /></method><method name="MethodOne" desc="()" line="34"><counter type="INSTRUCTION" missed="0" covered="1" /><counter type="LINE" missed="0" covered="1" /><counter type="METHOD" missed="0" covered="1" /></method><method name="MethodTwo" desc="()" line="39"><counter type="INSTRUCTION" missed="1" covered="0" /><counter type="LINE" missed="1" covered="0" /><counter type="METHOD" missed="1" covered="0" /></method><method name="&lt;script&gt;" desc="()" line="43"><counter type="INSTRUCTION" missed="0" covered="2" /><counter type="LINE" missed="0" covered="2" /><counter type="METHOD" missed="0" covered="1" /></method><counter type="INSTRUCTION" missed="3" covered="12" /><counter type="LINE" missed="2" covered="11" /><counter type="METHOD" missed="2" covered="5" /><counter type="CLASS" missed="0" covered="1" /></class><class name="TestScript2.ps1" sourcefilename="/TestScript2.ps1"><method name="&lt;script&gt;" desc="()" line="1"><counter type="INSTRUCTION" missed="0" covered="1" /><counter type="LINE" missed="0" covered="1" /><counter type="METHOD" missed="0" covered="1" /></method><counter type="INSTRUCTION" missed="0" covered="1" /><counter type="LINE" missed="0" covered="1" /><counter type="METHOD" missed="0" covered="1" /><counter type="CLASS" missed="0" covered="1" /></class><sourcefile name="/TestScript.ps1"><line nr="5" mi="0" ci="1" /><line nr="6" mi="0" ci="1" /><line nr="9" mi="0" ci="1" /><line nr="11" mi="0" ci="1" /><line nr="12" mi="0" ci="1" /><line nr="15" mi="1" ci="1" /><line nr="17" mi="0" ci="2" /><line nr="22" mi="1" ci="0" /><line nr="29" mi="0" ci="1" /><line nr="34" mi="0" ci="1" /><line nr="39" mi="1" ci="0" /><line nr="43" mi="0" ci="1" /><line nr="44" mi="0" ci="1" /><counter type="INSTRUCTION" missed="3" covered="12" /><counter type="LINE" missed="2" covered="11" /><counter type="METHOD" missed="2" covered="5" /><counter type="CLASS" missed="0" covered="1" /></sourcefile><sourcefile name="/TestScript2.ps1"><line nr="1" mi="0" ci="1" /><counter type="INSTRUCTION" missed="0" covered="1" /><counter type="LINE" missed="0" covered="1" /><counter type="METHOD" missed="0" covered="1" /><counter type="CLASS" missed="0" covered="1" /></sourcefile><counter type="INSTRUCTION" missed="3" covered="13" /><counter type="LINE" missed="2" covered="12" /><counter type="METHOD" missed="2" covered="6" /><counter type="CLASS" missed="0" covered="2" /></package><counter type="INSTRUCTION" missed="3" covered="13" /><counter type="LINE" missed="2" covered="12" /><counter type="METHOD" missed="2" covered="6" /><counter type="CLASS" missed="0" covered="2" /></report>'
             }
 
             It 'Reports the right line numbers' {
@@ -108,6 +141,37 @@ InModuleScope Pester {
             It 'Reports the right column numbers' {
                 $coverageReport.HitCommands[$coverageReport.NumberOfCommandsExecuted-1].StartColumn | Should -Be 13
                 $coverageReport.HitCommands[$coverageReport.NumberOfCommandsExecuted-1].EndColumn | Should -Be 24
+            }
+
+            Exit-CoverageAnalysis -PesterState $testState
+        }
+
+        Context 'Single class' {
+            $testState = New-PesterState -Path $root
+
+            Enter-CoverageAnalysis -CodeCoverage @{Path = "$(Join-Path -Path $root -ChildPath TestScript.ps1)"; Class = 'MyClass'} -PesterState $testState
+
+            It 'Has the proper number of breakpoints defined' {
+                $testState.CommandCoverage.Count | Should -Be 3
+            }
+
+            $null = & "$(Join-Path -Path $root -ChildPath TestScript.ps1)"
+            $coverageReport = Get-CoverageReport -PesterState $testState
+
+            It 'Reports the proper number of executed commands' {
+                $coverageReport.NumberOfCommandsExecuted | Should -Be 2
+            }
+
+            It 'Reports the proper number of analyzed commands' {
+                $coverageReport.NumberOfCommandsAnalyzed | Should -Be 3
+            }
+
+            It 'Reports the proper number of missed commands' {
+                $coverageReport.MissedCommands.Count | Should -Be 1
+            }
+
+            It 'Reports the proper number of hit commands' {
+                $coverageReport.HitCommands.Count | Should -Be 2
             }
 
             Exit-CoverageAnalysis -PesterState $testState
@@ -218,24 +282,55 @@ InModuleScope Pester {
             Exit-CoverageAnalysis -PesterState $testState
         }
 
-        Context 'Wildcard resolution' {
+        Context 'Class wildcard resolution' {
             $testState = New-PesterState -Path $root
 
-            Enter-CoverageAnalysis -CodeCoverage @{Path = "$(Join-Path -Path $root -ChildPath *.ps1)"; Function = '*' } -PesterState $testState
+            Enter-CoverageAnalysis -CodeCoverage @{Path = "$(Join-Path -Path $root -ChildPath TestScript.ps1)"; Class = '*'} -PesterState $testState
 
             It 'Has the proper number of breakpoints defined' {
-                $testState.CommandCoverage.Count | Should -Be 10
+                $testState.CommandCoverage.Count | Should -Be 3
             }
 
             $null = & "$(Join-Path -Path $root -ChildPath TestScript.ps1)"
             $coverageReport = Get-CoverageReport -PesterState $testState
 
             It 'Reports the proper number of executed commands' {
-                $coverageReport.NumberOfCommandsExecuted | Should -Be 8
+                $coverageReport.NumberOfCommandsExecuted | Should -Be 2
             }
 
             It 'Reports the proper number of analyzed commands' {
-                $coverageReport.NumberOfCommandsAnalyzed | Should -Be 10
+                $coverageReport.NumberOfCommandsAnalyzed | Should -Be 3
+            }
+
+            It 'Reports the proper number of missed commands' {
+                $coverageReport.MissedCommands.Count | Should -Be 1
+            }
+
+            It 'Reports the proper number of hit commands' {
+                $coverageReport.HitCommands.Count | Should -Be 2
+            }
+
+            Exit-CoverageAnalysis -PesterState $testState
+        }
+
+        Context 'Function wildcard resolution' {
+            $testState = New-PesterState -Path $root
+
+            Enter-CoverageAnalysis -CodeCoverage @{Path = "$(Join-Path -Path $root -ChildPath *.ps1)"; Function = '*' } -PesterState $testState
+
+            It 'Has the proper number of breakpoints defined' {
+                $testState.CommandCoverage.Count | Should -Be 13
+            }
+
+            $null = & "$(Join-Path -Path $root -ChildPath TestScript.ps1)"
+            $coverageReport = Get-CoverageReport -PesterState $testState
+
+            It 'Reports the proper number of executed commands' {
+                $coverageReport.NumberOfCommandsExecuted | Should -Be 10
+            }
+
+            It 'Reports the proper number of analyzed commands' {
+                $coverageReport.NumberOfCommandsAnalyzed | Should -Be 13
             }
 
             It 'Reports the proper number of analyzed files' {
@@ -243,7 +338,7 @@ InModuleScope Pester {
             }
 
             It 'Reports the proper number of missed commands' {
-                $coverageReport.MissedCommands.Count | Should -Be 2
+                $coverageReport.MissedCommands.Count | Should -Be 3
             }
 
             It 'Reports the correct missed command' {
@@ -252,11 +347,42 @@ InModuleScope Pester {
             }
 
             It 'Reports the proper number of hit commands' {
-                $coverageReport.HitCommands.Count | Should -Be 8
+                $coverageReport.HitCommands.Count | Should -Be 10
             }
 
             It 'Reports the correct hit command' {
                 $coverageReport.HitCommands[0].Command | Should -Be "'I am the nested function.'"
+            }
+
+            Exit-CoverageAnalysis -PesterState $testState
+        }
+
+        Context 'Class and function filter' {
+            $testState = New-PesterState -Path $root
+
+            Enter-CoverageAnalysis -CodeCoverage @{Path = "$(Join-Path -Path $root -ChildPath TestScript.ps1)"; Class = 'MyClass'; Function = 'MethodTwo'} -PesterState $testState
+
+            It 'Has the proper number of breakpoints defined' {
+                $testState.CommandCoverage.Count | Should -Be 1
+            }
+
+            $null = & "$(Join-Path -Path $root -ChildPath TestScript.ps1)"
+            $coverageReport = Get-CoverageReport -PesterState $testState
+
+            It 'Reports the proper number of executed commands' {
+                $coverageReport.NumberOfCommandsExecuted | Should -Be 0
+            }
+
+            It 'Reports the proper number of analyzed commands' {
+                $coverageReport.NumberOfCommandsAnalyzed | Should -Be 1
+            }
+
+            It 'Reports the proper number of missed commands' {
+                $coverageReport.MissedCommands.Count | Should -Be 1
+            }
+
+            It 'Reports the proper number of hit commands' {
+                $coverageReport.HitCommands.Count | Should -Be 0
             }
 
             Exit-CoverageAnalysis -PesterState $testState

--- a/Functions/Coverage.ps1
+++ b/Functions/Coverage.ps1
@@ -238,21 +238,25 @@ function Test-CommandInScope
     $functionResult = !$Function
     for ($ast = $Command; $null -ne $ast; $ast = $ast.Parent)
     {
-        if (!$classResult) {
+        if (!$classResult -and $PSVersionTable.PSVersion.Major -ge 5)
+        {
+            # Classes have been introduced in PowerShell 5.0
             $classAst = $ast -as [System.Management.Automation.Language.TypeDefinitionAst]
             if ($null -ne $classAst -and $classAst.Name -like $Class)
             {
                 $classResult = $true
             }
         }
-        if (!$functionResult) {
+        if (!$functionResult)
+        {
             $functionAst = $ast -as [System.Management.Automation.Language.FunctionDefinitionAst]
             if ($null -ne $functionAst -and $functionAst.Name -like $Function)
             {
                 $functionResult = $true
             }
         }
-        if ($classResult -and $functionResult) {
+        if ($classResult -and $functionResult)
+        {
             return $true
         }
     }
@@ -408,11 +412,16 @@ function Get-ParentClassName
 {
     param ([System.Management.Automation.Language.Ast] $Ast)
 
-    $parent = $Ast.Parent
-
-    while ($null -ne $parent -and $parent -isnot [System.Management.Automation.Language.TypeDefinitionAst])
+    if ($PSVersionTable.PSVersion.Major -ge 5)
     {
-        $parent = $parent.Parent
+        # Classes have been introduced in PowerShell 5.0
+
+        $parent = $Ast.Parent
+
+        while ($null -ne $parent -and $parent -isnot [System.Management.Automation.Language.TypeDefinitionAst])
+        {
+            $parent = $parent.Parent
+        }
     }
 
     if ($null -eq $parent)

--- a/Functions/Output.ps1
+++ b/Functions/Output.ps1
@@ -366,6 +366,7 @@ function Write-CoverageReport {
     $commonParent = Get-CommonParentPath -Path $CoverageReport.AnalyzedFiles
     $report = $CoverageReport.MissedCommands | & $SafeCommands['Select-Object'] -Property @(
         @{ Name = 'File'; Expression = { Get-RelativePath -Path $_.File -RelativeTo $commonParent } }
+        'Class'
         'Function'
         'Line'
         'Command'

--- a/Pester.psm1
+++ b/Pester.psm1
@@ -726,7 +726,7 @@ This feature is ideal for build systems and other processes that require success
 on every test.
 
 To help with test design, Invoke-Pester includes a CodeCoverage parameter that
-lists commands, functions, and lines of code that did not run during test
+lists commands, classes, functions, and lines of code that did not run during test
 execution and returns the code that ran as a percentage of all tested code.
 
 Invoke-Pester, and the Pester module that exports it, are products of an
@@ -838,16 +838,18 @@ Enter the path to the files of code under test (not the test file).
 Wildcard characters are supported. If you omit the path, the default is local
 directory, not the directory specified by the Script parameter.
 
-To run a code coverage test only on selected functions or lines in a script,
+To run a code coverage test only on selected classes, functions or lines in a script,
 enter a hash table value with the following keys:
 
 -- Path (P)(mandatory) <string>. Enter one path to the files. Wildcard characters
    are supported, but only one string is permitted.
 
-One of the following: Function or StartLine/EndLine
+One of the following: Class/Function or StartLine/EndLine
 
+-- Class (C) <string>: Enter the class name. Wildcard characters are
+   supported, but only one string is permitted. Default is *.
 -- Function (F) <string>: Enter the function name. Wildcard characters are
-   supported, but only one string is permitted.
+   supported, but only one string is permitted. Default is *.
 
 -or-
 


### PR DESCRIPTION
Per #731, introduce better support of PowerShell classes
- allow to filter on class names when asking for coverage
- provide class of each commands in coverage report
