### PR TITLE
Add alias for extension-less external commands in windows

### DIFF
--- a/Functions/Mock.Tests.ps1
+++ b/Functions/Mock.Tests.ps1
@@ -2133,3 +2133,68 @@ if ($PSVersionTable.PSVersion.Major -ge 3) {
 
     }
 }
+
+
+InModuleScope Pester {
+    Describe 'Alias for external commands' {
+        Context 'Without extensions' {
+            $case = @(
+                @{Command = 'notepad'}
+            )
+
+            if ((GetPesterOs) -ne 'Windows') {
+                $case = @(
+                    @{Command = 'ls'}
+                )
+            }
+
+            It 'mocks <Command> command' -TestCases $case {
+                param($Command)
+
+                Mock $Command { 'I am being mocked' }
+
+                & $Command | Should -Be 'I am being mocked'
+
+                Assert-MockCalled $Command -Scope It -Exactly 1
+            }
+        }
+
+        if ((GetPesterOs) -eq 'Windows') {
+            Context 'With extensions' {
+                It 'mocks notepad command with extension' {
+                    Mock notepad.exe { 'I am being mocked' }
+
+                    notepad.exe | Should -Be 'I am being mocked'
+
+                    Assert-MockCalled notepad.exe -Scope It -Exactly 1
+                }
+            }
+
+            Context 'Mixed usage' {
+                It 'mocks with extension and calls it without ext' {
+                    Mock notepad.exe { 'I am being mocked' }
+
+                    notepad | Should -Be 'I am being mocked'
+
+                    Assert-MockCalled notepad.exe -Scope It -Exactly 1
+                }
+
+                It 'mocks without extension and calls with extension' {
+                    Mock notepad { 'I am being mocked' }
+
+                    notepad.exe | Should -Be 'I am being mocked'
+                }
+
+                It 'assert that alias to mock works' {
+                    Set-Alias note notepad
+
+                    Mock notepad.exe { 'I am being mocked' }
+
+                    notepad | Should -Be 'I am being mocked'
+
+                    Assert-MockCalled note -Scope It -Exactly 1
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!--

Thank you for contributing to Pester! Please provide a descriptive title of the pull request in the field 'Title'.

-->

## 1. General summary of the pull request

<!--

Please describe what your pull request fixes, or how it improves Pester.

If your pull request resolves a reported issue, please mention it by using  `Fix #<issue_number>` on a new line, this will close the linked issue automatically when this PR is merged. For more info see: [Closing issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/).

If your pull request integrates Pester with another system, please tell us how the change can be tested.

Please remember to update [the Pester wiki](https://github.com/pester/Pester/wiki) if needed.

Before you continue, please review [Contributing to Pester](https://github.com/pester/Pester/wiki/Contributing-to-Pester) and [Development rules - technical](https://github.com/pester/Pester/wiki/Developement-rules---technical).

Our continuous integration system doesn't send any notifications about failed tests. Please return to the opened pull request (after ~60 minutes) to check if is everything OK.

-->

Fix #1043
