### PR TITLE
Improve export

### DIFF
--- a/Dependencies/TestUtilities/TestUtilities.psm1
+++ b/Dependencies/TestUtilities/TestUtilities.psm1
@@ -1,0 +1,24 @@
+# Helper function to get a XML node from a XPath expression
+function Get-XmlNode($xmlDocument, $xPath) {
+    return (Select-Xml -Xml $xmlDocument -XPath $xPath | Select-Object -ExpandProperty Node)
+}
+
+# Helper function to get the inner text of a XML node from a XPath expression
+function Get-XmlInnerText($xmlDocument, $xPath) {
+    return (Get-XmlNode $xmlDocument $xPath).InnerText
+}
+
+# Helper function to get the value of a XML node from a XPath expression
+function Get-XmlValue($xmlDocument, $xPath) {
+    return (Get-XmlNode $xmlDocument $xPath).Value
+}
+
+# Helper function to get the number of children of a XML node from a XPath expression
+function Get-XmlCount($xmlDocument, $xPath) {
+    return (Get-XmlNode $xmlDocument $xPath).Count
+}
+
+# Special helper function to get the text of the directly following pre element
+function Get-NextPreText($xmlDocument, $xPath) {
+    return Get-XmlInnerText $xmlDocument "$xPath/following-sibling::*[position()=1][name()='pre']"
+}

