### PR TITLE
Exclude Pester Tests from CodeCoverage by default

### DIFF
--- a/Functions/Coverage.Tests.ps1
+++ b/Functions/Coverage.Tests.ps1
@@ -475,6 +475,80 @@ InModuleScope Pester {
         }
     }
 
+    Describe 'Path resolution for test files' {
+        $root = (Get-PSDrive TestDrive).Root
+
+        $null = New-Item -Path $(Join-Path -Path $root -ChildPath TestScript.ps1) -ItemType File -ErrorAction SilentlyContinue
+
+        $null = New-Item -Path $(Join-Path -Path $root -ChildPath TestScript.tests.ps1) -ItemType File -ErrorAction SilentlyContinue
+
+        $null = New-Item -Path $(Join-Path -Path $root -ChildPath TestScript2.tests.ps1) -ItemType File -ErrorAction SilentlyContinue
+
+        Context 'Using Path-input (auto-detect)' {
+            It 'Excludes test files by default when using wildcard path' {
+                $coverageInfo = Get-CoverageInfoFromUserInput "$(Join-Path -Path $root -ChildPath *)"
+
+                $PesterTests = @($coverageInfo |
+                                Select-Object -ExpandProperty Path |
+                                Where-Object { $_ -match '\.tests.ps1$' })
+
+                $PesterTests | Should -BeNullOrEmpty
+            }
+
+            It 'Includes test files when specified in wildcard path' {
+                $coverageInfo = Get-CoverageInfoFromUserInput "$(Join-Path -Path $root -ChildPath *.tests.ps1)"
+
+                $PesterTests = @($coverageInfo |
+                                Select-Object -ExpandProperty Path |
+                                Where-Object { $_ -match '\.tests.ps1$' })
+
+                $PesterTests.Count | Should -Be 2
+                $PesterTests | Should -Contain $(Join-Path -Path $root -ChildPath TestScript.tests.ps1)
+                $PesterTests | Should -Contain $(Join-Path -Path $root -ChildPath TestScript2.tests.ps1)
+            }
+
+            It 'Includes test file when targeted directly using filepath' {
+                $path = Join-Path -Path $root -ChildPath TestScript.tests.ps1
+
+                $coverageInfo = Get-CoverageInfoFromUserInput $path
+
+                $PesterTests = $coverageInfo | Select-Object -ExpandProperty Path
+
+                $PesterTests | Should -Be $path
+            }
+
+        }
+
+        Context 'Using object-input' {
+            It 'Excludes test files when IncludeTests is not specified' {
+                $coverageInfo = Get-CoverageInfoFromUserInput @{ Path = "$(Join-Path -Path $root -ChildPath TestScript.tests.ps1)" }
+
+                $PesterTests = $coverageInfo | Select-Object -ExpandProperty Path
+
+                $PesterTests | Should -BeNullOrEmpty
+            }
+
+            It 'Excludes test files when IncludeTests is false' {
+                $coverageInfo = Get-CoverageInfoFromUserInput @{ Path = "$(Join-Path -Path $root -ChildPath TestScript.tests.ps1)"; IncludeTests = $false }
+
+                $PesterTests = $coverageInfo | Select-Object -ExpandProperty Path
+
+                $PesterTests | Should -BeNullOrEmpty
+            }
+
+            It 'Includes test files when IncludeTests is true' {
+                $path = Join-Path -Path $root -ChildPath TestScript.tests.ps1
+
+                $coverageInfo = Get-CoverageInfoFromUserInput @{ Path = $path; IncludeTests = $true }
+
+                $PesterTests = $coverageInfo | Select-Object -ExpandProperty Path
+
+                $PesterTests | Should -Be $path
+            }
+        }
+
+    }
+
     Describe 'Stripping common parent paths' {
 
         If ( (& $SafeCommands['Get-Variable'] -Name IsLinux -Scope Global -ErrorAction SilentlyContinue) -or

--- a/Functions/Coverage.Tests.ps1
+++ b/Functions/Coverage.Tests.ps1
@@ -545,6 +545,16 @@ InModuleScope Pester {
 
                 $PesterTests | Should -Be $path
             }
+
+            It 'Includes test files when t is true' {
+                $path = Join-Path -Path $root -ChildPath TestScript.tests.ps1
+
+                $coverageInfo = Get-CoverageInfoFromUserInput @{ p = $path; t = $true }
+
+                $PesterTests = $coverageInfo | Select-Object -ExpandProperty Path
+
+                $PesterTests | Should -Be $path
+            }
         }
 
     }

