### PR TITLE
remove the arrow in the output of string comparison.

### DIFF
--- a/Functions/Assertions/Be.Tests.ps1
+++ b/Functions/Assertions/Be.Tests.ps1
@@ -144,27 +144,27 @@ InModuleScope Pester {
         }
 
         It "Outputs verbose message for two strings of different length" {
-            ShouldBeFailureMessage "actual" "expected" | Verify-Equal "Expected strings to be the same, but they were different.`nExpected length: 8`nActual length:   6`nStrings differ at index 0.`nExpected: 'expected'`nBut was:  'actual'`n-----------^"
+            ShouldBeFailureMessage "actual" "expected" | Verify-Equal "Expected strings to be the same, but they were different.`nExpected length: 8`nActual length:   6`nStrings differ at index 0.`nExpected: 'expected'`nBut was:  'actual'"
         }
 
         It "Outputs verbose message for two strings of different length" {
-            ShouldBeFailureMessage "actual" "expected" -Because 'reason' | Verify-Equal "Expected strings to be the same, because reason, but they were different.`nExpected length: 8`nActual length:   6`nStrings differ at index 0.`nExpected: 'expected'`nBut was:  'actual'`n-----------^"
+            ShouldBeFailureMessage "actual" "expected" -Because 'reason' | Verify-Equal "Expected strings to be the same, because reason, but they were different.`nExpected length: 8`nActual length:   6`nStrings differ at index 0.`nExpected: 'expected'`nBut was:  'actual'"
         }
 
         It "Outputs verbose message for two different strings of the same length" {
-            ShouldBeFailureMessage "x" "y" | Verify-Equal "Expected strings to be the same, but they were different.`nString lengths are both 1.`nStrings differ at index 0.`nExpected: 'y'`nBut was:  'x'`n-----------^"
+            ShouldBeFailureMessage "x" "y" | Verify-Equal "Expected strings to be the same, but they were different.`nString lengths are both 1.`nStrings differ at index 0.`nExpected: 'y'`nBut was:  'x'"
         }
 
         It "Replaces non-printable characters correctly" {
-            ShouldBeFailureMessage "`n`r`b`0`tx" "`n`r`b`0`ty" | Verify-Equal "Expected strings to be the same, but they were different.`nString lengths are both 6.`nStrings differ at index 5.`nExpected: '\n\r\b\0\ty'`nBut was:  '\n\r\b\0\tx'`n---------------------^"
+            ShouldBeFailureMessage "`n`r`b`0`tx" "`n`r`b`0`ty" | Verify-Equal "Expected strings to be the same, but they were different.`nString lengths are both 6.`nStrings differ at index 5.`nExpected: '\n\r\b\0\ty'`nBut was:  '\n\r\b\0\tx'"
         }
 
         It "The arrow points to the correct position when non-printable characters are replaced before the difference" {
-            ShouldBeFailureMessage "123`n456" "123`n789" | Verify-Equal "Expected strings to be the same, but they were different.`nString lengths are both 7.`nStrings differ at index 4.`nExpected: '123\n789'`nBut was:  '123\n456'`n----------------^"
+            ShouldBeFailureMessage "123`n456" "123`n789" | Verify-Equal "Expected strings to be the same, but they were different.`nString lengths are both 7.`nStrings differ at index 4.`nExpected: '123\n789'`nBut was:  '123\n456'"
         }
 
         It "The arrow points to the correct position when non-printable characters are replaced after the difference" {
-            ShouldBeFailureMessage "abcd`n123" "abc!`n123" | Verify-Equal "Expected strings to be the same, but they were different.`nString lengths are both 8.`nStrings differ at index 3.`nExpected: 'abc!\n123'`nBut was:  'abcd\n123'`n--------------^"
+            ShouldBeFailureMessage "abcd`n123" "abc!`n123" | Verify-Equal "Expected strings to be the same, but they were different.`nString lengths are both 8.`nStrings differ at index 3.`nExpected: 'abc!\n123'`nBut was:  'abcd\n123'"
         }
     }
 }
