### PR TITLE
Stop execution of scenario if one step failed/inconclusive (#360)

### DIFF
--- a/Functions/Gherkin.Tests.ps1
+++ b/Functions/Gherkin.Tests.ps1
@@ -369,11 +369,11 @@ Describe "Check test results of steps" -Tag Gherkin {
     }
 
     It "Test result 11 is correct" {
-        $testResults[10] | Should -Be 'Passed'
+        $testResults[10] | Should -Be 'Inconclusive'
     }
 
     It "Test result 12 is correct" {
-        $testResults[11] | Should -Be 'Failed'
+        $testResults[11] | Should -Be 'Inconclusive'
     }
 
     It "Test result 13 is correct" {
@@ -381,7 +381,7 @@ Describe "Check test results of steps" -Tag Gherkin {
     }
 
     It "Test result 14 is correct" {
-        $testResults[13] | Should -Be 'Passed'
+        $testResults[13] | Should -Be 'Inconclusive'
     }
 
     It "Test result 15 is correct" {
@@ -389,7 +389,6 @@ Describe "Check test results of steps" -Tag Gherkin {
     }
 
 }
-
 
 Describe "A generated NUnit report" -Tag Gherkin {
 
@@ -523,13 +522,14 @@ Describe "A generated NUnit report" -Tag Gherkin {
         Get-XmlValue "($scenario2Examples1StepsXPath/@result)[3]" | Should -Be "Success"
         Get-XmlValue "($scenario2Examples1StepsXPath/@result)[4]" | Should -Be "Success"
         Get-XmlValue "($scenario2Examples1StepsXPath/@result)[5]" | Should -Be "Failure"
-        Get-XmlValue "($scenario2Examples1StepsXPath/@result)[6]" | Should -Be "Success"
+        Get-XmlValue "($scenario2Examples1StepsXPath/@result)[6]" | Should -Be "Inconclusive"
 
         Get-XmlInnerText "$scenario2Examples1StepsXPath[5]/failure/message" | Should -Be "An example error in the then clause"
         if ($expectFeatureFileNameInStackTrace) {
             Get-XmlInnerText "($scenario2Examples1StepsXPath)[5]/failure/stack-trace" | Should -BeLike "*From $($expectedFeatureFileName1): line 15*"
         }
         Get-XmlInnerText "($scenario2Examples1StepsXPath)[5]/failure/stack-trace" | Should -BeLike "*at <ScriptBlock>, $($expectedImplementationFileName): line 23*"
+        Get-XmlInnerText "($scenario2Examples1StepsXPath)[6]/reason/message" | Should -Be "Step skipped (previous step did not pass)"
     }
 
     It 'should contain all steps of scenario 2 (examples 2) with correct names and test results' {
@@ -587,13 +587,14 @@ Describe "A generated NUnit report" -Tag Gherkin {
 
         Get-XmlValue "($scenario4StepsXPath/@result)[1]" | Should -Be "Success"
         Get-XmlValue "($scenario4StepsXPath/@result)[2]" | Should -Be "Failure"
-        Get-XmlValue "($scenario4StepsXPath/@result)[3]" | Should -Be "Success"
+        Get-XmlValue "($scenario4StepsXPath/@result)[3]" | Should -Be "Inconclusive"
 
         Get-XmlInnerText "$scenario4StepsXPath[2]/failure/message" | Should -Be "An example error in the when clause"
         if ($expectFeatureFileNameInStackTrace) {
             Get-XmlInnerText "($scenario4StepsXPath)[2]/failure/stack-trace" | Should -BeLike "*From $($expectedFeatureFileName2): line 6*"
         }
         Get-XmlInnerText "($scenario4StepsXPath)[2]/failure/stack-trace" | Should -BeLike "*at <ScriptBlock>, $($expectedImplementationFileName): line 64*"
+        Get-XmlInnerText "($scenario4StepsXPath)[3]/reason/message" | Should -Be "Step skipped (previous step did not pass)"
     }
 
     It 'should contain all steps of scenario 5 (examples 1) with correct names and test results' {
@@ -652,8 +653,8 @@ Describe "A generated NUnit report" -Tag Gherkin {
         Get-XmlValue "($scenario5Examples3cStepsXPath/@name)[3]" | Should -Be "Scenario 5 [Examples 3 3].Then step_903"
 
         Get-XmlValue "($scenario5Examples3aStepsXPath/@result)[1]" | Should -Be "Failure"
-        Get-XmlValue "($scenario5Examples3aStepsXPath/@result)[2]" | Should -Be "Success"
-        Get-XmlValue "($scenario5Examples3aStepsXPath/@result)[3]" | Should -Be "Success"
+        Get-XmlValue "($scenario5Examples3aStepsXPath/@result)[2]" | Should -Be "Inconclusive"
+        Get-XmlValue "($scenario5Examples3aStepsXPath/@result)[3]" | Should -Be "Inconclusive"
         Get-XmlValue "($scenario5Examples3bStepsXPath/@result)[1]" | Should -Be "Inconclusive"
         Get-XmlValue "($scenario5Examples3bStepsXPath/@result)[2]" | Should -Be "Inconclusive"
         Get-XmlValue "($scenario5Examples3bStepsXPath/@result)[3]" | Should -Be "Inconclusive"
@@ -666,6 +667,8 @@ Describe "A generated NUnit report" -Tag Gherkin {
             Get-XmlInnerText "($scenario5Examples3aStepsXPath)[1]/failure/stack-trace" | Should -BeLike "*From $($expectedFeatureFileName2): line 11"
         }
         Get-XmlInnerText "($scenario5Examples3aStepsXPath)[1]/failure/stack-trace" | Should -BeLike "*at <ScriptBlock>, $($expectedImplementationFileName): line 71*"
+        Get-XmlInnerText "($scenario5Examples3aStepsXPath)[2]/reason/message" | Should -Be "Step skipped (previous step did not pass)"
+        Get-XmlInnerText "($scenario5Examples3aStepsXPath)[3]/reason/message" | Should -Be "Step skipped (previous step did not pass)"
         Get-XmlInnerText "($scenario5Examples3bStepsXPath)[1]/reason/message" | Should -Be "Could not find implementation for step!"
         Get-XmlInnerText "($scenario5Examples3bStepsXPath)[2]/reason/message" | Should -Be "Could not find implementation for step!"
         Get-XmlInnerText "($scenario5Examples3bStepsXPath)[3]/reason/message" | Should -Be "Could not find implementation for step!"


### PR DESCRIPTION
As described in #360 it does not make any sense to execute the next steps of a scenario if the current step fails or is inconclusive.

(A step is a Given/When/Then clause.)
(Also with the current pull request Pester should behave more like Cucumber.)