### PR TITLE
WIP: Improve logic for removal of symlinks during TestDrive tear down.

### DIFF
--- a/Functions/Output.ps1
+++ b/Functions/Output.ps1
@@ -279,7 +279,9 @@ function Write-PesterResult {
                 }
 
                 Skipped {
-                    $because = if ($testresult.ErrorRecord.TargetObject.Data.Because) {
+                    $targetObject = if ($null -ne $testresult.ErrorRecord -and
+                        ($o = $testresult.ErrorRecord.PSObject.Properties.Item("TargetObject"))) { $o.Value }
+                    $because = if ($targetObject -and $targetObject.Data.Because) {
                         ", because $($testresult.ErrorRecord.TargetObject.Data.Because)"
                     }
                     else {
@@ -488,7 +490,11 @@ function ConvertTo-FailureLines {
         ## convert the stack trace if present (there might be none if we are raising the error ourselves)
         # todo: this is a workaround see https://github.com/pester/Pester/pull/886
         if ($null -ne $ErrorRecord.ScriptStackTrace) {
+            write-host "there is stack trace"
             $traceLines = $ErrorRecord.ScriptStackTrace.Split([Environment]::NewLine, [System.StringSplitOptions]::RemoveEmptyEntries)
+        }
+        else {
+            write-Host "there is not stack trace"
         }
 
         $count = 0
@@ -519,19 +525,19 @@ function ConvertTo-FailureLines {
             $count ++
         }
 
-        if ($ExecutionContext.SessionState.PSVariable.GetValue("PesterDebugPreference_ShowFullErrors")) {
+        #if ($ExecutionContext.SessionState.PSVariable.GetValue("PesterDebugPreference_ShowFullErrors")) {
             $lines.Trace += $traceLines
-        }
-        else {
-            $lines.Trace += $traceLines |
-                & $SafeCommands['Select-Object'] -First $count |
-                & $SafeCommands['Where-Object'] {
-                $_ -notmatch $pattern2 -and
-                $_ -notmatch $pattern3 -and
-                $_ -notmatch $pattern4 -and
-                $_ -notmatch $pattern5
-            }
-        }
+        #}
+        # else {
+        #     $lines.Trace += $traceLines |
+        #         & $SafeCommands['Select-Object'] -First $count |
+        #         & $SafeCommands['Where-Object'] {
+        #         $_ -notmatch $pattern2 -and
+        #         $_ -notmatch $pattern3 -and
+        #         $_ -notmatch $pattern4 -and
+        #         $_ -notmatch $pattern5
+        #     }
+        # }
 
         return $lines
     }

--- a/Functions/Output.ps1
+++ b/Functions/Output.ps1
@@ -490,11 +490,7 @@ function ConvertTo-FailureLines {
         ## convert the stack trace if present (there might be none if we are raising the error ourselves)
         # todo: this is a workaround see https://github.com/pester/Pester/pull/886
         if ($null -ne $ErrorRecord.ScriptStackTrace) {
-            write-host "there is stack trace"
             $traceLines = $ErrorRecord.ScriptStackTrace.Split([Environment]::NewLine, [System.StringSplitOptions]::RemoveEmptyEntries)
-        }
-        else {
-            write-Host "there is not stack trace"
         }
 
         $count = 0
@@ -525,19 +521,19 @@ function ConvertTo-FailureLines {
             $count ++
         }
 
-        #if ($ExecutionContext.SessionState.PSVariable.GetValue("PesterDebugPreference_ShowFullErrors")) {
+        if ($ExecutionContext.SessionState.PSVariable.GetValue("PesterDebugPreference_ShowFullErrors")) {
             $lines.Trace += $traceLines
-        #}
-        # else {
-        #     $lines.Trace += $traceLines |
-        #         & $SafeCommands['Select-Object'] -First $count |
-        #         & $SafeCommands['Where-Object'] {
-        #         $_ -notmatch $pattern2 -and
-        #         $_ -notmatch $pattern3 -and
-        #         $_ -notmatch $pattern4 -and
-        #         $_ -notmatch $pattern5
-        #     }
-        # }
+        }
+        else {
+            $lines.Trace += $traceLines |
+                & $SafeCommands['Select-Object'] -First $count |
+                & $SafeCommands['Where-Object'] {
+                $_ -notmatch $pattern2 -and
+                $_ -notmatch $pattern3 -and
+                $_ -notmatch $pattern4 -and
+                $_ -notmatch $pattern5
+            }
+        }
 
         return $lines
     }

--- a/Functions/TestDrive.Tests.ps1
+++ b/Functions/TestDrive.Tests.ps1
@@ -214,7 +214,7 @@ InModuleScope Pester {
             @(Get-ChildItem -Path $root).Length | Should -Be 0 -Because "everything should be deleted including symlinks"
         }
 
-        It "Clear-TestDrive should not throw" {
+        It "Clear-TestDrive should not throw" -skip:$SkipTest {
             $null = New-Item -Type Directory TestDrive:/d1
             $null = New-Item -Type Directory TestDrive:/test
             $null = New-Item -Type SymbolicLink -Path TestDrive:/test/link1 -Target TestDrive:/d1

--- a/Functions/TestDrive.Tests.ps1
+++ b/Functions/TestDrive.Tests.ps1
@@ -226,10 +226,12 @@ InModuleScope Pester {
             $null = New-Item -Type SymbolicLink -Path TestDrive:/test/link2 -Target TestDrive:/d1
             $null = New-Item -Type SymbolicLink -Path TestDrive:/test/link2a -Target TestDrive:/test/link2
 
-            { Clear-TestDrive } | Should -Not -Throw
-
             $root    = (Get-PsDrive 'TestDrive').Root
-            @(Get-ChildItem -Path $root).Length | Should -Be 0 -Because "everything should be deleted including symlinks"
+            @(Get-ChildItem -Recurse -Path $root).Length | Should -Be 5 -Because "a pre-requisite is that directores and symlinks are in place"
+
+            Clear-TestDrive
+
+            @(Get-ChildItem -Path $root).Length | Should -Be 0 -Because "everything should be deleted"
         }
     }
 }

--- a/Functions/TestDrive.Tests.ps1
+++ b/Functions/TestDrive.Tests.ps1
@@ -183,9 +183,9 @@ InModuleScope Pester {
         if  ( (GetPesterOs) -eq "Windows" -and (GetPesterPSVersion) -ge 5 ) {
             $windowsIdentity = [Security.Principal.WindowsIdentity]::GetCurrent()
             $windowsPrincipal = new-object 'Security.Principal.WindowsPrincipal' $windowsIdentity
-            $IsAdmin = $windowsPrincipal.IsInRole("Administrators") -eq 1
+            $IsAdmin = $windowsPrincipal.IsInRole("Administrators") -eq $true
             # skip tests when not admin
-            $SkipTest = ! $IsAdmin
+            $SkipTest = -not $IsAdmin
         }
         elseif ( (GetPesterOs) -ne "Windows" ) {
             $SkipTest = $false
@@ -225,7 +225,11 @@ InModuleScope Pester {
             $null = New-Item -Type SymbolicLink -Path TestDrive:/test/link1 -Target TestDrive:/d1
             $null = New-Item -Type SymbolicLink -Path TestDrive:/test/link2 -Target TestDrive:/d1
             $null = New-Item -Type SymbolicLink -Path TestDrive:/test/link2a -Target TestDrive:/test/link2
+
             { Clear-TestDrive } | Should -Not -Throw
+
+            $root    = (Get-PsDrive 'TestDrive').Root
+            @(Get-ChildItem -Path $root).Length | Should -Be 0 -Because "everything should be deleted including symlinks"
         }
     }
 }

--- a/Functions/TestDrive.ps1
+++ b/Functions/TestDrive.ps1
@@ -113,8 +113,15 @@ function Remove-TestDriveSymbolicLinks ([String] $Path) {
     $reparsePoint = [System.IO.FileAttributes]::ReparsePoint
     & $SafeCommands["Get-ChildItem"] -Recurse -Path $Path |
         where-object { ($_.Attributes -band $reparsePoint) -eq $reparsePoint } |
-        % { $_.Delete() }
-
+        foreach-object { 
+            $item = $_
+            try { 
+                $item.Delete() 
+            }
+            catch {
+                Remove-Item $item -ErrorAction Stop
+            }
+        }
 }
 
 function Remove-TestDrive {

--- a/Functions/TestDrive.ps1
+++ b/Functions/TestDrive.ps1
@@ -109,19 +109,17 @@ function Remove-TestDriveSymbolicLinks ([String] $Path) {
     # & $SafeCommands["Get-ChildItem"] -Recurse -Path $Path -Attributes "ReparsePoint" |
     #    % { $_.Delete() }
 
+    # issue 621 was fixed before PowerShell 6.1
+    # now there is an issue with calling the Delete method in recent (6.1) builds of PowerShell
+    if ( $PSVersionTable.PSVersion -ge "6.1" ) {
+        return
+    }
+
     # powershell 2-compatible
     $reparsePoint = [System.IO.FileAttributes]::ReparsePoint
     & $SafeCommands["Get-ChildItem"] -Recurse -Path $Path |
         where-object { ($_.Attributes -band $reparsePoint) -eq $reparsePoint } |
-        foreach-object { 
-            $item = $_
-            try { 
-                $item.Delete() 
-            }
-            catch {
-                Remove-Item $item -ErrorAction Stop
-            }
-        }
+        foreach-object { $_.Delete() }
 }
 
 function Remove-TestDrive {

--- a/Functions/TestDrive.ps1
+++ b/Functions/TestDrive.ps1
@@ -111,7 +111,7 @@ function Remove-TestDriveSymbolicLinks ([String] $Path) {
 
     # issue 621 was fixed before PowerShell 6.1
     # now there is an issue with calling the Delete method in recent (6.1) builds of PowerShell
-    if ( $PSVersionTable.PSVersion -ge "6.1" ) {
+    if ( (GetPesterPSVersion) -ge 6) {
         return
     }
 


### PR DESCRIPTION


<!--

Thank you for contributing to Pester! Please provide a descriptive title of the pull request in the field 'Title'.

-->

## 1. General summary of the pull request

Under some circumstances, it appears that the delete method `FileInfo/DirectoryInfo` will throw which causes test failures. This change adds an invocation of  Remove-Item as a last-ditch effort to remove a symlink when the items' Delete method fails. I've also enabled the commented out tests for symlink removal under the appropriate circumstances by calculating whether the user is elevated on Windows. On non-Windows, symlink creation does not require elevation.

<!--

Please describe what your pull request fixes, or how it improves Pester.

If your pull request resolves a reported issue, please mention it by using  `Fix #<issue_number>` on a new line, this will close the linked issue automatically when this PR is merged. For more info see: [Closing issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/).

If your pull request integrates Pester with another system, please tell us how the change can be tested.

Please remember to update [the Pester wiki](https://github.com/pester/Pester/wiki) if needed.

Before you continue, please review [Contributing to Pester](https://github.com/pester/Pester/wiki/Contributing-to-Pester) and [Development rules - technical](https://github.com/pester/Pester/wiki/Developement-rules---technical).

Our continuous integration system doesn't send any notifications about failed tests. Please return to the opened pull request (after ~60 minutes) to check if is everything OK.

-->