@@ -206,7 +206,7 @@ InModuleScope Pester {
 
     Describe "ShouldBeExactlyFailureMessage" {
         It "Writes verbose message for strings that differ by case" {
-            ShouldBeExactlyFailureMessage "a" "A" -Because "reason" | Verify-Equal "Expected strings to be the same, because reason, but they were different.`nString lengths are both 1.`nStrings differ at index 0.`nExpected: 'A'`nBut was:  'a'`n-----------^"
+            ShouldBeExactlyFailureMessage "a" "A" -Because "reason" | Verify-Equal "Expected strings to be the same, because reason, but they were different.`nString lengths are both 1.`nStrings differ at index 0.`nExpected: 'A'`nBut was:  'a'"
         }
     }
 }

--- a/Functions/Assertions/Be.ps1
+++ b/Functions/Assertions/Be.ps1
@@ -181,26 +181,9 @@ function Get-CompareStringMessage {
         }
         $ellipsis = "..."
         $excerptSize = 5;
-        $longStringOffset = 0
         "Expected: '{0}'" -f ( $ExpectedValue | Format-AsExcerpt -startIndex $differenceIndex -excerptSize $excerptSize  -excerptMarker $ellipsis | Expand-SpecialCharacters )
         "But was:  '{0}'" -f ( $actual | Format-AsExcerpt -startIndex $differenceIndex -excerptSize $excerptSize -excerptMarker $ellipsis | Expand-SpecialCharacters )
 
-        $specialCharacterOffset = $null
-        if ($differenceIndex -ne 0) {
-            #count all the special characters before the difference
-            $specialCharacterOffset = ($actual[0..($differenceIndex - 1)] |
-                    & $SafeCommands['Where-Object'] {"`n", "`r", "`t", "`b", "`0" -contains $_} |
-                    & $SafeCommands['Measure-Object'] |
-                    & $SafeCommands['Select-Object'] -ExpandProperty Count)
-        }
-
-        # for excerpted strings, add in an additional length of arrow...
-        $excerptOffset = $ellipsis.Length + $excerptSize
-        if ($differenceIndex -ge $excerptOffset) {
-            $longStringOffset = $excerptOffset
-        }
-
-        '-' * (  $differenceIndex + $specialCharacterOffset + 11 + $longStringOffset) + '^'
     }
 }
 function Format-AsExcerpt {

--- a/Functions/Output.Tests.ps1
+++ b/Functions/Output.Tests.ps1
@@ -226,9 +226,8 @@ InModuleScope -ModuleName Pester -ScriptBlock {
                 $r.message[2] | Should -be 'Strings differ at index 0.'
                 $r.Message[3] | Should -be "Expected: 'Two'"
                 $r.Message[4] | Should -be "But was:  'One'"
-                $r.Message[5] | Should -be '-----------^'
-                $r.Message[6] | Should -match "'One' | Should -be 'Two'"
-                $r.Message.Count | Should -be 7
+                $r.Message[5] | Should -match "'One' | Should -be 'Two'"
+                $r.Message.Count | Should -be 6
             }
             # # todo: commented out because it does not work becuase of should, hopefully we can fix that later
             #         Context 'should fails in file' {


### PR DESCRIPTION
<!--

Thank you for contributing to Pester! Please provide a descriptive title of the pull request in the field 'Title'.

-->

## 1. General summary of the pull request
I removed the arrow in the output of string comparison. 
`Fix #1263 `

<!--

Please describe what your pull request fixes, or how it improves Pester.

If your pull request resolves a reported issue, please mention it by using  `Fix #<issue_number>` on a new line, this will close the linked issue automatically when this PR is merged. For more info see: [Closing issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/).

If your pull request integrates Pester with another system, please tell us how the change can be tested.

Please remember to update [the Pester wiki](https://github.com/pester/Pester/wiki) if needed.

Before you continue, please review [Contributing to Pester](https://github.com/pester/Pester/wiki/Contributing-to-Pester) and [Development rules - technical](https://github.com/pester/Pester/wiki/Developement-rules---technical).

Our continuous integration system doesn't send any notifications about failed tests. Please return to the opened pull request (after ~60 minutes) to check if is everything OK.

-->