--- a/Functions/Coverage.Tests.ps1
+++ b/Functions/Coverage.Tests.ps1
@@ -545,18 +545,7 @@ InModuleScope Pester {
 
                 $PesterTests | Should -Be $path
             }
-
-            It 'Includes test files when t is true' {
-                $path = Join-Path -Path $root -ChildPath TestScript.tests.ps1
-
-                $coverageInfo = Get-CoverageInfoFromUserInput @{ p = $path; t = $true }
-
-                $PesterTests = $coverageInfo | Select-Object -ExpandProperty Path
-
-                $PesterTests | Should -Be $path
-            }
         }
-
     }
 
     Describe 'Stripping common parent paths' {

--- a/Functions/Coverage.ps1
+++ b/Functions/Coverage.ps1
@@ -101,7 +101,7 @@ function Get-CoverageInfoFromDictionary
     $endLine = Get-DictionaryValueFromFirstKeyFound -Dictionary $Dictionary -Key 'EndLine', 'End', 'e'
     [string] $class = Get-DictionaryValueFromFirstKeyFound -Dictionary $Dictionary -Key 'Class', 'c'
     [string] $function = Get-DictionaryValueFromFirstKeyFound -Dictionary $Dictionary -Key 'Function', 'f'
-    $includeTests = Get-DictionaryValueFromFirstKeyFound -Dictionary $Dictionary -Key 'IncludeTests', 'Tests' 't'
+    $includeTests = Get-DictionaryValueFromFirstKeyFound -Dictionary $Dictionary -Key 'IncludeTests', 't'
 
     $startLine = Convert-UnknownValueToInt -Value $startLine -DefaultValue 0
     $endLine = Convert-UnknownValueToInt -Value $endLine -DefaultValue 0

--- a/Functions/Coverage.ps1
+++ b/Functions/Coverage.ps1
@@ -61,7 +61,12 @@ function Get-CoverageInfoFromUserInput
     }
     else
     {
-        $unresolvedCoverageInfo = New-CoverageInfo -Path ([string]$InputObject)
+        $Path = $InputObject -as [string]
+
+        # Auto-detect IncludeTests-value from path-input
+        $IncludeTests = $Path -match '\.tests\.ps1$'
+
+        $unresolvedCoverageInfo = New-CoverageInfo -Path $Path -IncludeTests $IncludeTests
     }
 
     Resolve-CoverageInfo -UnresolvedCoverageInfo $unresolvedCoverageInfo
