### PR TITLE
Allow aliases in Parameter Filters blocks

### DIFF
--- a/Functions/Gherkin.Tests.ps1
+++ b/Functions/Gherkin.Tests.ps1
@@ -8,6 +8,24 @@ $multiLanguageTestData = @{
     'de' = @{ namedScenario = 'Etwas verwendet MeinValidator'; additionalSteps = 0; additionalScenarios = 0 }
 }
 
+function Resolve-UTF8EncodingWithoutBOM
+{
+    [CmdletBinding()]
+    param()
+
+    try {
+        if ([Console]::InputEncoding -is [Text.UTF8Encoding] -and
+                [Console]::InputEncoding.GetPreamble().Length -ne 0) {
+            [Console]::InputEncoding = New-Object Text.UTF8Encoding $false
+        }
+    }
+    catch {
+        $PSCmdlet.ThrowTerminatingError($_)
+    }
+}
+
+Resolve-UTF8EncodingWithoutBOM
+
 foreach ($data in $multiLanguageTestData.GetEnumerator()) {
 
     $language = $data.Key

--- a/Functions/Mock.Tests.ps1
+++ b/Functions/Mock.Tests.ps1
@@ -2085,3 +2085,39 @@ Describe "Mocking functions with conflicting parameters" {
         }
     }
 }
+
+Describe "Usage of Alias in Parameter Filters" {
+
+    Context 'Mock definition' {
+
+        It "Uses parameter aliases in Parameter-Filter" {
+            Mock Get-Content { "default-get-content" }
+            Mock Get-Content -ParameterFilter {$Last -eq 100} -MockWith { "aliased-parameter-name" }
+
+            Get-Content -Path "c:\temp.txt" -Last 100 | Should -Be "aliased-parameter-name"
+            Get-Content -Path "c:\temp.txt" | Should -Be "default-get-content"
+         }
+
+         It 'works with read-only/constant automatic variables' {
+            function f { Get-Module foo -ListAvailable -PSEdition 'Desktop' }
+            Mock Get-Module -Verifiable { 'mocked' } -ParameterFilter {$PSEdition -eq 'Desktop' }
+
+            f
+
+            Assert-MockCalled Get-Module
+         }
+    }
+
+    Context 'Assert-MockCalled' {
+
+        It "Uses parameter aliases in Parameter-Filter" {
+            function f { Get-Content -Path 'temp.txt' -Tail 10 }
+            Mock Get-Content { }
+
+            f
+
+            Assert-MockCalled Get-Content -ParameterFilter { $Last -eq 10 } -Exactly 1 -Scope It
+        }
+    }
+
+}

--- a/Functions/Mock.Tests.ps1
+++ b/Functions/Mock.Tests.ps1
@@ -2105,14 +2105,16 @@ Describe "Usage of Alias in Parameter Filters" {
 
         }
 
-        Context 'Get-Module' {
-            It 'works with read-only/constant automatic variables' {
-                function f { Get-Module foo -ListAvailable -PSEdition 'Desktop' }
-                Mock Get-Module -Verifiable { 'mocked' } -ParameterFilter {$PSEdition -eq 'Desktop' }
+        if ($PSVersionTable.PSVersion.Major -ge 5.1) {
+            Context 'Get-Module' {
+                It 'works with read-only/constant automatic variables' {
+                    function f { Get-Module foo -ListAvailable -PSEdition 'Desktop' }
+                    Mock Get-Module -Verifiable { 'mocked' } -ParameterFilter {$PSEdition -eq 'Desktop' }
 
-                f
+                    f
 
-                Assert-MockCalled Get-Module
+                    Assert-MockCalled Get-Module
+                }
             }
         }
     }

--- a/Functions/Mock.Tests.ps1
+++ b/Functions/Mock.Tests.ps1
@@ -2105,7 +2105,7 @@ Describe "Usage of Alias in Parameter Filters" {
 
         }
 
-        if ($PSVersionTable.PSVersion.Major -ge 5.1) {
+        if ($PSVersionTable.PSVersion -ge 5.1) {
             Context 'Get-Module' {
                 It 'works with read-only/constant automatic variables' {
                     function f { Get-Module foo -ListAvailable -PSEdition 'Desktop' }

--- a/Functions/Mock.Tests.ps1
+++ b/Functions/Mock.Tests.ps1
@@ -2087,29 +2087,37 @@ Describe "Mocking functions with conflicting parameters" {
 }
 
 Describe "Usage of Alias in Parameter Filters" {
-
     Context 'Mock definition' {
 
-        It "Uses parameter aliases in Parameter-Filter" {
-            Mock Get-Content { "default-get-content" }
-            Mock Get-Content -ParameterFilter {$Last -eq 100} -MockWith { "aliased-parameter-name" }
+        Context 'Get-Content' {
+            BeforeAll {
+                Mock Get-Content { "default-get-content" }
+                Mock Get-Content -ParameterFilter {$Tail -eq 100} -MockWith { "aliased-parameter-name" }
+            }
 
-            Get-Content -Path "c:\temp.txt" -Last 100 | Should -Be "aliased-parameter-name"
-            Get-Content -Path "c:\temp.txt" | Should -Be "default-get-content"
-         }
+            It "returns mock that matches parameter filter block" {
+                Get-Content -Path "c:\temp.txt" -Last 100 | Should -Be "aliased-parameter-name"
+            }
 
-         It 'works with read-only/constant automatic variables' {
-            function f { Get-Module foo -ListAvailable -PSEdition 'Desktop' }
-            Mock Get-Module -Verifiable { 'mocked' } -ParameterFilter {$PSEdition -eq 'Desktop' }
+            It 'returns default mock' {
+                Get-Content -Path "c:\temp.txt" | Should -Be "default-get-content"
+            }
 
-            f
+        }
 
-            Assert-MockCalled Get-Module
-         }
+        Context 'Get-Module' {
+            It 'works with read-only/constant automatic variables' {
+                function f { Get-Module foo -ListAvailable -PSEdition 'Desktop' }
+                Mock Get-Module -Verifiable { 'mocked' } -ParameterFilter {$PSEdition -eq 'Desktop' }
+
+                f
+
+                Assert-MockCalled Get-Module
+            }
+        }
     }
 
     Context 'Assert-MockCalled' {
-
         It "Uses parameter aliases in Parameter-Filter" {
             function f { Get-Content -Path 'temp.txt' -Tail 10 }
             Mock Get-Content { }

--- a/Functions/Mock.ps1
+++ b/Functions/Mock.ps1
@@ -1637,7 +1637,7 @@ function New-BlockWithoutParameterAliases {
         $Block
     )
     try {
-        if ((GetPesterPsVersion) -ge 3) {
+        if ($PSVersionTable.PSVersion.Major -ge 3) {
             $params = $Metadata.Parameters.Values
             $ast = $Block.Ast
             $blockText = $ast.Extent.Text


### PR DESCRIPTION
## 1. General summary of the pull request

Fix #1128