### PR TITLE
Use real path to temp path on macOS and GetTempPath() otherwise when constructing TestDrive

### DIFF
--- a/Functions/Environment.Tests.ps1
+++ b/Functions/Environment.Tests.ps1
@@ -92,7 +92,7 @@ InModuleScope -ModuleName Pester {
 
     Describe 'Get-TempDirectory' {
         It 'returns the correct temp directory for Windows' -Skip:((GetPesterOs) -ne 'Windows') {
-            $expected = $env:TEMP = "$($env:SystemDrive)\temp"
+            $expected = [System.IO.Path]::GetTempPath()
 
             $temp = Get-TempDirectory
             $temp | Should -Not -BeNullOrEmpty

--- a/Functions/Environment.Tests.ps1
+++ b/Functions/Environment.Tests.ps1
@@ -91,11 +91,8 @@ InModuleScope -ModuleName Pester {
 
 
     Describe 'Get-TempDirectory' {
-        It 'returns the correct temp directory for Windows' {
-            Mock 'GetPesterOs' {
-                'Windows'
-            }
-            $expected = $env:TEMP = "C:\temp"
+        It 'returns the correct temp directory for Windows' -Skip:((GetPesterOs) -ne 'Windows') {
+            $expected = $env:TEMP = "$($env:SystemDrive)\temp"
 
             $temp = Get-TempDirectory
             $temp | Should -Not -BeNullOrEmpty
@@ -106,10 +103,10 @@ InModuleScope -ModuleName Pester {
             Mock 'GetPesterOs' {
                 'MacOS'
             }
-            Get-TempDirectory | Should -Be '/tmp'
+            Get-TempDirectory | Should -Be '/private/tmp'
         }
 
-        It "returns '/tmp' directory for Linux" {
+        It "returns '/tmp' directory for Linux" -Skip:((GetPesterOs) -ne 'Linux') {
             Mock 'GetPesterOs' {
                 'Linux'
             }

--- a/Functions/Environment.Tests.ps1
+++ b/Functions/Environment.Tests.ps1
@@ -99,7 +99,7 @@ InModuleScope -ModuleName Pester {
             $temp | Should -Be $expected
         }
 
-        It "returns '/tmp' directory for MacOS" {
+        It "returns '/private/tmp' directory for MacOS" {
             Mock 'GetPesterOs' {
                 'MacOS'
             }

--- a/Functions/Environment.ps1
+++ b/Functions/Environment.ps1
@@ -23,11 +23,12 @@ function GetPesterOs {
 }
 
 function Get-TempDirectory {
-    if ((GetPesterOs) -eq 'Windows') {
-        $env:TEMP
+    if ((GetPesterOs) -eq 'macOS') {
+        # Special case for macOS which returns a symlink to the real temp folder
+        "/private/tmp/"
     }
     else {
-        '/tmp'
+        [System.IO.Path]::GetTempPath()
     }
 }
 

--- a/Functions/Environment.ps1
+++ b/Functions/Environment.ps1
@@ -24,8 +24,8 @@ function GetPesterOs {
 
 function Get-TempDirectory {
     if ((GetPesterOs) -eq 'macOS') {
-        # Special case for macOS which returns a symlink to the real temp folder
-        "/private/tmp/"
+        # Special case for macOS using the real path instead of /tmp which is a symlink to this path
+        "/private/tmp"
     }
     else {
         [System.IO.Path]::GetTempPath()

--- a/Functions/TestDrive.Tests.ps1
+++ b/Functions/TestDrive.Tests.ps1
@@ -3,6 +3,9 @@ Set-StrictMode -Version Latest
 if ($PSVersionTable.PSVersion.Major -lt 6 -or $IsWindows) {
     $tempPath = $env:TEMP
 }
+elseif ($IsMacOS) {
+    $tempPath = '/private/tmp'
+}
 else {
     $tempPath = '/tmp'
 }
@@ -179,7 +182,7 @@ InModuleScope Pester {
         # Symlink cmdlets were introduced in PowerShell v5 and deleting them
         # requires running as admin, so skip tests when those conditions are
         # not met
-        if  ((GetPesterOs) -eq "Windows") {
+        if ((GetPesterOs) -eq "Windows") {
             if ($psVersion -lt 5) {
                 $skipTest = $true
             }
@@ -197,8 +200,8 @@ InModuleScope Pester {
         It "Deletes symbolic links in TestDrive" -skip:$skipTest {
 
             # using non-powershell paths here because we need to interop with cmd below
-            $root    = (Get-PsDrive 'TestDrive').Root
-            $source  = "$root\source"
+            $root = (Get-PsDrive 'TestDrive').Root
+            $source = "$root\source"
             $symlink = "$root\symlink"
 
             $null = New-Item -Type Directory -Path $source


### PR DESCRIPTION
special case macOS to use /private/tmp which is the real folder path
otherwise, use GetTempPath() so that on Windows it returns the long path

## 1. General summary of the pull request

On macOS, the `/tmp` path is a symlink to `/private/tmp`, this causes problems in tests that create a test file and later tries to validate the path:

```powershell
$testPath = Join-Path $TestDrive "foo"
...
$realPath | Should -BeExactly $testPath
```

This fails as $testPath will be something like: `/tmp/foo` but the real file path returned from some cmdlet or .NET API will be `/private/tmp/foo`.

On Windows, the problem is that `$env:TEMP` which is used to construct the TestDrive path uses the 8.1 path syntax.  So on AzDevOps, the user is called `VSSADMINISTRATOR` so `$env:TEMP` is `C:\Users\VSSADM~1\AppData\Local\Temp\` but similar to macOS where a test validates the paths, it will fail because a cmdlet or .NET API will often return the longpath `C:\Users\VSSADMINISTRATOR\AppData\Local\Temp\`.

On Linux, `GetTempPath()` simply returns `/tmp/` which is correct.
