### PR TITLE
Make hashtable key access be consistently cased to prevent symptom of PowerShell bug on Unix systems where LANG is set to C.UTF-8

### DIFF
--- a/Functions/Environment.ps1
+++ b/Functions/Environment.ps1
@@ -1,6 +1,6 @@
 function GetPesterPsVersion {
     # accessing the value indirectly so it can be mocked
-    (Get-Variable 'PSVersionTable' -ValueOnly).PsVersion.Major
+    (Get-Variable 'PSVersionTable' -ValueOnly).PSVersion.Major
 }
 
 function GetPesterOs {

--- a/Functions/It.ps1
+++ b/Functions/It.ps1
@@ -308,7 +308,7 @@ function Invoke-Test
 
             $result = ConvertTo-PesterResult -Name $Name -ErrorRecord $errorRecord
             $orderedParameters = Get-OrderedParameterDictionary -ScriptBlock $ScriptBlock -Dictionary $Parameters
-            $Pester.AddTestResult( $result.name, $result.Result, $null, $result.FailureMessage, $result.StackTrace, $ParameterizedSuiteName, $orderedParameters, $result.ErrorRecord )
+            $Pester.AddTestResult( $result.Name, $result.Result, $null, $result.FailureMessage, $result.StackTrace, $ParameterizedSuiteName, $orderedParameters, $result.ErrorRecord )
             #todo: disabling progress reporting see above & $SafeCommands['Write-Progress'] -Activity "Running test '$Name'" -Completed -Status Processing
         }
     }

