### PR TITLE
Remove the Quiet parameter

### DIFF
--- a/Functions/Gherkin.ps1
+++ b/Functions/Gherkin.ps1
@@ -111,10 +111,6 @@ function Invoke-Gherkin {
         .PARAMETER OutputFormat
             The format for output (LegacyNUnitXml or NUnitXml), defaults to NUnitXml
 
-        .PARAMETER Quiet
-            Disables the output Pester writes to screen. No other output is generated unless you specify PassThru,
-            or one of the Output parameters.
-
         .PARAMETER PesterOption
             Sets advanced options for the test execution. Enter a PesterOption object,
             such as one that you create by using the New-PesterOption cmdlet, or a hash table
@@ -142,7 +138,7 @@ function Invoke-Gherkin {
             By default, Invoke-Gherkin writes to the host program, not to the output stream (stdout).
             If you try to save the result in a variable, the variable is empty unless you
             use the PassThru parameter.
-            To suppress the host output, use the Quiet parameter.
+            To suppress the host output, use the Show parameter.
 
         .EXAMPLE
             Invoke-Gherkin
@@ -215,8 +211,6 @@ function Invoke-Gherkin {
         [ValidateSet('NUnitXml')]
         [string] $OutputFormat = 'NUnitXml',
 
-        [Switch]$Quiet,
-
         [object]$PesterOption,
 
         [Pester.OutputTypes]$Show = 'All',
@@ -247,15 +241,6 @@ function Invoke-Gherkin {
         }
     }
     end {
-        if ($PSBoundParameters.ContainsKey('Quiet')) {
-            & $SafeCommands["Write-Warning"] 'The -Quiet parameter has been deprecated; please use the new -Show parameter instead. To get no output use -Show None.'
-            & $SafeCommands["Start-Sleep"] -Seconds 2
-
-            if (!$PSBoundParameters.ContainsKey('Show')) {
-                $Show = [Pester.OutputTypes]::None
-            }
-        }
-
         if ($PSCmdlet.ParameterSetName -eq "RetestFailed" -and $FailedLast) {
             $ScenarioName = $script:GherkinFailedLast
             if (!$ScenarioName) {

--- a/Pester.psm1
+++ b/Pester.psm1
@@ -501,17 +501,6 @@ Currently supported formats are:
 Makes Pending and Skipped tests to Failed tests. Useful for continuous
 integration where you need to make sure all tests passed.
 
-.PARAMETER Quiet
-The parameter Quiet is deprecated since Pester v. 4.0 and will be deleted
-in the next major version of Pester. Please use the parameter Show
-with value 'None' instead.
-
-The parameter Quiet suppresses the output that Pester writes to the host program,
-including the result summary and CodeCoverage output.
-
-This parameter does not affect the PassThru custom object or the XML output that
-is written when you use the Output parameters.
-
 .PARAMETER Show
 Customizes the output Pester writes to the screen. Available options are None, Default,
 Passed, Failed, Pending, Skipped, Inconclusive, Describe, Context, Summary, Header, All, Fails.
@@ -698,15 +687,6 @@ New-PesterOption
     }
 
     end {
-        if ($PSBoundParameters.ContainsKey('Quiet')) {
-            & $script:SafeCommands['Write-Warning'] 'The -Quiet parameter has been deprecated; please use the new -Show parameter instead. To get no output use -Show None.'
-            & $script:SafeCommands['Start-Sleep'] -Seconds 2
-
-            if (!$PSBoundParameters.ContainsKey('Show')) {
-                $Show = [Pester.OutputTypes]::None
-            }
-        }
-
         $script:mockTable = @{}
         # todo: move mock cleanup to BeforeAllBlockContainer when there is any
         Remove-MockFunctionsAndAliases


### PR DESCRIPTION
## 1. General summary of the pull request

The pull requests removes - deprecated in the Pester v4 - the Quiet parameter.