### PR TITLE
Fix function definition in parameter filter

### DIFF
--- a/Functions/Mock.Tests.ps1
+++ b/Functions/Mock.Tests.ps1
@@ -2105,6 +2105,24 @@ if ($PSVersionTable.PSVersion.Major -ge 3) {
                 }
             }
 
+            Context 'Get-Content mock ParamFilter passed as function definition instead of scriptblock' {
+                BeforeAll {
+                    Function ParamFilter {
+                        $Tail -eq 100
+                    }
+                    Mock Get-Content { "default-get-content" }
+                    Mock Get-Content -ParameterFilter ${function:ParamFilter} -MockWith { "aliased-parameter-name" }
+                }
+
+                It "returns mock that matches parameter filter block" {
+                    Get-Content -Path "c:\temp.txt" -Last 100 | Should -Be "aliased-parameter-name"
+                }
+
+                It 'returns default mock' {
+                    Get-Content -Path "c:\temp.txt" | Should -Be "default-get-content"
+                }
+            }
+
             Context "Alias rewriting works when alias and parameter name differ in length" {
 
                 Mock New-Item { return "nic" } -ParameterFilter { $Type -ne $null -and $Type.StartsWith("nic") }

--- a/Functions/Mock.ps1
+++ b/Functions/Mock.ps1
@@ -1650,9 +1650,11 @@ function Get-ScriptBlockAST {
 
     if ($ScriptBlock.Ast -is [System.Management.Automation.Language.ScriptBlockAst]) {
         $ast = $Block.Ast.EndBlock
-    } elseif ($ScriptBlock.Ast -is [System.Management.Automation.Language.FunctionDefinitionAst]) {
+    }
+    elseif ($ScriptBlock.Ast -is [System.Management.Automation.Language.FunctionDefinitionAst]) {
         $ast = $Block.Ast.Body.EndBlock
-    } else {
+    }
+    else {
         throw "Pester failed to parse ParameterFilter, scriptblock is invalid type. Please reformat your ParameterFilter."
     }
 

--- a/Functions/Mock.ps1
+++ b/Functions/Mock.ps1
@@ -1664,7 +1664,8 @@ function New-BlockWithoutParameterAliases {
             }
             elseif ($Block.Ast -is [System.Management.Automation.Language.ScriptBlockAst]) {
                 $ast = $Block.Ast.EndBlock
-            } else {
+            }
+            else {
                 throw "Pester failed to parse ParameterFilter, scriptblock is invalid type. Please reformat your ParameterFilter."
             }
             $blockText = $ast.Extent.Text

--- a/Functions/Mock.ps1
+++ b/Functions/Mock.ps1
@@ -1659,7 +1659,12 @@ function New-BlockWithoutParameterAliases {
     try {
         if ($PSVersionTable.PSVersion.Major -ge 3) {
             $params = $Metadata.Parameters.Values
-            $ast = $Block.Ast.EndBlock
+            if ($block.Ast -is [System.Management.Automation.Language.FunctionDefinitionAst]) {
+                $ast = $block.Ast.Body.EndBlock
+            }
+            elseif ($block.Ast -is [System.Management.Automation.Language.ScriptBlockAst]) {
+                $ast = $Block.Ast.EndBlock
+            }
             $blockText = $ast.Extent.Text
             $variables = [array]($Ast.FindAll( { param($ast) $ast -is [System.Management.Automation.Language.VariableExpressionAst]}, $true))
             [array]::Reverse($variables)

--- a/Functions/Mock.ps1
+++ b/Functions/Mock.ps1
@@ -1659,11 +1659,13 @@ function New-BlockWithoutParameterAliases {
     try {
         if ($PSVersionTable.PSVersion.Major -ge 3) {
             $params = $Metadata.Parameters.Values
-            if ($block.Ast -is [System.Management.Automation.Language.FunctionDefinitionAst]) {
-                $ast = $block.Ast.Body.EndBlock
+            if ($Block.Ast -is [System.Management.Automation.Language.FunctionDefinitionAst]) {
+                $ast = $Block.Ast.Body.EndBlock
             }
-            elseif ($block.Ast -is [System.Management.Automation.Language.ScriptBlockAst]) {
+            elseif ($Block.Ast -is [System.Management.Automation.Language.ScriptBlockAst]) {
                 $ast = $Block.Ast.EndBlock
+            } else {
+                throw "Pester failed to parse ParameterFilter, scriptblock is invalid type. Please reformat your ParameterFilter."
             }
             $blockText = $ast.Extent.Text
             $variables = [array]($Ast.FindAll( { param($ast) $ast -is [System.Management.Automation.Language.VariableExpressionAst]}, $true))


### PR DESCRIPTION
## 1. Fix bug where function definition ( ${function:} ) pass to -ParameterFilter breaks upon AST.

Fix #1291 

This is a small fix to to the 'New-BlockWithoutParameterAliases' function. When a function definition was passed to -ParameterFilter and internally passed to 'New-BlockWithoutParameterAliases', the AST would fail because it was expecting a true scriptblock, so the AST was in a different location than expected.

It now checks to see if the passed scriptblock is a FunctionDefinitionAst or ScriptBlockAst and handles the AST appropriately.

Tests included.