### PR TITLE
Add list of all built-in readonly and constant variables

### DIFF
--- a/Functions/Mock.ps1
+++ b/Functions/Mock.ps1
@@ -1635,7 +1635,25 @@ function Reset-ConflictingParameters {
 }
 
 $script:ConflictingParameterNames = @(
-    "PSEdition"
+    '?'
+    'ConsoleFileName'
+    'EnabledExperimentalFeatures'
+    'Error'
+    'ExecutionContext'
+    'false'
+    'HOME'
+    'Host'
+    'IsCoreCLR'
+    'IsMacOS'
+    'IsWindows'
+    'PID'
+    'PSCulture'
+    'PSEdition'
+    'PSHOME'
+    'PSUICulture'
+    'PSVersionTable'
+    'ShellId'
+    'true'
 )
 
 function Get-ConflictingParameterNames {


### PR DESCRIPTION
Listed all built-in readonly and constant variables that are defined in PowerShell 5 and 6 and added them to conflicting names list.

Related #1292 #1290 
