### PR TITLE
Added -like operator for Should-Throw

### DIFF
--- a/Functions/Assertions/PesterThrow.Tests.ps1
+++ b/Functions/Assertions/PesterThrow.Tests.ps1
@@ -80,6 +80,29 @@ InModuleScope Pester {
             }
         }
 
+
+        Context "Matching error pattern" {
+            It "given scriptblock that throws exception with the expected pattern it passes" {
+                $expectedErrorMessage = "expected error message"
+                $expectedErrorPattern = "*error*"
+                { throw $expectedErrorMessage } | Should -Throw -like $expectedErrorPattern
+            }
+
+            It "given scriptblock that throws exception with the expected pattern in UPPERCASE it passes" {
+                $expectedErrorMessage = "expected error message"
+                $expectedErrorPattern = "*error*"
+                $errorMessage = $expectedErrorMessage.ToUpperInvariant()
+                { throw $errorMessage } | Should -Throw -like $expectedErrorPattern
+            }
+
+            It "given scriptblock that throws exception with a non-matching pattern it fails" {
+                $expectedErrorMessage = "expected error message"
+                $unexpectedErrorPattern = "*pass*"
+                $errorMessage = $expectedErrorMessage.ToUpperInvariant()
+                {  { throw $errorMessage } | Should -Throw  -like $unexpectedErrorPattern } | Verify-AssertionFailed
+            }
+        }
+
         Context "Matching ErrorId (FullyQualifiedErrorId)" {
             It "given scriptblock that throws exception with FullyQualifiedErrorId with the expected ErrorId it passes" {
                 $expectedErrorId = "expected error id"

--- a/Functions/Assertions/PesterThrow.ps1
+++ b/Functions/Assertions/PesterThrow.ps1
@@ -1,4 +1,4 @@
-function Should-Throw([scriptblock] $ActualValue, $ExpectedMessage, $ErrorId, [type]$ExceptionType, [switch] $Negate, [string] $Because, [switch] $PassThru) {
+function Should-Throw([scriptblock] $ActualValue, $ExpectedMessage, $ErrorId, [type]$ExceptionType, [switch] $Negate, [switch] $Like, [string] $Because, [switch] $PassThru) {
     <#
 .SYNOPSIS
 Checks if an exception was thrown. Enclose input in a script block.
@@ -105,8 +105,13 @@ It does not throw an error, so the test passes.
     $filterOnMessage = -not [string]::IsNullOrEmpty($ExpectedMessage -replace "\s")
     if ($filterOnMessage) {
         $filters += "with message $(Format-Nicely $ExpectedMessage)"
-        if ($actualExceptionWasThrown -and (-not (Get-DoValuesMatch $actualExceptionMessage $ExpectedMessage))) {
-            $buts += "the message was $(Format-Nicely $actualExceptionMessage)"
+        if ($actualExceptionWasThrown ) {
+            if (-not $like -and -not (Get-DoValuesMatch $actualExceptionMessage $ExpectedMessage)) {
+                $buts += "the message was $(Format-Nicely $actualExceptionMessage)"
+            }
+            if ($Like -and -not ($actualExceptionMessage -like $ExpectedMessage)) {
+                $buts += "the message did not match the expression $(Format-Nicely $actualExceptionMessage)"
+            }
         }
     }
 
@@ -116,9 +121,6 @@ It does not throw an error, so the test passes.
         if ($actualExceptionWasThrown -and (-not (Get-DoValuesMatch $actualErrorId $ErrorId))) {
             $buts += "the FullyQualifiedErrorId was $(Format-Nicely $actualErrorId)"
         }
-    }
-
-    if (-not $actualExceptionWasThrown) {
         $buts += "no exception was thrown"
     }
 
@@ -166,6 +168,10 @@ function ShouldThrowFailureMessage {
 function NotShouldThrowFailureMessage {
     # to make the should tests happy, for now
 }
+
+Add-AssertionOperator -Name         Throw `
+    -InternalName Should-Throw `
+    -Test         ${function:Should-Throw}
 
 Add-AssertionOperator -Name         Throw `
     -InternalName Should-Throw `


### PR DESCRIPTION
<!--

Thank you for contributing to Pester! Please provide a descriptive title of the pull request in the field 'Title'.

-->

## 1. General summary of the pull request
Added -Like parameter to Should-Throw, allowing wildcard patterns. Users can now write ``` Should -Throw -Like "*pattern*" in tests. Fix #1003 
<!--

Please describe what your pull request fixes, or how it improves Pester.

If your pull request resolves a reported issue, please mention it by using  `Fix #<issue_number>` on a new line, this will close the linked issue automatically when this PR is merged. For more info see: [Closing issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/).

If your pull request integrates Pester with another system, please tell us how the change can be tested.

Please remember to update [the Pester wiki](https://github.com/pester/Pester/wiki) if needed.

Before you continue, please review [Contributing to Pester](https://github.com/pester/Pester/wiki/Contributing-to-Pester) and [Development rules - technical](https://github.com/pester/Pester/wiki/Developement-rules---technical).

Our continuous integration system doesn't send any notifications about failed tests. Please return to the opened pull request (after ~60 minutes) to check if is everything OK.

-->
