### PR TITLE
WIP: Enforce test failure in non-passing results in strict mode

### DIFF
--- a/Functions/Output.ps1
+++ b/Functions/Output.ps1
@@ -200,15 +200,17 @@ function ConvertTo-PesterResult {
         $line = $details.Line
         $Text = $details.LineText
 
-        switch ($ErrorRecord.FullyQualifiedErrorID) {
-            PesterTestInconclusive {
-                $testResult.Result = "Inconclusive"; break;
-            }
-            PesterTestPending {
-                $testResult.Result = "Pending"; break;
-            }
-            PesterTestSkipped {
-                $testResult.Result = "Skipped"; break;
+        if (-not $script:Strict) {
+            switch ($ErrorRecord.FullyQualifiedErrorID) {
+                PesterTestInconclusive {
+                    $testResult.Result = "Inconclusive"; break;
+                }
+                PesterTestPending {
+                    $testResult.Result = "Pending"; break;
+                }
+                PesterTestSkipped {
+                    $testResult.Result = "Skipped"; break;
+                }
             }
         }
     }

--- a/Functions/Output.ps1
+++ b/Functions/Output.ps1
@@ -200,7 +200,7 @@ function ConvertTo-PesterResult {
         $line = $details.Line
         $Text = $details.LineText
 
-        if (-not $script:Strict) {
+        if (-not $Pester.Strict) {
             switch ($ErrorRecord.FullyQualifiedErrorID) {
                 PesterTestInconclusive {
                     $testResult.Result = "Inconclusive"; break;

--- a/Functions/PesterState.Tests.ps1
+++ b/Functions/PesterState.Tests.ps1
@@ -301,6 +301,54 @@ InModuleScope Pester {
                 $result.passed | should -be $false
                 $result.Result | Should -be "Failed"
             }
+
+            It "Changes Inconclusive state to Failed" {
+                $strict.AddTestResult("test", "Inconclusive")
+                $result = $strict.TestResult[-1]
+
+                $result.passed | should -be $false
+                $result.Result | Should -be "Failed"
+            }
+        }
+
+        Context 'Status counts in Strict mode' {
+            It "increases Passed count" {
+                $state = New-PesterState -Strict
+                $state.AddTestResult("test", "Passed")
+
+                $state.PassedCount | Should -Be 1
+            }
+
+            It "increases Failed count" {
+                $state = New-PesterState -Strict
+                $state.AddTestResult("test", "Failed")
+
+                $state.FailedCount | Should -Be 1
+            }
+
+            It "increases Failed count instead of Pending" {
+                $state = New-PesterState -Strict
+                $state.AddTestResult("test", "Pending")
+
+                $state.FailedCount | Should -Be 1
+                $state.PendingCount | Should -Be 0
+            }
+
+            It "increases Failed count instead of Skipped" {
+                $state = New-PesterState -Strict
+                $state.AddTestResult("test", "Skipped")
+
+                $state.FailedCount | Should -Be 1
+                $state.SkippedCount | Should -Be 0
+            }
+
+            It "increases Failed count instead of Inconclusive" {
+                $state = New-PesterState -Strict
+                $state.AddTestResult("test", "Inconclusive")
+
+                $state.FailedCount | Should -Be 1
+                $state.InconclusiveCount | Should -Be 0
+            }
         }
     }
 }

--- a/Functions/PesterState.ps1
+++ b/Functions/PesterState.ps1
@@ -162,13 +162,13 @@ function New-PesterState {
             }
 
             if (-not $script:Strict) {
-                $Passed = "Passed", "Skipped", "Pending" -contains $Result
+                $Passed = "Passed", "Skipped", "Pending", "Inconclusive" -contains $Result
             }
             else {
                 $Passed = $Result -eq "Passed"
-                if (($Result -eq "Skipped") -or ($Result -eq "Pending")) {
+                if (@("Skipped", "Pending", "Inconclusive") -contains $Result) {
                     $FailureMessage = "The test failed because the test was executed in Strict mode and the result '$result' was translated to Failed."
-                    $ErrorRecord = New-ErrorRecord -ErrorId 'PesterTestInconclusive' -Message $FailureMessage
+                    $ErrorRecord = New-ErrorRecord -ErrorId "PesterTest$Result" -Message $FailureMessage
                     $Result = "Failed"
                 }
 

--- a/Functions/PesterState.ps1
+++ b/Functions/PesterState.ps1
@@ -162,7 +162,7 @@ function New-PesterState {
             }
 
             if (-not $script:Strict) {
-                $Passed = "Passed", "Skipped", "Pending", "Inconclusive" -contains $Result
+                $Passed = "Passed", "Skipped", "Pending" -contains $Result
             }
             else {
                 $Passed = $Result -eq "Passed"

--- a/Functions/TestsRunningInCleanRunspace.Tests.ps1
+++ b/Functions/TestsRunningInCleanRunspace.Tests.ps1
@@ -139,16 +139,24 @@ Describe "Tests running in clean runspace" {
             Describe 'Mark skipped and pending tests as failed' {
                 It "skip" -Skip { $true | Should -Be $true }
                 It "pending" -Pending { $true | Should -Be $true }
-                # bug: #885 it does not fail in strict mode
-                # It "inconclusive forced" { Set-TestInconclusive ; $true | Should -Be $true }
+                It "inconclusive forced" { Set-TestInconclusive ; $true | Should -Be $true }
+                It 'skipped by Set-ItResult' {
+                    Set-ItResult -Skipped -Because "it is a test"
+                }
+                It 'pending by Set-ItResult' {
+                    Set-ItResult -Pending -Because "it is a test"
+                }
+                It 'inconclusive by Set-ItResult' {
+                    Set-ItResult -Inconclusive -Because "it is a test"
+                }
             }
         }
 
         $result = Invoke-PesterInJob -ScriptBlock $TestSuite -UseStrictPesterMode
         $result.PassedCount | Should Be 0
-        $result.FailedCount | Should Be 2
+        $result.FailedCount | Should Be 6
 
-        $result.TotalCount | Should Be 2
+        $result.TotalCount | Should Be 6
     }
 }
 


### PR DESCRIPTION
Fix #885 

Write-PesterResult checks for strict mode before setting the result
value for Pending, Skipped and Inconclusive
AddTestResult sets Pending, Skipped and Inconclusive as Failed in strict
mode
AddTestResult sets the ErrorId accordingly to PesterTestPending,
PesterTestSkipped and PesterTestInconclusive instead of plainly to
PesterTestInconclusive

Add tests