--- a/Functions/Export/Html.ps1
+++ b/Functions/Export/Html.ps1
@@ -1,0 +1,267 @@
+function Export-HtmlReport {
+    param (
+        [parameter(Mandatory = $true)]
+        $TestReport,
+
+        [parameter(Mandatory = $true)]
+        [String]$Path
+    )
+    Write-HtmlReport $TestReport | Out-File $Path
+}
+
+function Get-EncodedText([string] $Text) {
+    [System.Security.SecurityElement]::Escape($Text)
+}
+
+function Write-HtmlReport($TestReport) {
+    @"
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    <title>HTML Report</title>
+    <style>
+      body {
+        font-size: 12pt;
+        font-family: Georgia;
+      }
+      h1 { font-size:16pt; margin:14pt 0pt 20pt 0pt; padding:0pt 0pt 4pt 0pt; }
+      details { font-size:12pt; margin:7pt; padding:7pt 14pt 7pt 14pt; }
+      details.stacktrace { font-size:8pt; margin:0pt; padding:0pt 0pt 5pt 0pt; }
+      .stacktrace { font-size:8pt; }
+      h2 { font-size:12pt; margin:12pt 0pt 0pt 0pt; padding:0pt 0pt 3pt 0pt; }
+      .success      { background-color: #c5d88a; }
+      .inconclusive { background-color: #eaec2d; }
+      .failure      { background-color: #d88a8a; }
+      .failureMessage { background-color: #edbbbb; color:black; margin:0px; padding:5pt 0pt 5pt 5pt; }
+      .inconclusiveMessage { background-color: #ebec98; color:black; margin:0px; padding:5pt 0pt 5pt 5pt; }
+      .widthHeader  { width: 60pt; }
+      .widthHeader2 { width: 80pt; }
+      hr { width: 100%; height: 1pt; margin:14pt 0px 0px 0px; color: grey; background: grey; }
+      pre {
+          font-family: Consolas,monospace;
+          font-size: 12pt;
+          white-space: pre-wrap;
+          white-space: -moz-pre-wrap;
+          white-space: -pre-wrap;
+          white-space: -o-pre-wrap;
+          word-wrap: break-word;
+      }
+      table { border-spacing: 0; }
+      td, th { padding: 0pt 5pt 0pt 0pt; }
+      th, td { text-align: right; }
+      th.left, td.left { text-align: left; }
+      #overview { overflow:hidden; }
+      #results  { float: left; margin-bottom: 12pt; }
+      #summary  { float: right; clear:right; margin-top: 14pt; }
+    </style>
+  </head>
+  <body>
+"@
+    Write-HtmlSummary $TestReport
+    if ($TestReport.TestResult) {
+        Write-HtmlResults ($TestReport.TestResult) 0
+    }
+    @"
+  </body>
+</html>
+"@
+}
+
+function Write-HtmlSummary($TestReport) {
+    if ($PSVersionTable.Keys -contains "PSEdition") {
+        $extraVersionString = " ($($PSVersionTable.PSEdition))"
+    }
+    else {
+        $extraVersionString = ""
+    }
+    $powerShellVersion = "$($PSVersionTable.PSVersion)$extraVersionString"
+    if (-not $TestReport.Gherkin) {
+        $testRunTitle = "Pester Spec Run"
+        $mainGroupName = "Files"
+        $subGroupName = "Groups"
+        $testCasesName = "Specs"
+    }
+    else {
+        $testRunTitle = "Pester Gherkin Run"
+        $mainGroupName = "Features"
+        $subGroupName = "Scenarios"
+        $testCasesName = "Steps"
+    }
+    $operatingSystem = Get-EncodedText ((, ($TestReport.Environment.Platform) -split '\|')[0])
+    $osVersion = Get-EncodedText $TestReport.Environment.'os-version'
+    $user = Get-EncodedText $TestReport.Environment.'user'
+    $hostname = Get-EncodedText $TestReport.Environment.'machine-name'
+    $date = $TestReport.Date
+    $time = $TestReport.Time
+    $duration = Get-EncodedText "$($TestReport.Duration) seconds"
+    $culture = $TestReport.Culture
+    $uiCulture = $TestReport.UiCulture
+    @"
+    <div id="overview">
+      <div id="results">
+        <h1>$testRunTitle</h1>
+        <table>
+          <tr>
+            <td class="widthHeader2">&#160;</td>
+            <th class="widthHeader">Total</th>
+            <th class="success widthHeader">Passed</th>
+"@
+    # TODO Use term 'Inconclusive' instead of 'Skipped' in the summary
+    #      Currently 'Skipped' is chosen since 'Inconclusive' is long and makes the table ugly
+    @"
+            <th class="inconclusive widthHeader">Skipped</th>
+            <th class="failure widthHeader">Failed</th>
+          </tr>
+          <tr>
+            <th class="left">$($mainGroupName):</th>
+            <td>$($TestReport.MainGroupResult.TotalCount)</td>
+            <td class="success">$($TestReport.MainGroupResult.PassedCount)</td>
+            <td class="inconclusive">$($TestReport.MainGroupResult.InconclusiveCount)</td>
+            <td class="failure">$($TestReport.MainGroupResult.FailedCount)</td>
+          </tr>
+          <tr>
+            <th class="left">$($subGroupName):</th>
+            <td>$($TestReport.SubGroupResult.TotalCount)</td>
+            <td class="success">$($TestReport.SubGroupResult.PassedCount)</td>
+            <td class="inconclusive">$($TestReport.SubGroupResult.InconclusiveCount)</td>
+            <td class="failure">$($TestReport.SubGroupResult.FailedCount)</td>
+          </tr>
+          <tr>
+            <th class="left">$($testCasesName):</th>
+            <td>$($TestReport.TestResult.TotalCount)</td>
+            <td class="success">$($TestReport.TestResult.PassedCount)</td>
+            <td class="inconclusive">$($TestReport.TestResult.InconclusiveCount)</td>
+            <td class="failure">$($TestReport.TestResult.FailedCount)</td>
+          </tr>
+        </table>
+      </div>
+      <div id="summary">
+        <table>
+"@
+    if ($powerShellVersion) {
+        @"
+          <tr>
+            <th>PowerShell version:</th>
+            <td class="left">$powerShellVersion</td>
+          </tr>
+"@
+    }
+    @"
+          <tr>
+            <th>Operating system:</th>
+            <td class="left">$operatingSystem</td>
+          </tr>
+          <tr>
+            <th>Version:</th>
+            <td class="left">$osVersion</td>
+          </tr>
+          <tr>
+            <th>User:</th>
+            <td class="left">$user@$hostName</td>
+          </tr>
+          <tr>
+            <th>Date/time:</th>
+            <td class="left">$date $time</td>
+          </tr>
+          <tr>
+            <th>Duration:</th>
+            <td class="left">$duration</td>
+          </tr>
+          <tr>
+            <th>Culture:</th>
+            <td class="left">$culture</td>
+          </tr>
+"@
+    if ($culture -ne $uiCulture) {
+        @"
+            <tr>
+              <th>UI culture:</th>
+              <td class="left">$uiCulture</td>
+            </tr>
+"@
+    }
+    @"
+        </table>
+      </div>
+    </div>
+"@
+}
+
+function Write-HtmlResults($TestResult, $Level) {
+    if ($Level -eq 1) {
+        @"
+    <hr />
+    <h2>$(Get-EncodedText $TestResult.Name)</h2>
+"@
+    }
+    elseif ($Level -ge 2) {
+        $open = ''
+        if ($TestResult.PassedCount -gt 0 -and $TestResult.PassedCount -eq $TestResult.TotalCount) {
+            $testSuiteCssClass = 'success'
+        }
+        elseif ($TestResult.FailedCount -gt 0) {
+            $testSuiteCssClass = 'failure'
+            $open = ' open="open"'
+        }
+        else {
+            $testSuiteCssClass = 'inconclusive'
+        }
+        @"
+    <details class="$testSuiteCssClass"$open>
+      <summary>
+        <strong>$(Get-EncodedText $TestResult.Name)</strong>
+      </summary>
+"@
+    }
+    foreach ($child in $TestResult.Children) {
+        if (-not $child.IsTestCase) {
+            Write-HtmlResults $child ($Level + 1)
+        }
+        else {
+            Write-HtmlTestCase $child
+        }
+    }
+    if ($Level -eq 1) {
+    }
+    elseif ($Level -ge 2) {
+        @"
+    </details>
+"@
+    }
+}
+
+function Write-HtmlTestCase($TestResult) {
+    $showStackTrace = $false
+    switch ($TestResult.Outcome) {
+        'Passed' {
+            $testCaseCssClass = 'success'
+            $failureMessageClass = ''
+        }
+        'Inconclusive' {
+            $testCaseCssClass = 'inconclusive'
+            $failureMessageClass = 'inconclusiveMessage'
+        }
+        default {
+            $testCaseCssClass = 'failure'
+            $failureMessageClass = 'failureMessage'
+            $showStackTrace = $true
+        }
+    }
+    @"
+      <div class="$testCaseCssClass">$(Get-EncodedText $TestResult.Name)</div>
+"@
+    if ($TestResult.FailureMessage) {
+        @"
+      <pre class="$failureMessageClass">$(Get-EncodedText $TestResult.FailureMessage)</pre>
+"@
+        if ($showStackTrace) {
+            @"
+      <details class="stacktrace">
+          <summary>Error details</summary>
+          <pre class="$failureMessageClass stacktrace">$(Get-EncodedText $TestResult.StackTrace)</pre>
+      </details>
+"@
+        }
+    }
+}

--- a/Functions/Export/NUnit.ps1
+++ b/Functions/Export/NUnit.ps1
@@ -1,0 +1,256 @@
+function Export-NUnitReport {
+    param (
+        [parameter(Mandatory = $true)]
+        $TestReport,
+
+        [parameter(Mandatory = $true)]
+        [String]$Path
+    )
+
+    $settings = & $SafeCommands['New-Object'] -TypeName Xml.XmlWriterSettings -Property @{
+        Indent              = $true
+        NewLineOnAttributes = $false
+    }
+
+    $xmlFile = $null
+    $xmlWriter = $null
+    try {
+        $xmlFile = [IO.File]::Create($Path)
+        $xmlWriter = [Xml.XmlWriter]::Create($xmlFile, $settings)
+        Write-NUnitReport $TestReport $xmlWriter
+        $xmlWriter.Flush()
+        $xmlFile.Flush()
+    }
+    finally {
+        if ($null -ne $xmlWriter) {
+            try { $xmlWriter.Close() } catch {}
+        }
+        if ($null -ne $xmlFile) {
+            try { $xmlFile.Close() } catch {}
+        }
+    }
+}
+
+function Write-NUnitReport($TestReport, [System.Xml.XmlWriter] $XmlWriter) {
+    function Write-NUnitTestResultAttributes {
+        $TestResult = $TestReport.TestResult
+        $XmlWriter.WriteAttributeString('xmlns', 'xsi', $null, 'http://www.w3.org/2001/XMLSchema-instance')
+        $XmlWriter.WriteAttributeString('xsi', 'noNamespaceSchemaLocation', [Xml.Schema.XmlSchema]::InstanceNamespace , 'nunit_schema_2.5.xsd')
+        $XmlWriter.WriteAttributeString('name', $TestReport.Name)
+        $XmlWriter.WriteAttributeString('total', ($TestResult.TotalCount - $TestResult.SkippedCount))
+        $XmlWriter.WriteAttributeString('errors', '0')
+        $XmlWriter.WriteAttributeString('failures', $TestResult.FailedCount)
+        $XmlWriter.WriteAttributeString('not-run', '0')
+        $XmlWriter.WriteAttributeString('inconclusive', $TestResult.PendingCount + $TestResult.InconclusiveCount)
+        $XmlWriter.WriteAttributeString('ignored', $TestResult.SkippedCount)
+        $XmlWriter.WriteAttributeString('skipped', '0')
+        $XmlWriter.WriteAttributeString('invalid', '0')
+        $XmlWriter.WriteAttributeString('date', $TestReport.Date)
+        $XmlWriter.WriteAttributeString('time', $TestReport.Time)
+    }
+
+    function Write-NUnitTestResultChildNodes {
+        $TestResult = $TestReport.TestResult
+        Write-NUnitEnvironmentInformation
+        Write-NUnitCultureInformation
+        $TestResult = $TestReport.TestResult
+        $XmlWriter.WriteStartElement('test-suite')
+        Write-NUnitTestSuiteAttributes $TestResult
+        $XmlWriter.WriteStartElement('results')
+        foreach ($child in $TestResult.Children) {
+            Write-NUnitTestSuiteElements $child
+        }
+        $XmlWriter.WriteEndElement()
+        $XmlWriter.WriteEndElement()
+    }
+
+    function Write-NUnitEnvironmentInformation {
+        $XmlWriter.WriteStartElement('environment')
+        $environment = $TestReport.Environment
+        foreach ($keyValuePair in $environment.GetEnumerator()) {
+            $XmlWriter.WriteAttributeString($keyValuePair.Name, $keyValuePair.Value)
+        }
+        $XmlWriter.WriteEndElement()
+    }
+
+    function Write-NUnitCultureInformation {
+        $XmlWriter.WriteStartElement('culture-info')
+        $XmlWriter.WriteAttributeString('current-culture', $TestReport.Culture)
+        $XmlWriter.WriteAttributeString('current-uiculture', $TestReport.UiCulture)
+        $XmlWriter.WriteEndElement()
+    }
+
+    function Write-NUnitTestSuiteElements($TestResult) {
+        $XmlWriter.WriteStartElement('test-suite')
+        Write-NUnitTestSuiteAttributes $TestResult
+        $XmlWriter.WriteStartElement('results')
+        foreach ($child in $TestResult.Children) {
+            if (-not $child.IsTestCase) {
+                Write-NUnitTestSuiteElements $child
+            }
+            else {
+                Write-NUnitTestCaseElement $child
+            }
+        }
+        $XmlWriter.WriteEndElement()
+        $XmlWriter.WriteEndElement()
+    }
+
+    function Write-NUnitTestSuiteAttributes($TestResult) {
+        if (-not $TestResult.Parameterized) {
+            $testSuiteType = 'TestFixture'
+        }
+        else {
+            $testSuiteType = 'ParameterizedTest'
+        }
+        $success = if ($TestResult.FailedCount -eq 0) { 'True' } else { 'False' }
+        $XmlWriter.WriteAttributeString('description', $TestResult.Name)
+        $XmlWriter.WriteAttributeString('type', $testSuiteType)
+        $XmlWriter.WriteAttributeString('name', (Get-FullQualifiedName $TestResult))
+        $XmlWriter.WriteAttributeString('executed', 'True')
+        $XmlWriter.WriteAttributeString('result', (Get-NUnitTestSuiteResult($TestResult)))
+        $XmlWriter.WriteAttributeString('success', $success)
+        $XmlWriter.WriteAttributeString('time', (Convert-TimeSpan $TestResult.Time))
+        $XmlWriter.WriteAttributeString('asserts', '0')
+    }
+
+    function Write-NUnitTestCaseElement($TestResult) {
+        $XmlWriter.WriteStartElement('test-case')
+        Write-NUnitTestCaseAttributes $TestResult
+        $XmlWriter.WriteEndElement()
+    }
+
+    function Write-NUnitTestCaseAttributes($TestResult) {
+        $XmlWriter.WriteAttributeString('description', $TestResult.Name)
+        $XmlWriter.WriteAttributeString('name', (Get-FullQualifiedName $TestResult))
+        $XmlWriter.WriteAttributeString('time', (Convert-TimeSpan $TestResult.Time))
+        $XmlWriter.WriteAttributeString('asserts', '0')
+        $XmlWriter.WriteAttributeString('success', $TestResult.Passed)
+
+        switch ($TestResult.Outcome) {
+            Passed {
+                $XmlWriter.WriteAttributeString('result', 'Success')
+                $XmlWriter.WriteAttributeString('executed', 'True')
+                break
+            }
+            Skipped {
+                $XmlWriter.WriteAttributeString('result', 'Ignored')
+                $XmlWriter.WriteAttributeString('executed', 'False')
+                break
+            }
+
+            Pending {
+                $XmlWriter.WriteAttributeString('result', 'Inconclusive')
+                $XmlWriter.WriteAttributeString('executed', 'True')
+                break
+            }
+            Inconclusive {
+                $XmlWriter.WriteAttributeString('result', 'Inconclusive')
+                $XmlWriter.WriteAttributeString('executed', 'True')
+
+                if ($TestResult.FailureMessage) {
+                    $XmlWriter.WriteStartElement('reason')
+                    $xmlWriter.WriteElementString('message', $TestResult.FailureMessage)
+                    $XmlWriter.WriteEndElement() # Close reason tag
+                }
+                break
+            }
+            Failed {
+                $XmlWriter.WriteAttributeString('result', 'Failure')
+                $XmlWriter.WriteAttributeString('executed', 'True')
+                $XmlWriter.WriteStartElement('failure')
+                $xmlWriter.WriteElementString('message', $TestResult.FailureMessage)
+                $XmlWriter.WriteElementString('stack-trace', $TestResult.StackTrace)
+                $XmlWriter.WriteEndElement() # Close failure tag
+                break
+            }
+        }
+    }
+
+    function Get-FullQualifiedName($TestResult) {
+        $path = Get-NUnitPath $TestResult
+        if ($path) {
+            # We use the NUnit path as full qualified name for the test suite
+            return $path
+        }
+        # Since we got no NUnit path for the test suite, we use the simple name which is always present
+        return $TestResult.Name
+    }
+
+    function Get-NUnitPath($TestResult) {
+        if (-not $TestResult.Parent) {
+            # The top level test result has an empty NUnit path
+            return ""
+        }
+        if (-not $TestReport.Gherkin -and $TestResult.Hint -eq 'Script') {
+            # On PSpec the script level is the file name, which will not be included in the NUnit path
+            # On Gherkin we include it, since it is the feature name
+            return ""
+        }
+
+        # We initialize the resulted path with the test name
+        $testResultPath = $TestResult.Name
+        if ($TestResult.Name -eq $TestResult.Parent.GroupName) {
+            $paramString = Get-ParamsString $TestResult
+            if ($paramString) {
+                $testResultPath = "$testResultPath($paramString)"
+            }
+        }
+
+        $parent = $TestResult.Parent
+        if ($TestResult.Parent.Parameterized) {
+            # The direct parent is a parameterized test suite, we skip it in the NUnit path
+            $parent = $parent.Parent
+        }
+
+        # Recursively invoke this method to get the complete parent path
+        $parentPath = Get-NUnitPath $parent
+
+        $separator = if ($parentPath) {'.'} else { '' }
+        return "${parentPath}${separator}$testResultPath"
+    }
+
+    function Get-ParamsString($TestResult) {
+        if ($null -eq $TestResult.Parameters) {
+            return ""
+        }
+        @(
+            foreach ($value in $TestResult.Parameters.Values) {
+                if ($null -eq $value) {
+                    'null'
+                }
+                elseif ($value -is [string]) {
+                    '"{0}"' -f $value
+                }
+                else {
+                    # do not use .ToString() it uses the current culture settings
+                    # and we need to use en-US culture, which [string] or .ToString([Globalization.CultureInfo]'en-us') uses
+                    [string] $value
+                }
+            }
+        ) -join ','
+    }
+
+    function Get-NUnitTestSuiteResult($TestResult) {
+        # I am not sure about the result precedence, and can't find any good source
+        # TODO: Confirm this is the correct order of precedence
+        if ($TestResult.FailedCount -gt 0) { return 'Failure' }
+        if ($TestResult.SkippedCount -gt 0) { return 'Ignored' }
+        if ($TestResult.PendingCount -gt 0) { return 'Inconclusive' }
+        return 'Success'
+    }
+
+    # Write the XML Declaration
+    $XmlWriter.WriteStartDocument($false)
+
+    # Write Root Element
+    $xmlWriter.WriteStartElement('test-results')
+
+    if ($TestReport.TestResult) {
+        Write-NUnitTestResultAttributes
+    }
+    Write-NUnitTestResultChildNodes $TestReport $XmlWriter
+
+    $XmlWriter.WriteEndElement()
+
+}

--- a/Functions/Gherkin.Tests.ps1
+++ b/Functions/Gherkin.Tests.ps1
@@ -2,10 +2,28 @@
 
 $scriptRoot = Split-Path (Split-Path $MyInvocation.MyCommand.Path)
 
+# Include XML helper functions for testing
+Import-Module ("$scriptRoot{0}Dependencies{0}TestUtilities{0}TestUtilities.psm1" -f [System.IO.Path]::DirectorySeparatorChar)
+
 $multiLanguageTestData = @{
-    'en' = @{ namedScenario = 'When something uses MyValidator'; additionalSteps = 4; additionalScenarios = 2 }
-    'es' = @{ namedScenario = 'Algo usa MiValidator'; additionalSteps = 0; additionalScenarios = 0 }
-    'de' = @{ namedScenario = 'Etwas verwendet MeinValidator'; additionalSteps = 0; additionalScenarios = 0 }
+    'en' = @{
+        feature = 'A string validator function called MyValidator'
+        scenario = 'When something uses MyValidator'
+        additionalSteps = 4
+        additionalScenarios = 2
+    }
+    'es' = @{
+        feature = 'Una función para validar cadenas de caracteres llamada MiValidator'
+        scenario = 'Algo usa MiValidator'
+        additionalSteps = 0
+        additionalScenarios = 0
+    }
+    'de' = @{
+        feature = 'Eine Zeichenkettenprüfungsfunktion namens MeinValidator'
+        scenario = 'Etwas verwendet MeinValidator'
+        additionalSteps = 0
+        additionalScenarios = 0
+    }
 }
 
 foreach ($data in $multiLanguageTestData.GetEnumerator()) {
@@ -40,7 +58,7 @@ foreach ($data in $multiLanguageTestData.GetEnumerator()) {
                 Example1      = Invoke-Gherkin $fullFileName -WarningAction SilentlyContinue -PassThru -Tag Example1 -Show None
                 Example2      = Invoke-Gherkin $fullFileName -WarningAction SilentlyContinue -PassThru -Tag Example2 -Show None
                 Scenarios     = Invoke-Gherkin $fullFileName -WarningAction SilentlyContinue -PassThru -Tag Scenarios -Show None
-                NamedScenario = Invoke-Gherkin $fullFileName -WarningAction SilentlyContinue -PassThru -ScenarioName $featureTestData.namedScenario -Show None
+                NamedScenario = Invoke-Gherkin $fullFileName -WarningAction SilentlyContinue -PassThru -ScenarioName $featureTestData.scenario -Show None
                 NotMockery    = Invoke-Gherkin $fullFileName -WarningAction SilentlyContinue -PassThru -ExcludeTag Mockery -Show None
             }
         }
@@ -80,7 +98,7 @@ foreach ($data in $multiLanguageTestData.GetEnumerator()) {
             ($gherkin.NotMockery.TotalCount + $gherkin.Mockery.TotalCount) | Should -Be $gherkin.Results.TotalCount
         }
 
-        It "Supports running specific scenarios by name '$($featureTestData.namedScenario)'" {
+        It "Supports running specific scenarios by name '$($featureTestData.scenario)'" {
             $gherkin.NamedScenario.PassedCount | Should -Be 3
         }
 
@@ -96,7 +114,7 @@ foreach ($data in $multiLanguageTestData.GetEnumerator()) {
             $nUnitReportXml | Should -Not -BeNullOrEmpty
             $scenarioName = $nUnitReportXml.'test-results'.'test-suite'.results.'test-suite'.results.'test-suite'[0].name
             $scenarioName | Should -Not -BeNullOrEmpty
-            $scenarioName | Should -Be $featureTestData.namedScenario
+            $scenarioName | Should -Be "$($featureTestData.feature).$($featureTestData.scenario)"
         }
     }
 }
@@ -418,26 +436,6 @@ Describe "A generated NUnit report" -Tag Gherkin {
         # Will be evaluated below
     }
 
-    # Helper function to get a XML node from a XPath expression
-    function Get-XmlNode($xPath) {
-        return (Select-Xml -Xml $nUnitReportXml -XPath $xPath | Select-Object -ExpandProperty Node)
-    }
-
-    # Helper function to get the inner text of a XML node from a XPath expression
-    function Get-XmlInnerText($xPath) {
-        return (Get-XmlNode $xPath).InnerText
-    }
-
-    # Helper function to get the value of a XML node from a XPath expression
-    function Get-XmlValue($xPath) {
-        return (Get-XmlNode $xPath).Value
-    }
-
-    # Helper function to get the number of children of a XML node from a XPath expression
-    function Get-XmlCount($xPath) {
-        return (Get-XmlNode $xPath).Count
-    }
-
     $expectedFeatureFileName1 = (Join-Path $scriptRoot Examples\Gherkin\JustForReporting1.feature)
     $expectedFeatureFileName2 = (Join-Path $scriptRoot Examples\Gherkin\JustForReporting2.feature)
     $expectedImplementationFileName = (Join-Path $scriptRoot Examples\Gherkin\JustForReporting.Steps.ps1)
@@ -445,6 +443,9 @@ Describe "A generated NUnit report" -Tag Gherkin {
     $featuresXPath = "/test-results/test-suite/results/test-suite"
     $feature1ScenariosXPath = "$featuresXPath[1]/results/test-suite"
     $feature2ScenariosXPath = "$featuresXPath[2]/results/test-suite"
+
+    $feature1Name = "A test feature for reporting 1"
+    $feature2Name = "A test feature for reporting 2"
 
     $expectFeatureFileNameInStackTrace = $PSVersionTable.PSVersion.Major -gt 2
 
@@ -454,185 +455,235 @@ Describe "A generated NUnit report" -Tag Gherkin {
     }
 
     It 'should contain feature 1' {
-        Get-XmlValue "$featuresXPath[1]/@name" | Should -Be 'A test feature for reporting 1'
+        Get-XmlValue $nUnitReportXml "$featuresXPath[1]/@name" | Should -Be $feature1Name
+        Get-XmlValue $nUnitReportXml "$featuresXPath[1]/@description" | Should -Be $feature1Name
     }
 
     It 'should contain feature 2' {
-        Get-XmlValue "$featuresXPath[2]/@name" | Should -Be 'A test feature for reporting 2'
+        Get-XmlValue $nUnitReportXml "$featuresXPath[2]/@name" | Should -Be $feature2Name
+        Get-XmlValue $nUnitReportXml "$featuresXPath[2]/@description" | Should -Be $feature2Name
     }
 
     It 'should contain all scenarios of feature 1 with correct names and test results' {
-        Get-XmlCount $feature1ScenariosXPath | Should -Be 4
+        Get-XmlCount $nUnitReportXml $feature1ScenariosXPath | Should -Be 4
 
-        Get-XmlValue "$feature1ScenariosXPath[1]/@name" | Should -Be "Scenario 1"
-        Get-XmlValue "$feature1ScenariosXPath[2]/@name" | Should -Be "Scenario 2 [Examples 1 1]"
-        Get-XmlValue "$feature1ScenariosXPath[3]/@name" | Should -Be "Scenario 2 [Examples 2 1]"
-        Get-XmlValue "$feature1ScenariosXPath[4]/@name" | Should -Be "Scenario 3"
+        Get-XmlValue $nUnitReportXml "$feature1ScenariosXPath[1]/@name" | Should -Be "$feature1Name.Scenario 1"
+        Get-XmlValue $nUnitReportXml "$feature1ScenariosXPath[2]/@name" | Should -Be "$feature1Name.Scenario 2 [Examples 1 1]"
+        Get-XmlValue $nUnitReportXml "$feature1ScenariosXPath[3]/@name" | Should -Be "$feature1Name.Scenario 2 [Examples 2 1]"
+        Get-XmlValue $nUnitReportXml "$feature1ScenariosXPath[4]/@name" | Should -Be "$feature1Name.Scenario 3"
 
-        Get-XmlValue "$feature1ScenariosXPath[1]/@result" | Should -Be "Success"
-        Get-XmlValue "$feature1ScenariosXPath[2]/@result" | Should -Be "Success"
-        Get-XmlValue "$feature1ScenariosXPath[3]/@result" | Should -Be "Success"
-        Get-XmlValue "$feature1ScenariosXPath[4]/@result" | Should -Be "Success"
+        Get-XmlValue $nUnitReportXml "$feature1ScenariosXPath[1]/@description" | Should -Be "Scenario 1"
+        Get-XmlValue $nUnitReportXml "$feature1ScenariosXPath[2]/@description" | Should -Be "Scenario 2 [Examples 1 1]"
+        Get-XmlValue $nUnitReportXml "$feature1ScenariosXPath[3]/@description" | Should -Be "Scenario 2 [Examples 2 1]"
+        Get-XmlValue $nUnitReportXml "$feature1ScenariosXPath[4]/@description" | Should -Be "Scenario 3"
+
+        Get-XmlValue $nUnitReportXml "$feature1ScenariosXPath[1]/@result" | Should -Be "Success"
+        Get-XmlValue $nUnitReportXml "$feature1ScenariosXPath[2]/@result" | Should -Be "Failure"
+        Get-XmlValue $nUnitReportXml "$feature1ScenariosXPath[3]/@result" | Should -Be "Success"
+        Get-XmlValue $nUnitReportXml "$feature1ScenariosXPath[4]/@result" | Should -Be "Failure"
     }
 
     It 'should contain all scenarios of feature 2 with correct names and test results' {
-        Get-XmlCount $feature2ScenariosXPath | Should -Be 6
+        Get-XmlCount $nUnitReportXml $feature2ScenariosXPath | Should -Be 6
 
-        Get-XmlValue "$feature2ScenariosXPath[1]/@name" | Should -Be "Scenario 4"
-        Get-XmlValue "$feature2ScenariosXPath[2]/@name" | Should -Be "Scenario 5 [Examples 1 1]"
-        Get-XmlValue "$feature2ScenariosXPath[3]/@name" | Should -Be "Scenario 5 [Examples 2 1]"
-        Get-XmlValue "$feature2ScenariosXPath[4]/@name" | Should -Be "Scenario 5 [Examples 3 1]"
-        Get-XmlValue "$feature2ScenariosXPath[5]/@name" | Should -Be "Scenario 5 [Examples 3 2]"
-        Get-XmlValue "$feature2ScenariosXPath[6]/@name" | Should -Be "Scenario 5 [Examples 3 3]"
+        Get-XmlValue $nUnitReportXml "$feature2ScenariosXPath[1]/@name" | Should -Be "$feature2Name.Scenario 4"
+        Get-XmlValue $nUnitReportXml "$feature2ScenariosXPath[2]/@name" | Should -Be "$feature2Name.Scenario 5 [Examples 1 1]"
+        Get-XmlValue $nUnitReportXml "$feature2ScenariosXPath[3]/@name" | Should -Be "$feature2Name.Scenario 5 [Examples 2 1]"
+        Get-XmlValue $nUnitReportXml "$feature2ScenariosXPath[4]/@name" | Should -Be "$feature2Name.Scenario 5 [Examples 3 1]"
+        Get-XmlValue $nUnitReportXml "$feature2ScenariosXPath[5]/@name" | Should -Be "$feature2Name.Scenario 5 [Examples 3 2]"
+        Get-XmlValue $nUnitReportXml "$feature2ScenariosXPath[6]/@name" | Should -Be "$feature2Name.Scenario 5 [Examples 3 3]"
 
-        Get-XmlValue "$feature2ScenariosXPath[1]/@result" | Should -Be "Success"
-        Get-XmlValue "$feature2ScenariosXPath[2]/@result" | Should -Be "Success"
-        Get-XmlValue "$feature2ScenariosXPath[3]/@result" | Should -Be "Success"
-        Get-XmlValue "$feature2ScenariosXPath[4]/@result" | Should -Be "Success"
-        Get-XmlValue "$feature2ScenariosXPath[5]/@result" | Should -Be "Success"
-        Get-XmlValue "$feature2ScenariosXPath[6]/@result" | Should -Be "Success"
+        Get-XmlValue $nUnitReportXml "$feature2ScenariosXPath[1]/@description" | Should -Be "Scenario 4"
+        Get-XmlValue $nUnitReportXml "$feature2ScenariosXPath[2]/@description" | Should -Be "Scenario 5 [Examples 1 1]"
+        Get-XmlValue $nUnitReportXml "$feature2ScenariosXPath[3]/@description" | Should -Be "Scenario 5 [Examples 2 1]"
+        Get-XmlValue $nUnitReportXml "$feature2ScenariosXPath[4]/@description" | Should -Be "Scenario 5 [Examples 3 1]"
+        Get-XmlValue $nUnitReportXml "$feature2ScenariosXPath[5]/@description" | Should -Be "Scenario 5 [Examples 3 2]"
+        Get-XmlValue $nUnitReportXml "$feature2ScenariosXPath[6]/@description" | Should -Be "Scenario 5 [Examples 3 3]"
+
+        Get-XmlValue $nUnitReportXml "$feature2ScenariosXPath[1]/@result" | Should -Be "Failure"
+        Get-XmlValue $nUnitReportXml "$feature2ScenariosXPath[2]/@result" | Should -Be "Success"
+        Get-XmlValue $nUnitReportXml "$feature2ScenariosXPath[3]/@result" | Should -Be "Success"
+        Get-XmlValue $nUnitReportXml "$feature2ScenariosXPath[4]/@result" | Should -Be "Failure"
+        Get-XmlValue $nUnitReportXml "$feature2ScenariosXPath[5]/@result" | Should -Be "Success"
+        Get-XmlValue $nUnitReportXml "$feature2ScenariosXPath[6]/@result" | Should -Be "Success"
     }
 
     It 'should contain all steps of scenario 1 with correct names and test results' {
         $scenario1StepsXPath = "$feature1ScenariosXPath[1]//test-case"
 
-        Get-XmlCount $scenario1StepsXPath | Should -Be 3
+        Get-XmlCount $nUnitReportXml $scenario1StepsXPath | Should -Be 3
 
-        Get-XmlValue "($scenario1StepsXPath/@name)[1]" | Should -Be "Scenario 1.Given step_001"
-        Get-XmlValue "($scenario1StepsXPath/@name)[2]" | Should -Be "Scenario 1.When step_002"
-        Get-XmlValue "($scenario1StepsXPath/@name)[3]" | Should -Be "Scenario 1.Then step_003"
+        Get-XmlValue $nUnitReportXml "($scenario1StepsXPath/@name)[1]" | Should -Be "$feature1Name.Scenario 1.Given step_001"
+        Get-XmlValue $nUnitReportXml "($scenario1StepsXPath/@name)[2]" | Should -Be "$feature1Name.Scenario 1.When step_002"
+        Get-XmlValue $nUnitReportXml "($scenario1StepsXPath/@name)[3]" | Should -Be "$feature1Name.Scenario 1.Then step_003"
 
-        Get-XmlValue "($scenario1StepsXPath/@result)[1]" | Should -Be "Success"
-        Get-XmlValue "($scenario1StepsXPath/@result)[2]" | Should -Be "Success"
-        Get-XmlValue "($scenario1StepsXPath/@result)[3]" | Should -Be "Success"
+        Get-XmlValue $nUnitReportXml "($scenario1StepsXPath/@description)[1]" | Should -Be "Given step_001"
+        Get-XmlValue $nUnitReportXml "($scenario1StepsXPath/@description)[2]" | Should -Be "When step_002"
+        Get-XmlValue $nUnitReportXml "($scenario1StepsXPath/@description)[3]" | Should -Be "Then step_003"
+
+        Get-XmlValue $nUnitReportXml "($scenario1StepsXPath/@result)[1]" | Should -Be "Success"
+        Get-XmlValue $nUnitReportXml "($scenario1StepsXPath/@result)[2]" | Should -Be "Success"
+        Get-XmlValue $nUnitReportXml "($scenario1StepsXPath/@result)[3]" | Should -Be "Success"
     }
 
     It 'should contain all steps of scenario 2 (examples 1) with correct names and test results' {
         $scenario2Examples1StepsXPath = "$feature1ScenariosXPath[2]//test-case"
 
-        Get-XmlCount $scenario2Examples1StepsXPath | Should -Be 6
+        Get-XmlCount $nUnitReportXml $scenario2Examples1StepsXPath | Should -Be 6
 
-        Get-XmlValue "($scenario2Examples1StepsXPath/@name)[1]" | Should -Be "Scenario 2 [Examples 1 1].Given step_101"
-        Get-XmlValue "($scenario2Examples1StepsXPath/@name)[2]" | Should -Be "Scenario 2 [Examples 1 1].And and_101"
-        Get-XmlValue "($scenario2Examples1StepsXPath/@name)[3]" | Should -Be "Scenario 2 [Examples 1 1].When step_102"
-        Get-XmlValue "($scenario2Examples1StepsXPath/@name)[4]" | Should -Be "Scenario 2 [Examples 1 1].And and_102"
-        Get-XmlValue "($scenario2Examples1StepsXPath/@name)[5]" | Should -Be "Scenario 2 [Examples 1 1].Then step_103"
-        Get-XmlValue "($scenario2Examples1StepsXPath/@name)[6]" | Should -Be "Scenario 2 [Examples 1 1].And and_103"
+        Get-XmlValue $nUnitReportXml "($scenario2Examples1StepsXPath/@name)[1]" | Should -Be "$feature1Name.Scenario 2 [Examples 1 1].Given step_101"
+        Get-XmlValue $nUnitReportXml "($scenario2Examples1StepsXPath/@name)[2]" | Should -Be "$feature1Name.Scenario 2 [Examples 1 1].And and_101"
+        Get-XmlValue $nUnitReportXml "($scenario2Examples1StepsXPath/@name)[3]" | Should -Be "$feature1Name.Scenario 2 [Examples 1 1].When step_102"
+        Get-XmlValue $nUnitReportXml "($scenario2Examples1StepsXPath/@name)[4]" | Should -Be "$feature1Name.Scenario 2 [Examples 1 1].And and_102"
+        Get-XmlValue $nUnitReportXml "($scenario2Examples1StepsXPath/@name)[5]" | Should -Be "$feature1Name.Scenario 2 [Examples 1 1].Then step_103"
+        Get-XmlValue $nUnitReportXml "($scenario2Examples1StepsXPath/@name)[6]" | Should -Be "$feature1Name.Scenario 2 [Examples 1 1].And and_103"
 
-        Get-XmlValue "($scenario2Examples1StepsXPath/@result)[1]" | Should -Be "Success"
-        Get-XmlValue "($scenario2Examples1StepsXPath/@result)[2]" | Should -Be "Success"
-        Get-XmlValue "($scenario2Examples1StepsXPath/@result)[3]" | Should -Be "Success"
-        Get-XmlValue "($scenario2Examples1StepsXPath/@result)[4]" | Should -Be "Success"
-        Get-XmlValue "($scenario2Examples1StepsXPath/@result)[5]" | Should -Be "Failure"
-        Get-XmlValue "($scenario2Examples1StepsXPath/@result)[6]" | Should -Be "Inconclusive"
+        Get-XmlValue $nUnitReportXml "($scenario2Examples1StepsXPath/@description)[1]" | Should -Be "Given step_101"
+        Get-XmlValue $nUnitReportXml "($scenario2Examples1StepsXPath/@description)[2]" | Should -Be "And and_101"
+        Get-XmlValue $nUnitReportXml "($scenario2Examples1StepsXPath/@description)[3]" | Should -Be "When step_102"
+        Get-XmlValue $nUnitReportXml "($scenario2Examples1StepsXPath/@description)[4]" | Should -Be "And and_102"
+        Get-XmlValue $nUnitReportXml "($scenario2Examples1StepsXPath/@description)[5]" | Should -Be "Then step_103"
+        Get-XmlValue $nUnitReportXml "($scenario2Examples1StepsXPath/@description)[6]" | Should -Be "And and_103"
 
-        Get-XmlInnerText "$scenario2Examples1StepsXPath[5]/failure/message" | Should -Be "An example error in the then clause"
+        Get-XmlValue $nUnitReportXml "($scenario2Examples1StepsXPath/@result)[1]" | Should -Be "Success"
+        Get-XmlValue $nUnitReportXml "($scenario2Examples1StepsXPath/@result)[2]" | Should -Be "Success"
+        Get-XmlValue $nUnitReportXml "($scenario2Examples1StepsXPath/@result)[3]" | Should -Be "Success"
+        Get-XmlValue $nUnitReportXml "($scenario2Examples1StepsXPath/@result)[4]" | Should -Be "Success"
+        Get-XmlValue $nUnitReportXml "($scenario2Examples1StepsXPath/@result)[5]" | Should -Be "Failure"
+        Get-XmlValue $nUnitReportXml "($scenario2Examples1StepsXPath/@result)[6]" | Should -Be "Inconclusive"
+
+        Get-XmlInnerText $nUnitReportXml "$scenario2Examples1StepsXPath[5]/failure/message" | Should -Be "An example error in the then clause"
         if ($expectFeatureFileNameInStackTrace) {
-            Get-XmlInnerText "($scenario2Examples1StepsXPath)[5]/failure/stack-trace" | Should -BeLike "*From $($expectedFeatureFileName1): line 15*"
+            Get-XmlInnerText $nUnitReportXml "($scenario2Examples1StepsXPath)[5]/failure/stack-trace" | Should -BeLike "*From $($expectedFeatureFileName1): line 15*"
         }
-        Get-XmlInnerText "($scenario2Examples1StepsXPath)[5]/failure/stack-trace" | Should -BeLike "*at <ScriptBlock>, $($expectedImplementationFileName): line 23*"
-        Get-XmlInnerText "($scenario2Examples1StepsXPath)[6]/reason/message" | Should -Be "Step skipped (previous step did not pass)"
+        Get-XmlInnerText $nUnitReportXml "($scenario2Examples1StepsXPath)[5]/failure/stack-trace" | Should -BeLike "*at <ScriptBlock>, $($expectedImplementationFileName): line 23*"
+        Get-XmlInnerText $nUnitReportXml "($scenario2Examples1StepsXPath)[6]/reason/message" | Should -Be "Step skipped (previous step did not pass)"
     }
 
     It 'should contain all steps of scenario 2 (examples 2) with correct names and test results' {
         $scenario2Examples2StepsXPath = "$feature1ScenariosXPath[3]//test-case"
 
-        Get-XmlCount $scenario2Examples2StepsXPath | Should -Be 6
+        Get-XmlCount $nUnitReportXml $scenario2Examples2StepsXPath | Should -Be 6
 
-        Get-XmlValue "($scenario2Examples2StepsXPath/@name)[1]" | Should -Be "Scenario 2 [Examples 2 1].Given step_201"
-        Get-XmlValue "($scenario2Examples2StepsXPath/@name)[2]" | Should -Be "Scenario 2 [Examples 2 1].And and_201"
-        Get-XmlValue "($scenario2Examples2StepsXPath/@name)[3]" | Should -Be "Scenario 2 [Examples 2 1].When step_202"
-        Get-XmlValue "($scenario2Examples2StepsXPath/@name)[4]" | Should -Be "Scenario 2 [Examples 2 1].And and_202"
-        Get-XmlValue "($scenario2Examples2StepsXPath/@name)[5]" | Should -Be "Scenario 2 [Examples 2 1].Then step_203"
-        Get-XmlValue "($scenario2Examples2StepsXPath/@name)[6]" | Should -Be "Scenario 2 [Examples 2 1].And and_203"
+        Get-XmlValue $nUnitReportXml "($scenario2Examples2StepsXPath/@name)[1]" | Should -Be "$feature1Name.Scenario 2 [Examples 2 1].Given step_201"
+        Get-XmlValue $nUnitReportXml "($scenario2Examples2StepsXPath/@name)[2]" | Should -Be "$feature1Name.Scenario 2 [Examples 2 1].And and_201"
+        Get-XmlValue $nUnitReportXml "($scenario2Examples2StepsXPath/@name)[3]" | Should -Be "$feature1Name.Scenario 2 [Examples 2 1].When step_202"
+        Get-XmlValue $nUnitReportXml "($scenario2Examples2StepsXPath/@name)[4]" | Should -Be "$feature1Name.Scenario 2 [Examples 2 1].And and_202"
+        Get-XmlValue $nUnitReportXml "($scenario2Examples2StepsXPath/@name)[5]" | Should -Be "$feature1Name.Scenario 2 [Examples 2 1].Then step_203"
+        Get-XmlValue $nUnitReportXml "($scenario2Examples2StepsXPath/@name)[6]" | Should -Be "$feature1Name.Scenario 2 [Examples 2 1].And and_203"
 
-        Get-XmlValue "($scenario2Examples2StepsXPath/@result)[1]" | Should -Be "Success"
-        Get-XmlValue "($scenario2Examples2StepsXPath/@result)[2]" | Should -Be "Success"
-        Get-XmlValue "($scenario2Examples2StepsXPath/@result)[3]" | Should -Be "Success"
-        Get-XmlValue "($scenario2Examples2StepsXPath/@result)[4]" | Should -Be "Success"
-        Get-XmlValue "($scenario2Examples2StepsXPath/@result)[5]" | Should -Be "Success"
-        Get-XmlValue "($scenario2Examples2StepsXPath/@result)[6]" | Should -Be "Success"
+        Get-XmlValue $nUnitReportXml "($scenario2Examples2StepsXPath/@description)[1]" | Should -Be "Given step_201"
+        Get-XmlValue $nUnitReportXml "($scenario2Examples2StepsXPath/@description)[2]" | Should -Be "And and_201"
+        Get-XmlValue $nUnitReportXml "($scenario2Examples2StepsXPath/@description)[3]" | Should -Be "When step_202"
+        Get-XmlValue $nUnitReportXml "($scenario2Examples2StepsXPath/@description)[4]" | Should -Be "And and_202"
+        Get-XmlValue $nUnitReportXml "($scenario2Examples2StepsXPath/@description)[5]" | Should -Be "Then step_203"
+        Get-XmlValue $nUnitReportXml "($scenario2Examples2StepsXPath/@description)[6]" | Should -Be "And and_203"
+
+        Get-XmlValue $nUnitReportXml "($scenario2Examples2StepsXPath/@result)[1]" | Should -Be "Success"
+        Get-XmlValue $nUnitReportXml "($scenario2Examples2StepsXPath/@result)[2]" | Should -Be "Success"
+        Get-XmlValue $nUnitReportXml "($scenario2Examples2StepsXPath/@result)[3]" | Should -Be "Success"
+        Get-XmlValue $nUnitReportXml "($scenario2Examples2StepsXPath/@result)[4]" | Should -Be "Success"
+        Get-XmlValue $nUnitReportXml "($scenario2Examples2StepsXPath/@result)[5]" | Should -Be "Success"
+        Get-XmlValue $nUnitReportXml "($scenario2Examples2StepsXPath/@result)[6]" | Should -Be "Success"
     }
 
     It 'should contain all steps of scenario 3 with correct names and test results' {
         $scenario3StepsXPath = "$feature1ScenariosXPath[4]//test-case"
 
-        Get-XmlCount $scenario3StepsXPath | Should -Be 5
+        Get-XmlCount $nUnitReportXml $scenario3StepsXPath | Should -Be 5
 
-        Get-XmlValue "($scenario3StepsXPath/@name)[1]" | Should -Be "Scenario 3.Given step_301"
-        Get-XmlValue "($scenario3StepsXPath/@name)[2]" | Should -Be "Scenario 3.When step_302"
-        Get-XmlValue "($scenario3StepsXPath/@name)[3]" | Should -Be "Scenario 3.Then step_303"
-        Get-XmlValue "($scenario3StepsXPath/@name)[4]" | Should -Be "Scenario 3.When step_302"
-        Get-XmlValue "($scenario3StepsXPath/@name)[5]" | Should -Be "Scenario 3.Then step_304"
+        Get-XmlValue $nUnitReportXml "($scenario3StepsXPath/@name)[1]" | Should -Be "$feature1Name.Scenario 3.Given step_301"
+        Get-XmlValue $nUnitReportXml "($scenario3StepsXPath/@name)[2]" | Should -Be "$feature1Name.Scenario 3.When step_302"
+        Get-XmlValue $nUnitReportXml "($scenario3StepsXPath/@name)[3]" | Should -Be "$feature1Name.Scenario 3.Then step_303"
+        Get-XmlValue $nUnitReportXml "($scenario3StepsXPath/@name)[4]" | Should -Be "$feature1Name.Scenario 3.When step_302"
+        Get-XmlValue $nUnitReportXml "($scenario3StepsXPath/@name)[5]" | Should -Be "$feature1Name.Scenario 3.Then step_304"
 
-        Get-XmlValue "($scenario3StepsXPath/@result)[1]" | Should -Be "Success"
-        Get-XmlValue "($scenario3StepsXPath/@result)[2]" | Should -Be "Success"
-        Get-XmlValue "($scenario3StepsXPath/@result)[3]" | Should -Be "Success"
-        Get-XmlValue "($scenario3StepsXPath/@result)[4]" | Should -Be "Success"
-        Get-XmlValue "($scenario3StepsXPath/@result)[5]" | Should -Be "Failure"
+        Get-XmlValue $nUnitReportXml "($scenario3StepsXPath/@description)[1]" | Should -Be "Given step_301"
+        Get-XmlValue $nUnitReportXml "($scenario3StepsXPath/@description)[2]" | Should -Be "When step_302"
+        Get-XmlValue $nUnitReportXml "($scenario3StepsXPath/@description)[3]" | Should -Be "Then step_303"
+        Get-XmlValue $nUnitReportXml "($scenario3StepsXPath/@description)[4]" | Should -Be "When step_302"
+        Get-XmlValue $nUnitReportXml "($scenario3StepsXPath/@description)[5]" | Should -Be "Then step_304"
 
-        Get-XmlInnerText "$scenario3StepsXPath[5]/failure/message" | Should -Be "Another example error in the then clause"
+        Get-XmlValue $nUnitReportXml "($scenario3StepsXPath/@result)[1]" | Should -Be "Success"
+        Get-XmlValue $nUnitReportXml "($scenario3StepsXPath/@result)[2]" | Should -Be "Success"
+        Get-XmlValue $nUnitReportXml "($scenario3StepsXPath/@result)[3]" | Should -Be "Success"
+        Get-XmlValue $nUnitReportXml "($scenario3StepsXPath/@result)[4]" | Should -Be "Success"
+        Get-XmlValue $nUnitReportXml "($scenario3StepsXPath/@result)[5]" | Should -Be "Failure"
+
+        Get-XmlInnerText $nUnitReportXml "$scenario3StepsXPath[5]/failure/message" | Should -Be "Another example error in the then clause"
         if ($expectFeatureFileNameInStackTrace) {
-            Get-XmlInnerText "($scenario3StepsXPath)[5]/failure/stack-trace" | Should -BeLike "*From $($expectedFeatureFileName1): line 32*"
+            Get-XmlInnerText $nUnitReportXml "($scenario3StepsXPath)[5]/failure/stack-trace" | Should -BeLike "*From $($expectedFeatureFileName1): line 32*"
         }
-        Get-XmlInnerText "($scenario3StepsXPath)[5]/failure/stack-trace" | Should -BeLike "*at <ScriptBlock>, $($expectedImplementationFileName): line 57*"
+        Get-XmlInnerText $nUnitReportXml "($scenario3StepsXPath)[5]/failure/stack-trace" | Should -BeLike "*at <ScriptBlock>, $($expectedImplementationFileName): line 57*"
     }
 
     It 'should contain all steps of scenario 4 with correct names and test results' {
         $scenario4StepsXPath = "$feature2ScenariosXPath[1]//test-case"
 
-        Get-XmlCount $scenario4StepsXPath | Should -Be 3
+        Get-XmlCount $nUnitReportXml $scenario4StepsXPath | Should -Be 3
 
-        Get-XmlValue "($scenario4StepsXPath/@name)[1]" | Should -Be "Scenario 4.Given step_401"
-        Get-XmlValue "($scenario4StepsXPath/@name)[2]" | Should -Be "Scenario 4.When step_402"
-        Get-XmlValue "($scenario4StepsXPath/@name)[3]" | Should -Be "Scenario 4.Then step_403"
+        Get-XmlValue $nUnitReportXml "($scenario4StepsXPath/@name)[1]" | Should -Be "$feature2Name.Scenario 4.Given step_401"
+        Get-XmlValue $nUnitReportXml "($scenario4StepsXPath/@name)[2]" | Should -Be "$feature2Name.Scenario 4.When step_402"
+        Get-XmlValue $nUnitReportXml "($scenario4StepsXPath/@name)[3]" | Should -Be "$feature2Name.Scenario 4.Then step_403"
 
-        Get-XmlValue "($scenario4StepsXPath/@result)[1]" | Should -Be "Success"
-        Get-XmlValue "($scenario4StepsXPath/@result)[2]" | Should -Be "Failure"
-        Get-XmlValue "($scenario4StepsXPath/@result)[3]" | Should -Be "Inconclusive"
+        Get-XmlValue $nUnitReportXml "($scenario4StepsXPath/@description)[1]" | Should -Be "Given step_401"
+        Get-XmlValue $nUnitReportXml "($scenario4StepsXPath/@description)[2]" | Should -Be "When step_402"
+        Get-XmlValue $nUnitReportXml "($scenario4StepsXPath/@description)[3]" | Should -Be "Then step_403"
 
-        Get-XmlInnerText "$scenario4StepsXPath[2]/failure/message" | Should -Be "An example error in the when clause"
+        Get-XmlValue $nUnitReportXml "($scenario4StepsXPath/@result)[1]" | Should -Be "Success"
+        Get-XmlValue $nUnitReportXml "($scenario4StepsXPath/@result)[2]" | Should -Be "Failure"
+        Get-XmlValue $nUnitReportXml "($scenario4StepsXPath/@result)[3]" | Should -Be "Inconclusive"
+
+        Get-XmlInnerText $nUnitReportXml "$scenario4StepsXPath[2]/failure/message" | Should -Be "An example error in the when clause"
         if ($expectFeatureFileNameInStackTrace) {
-            Get-XmlInnerText "($scenario4StepsXPath)[2]/failure/stack-trace" | Should -BeLike "*From $($expectedFeatureFileName2): line 6*"
+            Get-XmlInnerText $nUnitReportXml "($scenario4StepsXPath)[2]/failure/stack-trace" | Should -BeLike "*From $($expectedFeatureFileName2): line 6*"
         }
-        Get-XmlInnerText "($scenario4StepsXPath)[2]/failure/stack-trace" | Should -BeLike "*at <ScriptBlock>, $($expectedImplementationFileName): line 64*"
-        Get-XmlInnerText "($scenario4StepsXPath)[3]/reason/message" | Should -Be "Step skipped (previous step did not pass)"
+        Get-XmlInnerText $nUnitReportXml "($scenario4StepsXPath)[2]/failure/stack-trace" | Should -BeLike "*at <ScriptBlock>, $($expectedImplementationFileName): line 64*"
+        Get-XmlInnerText $nUnitReportXml "($scenario4StepsXPath)[3]/reason/message" | Should -Be "Step skipped (previous step did not pass)"
     }
 
     It 'should contain all steps of scenario 5 (examples 1) with correct names and test results' {
         $scenario5Examples1StepsXPath = "$feature2ScenariosXPath[2]//test-case"
 
-        Get-XmlCount $scenario5Examples1StepsXPath | Should -Be 3
+        Get-XmlCount $nUnitReportXml $scenario5Examples1StepsXPath | Should -Be 3
 
-        Get-XmlValue "($scenario5Examples1StepsXPath/@name)[1]" | Should -Be "Scenario 5 [Examples 1 1].Given step_501"
-        Get-XmlValue "($scenario5Examples1StepsXPath/@name)[2]" | Should -Be "Scenario 5 [Examples 1 1].When step_502"
-        Get-XmlValue "($scenario5Examples1StepsXPath/@name)[3]" | Should -Be "Scenario 5 [Examples 1 1].Then step_503"
+        Get-XmlValue $nUnitReportXml "($scenario5Examples1StepsXPath/@name)[1]" | Should -Be "$feature2Name.Scenario 5 [Examples 1 1].Given step_501"
+        Get-XmlValue $nUnitReportXml "($scenario5Examples1StepsXPath/@name)[2]" | Should -Be "$feature2Name.Scenario 5 [Examples 1 1].When step_502"
+        Get-XmlValue $nUnitReportXml "($scenario5Examples1StepsXPath/@name)[3]" | Should -Be "$feature2Name.Scenario 5 [Examples 1 1].Then step_503"
 
-        Get-XmlValue "($scenario5Examples1StepsXPath/@result)[1]" | Should -Be "Inconclusive"
-        Get-XmlValue "($scenario5Examples1StepsXPath/@result)[2]" | Should -Be "Inconclusive"
-        Get-XmlValue "($scenario5Examples1StepsXPath/@result)[3]" | Should -Be "Inconclusive"
+        Get-XmlValue $nUnitReportXml "($scenario5Examples1StepsXPath/@description)[1]" | Should -Be "Given step_501"
+        Get-XmlValue $nUnitReportXml "($scenario5Examples1StepsXPath/@description)[2]" | Should -Be "When step_502"
+        Get-XmlValue $nUnitReportXml "($scenario5Examples1StepsXPath/@description)[3]" | Should -Be "Then step_503"
 
-        Get-XmlInnerText "($scenario5Examples1StepsXPath)[1]/reason/message" | Should -Be "Could not find implementation for step!"
-        Get-XmlInnerText "($scenario5Examples1StepsXPath)[2]/reason/message" | Should -Be "Could not find implementation for step!"
-        Get-XmlInnerText "($scenario5Examples1StepsXPath)[3]/reason/message" | Should -Be "Could not find implementation for step!"
+        Get-XmlValue $nUnitReportXml "($scenario5Examples1StepsXPath/@result)[1]" | Should -Be "Inconclusive"
+        Get-XmlValue $nUnitReportXml "($scenario5Examples1StepsXPath/@result)[2]" | Should -Be "Inconclusive"
+        Get-XmlValue $nUnitReportXml "($scenario5Examples1StepsXPath/@result)[3]" | Should -Be "Inconclusive"
+
+        Get-XmlInnerText $nUnitReportXml "($scenario5Examples1StepsXPath)[1]/reason/message" | Should -Be "Could not find implementation for step!"
+        Get-XmlInnerText $nUnitReportXml "($scenario5Examples1StepsXPath)[2]/reason/message" | Should -Be "Could not find implementation for step!"
+        Get-XmlInnerText $nUnitReportXml "($scenario5Examples1StepsXPath)[3]/reason/message" | Should -Be "Could not find implementation for step!"
     }
 
     It 'should contain all steps of scenario 5 (examples 2) with correct names and test results' {
         $scenario5Examples2StepsXPath = "$feature2ScenariosXPath[3]//test-case"
 
-        Get-XmlCount $scenario5Examples2StepsXPath | Should -Be 3
+        Get-XmlCount $nUnitReportXml $scenario5Examples2StepsXPath | Should -Be 3
 
-        Get-XmlValue "($scenario5Examples2StepsXPath/@name)[1]" | Should -Be "Scenario 5 [Examples 2 1].Given step_601"
-        Get-XmlValue "($scenario5Examples2StepsXPath/@name)[2]" | Should -Be "Scenario 5 [Examples 2 1].When step_602"
-        Get-XmlValue "($scenario5Examples2StepsXPath/@name)[3]" | Should -Be "Scenario 5 [Examples 2 1].Then step_603"
+        Get-XmlValue $nUnitReportXml "($scenario5Examples2StepsXPath/@name)[1]" | Should -Be "$feature2Name.Scenario 5 [Examples 2 1].Given step_601"
+        Get-XmlValue $nUnitReportXml "($scenario5Examples2StepsXPath/@name)[2]" | Should -Be "$feature2Name.Scenario 5 [Examples 2 1].When step_602"
+        Get-XmlValue $nUnitReportXml "($scenario5Examples2StepsXPath/@name)[3]" | Should -Be "$feature2Name.Scenario 5 [Examples 2 1].Then step_603"
 
-        Get-XmlValue "($scenario5Examples2StepsXPath/@result)[1]" | Should -Be "Inconclusive"
-        Get-XmlValue "($scenario5Examples2StepsXPath/@result)[2]" | Should -Be "Inconclusive"
-        Get-XmlValue "($scenario5Examples2StepsXPath/@result)[3]" | Should -Be "Inconclusive"
+        Get-XmlValue $nUnitReportXml "($scenario5Examples2StepsXPath/@description)[1]" | Should -Be "Given step_601"
+        Get-XmlValue $nUnitReportXml "($scenario5Examples2StepsXPath/@description)[2]" | Should -Be "When step_602"
+        Get-XmlValue $nUnitReportXml "($scenario5Examples2StepsXPath/@description)[3]" | Should -Be "Then step_603"
 
-        Get-XmlInnerText "($scenario5Examples2StepsXPath)[1]/reason/message" | Should -Be "Could not find implementation for step!"
-        Get-XmlInnerText "($scenario5Examples2StepsXPath)[2]/reason/message" | Should -Be "Could not find implementation for step!"
-        Get-XmlInnerText "($scenario5Examples2StepsXPath)[3]/reason/message" | Should -Be "Could not find implementation for step!"
+        Get-XmlValue $nUnitReportXml "($scenario5Examples2StepsXPath/@result)[1]" | Should -Be "Inconclusive"
+        Get-XmlValue $nUnitReportXml "($scenario5Examples2StepsXPath/@result)[2]" | Should -Be "Inconclusive"
+        Get-XmlValue $nUnitReportXml "($scenario5Examples2StepsXPath/@result)[3]" | Should -Be "Inconclusive"
+
+        Get-XmlInnerText $nUnitReportXml "($scenario5Examples2StepsXPath)[1]/reason/message" | Should -Be "Could not find implementation for step!"
+        Get-XmlInnerText $nUnitReportXml "($scenario5Examples2StepsXPath)[2]/reason/message" | Should -Be "Could not find implementation for step!"
+        Get-XmlInnerText $nUnitReportXml "($scenario5Examples2StepsXPath)[3]/reason/message" | Should -Be "Could not find implementation for step!"
     }
 
     It 'should contain all steps of scenario 5 (examples 3) with correct names and test results' {
@@ -640,43 +691,472 @@ Describe "A generated NUnit report" -Tag Gherkin {
         $scenario5Examples3bStepsXPath = "$feature2ScenariosXPath[5]//test-case"
         $scenario5Examples3cStepsXPath = "$feature2ScenariosXPath[6]//test-case"
 
-        Get-XmlCount $scenario5Examples3aStepsXPath | Should -Be 3
-        Get-XmlCount $scenario5Examples3bStepsXPath | Should -Be 3
-        Get-XmlCount $scenario5Examples3cStepsXPath | Should -Be 3
+        Get-XmlCount $nUnitReportXml $scenario5Examples3aStepsXPath | Should -Be 3
+        Get-XmlCount $nUnitReportXml $scenario5Examples3bStepsXPath | Should -Be 3
+        Get-XmlCount $nUnitReportXml $scenario5Examples3cStepsXPath | Should -Be 3
 
-        Get-XmlValue "($scenario5Examples3aStepsXPath/@name)[1]" | Should -Be "Scenario 5 [Examples 3 1].Given step_701"
-        Get-XmlValue "($scenario5Examples3aStepsXPath/@name)[2]" | Should -Be "Scenario 5 [Examples 3 1].When step_702"
-        Get-XmlValue "($scenario5Examples3aStepsXPath/@name)[3]" | Should -Be "Scenario 5 [Examples 3 1].Then step_703"
-        Get-XmlValue "($scenario5Examples3bStepsXPath/@name)[1]" | Should -Be "Scenario 5 [Examples 3 2].Given step_801"
-        Get-XmlValue "($scenario5Examples3bStepsXPath/@name)[2]" | Should -Be "Scenario 5 [Examples 3 2].When step_802"
-        Get-XmlValue "($scenario5Examples3bStepsXPath/@name)[3]" | Should -Be "Scenario 5 [Examples 3 2].Then step_803"
-        Get-XmlValue "($scenario5Examples3cStepsXPath/@name)[1]" | Should -Be "Scenario 5 [Examples 3 3].Given step_901"
-        Get-XmlValue "($scenario5Examples3cStepsXPath/@name)[2]" | Should -Be "Scenario 5 [Examples 3 3].When step_902"
-        Get-XmlValue "($scenario5Examples3cStepsXPath/@name)[3]" | Should -Be "Scenario 5 [Examples 3 3].Then step_903"
+        Get-XmlValue $nUnitReportXml "($scenario5Examples3aStepsXPath/@name)[1]" | Should -Be "$feature2Name.Scenario 5 [Examples 3 1].Given step_701"
+        Get-XmlValue $nUnitReportXml "($scenario5Examples3aStepsXPath/@name)[2]" | Should -Be "$feature2Name.Scenario 5 [Examples 3 1].When step_702"
+        Get-XmlValue $nUnitReportXml "($scenario5Examples3aStepsXPath/@name)[3]" | Should -Be "$feature2Name.Scenario 5 [Examples 3 1].Then step_703"
+        Get-XmlValue $nUnitReportXml "($scenario5Examples3bStepsXPath/@name)[1]" | Should -Be "$feature2Name.Scenario 5 [Examples 3 2].Given step_801"
+        Get-XmlValue $nUnitReportXml "($scenario5Examples3bStepsXPath/@name)[2]" | Should -Be "$feature2Name.Scenario 5 [Examples 3 2].When step_802"
+        Get-XmlValue $nUnitReportXml "($scenario5Examples3bStepsXPath/@name)[3]" | Should -Be "$feature2Name.Scenario 5 [Examples 3 2].Then step_803"
+        Get-XmlValue $nUnitReportXml "($scenario5Examples3cStepsXPath/@name)[1]" | Should -Be "$feature2Name.Scenario 5 [Examples 3 3].Given step_901"
+        Get-XmlValue $nUnitReportXml "($scenario5Examples3cStepsXPath/@name)[2]" | Should -Be "$feature2Name.Scenario 5 [Examples 3 3].When step_902"
+        Get-XmlValue $nUnitReportXml "($scenario5Examples3cStepsXPath/@name)[3]" | Should -Be "$feature2Name.Scenario 5 [Examples 3 3].Then step_903"
 
-        Get-XmlValue "($scenario5Examples3aStepsXPath/@result)[1]" | Should -Be "Failure"
-        Get-XmlValue "($scenario5Examples3aStepsXPath/@result)[2]" | Should -Be "Inconclusive"
-        Get-XmlValue "($scenario5Examples3aStepsXPath/@result)[3]" | Should -Be "Inconclusive"
-        Get-XmlValue "($scenario5Examples3bStepsXPath/@result)[1]" | Should -Be "Inconclusive"
-        Get-XmlValue "($scenario5Examples3bStepsXPath/@result)[2]" | Should -Be "Inconclusive"
-        Get-XmlValue "($scenario5Examples3bStepsXPath/@result)[3]" | Should -Be "Inconclusive"
-        Get-XmlValue "($scenario5Examples3cStepsXPath/@result)[1]" | Should -Be "Inconclusive"
-        Get-XmlValue "($scenario5Examples3cStepsXPath/@result)[2]" | Should -Be "Inconclusive"
-        Get-XmlValue "($scenario5Examples3cStepsXPath/@result)[3]" | Should -Be "Inconclusive"
+        Get-XmlValue $nUnitReportXml "($scenario5Examples3aStepsXPath/@description)[1]" | Should -Be "Given step_701"
+        Get-XmlValue $nUnitReportXml "($scenario5Examples3aStepsXPath/@description)[2]" | Should -Be "When step_702"
+        Get-XmlValue $nUnitReportXml "($scenario5Examples3aStepsXPath/@description)[3]" | Should -Be "Then step_703"
+        Get-XmlValue $nUnitReportXml "($scenario5Examples3bStepsXPath/@description)[1]" | Should -Be "Given step_801"
+        Get-XmlValue $nUnitReportXml "($scenario5Examples3bStepsXPath/@description)[2]" | Should -Be "When step_802"
+        Get-XmlValue $nUnitReportXml "($scenario5Examples3bStepsXPath/@description)[3]" | Should -Be "Then step_803"
+        Get-XmlValue $nUnitReportXml "($scenario5Examples3cStepsXPath/@description)[1]" | Should -Be "Given step_901"
+        Get-XmlValue $nUnitReportXml "($scenario5Examples3cStepsXPath/@description)[2]" | Should -Be "When step_902"
+        Get-XmlValue $nUnitReportXml "($scenario5Examples3cStepsXPath/@description)[3]" | Should -Be "Then step_903"
 
-        Get-XmlInnerText "$scenario5Examples3aStepsXPath[1]/failure/message" | Should -Be "An example error in the given clause"
+        Get-XmlValue $nUnitReportXml "($scenario5Examples3aStepsXPath/@result)[1]" | Should -Be "Failure"
+        Get-XmlValue $nUnitReportXml "($scenario5Examples3aStepsXPath/@result)[2]" | Should -Be "Inconclusive"
+        Get-XmlValue $nUnitReportXml "($scenario5Examples3aStepsXPath/@result)[3]" | Should -Be "Inconclusive"
+        Get-XmlValue $nUnitReportXml "($scenario5Examples3bStepsXPath/@result)[1]" | Should -Be "Inconclusive"
+        Get-XmlValue $nUnitReportXml "($scenario5Examples3bStepsXPath/@result)[2]" | Should -Be "Inconclusive"
+        Get-XmlValue $nUnitReportXml "($scenario5Examples3bStepsXPath/@result)[3]" | Should -Be "Inconclusive"
+        Get-XmlValue $nUnitReportXml "($scenario5Examples3cStepsXPath/@result)[1]" | Should -Be "Inconclusive"
+        Get-XmlValue $nUnitReportXml "($scenario5Examples3cStepsXPath/@result)[2]" | Should -Be "Inconclusive"
+        Get-XmlValue $nUnitReportXml "($scenario5Examples3cStepsXPath/@result)[3]" | Should -Be "Inconclusive"
+
+        Get-XmlInnerText $nUnitReportXml "$scenario5Examples3aStepsXPath[1]/failure/message" | Should -Be "An example error in the given clause"
         if ($expectFeatureFileNameInStackTrace) {
-            Get-XmlInnerText "($scenario5Examples3aStepsXPath)[1]/failure/stack-trace" | Should -BeLike "*From $($expectedFeatureFileName2): line 11"
+            Get-XmlInnerText $nUnitReportXml "($scenario5Examples3aStepsXPath)[1]/failure/stack-trace" | Should -BeLike "*From $($expectedFeatureFileName2): line 11"
         }
-        Get-XmlInnerText "($scenario5Examples3aStepsXPath)[1]/failure/stack-trace" | Should -BeLike "*at <ScriptBlock>, $($expectedImplementationFileName): line 71*"
-        Get-XmlInnerText "($scenario5Examples3aStepsXPath)[2]/reason/message" | Should -Be "Step skipped (previous step did not pass)"
-        Get-XmlInnerText "($scenario5Examples3aStepsXPath)[3]/reason/message" | Should -Be "Step skipped (previous step did not pass)"
-        Get-XmlInnerText "($scenario5Examples3bStepsXPath)[1]/reason/message" | Should -Be "Could not find implementation for step!"
-        Get-XmlInnerText "($scenario5Examples3bStepsXPath)[2]/reason/message" | Should -Be "Could not find implementation for step!"
-        Get-XmlInnerText "($scenario5Examples3bStepsXPath)[3]/reason/message" | Should -Be "Could not find implementation for step!"
-        Get-XmlInnerText "($scenario5Examples3cStepsXPath)[1]/reason/message" | Should -Be "Could not find implementation for step!"
-        Get-XmlInnerText "($scenario5Examples3cStepsXPath)[2]/reason/message" | Should -Be "Could not find implementation for step!"
-        Get-XmlInnerText "($scenario5Examples3cStepsXPath)[3]/reason/message" | Should -Be "Could not find implementation for step!"
+        Get-XmlInnerText $nUnitReportXml "($scenario5Examples3aStepsXPath)[1]/failure/stack-trace" | Should -BeLike "*at <ScriptBlock>, $($expectedImplementationFileName): line 71*"
+        Get-XmlInnerText $nUnitReportXml "($scenario5Examples3aStepsXPath)[2]/reason/message" | Should -Be "Step skipped (previous step did not pass)"
+        Get-XmlInnerText $nUnitReportXml "($scenario5Examples3aStepsXPath)[3]/reason/message" | Should -Be "Step skipped (previous step did not pass)"
+        Get-XmlInnerText $nUnitReportXml "($scenario5Examples3bStepsXPath)[1]/reason/message" | Should -Be "Could not find implementation for step!"
+        Get-XmlInnerText $nUnitReportXml "($scenario5Examples3bStepsXPath)[2]/reason/message" | Should -Be "Could not find implementation for step!"
+        Get-XmlInnerText $nUnitReportXml "($scenario5Examples3bStepsXPath)[3]/reason/message" | Should -Be "Could not find implementation for step!"
+        Get-XmlInnerText $nUnitReportXml "($scenario5Examples3cStepsXPath)[1]/reason/message" | Should -Be "Could not find implementation for step!"
+        Get-XmlInnerText $nUnitReportXml "($scenario5Examples3cStepsXPath)[2]/reason/message" | Should -Be "Could not find implementation for step!"
+        Get-XmlInnerText $nUnitReportXml "($scenario5Examples3cStepsXPath)[3]/reason/message" | Should -Be "Could not find implementation for step!"
+    }
+
+}
+
+Describe "A created HTML report" -Tag Gherkin {
+
+    # Use temporary HTML file with Pester's test drive feature
+    $htmlFile = "$TestDrive\my_unit.html"
+
+    # Calling this in a job so we don't monkey with the active pester state that's already running
+    $job = Start-Job -ArgumentList $scriptRoot, $htmlFile -ScriptBlock {
+        param ($scriptRoot, $htmlFile)
+        Get-Module Pester | Remove-Module -Force
+        Import-Module $scriptRoot\Pester.psd1 -Force
+
+        New-Object psobject -Property @{
+            Results = Invoke-Gherkin (Join-Path $scriptRoot Examples\Gherkin\JustForReporting*.feature) -PassThru -Show None -OutputFile $htmlFile -OutputFormat "html"
+        }
+    }
+
+    $gherkin = $job | Wait-Job | Receive-Job
+    Remove-Job $job
+
+    [xml] $xhtmlReport = $null
+    try {
+        $xhtmlReport = Get-Content -Path $htmlFile
+    }
+    catch {
+        # Will be evaluated below
+    }
+
+    $featuresXPath = "/html/body/h2"
+
+    $scenariosXPath = "/html/body/details"
+    $stepsXPath = "/html/body/details/div"
+
+    $feature1ScenariosStartIndex = 1
+    $feature2ScenariosStartIndex = 5
+
+    It 'should be an existing and well formed XML file' {
+        $htmlFile | Should -Exist
+        $xhtmlReport | Should -Not -BeNullOrEmpty
+    }
+
+    It 'should contain the expected number of features' {
+        Get-XmlCount $xhtmlReport $featuresXPath | Should -Be 2
+    }
+
+    It 'should contain the expected number of scenarios' {
+        Get-XmlCount $xhtmlReport $scenariosXPath | Should -Be 10
+    }
+
+    It 'should contain the expected number of steps' {
+        Get-XmlCount $xhtmlReport $stepsXPath | Should -Be 38
+    }
+
+    It 'should contain feature 1' {
+        Get-XmlInnerText $xhtmlReport "$featuresXPath[1]" | Should -Be "A test feature for reporting 1"
+    }
+
+    It 'should contain feature 2' {
+        Get-XmlInnerText $xhtmlReport "$featuresXPath[2]" | Should -Be "A test feature for reporting 2"
+    }
+
+    It 'should contain all scenarios of feature 1 with correct names and test results' {
+        $feature1Scenario1XPath = "$scenariosXPath[1]"
+        $feature1Scenario2XPath = "$scenariosXPath[2]"
+        $feature1Scenario3XPath = "$scenariosXPath[3]"
+        $feature1Scenario4XPath = "$scenariosXPath[4]"
+
+        Get-XmlInnerText $xhtmlReport "$feature1Scenario1XPath/summary/strong" | Should -Be "Scenario 1"
+        Get-XmlInnerText $xhtmlReport "$feature1Scenario2XPath/summary/strong" | Should -Be "Scenario 2 [Examples 1 1]"
+        Get-XmlInnerText $xhtmlReport "$feature1Scenario3XPath/summary/strong" | Should -Be "Scenario 2 [Examples 2 1]"
+        Get-XmlInnerText $xhtmlReport "$feature1Scenario4XPath/summary/strong" | Should -Be "Scenario 3"
+
+        Get-XmlValue $xhtmlReport "$feature1Scenario1XPath/@class" | Should -BeExactly "success"
+        Get-XmlValue $xhtmlReport "$feature1Scenario2XPath/@class" | Should -BeExactly "failure"
+        Get-XmlValue $xhtmlReport "$feature1Scenario3XPath/@class" | Should -BeExactly "success"
+        Get-XmlValue $xhtmlReport "$feature1Scenario4XPath/@class" | Should -BeExactly "failure"
+    }
+
+    It 'should contain all scenarios of feature 2 with correct names and test results' {
+        $feature2Scenario1XPath = "$scenariosXPath[5]"
+        $feature2Scenario2XPath = "$scenariosXPath[6]"
+        $feature2Scenario3XPath = "$scenariosXPath[7]"
+        $feature2Scenario4XPath = "$scenariosXPath[8]"
+        $feature2Scenario5XPath = "$scenariosXPath[9]"
+        $feature2Scenario6XPath = "$scenariosXPath[10]"
+
+        Get-XmlInnerText $xhtmlReport "$feature2Scenario1XPath/summary/strong" | Should -Be "Scenario 4"
+        Get-XmlInnerText $xhtmlReport "$feature2Scenario2XPath/summary/strong" | Should -Be "Scenario 5 [Examples 1 1]"
+        Get-XmlInnerText $xhtmlReport "$feature2Scenario3XPath/summary/strong" | Should -Be "Scenario 5 [Examples 2 1]"
+        Get-XmlInnerText $xhtmlReport "$feature2Scenario4XPath/summary/strong" | Should -Be "Scenario 5 [Examples 3 1]"
+        Get-XmlInnerText $xhtmlReport "$feature2Scenario5XPath/summary/strong" | Should -Be "Scenario 5 [Examples 3 2]"
+        Get-XmlInnerText $xhtmlReport "$feature2Scenario6XPath/summary/strong" | Should -Be "Scenario 5 [Examples 3 3]"
+
+        Get-XmlValue $xhtmlReport "$feature2Scenario1XPath/@class" | Should -Be "failure"
+        Get-XmlValue $xhtmlReport "$feature2Scenario2XPath/@class" | Should -Be "inconclusive"
+        Get-XmlValue $xhtmlReport "$feature2Scenario3XPath/@class" | Should -Be "inconclusive"
+        Get-XmlValue $xhtmlReport "$feature2Scenario4XPath/@class" | Should -Be "failure"
+        Get-XmlValue $xhtmlReport "$feature2Scenario5XPath/@class" | Should -Be "inconclusive"
+        Get-XmlValue $xhtmlReport "$feature2Scenario6XPath/@class" | Should -Be "inconclusive"
+    }
+
+    It 'should contain all steps of scenario 1 with correct names and test results' {
+        $scenario1StepsXPath = "$scenariosXPath[1]/div"
+
+        Get-XmlCount $xhtmlReport $scenario1StepsXPath | Should -Be 3
+
+        Get-XmlInnerText $xhtmlReport "$scenario1StepsXPath[1]" | Should -Be "Given step_001"
+        Get-XmlInnerText $xhtmlReport "$scenario1StepsXPath[2]" | Should -Be "When step_002"
+        Get-XmlInnerText $xhtmlReport "$scenario1StepsXPath[3]" | Should -Be "Then step_003"
+
+        Get-XmlValue $xhtmlReport "$scenario1StepsXPath[1]/@class" | Should -BeExactly "success"
+        Get-XmlValue $xhtmlReport "$scenario1StepsXPath[2]/@class" | Should -BeExactly "success"
+        Get-XmlValue $xhtmlReport "$scenario1StepsXPath[3]/@class" | Should -BeExactly "success"
+    }
+
+    It 'should contain all steps of scenario 2 (examples 1) with correct names and test results' {
+        $scenario2Examples1StepsXPath = "$scenariosXPath[2]/div"
+
+        Get-XmlCount $xhtmlReport $scenario2Examples1StepsXPath | Should -Be 6
+
+        Get-XmlInnerText $xhtmlReport "$scenario2Examples1StepsXPath[1]" | Should -Be "Given step_101"
+        Get-XmlInnerText $xhtmlReport "$scenario2Examples1StepsXPath[2]" | Should -Be "And and_101"
+        Get-XmlInnerText $xhtmlReport "$scenario2Examples1StepsXPath[3]" | Should -Be "When step_102"
+        Get-XmlInnerText $xhtmlReport "$scenario2Examples1StepsXPath[4]" | Should -Be "And and_102"
+        Get-XmlInnerText $xhtmlReport "$scenario2Examples1StepsXPath[5]" | Should -Be "Then step_103"
+        Get-XmlInnerText $xhtmlReport "$scenario2Examples1StepsXPath[6]" | Should -Be "And and_103"
+
+        Get-XmlValue $xhtmlReport "$scenario2Examples1StepsXPath[1]/@class" | Should -BeExactly "success"
+        Get-XmlValue $xhtmlReport "$scenario2Examples1StepsXPath[2]/@class" | Should -BeExactly "success"
+        Get-XmlValue $xhtmlReport "$scenario2Examples1StepsXPath[3]/@class" | Should -BeExactly "success"
+        Get-XmlValue $xhtmlReport "$scenario2Examples1StepsXPath[4]/@class" | Should -BeExactly "success"
+        Get-XmlValue $xhtmlReport "$scenario2Examples1StepsXPath[5]/@class" | Should -BeExactly "failure"
+        Get-XmlValue $xhtmlReport "$scenario2Examples1StepsXPath[6]/@class" | Should -BeExactly "inconclusive"
+
+        Get-NextPreText $xhtmlReport "$scenario2Examples1StepsXPath[5]" | Should -Be "An example error in the then clause"
+        Get-NextPreText $xhtmlReport "$scenario2Examples1StepsXPath[6]" | Should -Be "Step skipped (previous step did not pass)"
+    }
+
+    It 'should contain all steps of scenario 2 (examples 2) with correct names and test results' {
+        $scenario2Examples2StepsXPath = "$scenariosXPath[3]/div"
+
+        Get-XmlCount $xhtmlReport $scenario2Examples2StepsXPath | Should -Be 6
+
+        Get-XmlInnerText $xhtmlReport "$scenario2Examples2StepsXPath[1]" | Should -Be "Given step_201"
+        Get-XmlInnerText $xhtmlReport "$scenario2Examples2StepsXPath[2]" | Should -Be "And and_201"
+        Get-XmlInnerText $xhtmlReport "$scenario2Examples2StepsXPath[3]" | Should -Be "When step_202"
+        Get-XmlInnerText $xhtmlReport "$scenario2Examples2StepsXPath[4]" | Should -Be "And and_202"
+        Get-XmlInnerText $xhtmlReport "$scenario2Examples2StepsXPath[5]" | Should -Be "Then step_203"
+        Get-XmlInnerText $xhtmlReport "$scenario2Examples2StepsXPath[6]" | Should -Be "And and_203"
+
+        Get-XmlValue $xhtmlReport "$scenario2Examples2StepsXPath[1]/@class" | Should -BeExactly "success"
+        Get-XmlValue $xhtmlReport "$scenario2Examples2StepsXPath[2]/@class" | Should -BeExactly "success"
+        Get-XmlValue $xhtmlReport "$scenario2Examples2StepsXPath[3]/@class" | Should -BeExactly "success"
+        Get-XmlValue $xhtmlReport "$scenario2Examples2StepsXPath[4]/@class" | Should -BeExactly "success"
+        Get-XmlValue $xhtmlReport "$scenario2Examples2StepsXPath[5]/@class" | Should -BeExactly "success"
+        Get-XmlValue $xhtmlReport "$scenario2Examples2StepsXPath[6]/@class" | Should -BeExactly "success"
+    }
+
+    It 'should contain all steps of scenario 3 with correct names and test results' {
+        $scenario3StepsXPath = "$scenariosXPath[4]/div"
+
+        Get-XmlCount $xhtmlReport $scenario3StepsXPath | Should -Be 5
+
+        Get-XmlInnerText $xhtmlReport "$scenario3StepsXPath[1]" | Should -Be "Given step_301"
+        Get-XmlInnerText $xhtmlReport "$scenario3StepsXPath[2]" | Should -Be "When step_302"
+        Get-XmlInnerText $xhtmlReport "$scenario3StepsXPath[3]" | Should -Be "Then step_303"
+        Get-XmlInnerText $xhtmlReport "$scenario3StepsXPath[4]" | Should -Be "When step_302"
+        Get-XmlInnerText $xhtmlReport "$scenario3StepsXPath[5]" | Should -Be "Then step_304"
+
+        Get-XmlValue $xhtmlReport "$scenario3StepsXPath[1]/@class" | Should -BeExactly "success"
+        Get-XmlValue $xhtmlReport "$scenario3StepsXPath[2]/@class" | Should -BeExactly "success"
+        Get-XmlValue $xhtmlReport "$scenario3StepsXPath[3]/@class" | Should -BeExactly "success"
+        Get-XmlValue $xhtmlReport "$scenario3StepsXPath[4]/@class" | Should -BeExactly "success"
+        Get-XmlValue $xhtmlReport "$scenario3StepsXPath[5]/@class" | Should -BeExactly "failure"
+
+        Get-NextPreText $xhtmlReport "$scenario3StepsXPath[5]" | Should -Be "Another example error in the then clause"
+    }
+
+    It 'should contain all steps of scenario 4 with correct names and test results' {
+        $scenario4StepsXPath = "$scenariosXPath[5]/div"
+
+        Get-XmlCount $xhtmlReport $scenario4StepsXPath | Should -Be 3
+
+        Get-XmlInnerText $xhtmlReport "$scenario4StepsXPath[1]" | Should -Be "Given step_401"
+        Get-XmlInnerText $xhtmlReport "$scenario4StepsXPath[2]" | Should -Be "When step_402"
+        Get-XmlInnerText $xhtmlReport "$scenario4StepsXPath[3]" | Should -Be "Then step_403"
+
+        Get-XmlValue $xhtmlReport "$scenario4StepsXPath[1]/@class" | Should -BeExactly "success"
+        Get-XmlValue $xhtmlReport "$scenario4StepsXPath[2]/@class" | Should -BeExactly "failure"
+        Get-XmlValue $xhtmlReport "$scenario4StepsXPath[3]/@class" | Should -BeExactly "inconclusive"
+
+        Get-NextPreText $xhtmlReport "$scenario4StepsXPath[2]" | Should -Be "An example error in the when clause"
+        Get-NextPreText $xhtmlReport "$scenario4StepsXPath[3]" | Should -Be "Step skipped (previous step did not pass)"
+    }
+
+    It 'should contain all steps of scenario 5 (examples 1) with correct names and test results' {
+        $scenario5Examples1StepsXPath = "$scenariosXPath[6]/div"
+
+        Get-XmlCount $xhtmlReport $scenario5Examples1StepsXPath | Should -Be 3
+
+        Get-XmlInnerText $xhtmlReport "$scenario5Examples1StepsXPath[1]" | Should -Be "Given step_501"
+        Get-XmlInnerText $xhtmlReport "$scenario5Examples1StepsXPath[2]" | Should -Be "When step_502"
+        Get-XmlInnerText $xhtmlReport "$scenario5Examples1StepsXPath[3]" | Should -Be "Then step_503"
+
+        Get-XmlValue $xhtmlReport "$scenario5Examples1StepsXPath[1]/@class" | Should -BeExactly "inconclusive"
+        Get-XmlValue $xhtmlReport "$scenario5Examples1StepsXPath[2]/@class" | Should -BeExactly "inconclusive"
+        Get-XmlValue $xhtmlReport "$scenario5Examples1StepsXPath[3]/@class" | Should -BeExactly "inconclusive"
+
+        Get-NextPreText $xhtmlReport "$scenario5Examples1StepsXPath[1]" | Should -Be "Could not find implementation for step!"
+        Get-NextPreText $xhtmlReport "$scenario5Examples1StepsXPath[2]" | Should -Be "Could not find implementation for step!"
+        Get-NextPreText $xhtmlReport "$scenario5Examples1StepsXPath[3]" | Should -Be "Could not find implementation for step!"
+    }
+
+    It 'should contain all steps of scenario 5 (examples 2) with correct names and test results' {
+        $scenario5Examples2StepsXPath = "$scenariosXPath[7]/div"
+
+        Get-XmlCount $xhtmlReport $scenario5Examples2StepsXPath | Should -Be 3
+
+        Get-XmlInnerText $xhtmlReport "$scenario5Examples2StepsXPath[1]" | Should -Be "Given step_601"
+        Get-XmlInnerText $xhtmlReport "$scenario5Examples2StepsXPath[2]" | Should -Be "When step_602"
+        Get-XmlInnerText $xhtmlReport "$scenario5Examples2StepsXPath[3]" | Should -Be "Then step_603"
+
+        Get-XmlValue $xhtmlReport "$scenario5Examples2StepsXPath[1]/@class" | Should -BeExactly "inconclusive"
+        Get-XmlValue $xhtmlReport "$scenario5Examples2StepsXPath[2]/@class" | Should -BeExactly "inconclusive"
+        Get-XmlValue $xhtmlReport "$scenario5Examples2StepsXPath[3]/@class" | Should -BeExactly "inconclusive"
+
+        Get-NextPreText $xhtmlReport "$scenario5Examples2StepsXPath[1]" | Should -Be "Could not find implementation for step!"
+        Get-NextPreText $xhtmlReport "$scenario5Examples2StepsXPath[2]" | Should -Be "Could not find implementation for step!"
+        Get-NextPreText $xhtmlReport "$scenario5Examples2StepsXPath[3]" | Should -Be "Could not find implementation for step!"
+    }
+
+    It 'should contain all steps of scenario 5 (examples 3) with correct names and test results' {
+        $scenario5Examples3aStepsXPath = "$scenariosXPath[8]/div"
+        $scenario5Examples3bStepsXPath = "$scenariosXPath[9]/div"
+        $scenario5Examples3cStepsXPath = "$scenariosXPath[10]/div"
+
+        Get-XmlCount $xhtmlReport $scenario5Examples3aStepsXPath | Should -Be 3
+        Get-XmlCount $xhtmlReport $scenario5Examples3bStepsXPath | Should -Be 3
+        Get-XmlCount $xhtmlReport $scenario5Examples3cStepsXPath | Should -Be 3
+
+        Get-XmlInnerText $xhtmlReport "$scenario5Examples3aStepsXPath[1]" | Should -Be "Given step_701"
+        Get-XmlInnerText $xhtmlReport "$scenario5Examples3aStepsXPath[2]" | Should -Be "When step_702"
+        Get-XmlInnerText $xhtmlReport "$scenario5Examples3aStepsXPath[3]" | Should -Be "Then step_703"
+        Get-XmlInnerText $xhtmlReport "$scenario5Examples3bStepsXPath[1]" | Should -Be "Given step_801"
+        Get-XmlInnerText $xhtmlReport "$scenario5Examples3bStepsXPath[2]" | Should -Be "When step_802"
+        Get-XmlInnerText $xhtmlReport "$scenario5Examples3bStepsXPath[3]" | Should -Be "Then step_803"
+        Get-XmlInnerText $xhtmlReport "$scenario5Examples3cStepsXPath[1]" | Should -Be "Given step_901"
+        Get-XmlInnerText $xhtmlReport "$scenario5Examples3cStepsXPath[2]" | Should -Be "When step_902"
+        Get-XmlInnerText $xhtmlReport "$scenario5Examples3cStepsXPath[3]" | Should -Be "Then step_903"
+
+        Get-XmlValue $xhtmlReport "$scenario5Examples3aStepsXPath[1]/@class" | Should -Be "failure"
+        Get-XmlValue $xhtmlReport "$scenario5Examples3aStepsXPath[2]/@class" | Should -Be "inconclusive"
+        Get-XmlValue $xhtmlReport "$scenario5Examples3aStepsXPath[3]/@class" | Should -Be "inconclusive"
+        Get-XmlValue $xhtmlReport "$scenario5Examples3bStepsXPath[1]/@class" | Should -Be "inconclusive"
+        Get-XmlValue $xhtmlReport "$scenario5Examples3bStepsXPath[2]/@class" | Should -Be "inconclusive"
+        Get-XmlValue $xhtmlReport "$scenario5Examples3bStepsXPath[3]/@class" | Should -Be "inconclusive"
+        Get-XmlValue $xhtmlReport "$scenario5Examples3cStepsXPath[1]/@class" | Should -Be "inconclusive"
+        Get-XmlValue $xhtmlReport "$scenario5Examples3cStepsXPath[2]/@class" | Should -Be "inconclusive"
+        Get-XmlValue $xhtmlReport "$scenario5Examples3cStepsXPath[3]/@class" | Should -Be "inconclusive"
+
+        Get-NextPreText $xhtmlReport "$scenario5Examples3aStepsXPath[1]" | Should -Be "An example error in the given clause"
+        Get-NextPreText $xhtmlReport "$scenario5Examples3aStepsXPath[2]" | Should -Be "Step skipped (previous step did not pass)"
+        Get-NextPreText $xhtmlReport "$scenario5Examples3aStepsXPath[3]" | Should -Be "Step skipped (previous step did not pass)"
+        Get-NextPreText $xhtmlReport "$scenario5Examples3bStepsXPath[1]" | Should -Be "Could not find implementation for step!"
+        Get-NextPreText $xhtmlReport "$scenario5Examples3bStepsXPath[2]" | Should -Be "Could not find implementation for step!"
+        Get-NextPreText $xhtmlReport "$scenario5Examples3bStepsXPath[3]" | Should -Be "Could not find implementation for step!"
+        Get-NextPreText $xhtmlReport "$scenario5Examples3cStepsXPath[1]" | Should -Be "Could not find implementation for step!"
+        Get-NextPreText $xhtmlReport "$scenario5Examples3cStepsXPath[2]" | Should -Be "Could not find implementation for step!"
+        Get-NextPreText $xhtmlReport "$scenario5Examples3cStepsXPath[3]" | Should -Be "Could not find implementation for step!"
+    }
+
+    It 'should contain a headline for the test results' {
+        Get-XmlInnerText $xhtmlReport "//h1[1]" | Should -BeExactly "Pester Gherkin Run"
+    }
+
+    It 'should contain a table of test results' {
+        $resultsTableXPath = '//div[@id="results"]//table'
+
+        Get-XmlInnerText $xhtmlReport "$resultsTableXPath/tr[2]/th[1]" | Should -BeExactly "Features:"
+        Get-XmlInnerText $xhtmlReport "$resultsTableXPath/tr[3]/th[1]" | Should -BeExactly "Scenarios:"
+        Get-XmlInnerText $xhtmlReport "$resultsTableXPath/tr[4]/th[1]" | Should -BeExactly "Steps:"
+
+        Get-XmlInnerText $xhtmlReport "$resultsTableXPath/tr[1]/th[1]" | Should -BeExactly "Total"
+        Get-XmlInnerText $xhtmlReport "$resultsTableXPath/tr[2]/td[1]" | Should -BeExactly "2"
+        Get-XmlInnerText $xhtmlReport "$resultsTableXPath/tr[3]/td[1]" | Should -BeExactly "10"
+        Get-XmlInnerText $xhtmlReport "$resultsTableXPath/tr[4]/td[1]" | Should -BeExactly "38"
+
+        Get-XmlInnerText $xhtmlReport "$resultsTableXPath/tr[1]/th[2]" | Should -BeExactly "Passed"
+        Get-XmlInnerText $xhtmlReport "$resultsTableXPath/tr[2]/td[2]" | Should -BeExactly "0"
+        Get-XmlInnerText $xhtmlReport "$resultsTableXPath/tr[3]/td[2]" | Should -BeExactly "2"
+        Get-XmlInnerText $xhtmlReport "$resultsTableXPath/tr[4]/td[2]" | Should -BeExactly "18"
+        Get-XmlValue $xhtmlReport "$resultsTableXPath/tr[1]/th[2]/@class" | Should -BeLike "*success*"
+        Get-XmlValue $xhtmlReport "$resultsTableXPath/tr[2]/td[2]/@class" | Should -BeLike "*success*"
+        Get-XmlValue $xhtmlReport "$resultsTableXPath/tr[3]/td[2]/@class" | Should -BeLike "*success*"
+        Get-XmlValue $xhtmlReport "$resultsTableXPath/tr[4]/td[2]/@class" | Should -BeLike "*success*"
+
+        Get-XmlInnerText $xhtmlReport "$resultsTableXPath/tr[1]/th[3]" | Should -BeExactly "Skipped"
+        Get-XmlInnerText $xhtmlReport "$resultsTableXPath/tr[2]/td[3]" | Should -BeExactly "0"
+        Get-XmlInnerText $xhtmlReport "$resultsTableXPath/tr[3]/td[3]" | Should -BeExactly "4"
+        Get-XmlInnerText $xhtmlReport "$resultsTableXPath/tr[4]/td[3]" | Should -BeExactly "16"
+        Get-XmlValue $xhtmlReport "$resultsTableXPath/tr[1]/th[3]/@class" | Should -BeLike "*inconclusive*"
+        Get-XmlValue $xhtmlReport "$resultsTableXPath/tr[2]/td[3]/@class" | Should -BeLike "*inconclusive*"
+        Get-XmlValue $xhtmlReport "$resultsTableXPath/tr[3]/td[3]/@class" | Should -BeLike "*inconclusive*"
+        Get-XmlValue $xhtmlReport "$resultsTableXPath/tr[4]/td[3]/@class" | Should -BeLike "*inconclusive*"
+
+        Get-XmlInnerText $xhtmlReport "$resultsTableXPath/tr[1]/th[4]" | Should -BeExactly "Failed"
+        Get-XmlInnerText $xhtmlReport "$resultsTableXPath/tr[2]/td[4]" | Should -BeExactly "2"
+        Get-XmlInnerText $xhtmlReport "$resultsTableXPath/tr[3]/td[4]" | Should -BeExactly "4"
+        Get-XmlInnerText $xhtmlReport "$resultsTableXPath/tr[4]/td[4]" | Should -BeExactly "4"
+        Get-XmlValue $xhtmlReport "$resultsTableXPath/tr[1]/th[4]/@class" | Should -BeLike "*failure*"
+        Get-XmlValue $xhtmlReport "$resultsTableXPath/tr[2]/td[4]/@class" | Should -BeLike "*failure*"
+        Get-XmlValue $xhtmlReport "$resultsTableXPath/tr[3]/td[4]/@class" | Should -BeLike "*failure*"
+        Get-XmlValue $xhtmlReport "$resultsTableXPath/tr[4]/td[4]/@class" | Should -BeLike "*failure*"
+    }
+
+    It 'should contain a table of summary information' {
+        $summaryTableXPath = '//div[@id="summary"]//table'
+
+        Get-XmlInnerText $xhtmlReport "$summaryTableXPath/tr[1]/th[1]" | Should -BeExactly "PowerShell version:"
+        Get-XmlInnerText $xhtmlReport "$summaryTableXPath/tr[1]/td[1]" | Should -Match "\d+\.\d+.*"
+        Get-XmlInnerText $xhtmlReport "$summaryTableXPath/tr[2]/th[1]" | Should -BeExactly "Operating system:"
+        Get-XmlInnerText $xhtmlReport "$summaryTableXPath/tr[2]/td[1]" | Should -Match ".+"
+        Get-XmlInnerText $xhtmlReport "$summaryTableXPath/tr[3]/th[1]" | Should -BeExactly "Version:"
+        Get-XmlInnerText $xhtmlReport "$summaryTableXPath/tr[3]/td[1]" | Should -Match ".+"
+        Get-XmlInnerText $xhtmlReport "$summaryTableXPath/tr[4]/th[1]" | Should -BeExactly "User:"
+        Get-XmlInnerText $xhtmlReport "$summaryTableXPath/tr[4]/td[1]" | Should -Match ".+@.+"
+        Get-XmlInnerText $xhtmlReport "$summaryTableXPath/tr[5]/th[1]" | Should -BeExactly "Date/time:"
+        Get-XmlInnerText $xhtmlReport "$summaryTableXPath/tr[5]/td[1]" | Should -Match "\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}"
+        Get-XmlInnerText $xhtmlReport "$summaryTableXPath/tr[6]/th[1]" | Should -BeExactly "Duration:"
+        Get-XmlInnerText $xhtmlReport "$summaryTableXPath/tr[6]/td[1]" | Should -Match "\d+\.\d+ seconds"
+        Get-XmlInnerText $xhtmlReport "$summaryTableXPath/tr[7]/th[1]" | Should -BeExactly "Culture:"
+        Get-XmlInnerText $xhtmlReport "$summaryTableXPath/tr[7]/td[1]" | Should -Match "\w{2}-\w{2}"
+    }
+}
+
+Describe "Check test results of steps" -Tag Gherkin {
+    # Calling this in a job so we don't monkey with the active pester state that's already running
+    $job = Start-Job -ArgumentList $scriptRoot -ScriptBlock {
+        param ($scriptRoot)
+        Get-Module Pester | Remove-Module -Force
+        Import-Module $scriptRoot\Pester.psd1 -Force
+
+        New-Object psobject -Property @{
+            Results = Invoke-Gherkin (Join-Path $scriptRoot Examples\Gherkin\Gherkin-PesterResultShowsFeatureAndScenarioNames.feature) -PassThru -Show None
+        }
+    }
+
+    $gherkin = $job | Wait-Job | Receive-Job
+    Remove-Job $job
+
+    $testResults = $gherkin.Results |
+        Select-Object -ExpandProperty TestResult |
+        Select-Object -ExpandProperty Result
+
+    It "Should have the expected number of test results" {
+        $testResults.Count | Should -Be 15
+    }
+
+    It "Test result 1 is correct" {
+        $testResults[0] | Should -Be 'Passed'
+    }
+
+    It "Test result 2 is correct" {
+        $testResults[1] | Should -Be 'Passed'
+    }
+
+    It "Test result 3 is correct" {
+        $testResults[2] | Should -Be 'Passed'
+    }
+
+    It "Test result 4 is correct" {
+        $testResults[3] | Should -Be 'Passed'
+    }
+
+    It "Test result 5 is correct" {
+        $testResults[4] | Should -Be 'Passed'
+    }
+
+    It "Test result 6 is correct" {
+        $testResults[5] | Should -Be 'Passed'
+    }
+
+    It "Test result 7 is correct" {
+        $testResults[6] | Should -Be 'Passed'
+    }
+
+    It "Test result 8 is correct" {
+        $testResults[7] | Should -Be 'Passed'
+    }
+
+    It "Test result 9 is correct" {
+        $testResults[8] | Should -Be 'Failed'
+    }
+
+    It "Test result 10 is correct" {
+        $testResults[9] | Should -Be "Failed"
+    }
+
+    It "Test result 11 is correct" {
+        $testResults[10] | Should -Be 'Inconclusive'
+    }
+
+    It "Test result 12 is correct" {
+        $testResults[11] | Should -Be 'Inconclusive'
+    }
+
+    It "Test result 13 is correct" {
+        $testResults[12] | Should -Be 'Inconclusive'
+    }
+
+    It "Test result 14 is correct" {
+        $testResults[13] | Should -Be 'Inconclusive'
+    }
+
+    It "Test result 15 is correct" {
+        $testResults[14] | Should -Be 'Inconclusive'
     }
 
 }

--- a/Functions/Gherkin.ps1
+++ b/Functions/Gherkin.ps1
@@ -108,8 +108,14 @@ function Invoke-Gherkin {
         .PARAMETER OutputFile
             The path to write a report file to. If this path is not provided, no log will be generated.
 
+            Since OutputFile is a string array, multiple output files may be specified.
+            The order of the OutputFile parameter must match with the order of the OutputFormat parameter.
+
         .PARAMETER OutputFormat
-            The format for output (LegacyNUnitXml or NUnitXml), defaults to NUnitXml
+            The format of output. Two formats of output are supported: NUnitXML and html.
+
+            Since OutputFormat is a string array, multiple output formats may be specified.
+            The order of the OutputFormat parameter must match with the order of the OutputFile parameter.
 
         .PARAMETER Quiet
             Disables the output Pester writes to screen. No other output is generated unless you specify PassThru,
@@ -210,10 +216,10 @@ function Invoke-Gherkin {
 
         [Switch]$Strict,
 
-        [string] $OutputFile,
+        [string[]] $OutputFile,
 
-        [ValidateSet('NUnitXml')]
-        [string] $OutputFormat = 'NUnitXml',
+        [ValidateSet('NUnitXml', 'html')]
+        [string[]] $OutputFormat = @('NUnitXml', 'html'),
 
         [Switch]$Quiet,
 
@@ -300,7 +306,7 @@ function Invoke-Gherkin {
         Exit-CoverageAnalysis -PesterState $pester
 
         if (& $SafeCommands["Get-Variable"]-Name OutputFile -ValueOnly -ErrorAction $script:IgnoreErrorPreference) {
-            Export-PesterResults -PesterState $pester -Path $OutputFile -Format $OutputFormat
+            Export-PesterResults -PesterState $pester -Path $OutputFile -Format $OutputFormat -Gherkin
         }
 
         if ($PassThru) {

--- a/Functions/TestResults.ps1
+++ b/Functions/TestResults.ps1
@@ -1,3 +1,39 @@
+function Export-PesterResults {
+    param (
+        $PesterState,
+        [string[]] $Path,
+        [string[]] $Format,
+        [switch] $Gherkin
+    )
+    if ($Format.Count -lt $Path.Count) {
+        throw "Please specify the formats for all provided paths"
+    }
+
+    # We create a generic test report object which may be exported into different formats
+    $testReport = New-TestReport $PesterState -Gherkin:$Gherkin
+
+    for ($i = 0; $i -lt $Path.Count; $i++) {
+        $singleFormat = $Format[$i]
+
+        # the xml writer create method and other tools may resolve relatives paths by itself. but its current directory
+        # might be different from what PowerShell sees as the current directory so I have to resolve the path beforehand
+        # working around the limitations of Resolve-Path
+        $fullPath = GetFullPath -Path $Path[$i]
+
+        # Display performance in verbose mode
+        $stopwatch = [System.Diagnostics.Stopwatch]::StartNew()
+        switch ($singleFormat) {
+            "NUnitXml" { Export-NUnitReport $testReport $fullPath }
+            "html" { Export-HtmlReport $testReport $fullPath }
+            default {
+                throw "'$singleFormat' is not a valid Pester export format."
+            }
+        }
+        Write-Verbose "Pester test results exported to $singleFormat file $fullPath in $($stopWatch.Elapsed)"
+    }
+}
+
+# Used by output
 function Get-HumanTime($Seconds) {
     if ($Seconds -gt 0.99) {
         $time = [math]::Round($Seconds, 2)
@@ -10,7 +46,8 @@ function Get-HumanTime($Seconds) {
     return "$time$unit"
 }
 
-function GetFullPath ([string]$Path) {
+# Used in this script and in TestResults.Tests.ps1
+function GetFullPath([string]$Path) {
     $Folder = & $SafeCommands['Split-Path'] -Path $Path -Parent
     $File = & $SafeCommands['Split-Path'] -Path $Path -Leaf
 
@@ -26,273 +63,7 @@ function GetFullPath ([string]$Path) {
     return $Path
 }
 
-function Export-PesterResults {
-    param (
-        $PesterState,
-        [string] $Path,
-        [string] $Format
-    )
-
-    switch ($Format) {
-        'NUnitXml' {
-            Export-NUnitReport -PesterState $PesterState -Path $Path
-        }
-
-        default {
-            throw "'$Format' is not a valid Pester export format."
-        }
-    }
-}
-function Export-NUnitReport {
-    param (
-        [parameter(Mandatory = $true, ValueFromPipeline = $true)]
-        $PesterState,
-
-        [parameter(Mandatory = $true)]
-        [String]$Path
-    )
-
-    #the xmlwriter create method can resolve relatives paths by itself. but its current directory might
-    #be different from what PowerShell sees as the current directory so I have to resolve the path beforehand
-    #working around the limitations of Resolve-Path
-
-    $Path = GetFullPath -Path $Path
-
-    $settings = & $SafeCommands['New-Object'] -TypeName Xml.XmlWriterSettings -Property @{
-        Indent              = $true
-        NewLineOnAttributes = $false
-    }
-
-    $xmlFile = $null
-    $xmlWriter = $null
-    try {
-        $xmlFile = [IO.File]::Create($Path)
-        $xmlWriter = [Xml.XmlWriter]::Create($xmlFile, $settings)
-
-        Write-NUnitReport -XmlWriter $xmlWriter -PesterState $PesterState
-
-        $xmlWriter.Flush()
-        $xmlFile.Flush()
-    }
-    finally {
-        if ($null -ne $xmlWriter) {
-            try {
-                $xmlWriter.Close()
-            }
-            catch {
-            }
-        }
-        if ($null -ne $xmlFile) {
-            try {
-                $xmlFile.Close()
-            }
-            catch {
-            }
-        }
-    }
-}
-
-function Write-NUnitReport($PesterState, [System.Xml.XmlWriter] $XmlWriter) {
-    # Write the XML Declaration
-    $XmlWriter.WriteStartDocument($false)
-
-    # Write Root Element
-    $xmlWriter.WriteStartElement('test-results')
-
-    Write-NUnitTestResultAttributes @PSBoundParameters
-    Write-NUnitTestResultChildNodes @PSBoundParameters
-
-    $XmlWriter.WriteEndElement()
-}
-
-function Write-NUnitTestResultAttributes($PesterState, [System.Xml.XmlWriter] $XmlWriter) {
-    $XmlWriter.WriteAttributeString('xmlns', 'xsi', $null, 'http://www.w3.org/2001/XMLSchema-instance')
-    $XmlWriter.WriteAttributeString('xsi', 'noNamespaceSchemaLocation', [Xml.Schema.XmlSchema]::InstanceNamespace , 'nunit_schema_2.5.xsd')
-    $XmlWriter.WriteAttributeString('name', 'Pester')
-    $XmlWriter.WriteAttributeString('total', ($PesterState.TotalCount - $PesterState.SkippedCount))
-    $XmlWriter.WriteAttributeString('errors', '0')
-    $XmlWriter.WriteAttributeString('failures', $PesterState.FailedCount)
-    $XmlWriter.WriteAttributeString('not-run', '0')
-    $XmlWriter.WriteAttributeString('inconclusive', $PesterState.PendingCount + $PesterState.InconclusiveCount)
-    $XmlWriter.WriteAttributeString('ignored', $PesterState.SkippedCount)
-    $XmlWriter.WriteAttributeString('skipped', '0')
-    $XmlWriter.WriteAttributeString('invalid', '0')
-    $date = & $SafeCommands['Get-Date']
-    $XmlWriter.WriteAttributeString('date', (& $SafeCommands['Get-Date'] -Date $date -Format 'yyyy-MM-dd'))
-    $XmlWriter.WriteAttributeString('time', (& $SafeCommands['Get-Date'] -Date $date -Format 'HH:mm:ss'))
-}
-
-function Write-NUnitTestResultChildNodes($PesterState, [System.Xml.XmlWriter] $XmlWriter) {
-    Write-NUnitEnvironmentInformation @PSBoundParameters
-    Write-NUnitCultureInformation @PSBoundParameters
-
-    $suiteInfo = Get-TestSuiteInfo -TestSuite $PesterState -TestSuiteName $PesterState.TestSuiteName
-
-    $XmlWriter.WriteStartElement('test-suite')
-
-    Write-NUnitTestSuiteAttributes -TestSuiteInfo $suiteInfo -XmlWriter $XmlWriter
-
-    $XmlWriter.WriteStartElement('results')
-
-    foreach ($action in $PesterState.TestActions.Actions) {
-        Write-NUnitTestSuiteElements -XmlWriter $XmlWriter -Node $action
-    }
-
-    $XmlWriter.WriteEndElement()
-    $XmlWriter.WriteEndElement()
-}
-
-function Write-NUnitEnvironmentInformation($PesterState, [System.Xml.XmlWriter] $XmlWriter) {
-    $XmlWriter.WriteStartElement('environment')
-
-    $environment = Get-RunTimeEnvironment
-    foreach ($keyValuePair in $environment.GetEnumerator()) {
-        $XmlWriter.WriteAttributeString($keyValuePair.Name, $keyValuePair.Value)
-    }
-
-    $XmlWriter.WriteEndElement()
-}
-
-function Write-NUnitCultureInformation($PesterState, [System.Xml.XmlWriter] $XmlWriter) {
-    $XmlWriter.WriteStartElement('culture-info')
-
-    $XmlWriter.WriteAttributeString('current-culture', ([System.Threading.Thread]::CurrentThread.CurrentCulture).Name)
-    $XmlWriter.WriteAttributeString('current-uiculture', ([System.Threading.Thread]::CurrentThread.CurrentUiCulture).Name)
-
-    $XmlWriter.WriteEndElement()
-}
-
-function Write-NUnitTestSuiteElements($Node, [System.Xml.XmlWriter] $XmlWriter, [string] $Path) {
-    $suiteInfo = Get-TestSuiteInfo $Node
-
-    $XmlWriter.WriteStartElement('test-suite')
-
-    Write-NUnitTestSuiteAttributes -TestSuiteInfo $suiteInfo -XmlWriter $XmlWriter
-
-    $XmlWriter.WriteStartElement('results')
-
-    $separator = if ($Path) {
-        '.'
-    }
-    else {
-        ''
-    }
-    $newName = if ($Node.Hint -ne 'Script') {
-        $suiteInfo.Name
-    }
-    else {
-        ''
-    }
-    $newPath = "${Path}${separator}${newName}"
-
-    foreach ($action in $Node.Actions) {
-        if ($action.Type -eq 'TestGroup') {
-            Write-NUnitTestSuiteElements -Node $action -XmlWriter $XmlWriter -Path $newPath
-        }
-    }
-
-    $suites = @(
-        $Node.Actions |
-            & $SafeCommands['Where-Object'] { $_.Type -eq 'TestCase' } |
-            & $SafeCommands['Group-Object'] -Property ParameterizedSuiteName
-    )
-
-    foreach ($suite in $suites) {
-        if ($suite.Name) {
-            $parameterizedSuiteInfo = Get-ParameterizedTestSuiteInfo -TestSuiteGroup $suite
-
-            $XmlWriter.WriteStartElement('test-suite')
-
-            Write-NUnitTestSuiteAttributes -TestSuiteInfo $parameterizedSuiteInfo -TestSuiteType 'ParameterizedTest' -XmlWriter $XmlWriter -Path $newPath
-
-            $XmlWriter.WriteStartElement('results')
-        }
-
-        foreach ($testCase in $suite.Group) {
-            Write-NUnitTestCaseElement -TestResult $testCase -XmlWriter $XmlWriter -Path $newPath -ParameterizedSuiteName $suite.Name
-        }
-
-        if ($suite.Name) {
-            $XmlWriter.WriteEndElement()
-            $XmlWriter.WriteEndElement()
-        }
-    }
-
-    $XmlWriter.WriteEndElement()
-    $XmlWriter.WriteEndElement()
-}
-
-function Get-ParameterizedTestSuiteInfo ([Microsoft.PowerShell.Commands.GroupInfo] $TestSuiteGroup) {
-    $node = & $SafeCommands['New-Object'] psobject -Property @{
-        Name              = $TestSuiteGroup.Name
-        TotalCount        = 0
-        Time              = [timespan]0
-        PassedCount       = 0
-        FailedCount       = 0
-        SkippedCount      = 0
-        PendingCount      = 0
-        InconclusiveCount = 0
-    }
-
-    foreach ($testCase in $TestSuiteGroup.Group) {
-        $node.TotalCount++
-
-        switch ($testCase.Result) {
-            Passed {
-                $Node.PassedCount++; break;
-            }
-            Failed {
-                $Node.FailedCount++; break;
-            }
-            Skipped {
-                $Node.SkippedCount++; break;
-            }
-            Pending {
-                $Node.PendingCount++; break;
-            }
-            Inconclusive {
-                $Node.InconclusiveCount++; break;
-            }
-        }
-
-        $Node.Time += $testCase.Time
-    }
-
-    return Get-TestSuiteInfo -TestSuite $node
-}
-
-function Get-TestSuiteInfo ($TestSuite, $TestSuiteName) {
-    if (-not $PSBoundParameters.ContainsKey('TestSuiteName')) {
-        $TestSuiteName = $TestSuite.Name
-    }
-
-    $suite = @{
-        resultMessage = 'Failure'
-        success       = if ($TestSuite.FailedCount -eq 0) {
-            'True'
-        }
-        else {
-            'False'
-        }
-        totalTime     = Convert-TimeSpan $TestSuite.Time
-        name          = $TestSuiteName
-        description   = $TestSuiteName
-    }
-
-    $suite.resultMessage = Get-GroupResult $TestSuite
-    $suite
-}
-
-function Get-TestTime($tests) {
-    [TimeSpan]$totalTime = 0;
-    if ($tests) {
-        foreach ($test in $tests) {
-            $totalTime += $test.time
-        }
-    }
-
-    Convert-TimeSpan -TimeSpan $totalTime
-}
+# Used by NUnit and HTML export
 function Convert-TimeSpan {
     param (
         [Parameter(ValueFromPipeline = $true)]
@@ -307,197 +78,284 @@ function Convert-TimeSpan {
         }
     }
 }
-function Get-TestSuccess($tests) {
-    $result = $true
-    if ($tests) {
-        foreach ($test in $tests) {
-            if (-not $test.Passed) {
-                $result = $false
-                break
-            }
-        }
-    }
-    [String]$result
-}
-function Write-NUnitTestSuiteAttributes($TestSuiteInfo, [string] $TestSuiteType = 'TestFixture', [System.Xml.XmlWriter] $XmlWriter, [string] $Path) {
-    $name = $TestSuiteInfo.Name
 
-    if ($TestSuiteType -eq 'ParameterizedTest' -and $Path) {
-        $name = "$Path.$name"
-    }
-
-    $XmlWriter.WriteAttributeString('type', $TestSuiteType)
-    $XmlWriter.WriteAttributeString('name', $name)
-    $XmlWriter.WriteAttributeString('executed', 'True')
-    $XmlWriter.WriteAttributeString('result', $TestSuiteInfo.resultMessage)
-    $XmlWriter.WriteAttributeString('success', $TestSuiteInfo.success)
-    $XmlWriter.WriteAttributeString('time', $TestSuiteInfo.totalTime)
-    $XmlWriter.WriteAttributeString('asserts', '0')
-    $XmlWriter.WriteAttributeString('description', $TestSuiteInfo.Description)
-}
-
-function Write-NUnitTestCaseElement($TestResult, [System.Xml.XmlWriter] $XmlWriter, [string] $ParameterizedSuiteName, [string] $Path) {
-    $XmlWriter.WriteStartElement('test-case')
-
-    Write-NUnitTestCaseAttributes -TestResult $TestResult -XmlWriter $XmlWriter -ParameterizedSuiteName $ParameterizedSuiteName -Path $Path
-
-    $XmlWriter.WriteEndElement()
-}
-
-function Write-NUnitTestCaseAttributes($TestResult, [System.Xml.XmlWriter] $XmlWriter, [string] $ParameterizedSuiteName, [string] $Path) {
-    $testName = $TestResult.Name
-
-    if ($testName -eq $ParameterizedSuiteName) {
-        $paramString = ''
-        if ($null -ne $TestResult.Parameters) {
-            $params = @(
-                foreach ($value in $TestResult.Parameters.Values) {
-                    if ($null -eq $value) {
-                        'null'
-                    }
-                    elseif ($value -is [string]) {
-                        '"{0}"' -f $value
-                    }
-                    else {
-                        #do not use .ToString() it uses the current culture settings
-                        #and we need to use en-US culture, which [string] or .ToString([Globalization.CultureInfo]'en-us') uses
-                        [string]$value
-                    }
-                }
-            )
-
-            $paramString = $params -join ','
-        }
-
-        $testName = "$testName($paramString)"
-    }
-
-    $separator = if ($Path) {
-        '.'
-    }
-    else {
-        ''
-    }
-    $testName = "${Path}${separator}${testName}"
-
-    $XmlWriter.WriteAttributeString('description', $TestResult.Name)
-
-    $XmlWriter.WriteAttributeString('name', $testName)
-    $XmlWriter.WriteAttributeString('time', (Convert-TimeSpan $TestResult.Time))
-    $XmlWriter.WriteAttributeString('asserts', '0')
-    $XmlWriter.WriteAttributeString('success', $TestResult.Passed)
-
-    switch ($TestResult.Result) {
-        Passed {
-            $XmlWriter.WriteAttributeString('result', 'Success')
-            $XmlWriter.WriteAttributeString('executed', 'True')
-            break
-        }
-        Skipped {
-            $XmlWriter.WriteAttributeString('result', 'Ignored')
-            $XmlWriter.WriteAttributeString('executed', 'False')
-            break
-        }
-
-        Pending {
-            $XmlWriter.WriteAttributeString('result', 'Inconclusive')
-            $XmlWriter.WriteAttributeString('executed', 'True')
-            break
-        }
-        Inconclusive {
-            $XmlWriter.WriteAttributeString('result', 'Inconclusive')
-            $XmlWriter.WriteAttributeString('executed', 'True')
-
-            if ($TestResult.FailureMessage) {
-                $XmlWriter.WriteStartElement('reason')
-                $xmlWriter.WriteElementString('message', $TestResult.FailureMessage)
-                $XmlWriter.WriteEndElement() # Close reason tag
-            }
-
-            break
-        }
-        Failed {
-            $XmlWriter.WriteAttributeString('result', 'Failure')
-            $XmlWriter.WriteAttributeString('executed', 'True')
-            $XmlWriter.WriteStartElement('failure')
-            $xmlWriter.WriteElementString('message', $TestResult.FailureMessage)
-            $XmlWriter.WriteElementString('stack-trace', $TestResult.StackTrace)
-            $XmlWriter.WriteEndElement() # Close failure tag
-            break
-        }
-    }
-}
-function Get-RunTimeEnvironment() {
-    # based on what we found during startup, use the appropriate cmdlet
-    $computerName = $env:ComputerName
-    $userName = $env:Username
-    if ($null -ne $SafeCommands['Get-CimInstance']) {
-        $osSystemInformation = (& $SafeCommands['Get-CimInstance'] Win32_OperatingSystem)
-    }
-    elseif ($null -ne $SafeCommands['Get-WmiObject']) {
-        $osSystemInformation = (& $SafeCommands['Get-WmiObject'] Win32_OperatingSystem)
-    }
-    elseif ($IsMacOS -or $IsLinux) {
-        $osSystemInformation = @{
-            Name    = "Unknown"
-            Version = "0.0.0.0"
-        }
-        try {
-            if ($null -ne $SafeCommands['uname']) {
-                $osSystemInformation.Version = & $SafeCommands['uname'] -r
-                $osSystemInformation.Name = & $SafeCommands['uname'] -s
-                $computerName = & $SafeCommands['uname'] -n
-            }
-            if ($null -ne $SafeCommands['id']) {
-                $userName = & $SafeCommands['id'] -un
-            }
-        }
-        catch {
-            # well, we tried
-        }
-    }
-    else {
-        $osSystemInformation = @{
-            Name    = "Unknown"
-            Version = "0.0.0.0"
-        }
-    }
-
-    if ( ($PSVersionTable.ContainsKey('PSEdition')) -and ($PSVersionTable.PSEdition -eq 'Core')) {
-        $CLrVersion = "Unknown"
-
-    }
-    else {
-        $CLrVersion = [string]$PSVersionTable.ClrVersion
-    }
-
-    @{
-        'nunit-version' = '2.5.8.0'
-        'os-version'    = $osSystemInformation.Version
-        platform        = $osSystemInformation.Name
-        cwd             = (& $SafeCommands['Get-Location']).Path #run path
-        'machine-name'  = $computerName
-        user            = $username
-        'user-domain'   = $env:userDomain
-        'clr-version'   = $CLrVersion
-    }
-}
-
+# Used by Pester and Gherkin
 function Exit-WithCode ($FailedCount) {
     $host.SetShouldExit($FailedCount)
 }
 
-function Get-GroupResult ($InputObject) {
-    #I am not sure about the result precedence, and can't find any good source
-    #TODO: Confirm this is the correct order of precedence
-    if ($inputObject.FailedCount -gt 0) {
-        return 'Failure'
+function New-TestReport($PesterState, $Name = "Pester", [switch] $Gherkin) {
+
+    # Gets system values
+    function Get-RunTimeEnvironment() {
+        # based on what we found during startup, use the appropriate cmdlet
+        $computerName = $env:ComputerName
+        $userName = $env:Username
+        if ($null -ne $SafeCommands['Get-CimInstance']) {
+            $osSystemInformation = (& $SafeCommands['Get-CimInstance'] Win32_OperatingSystem)
+        }
+        elseif ($null -ne $SafeCommands['Get-WmiObject']) {
+            $osSystemInformation = (& $SafeCommands['Get-WmiObject'] Win32_OperatingSystem)
+        }
+        elseif ($IsMacOS -or $IsLinux) {
+            $osSystemInformation = @{
+                Name    = "Unknown"
+                Version = "0.0.0.0"
+            }
+            try {
+                if ($null -ne $SafeCommands['uname']) {
+                    $osSystemInformation.Version = & $SafeCommands['uname'] -r
+                    $osSystemInformation.Name = & $SafeCommands['uname'] -s
+                    $computerName = & $SafeCommands['uname'] -n
+                }
+                if ($null -ne $SafeCommands['id']) {
+                    $userName = & $SafeCommands['id'] -un
+                }
+            }
+            catch {
+                # well, we tried
+            }
+        }
+        else {
+            $osSystemInformation = @{
+                Name    = "Unknown"
+                Version = "0.0.0.0"
+            }
+        }
+
+        if ( ($PSVersionTable.ContainsKey('PSEdition')) -and ($PSVersionTable.PSEdition -eq 'Core')) {
+            $CLrVersion = "Unknown"
+
+        }
+        else {
+            $CLrVersion = [string]$PSVersionTable.ClrVersion
+        }
+
+        @{
+            'nunit-version' = '2.5.8.0'
+            'os-version'    = $osSystemInformation.Version
+            platform        = $osSystemInformation.Name
+            cwd             = (& $SafeCommands['Get-Location']).Path #run path
+            'machine-name'  = $computerName
+            user            = $username
+            'user-domain'   = $env:userDomain
+            'clr-version'   = $CLrVersion
+        }
     }
-    if ($InputObject.SkippedCount -gt 0) {
-        return 'Ignored'
+
+    $currentDate = & $SafeCommands['Get-Date']
+    $mainGroupName = if (-not $Gherkin) { 'Pester Specs' } else { 'Features' }
+
+    $testReport = New-Object PsObject -Property @{
+        Name            = $Name
+        TestResult      = (New-TestResult -GroupName $mainGroupName)
+        MainGroupResult = New-TestResult
+        SubGroupResult  = New-TestResult
+        Date            = (& $SafeCommands['Get-Date'] -Date $currentDate -Format 'yyyy-MM-dd')
+        Time            = (& $SafeCommands['Get-Date'] -Date $currentDate -Format 'HH:mm:ss')
+        Culture         = (Get-EncodedText (([System.Threading.Thread]::CurrentThread.CurrentCulture).Name))
+        UiCulture       = (Get-EncodedText (([System.Threading.Thread]::CurrentThread.CurrentUiCulture).Name))
+        Duration        = (Convert-TimeSpan $PesterState.Time)
+        Environment     = Get-RunTimeEnvironment
+        Gherkin         = $Gherkin
     }
-    if ($InputObject.PendingCount -gt 0) {
-        return 'Inconclusive'
+
+    # Add main test actions of pester state to root node of test report ($testReport.TestResult)
+    foreach ($testAction in $PesterState.TestActions.Actions) {
+        $testReport.TestResult.AddChild((New-TestResultTree $testAction))
     }
-    return 'Success'
+
+    # Create grouped test results
+    # Part one: Iterate over the main test results
+    # We do not need recursion here, since test results already contain the values of their children
+    foreach ($child in $testReport.TestResult.Children) {
+        $testReport.MainGroupResult.Sum((Group-TestResult $child))
+
+        # Part two: Iterate over the second-level test results
+        foreach ($subChild in $child.Children) {
+            # Groups/specifications are the second level of test results (again we do not need any recursion)
+            $testReport.SubGroupResult.Sum((Group-TestResult $subChild))
+        }
+    }
+
+    return $testReport
+}
+
+function New-TestResult($TotalCount = 0, $PassedCount = 0, $FailedCount = 0, $InconclusiveCount = 0, $PendingCount = 0, $SkippedCount = 0, $TestAction = $null, $GroupName = "", [timespan] $Time = 0, [switch] $Parameterized) {
+    $testResult = New-Object PsObject -Property @{
+        TotalCount        = $TotalCount
+        PassedCount       = $PassedCount
+        FailedCount       = $FailedCount
+        InconclusiveCount = $InconclusiveCount
+        PendingCount      = $PendingCount
+        SkippedCount      = $SkippedCount
+        TestAction        = $TestAction
+        Time              = $Time
+        Parent            = $null
+        Children          = $(New-Object System.Collections.ArrayList)
+        GroupName         = $GroupName
+        Parameterized     = [bool] $Parameterized
+    }
+
+    # Gets the name for this test result
+    $testResult | Add-Member -MemberType ScriptProperty -Name "Name" -Value {
+        if ($null -ne $this.TestAction) {
+            $this.TestAction.Name
+        }
+        elseif ($this.GroupName) {
+            $this.GroupName
+        }
+        else {
+            "test results"
+        }
+    }
+
+    # Checks if the current test result is associated with a test case
+    $testResult | Add-Member -MemberType ScriptProperty -Name "IsTestCase" -Value {
+        [bool] ($this.TestAction.Type -eq 'TestCase')
+    }
+
+    # Adds the values of the passed the test result to the current test result
+    $testResult | Add-Member -MemberType ScriptMethod -Name "Sum" -Value {
+        param ($Other, [bool] $WithTimeValue = $true)
+        if ($null -eq $Other) {
+            throw "Null object passed to sum method of test result object"
+        }
+        $this.TotalCount += $Other.TotalCount
+        $this.PassedCount += $Other.PassedCount
+        $this.FailedCount += $Other.FailedCount
+        $this.InconclusiveCount += $Other.InconclusiveCount
+        $this.PendingCount += $Other.PendingCount
+        $this.SkippedCount += $Other.SkippedCount
+        if ($WithTimeValue) {
+            $this.Time += $Other.Time
+        }
+    }
+
+    # Adds a new child test result to the current test result
+    $testResult | Add-Member -MemberType ScriptMethod -Name "AddChild" -Value {
+        param ($Child)
+
+        # Set bidirectional references
+        $this.Children.Add($Child) | Out-Null
+        $Child.Parent = $this
+
+        # The test group provides its own time value which is higher than a simple sum of all test cases
+        # Thus we have to check it here
+        if ($this.TestAction -and $this.TestAction.Type -eq 'TestGroup') {
+            # Sum new values, but always use the time of the test group action
+            $this.Sum($Child, $false)
+            $this.Time = $this.TestAction.Time
+        }
+        else {
+            # Sum new values with time of the added child
+            $this.Sum($Child, $true)
+        }
+    }
+
+    # Gets a property value from the test action as string
+    $testResult | Add-Member -MemberType ScriptMethod -Name "GetTestActionValue" -Value {
+        param ($Property)
+        if ($null -ne $this.TestAction) { $this.TestAction.$Property }
+    }
+
+    # Override ToString()
+    $testResult | Add-Member -MemberType ScriptMethod -Name "ToString" -Force -Value {
+        $this.Name
+    }
+
+    $properties = @{
+        'Outcome'        = $( { $testResult.GetTestActionValue('Result') })
+        'FailureMessage' = $( { $testResult.GetTestActionValue('FailureMessage') })
+        'StackTrace'     = $( { $testResult.GetTestActionValue('StackTrace') })
+        'Hint'           = $( { $testResult.GetTestActionValue('Hint') })
+        'Parameters'     = $( { $testResult.GetTestActionValue('Parameters') })
+        'Passed'         = $( { $testResult.GetTestActionValue('Passed') })
+    }
+    foreach ($property in $properties.GetEnumerator()) {
+        $testResult | Add-Member -MemberType ScriptProperty -Name $property.Key -Value $property.Value
+    }
+
+    return $testResult
+}
+
+function Group-TestResult($TestResult) {
+    # The total count of grouped test result is always 1
+    # If we group a result which contains nothing, the skipped count wil be also 1
+    $totalCount = 1
+    $passedCount = 0
+    $failedCount = 0
+    $inconclusiveCount = 0
+    $skippedCount = 0
+    $pendingCount = 0
+    if ($TestResult.PassedCount -gt 0 -and $TestResult.PassedCount -eq $TestResult.TotalCount) {
+        $passedCount = 1
+    }
+    elseif ($TestResult.FailedCount -gt 0) {
+        $failedCount = 1
+    }
+    elseif ($TestResult.SkippedCount -gt 0) {
+        $skippedCount = 1
+    }
+    elseif ($TestResult.PendingCount -gt 0) {
+        $pendingCount = 1
+    }
+    else {
+        $inconclusiveCount = 1
+    }
+    New-TestResult $totalCount $passedCount $failedCount $inconclusiveCount $pendingCount $skippedCount
+}
+
+function New-TestResultTree($TestAction) {
+    $newParent = New-TestResult -TestAction $TestAction
+    foreach ($childTestAction in $TestAction.Actions) {
+        if ($childTestAction.Type -eq 'TestGroup') {
+            $newParent.AddChild((New-TestResultTree $childTestAction))
+        }
+    }
+    $suites = @(
+        $TestAction.Actions |
+            & $SafeCommands['Where-Object'] { $_.Type -eq 'TestCase' } |
+            & $SafeCommands['Group-Object'] -Property ParameterizedSuiteName
+    )
+    foreach ($suite in $suites) {
+        if (-not $suite.Name) {
+            # Non-parameterized test suite, all test results will be directly added to $newParent
+            $suiteParent = $newParent
+        }
+        else {
+            # Create a intermediate element for parameterized test suite which will be added below to $newParent
+            $suiteParent = New-TestResult -GroupName ($suite.Name) -Parameterized
+        }
+        foreach ($testCase in $suite.Group) {
+            # Add test case to suite parent which recalculates values
+            $suiteParent.AddChild((ConvertTo-TestResult $testCase))
+        }
+        if ($suite.Name) {
+            # After all test cases have been added, the intermediate element contains the correct values
+            # and it can be added to suite parent finally
+            $newParent.AddChild($suiteParent)
+        }
+    }
+    return $newParent
+}
+
+function ConvertTo-TestResult($TestAction) {
+    if ($TestAction.Type -ne 'TestCase') {
+        throw "Only test cases can be converted directly to test results"
+    }
+    $totalCount = 1
+    $passedCount = 0
+    $failedCount = 0
+    $inconclusiveCount = 0
+    $pendingCount = 0
+    $skippedCount = 0
+    switch ($TestAction.Result) {
+        'Passed' { $passedCount = 1 }
+        'Inconclusive' { $inconclusiveCount = 1 }
+        'Pending' { $pendingCount = 1 }
+        'Skipped' { $skippedCount = 1 }
+        default { $failedCount = 1 }
+    }
+    return New-TestResult $totalCount $passedCount $failedCount $inconclusiveCount $pendingCount $skippedCount $TestAction -Time ($TestAction.Time)
 }

--- a/Pester.psm1
+++ b/Pester.psm1
@@ -616,7 +616,7 @@ function Get-AssertionDynamicParams {
 }
 
 $Script:PesterRoot = & $SafeCommands['Split-Path'] -Path $MyInvocation.MyCommand.Path
-"$PesterRoot\Functions\*.ps1", "$PesterRoot\Functions\Assertions\*.ps1" |
+"$PesterRoot\Functions\*.ps1", "$PesterRoot\Functions\Assertions\*.ps1", "$PesterRoot\Functions\Export\*.ps1" |
     & $script:SafeCommands['Resolve-Path'] |
     & $script:SafeCommands['Where-Object'] { -not ($_.ProviderPath.ToLower().Contains(".tests.")) } |
     & $script:SafeCommands['ForEach-Object'] { . $_.ProviderPath }
@@ -756,9 +756,14 @@ the xml extension.
 
 If this path is not provided, no log will be generated.
 
+Since OutputFile is a string array, multiple output files may be specified.
+The order of the OutputFile parameter must match with the order of the OutputFormat parameter.
+
 .PARAMETER OutputFormat
-The format of output. Two formats of output are supported: NUnitXML and
-LegacyNUnitXML.
+The format of output. Two formats of output are supported: NUnitXML and html.
+
+Since OutputFormat is a string array, multiple output formats may be specified.
+The order of the OutputFormat parameter must match with the order of the OutputFile parameter.
 
 .PARAMETER Tag
 Runs only tests in Describe blocks with the specified Tag parameter values.
@@ -1039,11 +1044,11 @@ New-PesterOption
         [Switch]$Strict,
 
         [Parameter(Mandatory = $true, ParameterSetName = 'NewOutputSet')]
-        [string] $OutputFile,
+        [string[]] $OutputFile,
 
         [Parameter(ParameterSetName = 'NewOutputSet')]
-        [ValidateSet('NUnitXml')]
-        [string] $OutputFormat = 'NUnitXml',
+        [ValidateSet('NUnitXml', 'html')]
+        [string[]] $OutputFormat = @('NUnitXml', 'html'),
 
         [Switch]$Quiet,
 

--- a/cleanUpBeforeBuild.ps1
+++ b/cleanUpBeforeBuild.ps1
@@ -25,5 +25,10 @@ if (Test-Path "$PSScriptRoot\images") {
     Remove-Item "$PSScriptRoot\images" -Recurse -Force -Confirm:$false -Verbose -ErrorAction 'Stop'
 }
 
+if (Test-Path "$PSScriptRoot\Dependencies\TestUtilities") {
+    Write-Verbose "Removing test utilities"
+    Remove-Item "$PSScriptRoot\Dependencies\TestUtilities" -Recurse -Force -Confirm:$false -Verbose -ErrorAction 'Stop'
+}
+
 Write-Verbose "Removing all Test Files"
 Get-ChildItem $PSScriptRoot -Recurse -Filter *.Tests.ps1 | Remove-Item -Force -Verbose -ErrorAction 'Stop'


### PR DESCRIPTION
This pull requests improves the export of Pester test results.

I am opening this pull request because of the following comments:

- from fourpastmidnight: https://github.com/pester/Pester/pull/1186#issuecomment-451665563
- from nohwnd: https://github.com/pester/Pester/pull/1186#issuecomment-451670480

(both from PR #1186)

The code has the following characteristics:

- It creates a test report object wich contains a tree of test results which are suitable for the export in different formats
- 99 percent of the code is equal for PSpec and Gherkin
- It refactors the existing NUnit export with maintenance in mind
- Also it fixes some NUnit report bugs for Gherkin
- It introduced a shared test code module for XML tests (which will be removed on release)

Also, I carefully compared the output of my changes with the last output of the master.
It is the same (without time values).

I am still convinced, that Pester should support a small amount of some standard outputs say like Cucumber.

I think the following formats would be fine:

- NUnit 2
- Nunit 3
- HTML (single page)
- JSON (for tools like Donut)

More output formats could be provided as extra modules.

The following issues/pull requests I have been found about output/NUnit results.

- #301 
- #1087
- #1194
- #1186
- #1089

Hopefully I'm not too overwhelming.
The code I have been provided can be uses as it is.
Or can used as starting point of discussion about the topic.

By the way: the object which is returned by `passthru` parameter seems not to be sufficient for me so I used the internal Pester state object.

Please give feedback to the code!
I would highly appreciate suggestions for improvements!