### PR TITLE
Add a new exception and clarify exception wording to It, Describe, and Context

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 build/
 Test.xml
 vendor/packages/
+.vscode/

--- a/Functions/Context.Tests.ps1
+++ b/Functions/Context.Tests.ps1
@@ -1,0 +1,22 @@
+Set-StrictMode -Version Latest
+
+Describe 'Testing Context' {
+    It "Context throws a missing name error" {
+        { Context {
+                it "runs a test" {
+
+                }
+            }
+        }| should -Throw  'Test fixture name has multiple lines and no test fixture is provided. (Have you provided a name for the test group?)'
+    }
+
+    It "Has a name that looks like a script block" {
+        { Context "context"
+            {
+                it "runs a test" {
+
+                }
+            }
+        }| should -Throw  'No test fixture is provided. (Have you put the open curly brace on the next line?)'
+    }
+}

--- a/Functions/Context.ps1
+++ b/Functions/Context.ps1
@@ -58,10 +58,16 @@ about_TestDrive
         [string[]] $Tag = @(),
 
         [Parameter(Position = 1)]
-        [ValidateNotNull()]
-        [ScriptBlock] $Fixture = $(Throw "No test script block is provided. (Have you put the open curly brace on the next line?)")
+        [ScriptBlock] $Fixture
     )
-
+    if ($Fixture -eq $null) {
+        if ($Name.Contains("`n")) {
+            throw "Test fixture name has multiple lines and no test fixture is provided. (Have you provided a name for the test group?)"
+        }
+        else {
+            throw 'No test fixture is provided. (Have you put the open curly brace on the next line?)'
+        }
+    }
     if ($null -eq (& $SafeCommands['Get-Variable'] -Name Pester -ValueOnly -ErrorAction $script:IgnoreErrorPreference)) {
         # User has executed a test script directly instead of calling Invoke-Pester
         $sessionState = Set-SessionStateHint -PassThru -Hint "Caller - Captured in Context" -SessionState $PSCmdlet.SessionState

--- a/Functions/Describe.Tests.ps1
+++ b/Functions/Describe.Tests.ps1
@@ -14,7 +14,27 @@ Describe 'Testing Describe' {
 
         $isMandatory | Should -Be $false
 
-        { Describe Bogus } | Should -Throw 'No test script block is provided'
+        { Describe Bogus } | Should -Throw 'No test fixture is provided. (Have you put the open curly brace on the next line?)'
+    }
+
+    It 'Has a name that looks like a test fixture' {
+        $command = Get-Command Describe -Module Pester
+        $command | Should -Not -Be $null
+
+        $parameter = $command.Parameters['Fixture']
+        $parameter | Should -Not -Be $null
+
+        # Some environments (Nano/CoreClr) don't have all the type extensions
+        $attribute = $parameter.Attributes | Where-Object { $_ -is [System.Management.Automation.ParameterAttribute] }
+        $isMandatory = $null -ne $attribute -and $attribute.Mandatory
+
+        $isMandatory | Should -Be $false
+
+        {
+            Describe {
+                "test block"
+            }
+        } | Should -Throw 'Test fixture name has multiple lines and no test fixture is provided. (Have you provided a name for the test group?)'
     }
 }
 

--- a/Functions/Describe.ps1
+++ b/Functions/Describe.ps1
@@ -70,9 +70,16 @@ about_TestDrive
 
         [Parameter(Position = 1)]
         [ValidateNotNull()]
-        [ScriptBlock] $Fixture = $(Throw "No test script block is provided. (Have you put the open curly brace on the next line?)")
+        [ScriptBlock] $Fixture
     )
-
+    if ($Fixture -eq $null) {
+        if ($Name.Contains("`n")) {
+            throw "Test fixture name has multiple lines and no test fixture is provided. (Have you provided a name for the test group?)"
+        }
+        else {
+            throw 'No test fixture is provided. (Have you put the open curly brace on the next line?)'
+        }
+    }
     if ($null -eq (& $SafeCommands['Get-Variable'] -Name Pester -ValueOnly -ErrorAction $script:IgnoreErrorPreference)) {
         # User has executed a test script directly instead of calling Invoke-Pester
         Remove-MockFunctionsAndAliases

--- a/Functions/It.Tests.ps1
+++ b/Functions/It.Tests.ps1
@@ -10,6 +10,16 @@ InModuleScope Pester {
             $scriptBlock | Should -Throw 'No test script block is provided. (Have you put the open curly brace on the next line?)'
         }
 
+
+        It 'Throws an error if your name looks like a test block' {
+            $scriptBlock = {
+                ItImpl -Pester $testState {
+                    "A test script block"
+                }
+            }
+            $scriptBlock | Should -Throw 'Name parameter has multiple lines and no script block is provided. (Have you provided a name for the test group?)'
+        }
+
         It 'Does not throw an error if It is passed a script block, and adds a successful test result.' {
             $scriptBlock = { ItImpl -Pester $testState 'Enters an It block inside a Describe' { } }
             $scriptBlock | Should -Not -Throw

--- a/Functions/It.ps1
+++ b/Functions/It.ps1
@@ -126,8 +126,10 @@ function ItImpl {
     param(
         [Parameter(Mandatory = $true, Position = 0)]
         [string]$Name,
+
         [Parameter(Position = 1)]
         [ScriptBlock] $Test,
+
         [System.Collections.IDictionary[]] $TestCases,
         [Parameter(ParameterSetName = 'Pending')]
         [Switch] $Pending,
@@ -152,7 +154,12 @@ function ItImpl {
 
     #unless Skip or Pending is specified you must specify a ScriptBlock to the Test parameter
     if (-not ($PSBoundParameters.ContainsKey('test') -or $Skip -or $Pending)) {
-        throw 'No test script block is provided. (Have you put the open curly brace on the next line?)'
+        If ($Name.Contains("`n")) {
+            throw "Name parameter has multiple lines and no script block is provided. (Have you provided a name for the test group?)"
+        }
+        else {
+            throw 'No test script block is provided. (Have you put the open curly brace on the next line?)'
+        }
     }
 
     #the function is called with Pending or Skipped set the script block if needed


### PR DESCRIPTION
<!--

Thank you for contributing to Pester! Please provide a descriptive title of the pull request in the field 'Title'.

-->

## 1. General summary of the pull request
Fix #496 
Add new exceptions and clarify exception wording when a parameter to It, Describe, or Context is missing. Clarify for the use whether a name or script block is missing. 