### PR TITLE
Fix .Length mispelling in duplicate certificate thumbprint check in signModule.ps1

### DIFF
--- a/signModule.ps1
+++ b/signModule.ps1
@@ -8,7 +8,7 @@ if ($null -eq $cert) {
     throw "No certificate was found."
 }
 
-if (@($cert).Lenght -gt 1) {
+if (@($cert).Length -gt 1) {
     throw "More than one cerfificate with the given thumbprint was found."
 }
 


### PR DESCRIPTION
## 1. General summary of the pull request

Fixes a misspelling in `signModule.ps1`: where the check for duplicate thumbprint(s) is performed, the property to enumerate over the array of certifiates should be `.Length`.