@@ -70,12 +75,6 @@ function Get-CoverageInfoFromUserInput
 function New-CoverageInfo
 {
     param ([string] $Path, [string] $Class = $null, [string] $Function = $null, [int] $StartLine = 0, [int] $EndLine = 0, [bool] $IncludeTests = $false)
-
-    # If user did not specify IncludeTests-value then auto-detect based on path
-    if ($PSBoundParameters.ContainsKey("IncludeTests") -eq $false) {
-        $testsPattern = '\.tests\.ps1$'
-        $IncludeTests = $Path -match $testsPattern
-    }
 
     return [pscustomobject]@{
         Path = $Path
@@ -101,7 +100,7 @@ function Get-CoverageInfoFromDictionary
     $endLine = Get-DictionaryValueFromFirstKeyFound -Dictionary $Dictionary -Key 'EndLine', 'End', 'e'
     [string] $class = Get-DictionaryValueFromFirstKeyFound -Dictionary $Dictionary -Key 'Class', 'c'
     [string] $function = Get-DictionaryValueFromFirstKeyFound -Dictionary $Dictionary -Key 'Function', 'f'
-    $includeTests = Get-DictionaryValueFromFirstKeyFound -Dictionary $Dictionary -Key 'IncludeTests', 't'
+    $includeTests = Get-DictionaryValueFromFirstKeyFound -Dictionary $Dictionary -Key 'IncludeTests'
 
     $startLine = Convert-UnknownValueToInt -Value $startLine -DefaultValue 0
     $endLine = Convert-UnknownValueToInt -Value $endLine -DefaultValue 0
@@ -136,7 +135,7 @@ function Resolve-CoverageInfo
     try
     {
         $resolvedPaths =  & $SafeCommands['Resolve-Path'] -Path $path -ErrorAction Stop |
-                        & $SafeCommands['Where-Object'] { if($_.Path -match $testsPattern) { $includeTests } else { $true } }
+                        & $SafeCommands['Where-Object'] { $includeTests -or $_.Path -notmatch $testsPattern }
     }
     catch
     {

--- a/Pester.psm1
+++ b/Pester.psm1
@@ -836,13 +836,17 @@ any code coverage information, because it's not supported by the schema.
 
 Enter the path to the files of code under test (not the test file).
 Wildcard characters are supported. If you omit the path, the default is local
-directory, not the directory specified by the Script parameter.
+directory, not the directory specified by the Script parameter. Pester test files
+are excluded by default when using path input, unless a specific test file or
+a path that ends with *.tests.ps1 is provided.
 
 To run a code coverage test only on selected classes, functions or lines in a script,
 enter a hash table value with the following keys:
 
--- Path (P)(mandatory) <string>. Enter one path to the files. Wildcard characters
+-- Path (P)(mandatory) <string>: Enter one path to the files. Wildcard characters
    are supported, but only one string is permitted.
+-- IncludeTests (T) <bool>: Includes code coverage for Pester test files (*.tests.ps1).
+   Default is false.
 
 One of the following: Class/Function or StartLine/EndLine
 

--- a/Pester.psm1
+++ b/Pester.psm1
@@ -837,15 +837,17 @@ any code coverage information, because it's not supported by the schema.
 Enter the path to the files of code under test (not the test file).
 Wildcard characters are supported. If you omit the path, the default is local
 directory, not the directory specified by the Script parameter. Pester test files
-are excluded by default when using path input, unless a specific test file or
-a path that ends with *.tests.ps1 is provided.
+are by default excluded from code coverage when a directory is provided. When you
+provide a test file directly using string, code coverage will be measured. To include
+tests in code coverage of a directory, use the dictionary syntax and provide
+IncludeTests = $true option, as shown below.
 
 To run a code coverage test only on selected classes, functions or lines in a script,
 enter a hash table value with the following keys:
 
 -- Path (P)(mandatory) <string>: Enter one path to the files. Wildcard characters
    are supported, but only one string is permitted.
--- IncludeTests (T) <bool>: Includes code coverage for Pester test files (*.tests.ps1).
+-- IncludeTests <bool>: Includes code coverage for Pester test files (*.tests.ps1).
    Default is false.
 
 One of the following: Class/Function or StartLine/EndLine


### PR DESCRIPTION
## 1. General summary of the pull request

Using `-CodeCoverage *` includes test coverage for Pester Tests (`*.tests.ps1`) by default which is rarely useful information. This PR changes the behaviour to exclude Pester Tests if not specifically specified using a path that ends with "*.test.ps1" or a specific test-filename.

Fixes #1014

## 2. Looking for input

### Design

I could think of three possible solutions to this feature:

1. Introduce a new switch like `-IncludeTestsInCoverage` in `Invoke-Pester`. That would require more changes and make `Invoke-Pester` even more complex while still not being able to activate it for a specific path if you're using multiple paths/coverageinfo in a single `Invoke-Pester` call. Decided to skip this.
2. (**Initial implementation**) Exclude/Include Pester Tests based on the path provided. Since you can specify an array of CoverageInfo-objects or paths then we could ignore tests when using wildcard, unless you specifically add one that ends with `*.tests.ps1`. This way you can include some tests, while ignoring others. You may also specify a single test-file directly.
3. Extend the CoverageInfo-object to include a new `IncludeTests` with a default value of false. That way users can enable it for a specific file or wildcard-path. We could also allow the use of `*.tests.ps1` in a string path input to activate it by checking the path in `New-CoverageInfo` and setting `IncludeTests` to true if it matches.

What do you think? Keep solution 2 or change to solution 3?

### Other questions

- Due to the behaviour being controlled by the path provided in the current draft, I included a warning message when using `*` or `*.ps1` at the end of the path to explain why tests are not covered and how to include them. Keep it or remove it and add the tip to the help for `-CodeCoverage` in `Invoke-Pester` and/or wiki?

Example:

```
PS> Invoke-Pester -Path $null -CodeCoverage C:\Git\Pester\Functions\Coverage*
WARNING: CodeCoverage for Pester Tests (*.tests.ps1) are excluded for path 'C:\Git\Pester\Functions\Coverage.tests*'. Include a path ending with '*.tests.ps1' or a specific file to include Pester Tests.
Executing all tests in ''
Tests completed in 0ms
Tests Passed: 0, Failed: 0, Skipped: 0, Pending: 0, Inconclusive: 0
Code coverage report:
Covered 27,02 % of 396 analyzed Commands in 1 File.
Missed commands:

File         Function                         Line Command
----         --------                         ---- -------
Coverage.ps1                                     1 if ($PSVersionTable.PSVersion.Major -le 2)...
...
```

- I've used some internal functions for the unit tests to isolate it, so I didn't think that it belonged in the normal "Code Coverage Analysis"-describe block. What do you think?