### PR TITLE
WIP DO NOT MERGE : Fix for 1163 - Add alias section to Get-AssertionOperator output

### DIFF
--- a/Functions/Get-ShouldOperator.ps1
+++ b/Functions/Get-ShouldOperator.ps1
@@ -65,12 +65,16 @@ function Get-ShouldOperator {
 
     END {
         if ($Name) {
+           
             $operator = $AssertionOperators.Values | Where-Object { $Name -eq $_.Name -or $_.Alias -contains $Name }
             $help = Get-Help $operator.InternalName -Examples -ErrorAction SilentlyContinue
 
             if (($help | Measure-Object).Count -ne 1) {
                 Write-Warning ("No help found for Should operator '{0}'" -f ((Get-AssertionOperatorEntry $Name).InternalName))
             } else {
+                $aliases = (Get-AssertionOperatorEntry -Name $Name).Alias
+                $Alias = $aliases -join ', '
+                Add-Member -InputObject $Help -Name "Aliases" -Value $Alias -MemberType NoteProperty
                 $help
             }
         } else {


### PR DESCRIPTION
<!--

Thank you for contributing to Pester! Please provide a descriptive title of the pull request in the field 'Title'.

-->


# WIP.PLEASE DO NOT MERGE YET.

## 1. General summary of the pull request


Hi, this is a fix for https://github.com/pester/Pester/issues/1163


I think I have it working, but the output of the command is not quite how it should be.
Currently, by default, it doesn't include the Alias property.

I tried playing a bit with something around the lines of `$Help | Select Name,Synopsis,Alias,Examples -ExpandProperty Examples` but that out put is not as it was before.

So before I go further in this, it would be cool if you can give some feedback already and perhaps you have an idea / way of how we can return all the properties without 1) destroying the object with a `Select` statement. 2) how to get the output exactly as a regular output from a Get-Help cmdlet (If that is what you want of course)

