### PR TITLE
WIP: Added regex to filter out ErrorLines.

### DIFF
--- a/Functions/Output.ps1
+++ b/Functions/Output.ps1
@@ -504,6 +504,7 @@ function ConvertTo-FailureLines {
             [String]$pattern3 = '^at Assert-MockCalled, .*/Functions/Mock.ps1: line [0-9]*$'
             [String]$pattern4 = '^at Invoke-Assertion, .*/Functions/.*.ps1: line [0-9]*$'
             [String]$pattern5 = '^at (<ScriptBlock>|Invoke-Gherkin.*), (<No file>|.*/Functions/.*.ps1): line [0-9]*$'
+            [String]$pattern6 = '^at Invoke-LegacyAssertion, .*/Functions/.*.ps1: line [0-9]*$'
         }
         Else {
 
@@ -512,6 +513,7 @@ function ConvertTo-FailureLines {
             [String]$pattern3 = '^at Assert-MockCalled, .*\\Functions\\Mock.ps1: line [0-9]*$'
             [String]$pattern4 = '^at Invoke-Assertion, .*\\Functions\\.*.ps1: line [0-9]*$'
             [String]$pattern5 = '^at (<ScriptBlock>|Invoke-Gherkin.*), (<No file>|.*\\Functions\\.*.ps1): line [0-9]*$'
+            [String]$pattern6 = '^at Invoke-LegacyAssertion, .*\\Functions\\.*.ps1: line [0-9]*$'
         }
 
         foreach ( $line in $traceLines ) {
@@ -531,7 +533,8 @@ function ConvertTo-FailureLines {
                 $_ -notmatch $pattern2 -and
                 $_ -notmatch $pattern3 -and
                 $_ -notmatch $pattern4 -and
-                $_ -notmatch $pattern5
+                $_ -notmatch $pattern5 -and
+                $_ -notmatch $pattern6
             }
         }
 


### PR DESCRIPTION
<!--

Thank you for contributing to Pester! Please provide a descriptive title of the pull request in the field 'Title'.

-->

## 1. General summary of the pull request

Added regex statements to filter out Invoke-LegacyAssertions from error messages. 

### Testing
Wasn't able to write tests for this. Could you provide me with assistance in regards to this?

<!--

Please describe what your pull request fixes, or how it improves Pester.

If your pull request resolves a reported issue, please mention it by using  `Fix #<issue_number>` on a new line, this will close the linked issue automatically when this PR is merged. For more info see: [Closing issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/).

If your pull request integrates Pester with another system, please tell us how the change can be tested.

Please remember to update [the Pester wiki](https://github.com/pester/Pester/wiki) if needed.

Before you continue, please review [Contributing to Pester](https://github.com/pester/Pester/wiki/Contributing-to-Pester) and [Development rules - technical](https://github.com/pester/Pester/wiki/Developement-rules---technical).

Our continuous integration system doesn't send any notifications about failed tests. Please return to the opened pull request (after ~60 minutes) to check if is everything OK.

-->
