### PR TITLE
Remove Invoke-GherkinStep from exported functions

### DIFF
--- a/Pester.psd1
+++ b/Pester.psd1
@@ -59,7 +59,6 @@
 
         # Gherkin Support:
         'Invoke-Gherkin'
-        'Invoke-GherkinStep'
         'Find-GherkinStep'
         'GherkinStep'
         'BeforeEachFeature'


### PR DESCRIPTION
## 1. General summary of the pull request

The function Invoke-GherkinStep should not be exported. The previous exclusion of it #948 is inconsistent so that pull request corrects that.