--- a/Functions/Output.Tests.ps1
+++ b/Functions/Output.Tests.ps1
@@ -71,7 +71,7 @@ Describe 'ConvertTo-PesterResult' {
         $result = & $getPesterResult -Time 0 -ErrorRecord $errorRecord
 
         It 'records the correct stack line number' {
-            $result.Stacktrace | should -match "${thisScriptRegex}: line $($script.startPosition.StartLine)"
+            $result.StackTrace | should -match "${thisScriptRegex}: line $($script.startPosition.StartLine)"
         }
         It 'records the correct error record' {
             $result.ErrorRecord -is [System.Management.Automation.ErrorRecord] | Should -be $true
@@ -111,7 +111,7 @@ Describe 'ConvertTo-PesterResult' {
 
 
         It 'records the correct stack line number' {
-            $result.Stacktrace | should -match "${escapedTestPath}: line 2"
+            $result.StackTrace | should -match "${escapedTestPath}: line 2"
         }
         It 'records the correct error record' {
             $result.ErrorRecord -is [System.Management.Automation.ErrorRecord] | Should -be $true

--- a/Functions/Output.ps1
+++ b/Functions/Output.ps1
@@ -168,13 +168,13 @@ function ConvertTo-PesterResult {
     )
 
     $testResult = @{
-        name = $Name
-        time = $time
-        failureMessage = ""
-        stackTrace = ""
+        Name = $Name
+        Time = $time
+        FailureMessage = ""
+        StackTrace = ""
         ErrorRecord = $null
-        success = $false
-        result = "Failed"
+        Success = $false
+        Result = "Failed"
     }
 
     if(-not $ErrorRecord)

--- a/Functions/Output.ps1
+++ b/Functions/Output.ps1
@@ -180,7 +180,7 @@ function ConvertTo-PesterResult {
     if(-not $ErrorRecord)
     {
         $testResult.Result = "Passed"
-        $testResult.success = $true
+        $testResult.Success = $true
         return $testResult
     }
 
@@ -205,8 +205,8 @@ function ConvertTo-PesterResult {
         $Text = $ErrorRecord.InvocationInfo.Line
     }
 
-    $testResult.failureMessage = $failureMessage
-    $testResult.stackTrace = "at <ScriptBlock>, ${file}: line ${line}$([System.Environment]::NewLine)${line}: ${Text}"
+    $testResult.FailureMessage = $failureMessage
+    $testResult.StackTrace = "at <ScriptBlock>, ${file}: line ${line}$([System.Environment]::NewLine)${line}: ${Text}"
     $testResult.ErrorRecord = $ErrorRecord
 
     return $testResult
@@ -236,7 +236,7 @@ function Write-PesterResult {
 
         $margin = $ReportStrings.Margin * ($pester.IndentLevel + 1)
         $error_margin = $margin + $ReportStrings.Margin
-        $output = $TestResult.name
+        $output = $TestResult.Name
         $humanTime = Get-HumanTime $TestResult.Time.TotalSeconds
 
         if (-not ($OutputType | Has-Flag 'Default, Summary'))
@@ -254,8 +254,8 @@ function Write-PesterResult {
                     & $SafeCommands['Write-Host'] -ForegroundColor $ReportTheme.FailTime " $humanTime"
 
                     if($pester.IncludeVSCodeMarker) {
-                        & $SafeCommands['Write-Host'] -ForegroundColor $ReportTheme.Fail $($TestResult.stackTrace -replace '(?m)^',$error_margin)
-                        & $SafeCommands['Write-Host'] -ForegroundColor $ReportTheme.Fail $($TestResult.failureMessage -replace '(?m)^',$error_margin)
+                        & $SafeCommands['Write-Host'] -ForegroundColor $ReportTheme.Fail $($TestResult.StackTrace -replace '(?m)^',$error_margin)
+                        & $SafeCommands['Write-Host'] -ForegroundColor $ReportTheme.Fail $($TestResult.FailureMessage -replace '(?m)^',$error_margin)
                     }
                     else {
                         $TestResult.ErrorRecord |

--- a/Pester.Tests.ps1
+++ b/Pester.Tests.ps1
@@ -271,7 +271,7 @@ InModuleScope Pester {
         }
 
         Context 'Passing in Dictionaries instead of Strings' {
-            It 'Allows the use of a "P" key instead of "Path"' {
+            It 'Allows the use of a "p" key instead of "Path"' {
                 $result = @(ResolveTestScripts @{ p = (Join-Path $TestDrive 'SomeFile.ps1') })
 
                 $result.Count | Should -Be 1
@@ -289,7 +289,7 @@ InModuleScope Pester {
                 $result[0].Arguments[0] | Should -Be 'I am a string'
             }
 
-            It 'Allows the use of an "Args" key in the dictionary' {
+            It 'Allows the use of an "args" key in the dictionary' {
                 $result = @(ResolveTestScripts @{ Path = (Join-Path $TestDrive 'SomeFile.ps1'); args = $testArgs })
 
                 $result.Count | Should -Be 1
@@ -299,7 +299,7 @@ InModuleScope Pester {
                 $result[0].Arguments[0] | Should -Be 'I am a string'
             }
 
-            It 'Allows the use of an "A" key in the dictionary' {
+            It 'Allows the use of an "a" key in the dictionary' {
                 $result = @(ResolveTestScripts @{ Path = (Join-Path $TestDrive 'SomeFile.ps1'); a = $testArgs })
 
                 $result.Count | Should -Be 1
@@ -320,7 +320,7 @@ InModuleScope Pester {
                 $result[0].Parameters['MyKey'] | Should -Be 'MyValue'
             }
 
-            It 'Allows the use of a "Params" key in the dictionary' {
+            It 'Allows the use of a "params" key in the dictionary' {
                 $result = @(ResolveTestScripts @{ Path = (Join-Path $TestDrive 'SomeFile.ps1'); params = $testParams })
 
                 $result.Count | Should -Be 1

--- a/Pester.Tests.ps1
+++ b/Pester.Tests.ps1
@@ -272,7 +272,7 @@ InModuleScope Pester {
 
         Context 'Passing in Dictionaries instead of Strings' {
             It 'Allows the use of a "P" key instead of "Path"' {
-                $result = @(ResolveTestScripts @{ P = (Join-Path $TestDrive 'SomeFile.ps1') })
+                $result = @(ResolveTestScripts @{ p = (Join-Path $TestDrive 'SomeFile.ps1') })
 
                 $result.Count | Should -Be 1
                 $result[0].Path | Should -Be (Join-Path $TestDrive 'SomeFile.ps1')
@@ -290,7 +290,7 @@ InModuleScope Pester {
             }
 
             It 'Allows the use of an "Args" key in the dictionary' {
-                $result = @(ResolveTestScripts @{ Path = (Join-Path $TestDrive 'SomeFile.ps1'); Args = $testArgs })
+                $result = @(ResolveTestScripts @{ Path = (Join-Path $TestDrive 'SomeFile.ps1'); args = $testArgs })
 
                 $result.Count | Should -Be 1
                 $result[0].Path | Should -Be (Join-Path $TestDrive 'SomeFile.ps1')
@@ -300,7 +300,7 @@ InModuleScope Pester {
             }
 
             It 'Allows the use of an "A" key in the dictionary' {
-                $result = @(ResolveTestScripts @{ Path = (Join-Path $TestDrive 'SomeFile.ps1'); A = $testArgs })
+                $result = @(ResolveTestScripts @{ Path = (Join-Path $TestDrive 'SomeFile.ps1'); a = $testArgs })
 
                 $result.Count | Should -Be 1
                 $result[0].Path | Should -Be (Join-Path $TestDrive 'SomeFile.ps1')
@@ -321,7 +321,7 @@ InModuleScope Pester {
             }
 
             It 'Allows the use of a "Params" key in the dictionary' {
-                $result = @(ResolveTestScripts @{ Path = (Join-Path $TestDrive 'SomeFile.ps1'); Params = $testParams })
+                $result = @(ResolveTestScripts @{ Path = (Join-Path $TestDrive 'SomeFile.ps1'); params = $testParams })
 
                 $result.Count | Should -Be 1
                 $result[0].Path | Should -Be (Join-Path $TestDrive 'SomeFile.ps1')


### PR DESCRIPTION
Fixes #1101
The issue is that when the environment variable `LANG` is set to `C.UTF-8` on Unix systems, which has now become the default for Ubuntu 18 (and it also the case for AppVeyor's `Ubuntu` image), then PowerShell's hashtable keys access is case sensitive, see [this](https://github.com/PowerShell/PowerShell/issues/7761) PowerShell issue (which will only get fixed in 6.2) due to the way .Net Core respects this culture as being 'invariant'.
This PR ensures that hashtable key casing inconsistency in Pester get fixed so that Pester still works in such environments.
Thanks @ffeldhaus for debugging this issue and providing the relevant details to avoid the symptoms of this bug