### PR TITLE
New new runtime

### DIFF
--- a/Functions/Output.ps1
+++ b/Functions/Output.ps1
@@ -485,7 +485,7 @@ function Get-WriteScreenPlugin {
         $level = $_test.Path.Length
         $margin = $ReportStrings.Margin * ($level)
         $error_margin = $margin + $ReportStrings.Margin
-        $output = $_test.ExpandedName
+        $out = $_test.ExpandedName
         $humanTime = "$(Get-HumanTime ($_test.Duration + $_test.FrameworkDuration)) ($(Get-HumanTime $_test.Duration)|$(Get-HumanTime $_test.FrameworkDuration))"
 
         # TODO: Add output options
@@ -495,13 +495,13 @@ function Get-WriteScreenPlugin {
         $result = if ($_test.Passed) { "Passed" } else { "Failed" }
         switch ($result) {
             Passed {
-                & $SafeCommands['Write-Host'] -ForegroundColor $ReportTheme.Pass "$margin[+] $output" -NoNewLine
+                & $SafeCommands['Write-Host'] -ForegroundColor $ReportTheme.Pass "$margin[+] $out" -NoNewLine
                 & $SafeCommands['Write-Host'] -ForegroundColor $ReportTheme.PassTime " $humanTime"
                 break
             }
 
             Failed {
-                & $SafeCommands['Write-Host'] -ForegroundColor $ReportTheme.Fail "$margin[-] $output" -NoNewLine
+                & $SafeCommands['Write-Host'] -ForegroundColor $ReportTheme.Fail "$margin[-] $out" -NoNewLine
                 & $SafeCommands['Write-Host'] -ForegroundColor $ReportTheme.FailTime " $humanTime"
 
                 # TODO: Add include VSCodeMarker
@@ -517,7 +517,7 @@ function Get-WriteScreenPlugin {
 
             Skipped {
                 $because = if ($_test.FailureMessage) { ", because $($_test.FailureMessage)"} else { $null }
-                & $SafeCommands['Write-Host'] -ForegroundColor $ReportTheme.Skipped "$margin[!] $output" -NoNewLine
+                & $SafeCommands['Write-Host'] -ForegroundColor $ReportTheme.Skipped "$margin[!] $out" -NoNewLine
                 & $SafeCommands['Write-Host'] -ForegroundColor $ReportTheme.Skipped ", is skipped$because" -NoNewLine
                 & $SafeCommands['Write-Host'] -ForegroundColor $ReportTheme.SkippedTime " $humanTime"
                 break
@@ -525,7 +525,7 @@ function Get-WriteScreenPlugin {
 
             Pending {
                 $because = if ($_test.FailureMessage) { ", because $($_test.FailureMessage)"} else { $null }
-                & $SafeCommands['Write-Host'] -ForegroundColor $ReportTheme.Pending "$margin[?] $output" -NoNewLine
+                & $SafeCommands['Write-Host'] -ForegroundColor $ReportTheme.Pending "$margin[?] $out" -NoNewLine
                 & $SafeCommands['Write-Host'] -ForegroundColor $ReportTheme.Pending ", is pending$because" -NoNewLine
                 & $SafeCommands['Write-Host'] -ForegroundColor $ReportTheme.PendingTime " $humanTime"
                 break
@@ -533,7 +533,7 @@ function Get-WriteScreenPlugin {
 
             Inconclusive {
                 $because = if ($_test.FailureMessage) { ", because $($_test.FailureMessage)"} else { $null }
-                & $SafeCommands['Write-Host'] -ForegroundColor $ReportTheme.Inconclusive "$margin[?] $output" -NoNewLine
+                & $SafeCommands['Write-Host'] -ForegroundColor $ReportTheme.Inconclusive "$margin[?] $out" -NoNewLine
                 & $SafeCommands['Write-Host'] -ForegroundColor $ReportTheme.Inconclusive ", is inconclusive$because" -NoNewLine
                 & $SafeCommands['Write-Host'] -ForegroundColor $ReportTheme.InconclusiveTime " $humanTime"
 
@@ -543,7 +543,7 @@ function Get-WriteScreenPlugin {
             default {
                 # TODO:  Add actual Incomplete status as default rather than checking for null time.
                 if ($null -eq $_test.Duration) {
-                    & $SafeCommands['Write-Host'] -ForegroundColor $ReportTheme.Incomplete "$margin[?] $output" -NoNewLine
+                    & $SafeCommands['Write-Host'] -ForegroundColor $ReportTheme.Incomplete "$margin[?] $out" -NoNewLine
                     & $SafeCommands['Write-Host'] -ForegroundColor $ReportTheme.IncompleteTime " $humanTime"
                 }
             }

--- a/new-runtimepoc/Pester.Runtime.psm1
+++ b/new-runtimepoc/Pester.Runtime.psm1
@@ -248,147 +248,183 @@ function New-Block {
     }
 }
 
-function Invoke-Block {
+function Invoke-Block ($previousBlock) {
     Switch-Timer -Scope Framework
     $overheadStartTime = $state.FrameworkStopWatch.Elapsed
     $blockStartTime = $state.UserCodeStopWatch.Elapsed
 
-    Push-Scope -Scope (New-Scope -Name $Name -Hint Block)
-    $path = @(foreach ($h in (Get-ScopeHistory)) { $h.Name })
     if ($PesterDebugPreference.WriteDebugMessages) {
         Write-PesterDebugMessage -Scope Runtime "Entering path $($path -join '.')"
     }
 
-    $block = $null
-
-    $previousBlock = Get-CurrentBlock
-
-    if (-not $previousBlock.FrameworkData.ContainsKey("PreviouslyGeneratedBlocks")) {
-        $previousBlock.FrameworkData.Add("PreviouslyGeneratedBlocks", @{ })
-    }
-    $hasExternalId = -not [string]::IsNullOrWhiteSpace($Id)
-    $Id = if (-not $hasExternalId) {
-        $previouslyGeneratedBlocks = $previousBlock.FrameworkData.PreviouslyGeneratedBlocks
-        Get-Id -ScriptBlock $ScriptBlock -Previous $previouslyGeneratedBlocks
-    }
-    else {
-        $Id
-    }
-
-    if ($null -eq $block) {
-        $block = Find-CurrentBlock -Block $previousBlock -Name $Name -ScriptBlock $ScriptBlock -Id $Id
-    }
-
-    Set-CurrentBlock -Block $block
-    try {
-        if (-not $block.ShouldRun) {
-            if ($PesterDebugPreference.WriteDebugMessages) {
-                Write-PesterDebugMessage -Scope Runtime "Block is excluded from run, returning"
+    foreach ($item in $previousBlock.Order) {
+        if ('Test' -eq $item.ItemType) {
+            Invoke-TestItem -Test $item
+        }
+        else {
+            $block = $item
+            if (-not $previousBlock.FrameworkData.ContainsKey("PreviouslyGeneratedBlocks")) {
+                $previousBlock.FrameworkData.Add("PreviouslyGeneratedBlocks", @{ })
             }
-            return
-        }
+            $hasExternalId = -not [string]::IsNullOrWhiteSpace($Id)
+            $Id = if (-not $hasExternalId) {
+                    $previouslyGeneratedBlocks = $previousBlock.FrameworkData.PreviouslyGeneratedBlocks
+                    Get-Id -ScriptBlock $block.ScriptBlock -Previous $previouslyGeneratedBlocks
+                }
+                else {
+                    $Id
+                }
 
-        $block.ExecutedAt = [DateTime]::Now
-        $block.Executed = $true
-        if ($PesterDebugPreference.WriteDebugMessages) {
-            Write-PesterDebugMessage -Scope Runtime "Executing body of block $Name"
-        }
+            Set-CurrentBlock -Block $block
+            try {
+                if (-not $block.ShouldRun) {
+                    if ($PesterDebugPreference.WriteDebugMessages) {
+                        Write-PesterDebugMessage -Scope Runtime "Block is excluded from run, returning"
+                    }
+                    return
+                }
 
-        # TODO: no callbacks are provided because we are not transitioning between any states,
-        # it might be nice to add a parameter to indicate that we run in the same scope
-        # so we can avoid getting and setting the scope on scriptblock that already has that
-        # scope, which is _potentially_ slow because of reflection, it would also allow
-        # making the transition callbacks mandatory unless the parameter is provided
-        $frameworkSetupResult = Invoke-ScriptBlock `
-            -OuterSetup @(
-            if ($block.First) { selectNonNull $state.Plugin.OneTimeBlockSetupStart }
-        ) `
-            -Setup @( selectNonNull $state.Plugin.EachBlockSetupStart ) `
-            -ScriptBlock { } `
-            -Context @{
-            Context = @{
-                # context that is visible to plugins
-                Block         = $block
-                Test          = $null
-                Configuration = $state.PluginConfiguration
+                $block.ExecutedAt = [DateTime]::Now
+                $block.Executed = $true
+                if ($PesterDebugPreference.WriteDebugMessages) {
+                    Write-PesterDebugMessage -Scope Runtime "Executing body of block $Name"
+                }
+
+                # TODO: no callbacks are provided because we are not transitioning between any states,
+                # it might be nice to add a parameter to indicate that we run in the same scope
+                # so we can avoid getting and setting the scope on scriptblock that already has that
+                # scope, which is _potentially_ slow because of reflection, it would also allow
+                # making the transition callbacks mandatory unless the parameter is provided
+                $frameworkSetupResult = Invoke-ScriptBlock `
+                    -OuterSetup @(
+                    if ($block.First) { selectNonNull $state.Plugin.OneTimeBlockSetupStart }
+                ) `
+                    -Setup @( selectNonNull $state.Plugin.EachBlockSetupStart ) `
+                    -ScriptBlock { } `
+                    -Context @{
+                    Context = @{
+                        # context that is visible to plugins
+                        Block         = $block
+                        Test          = $null
+                        Configuration = $state.PluginConfiguration
+                    }
+                }
+
+                if ($frameworkSetupResult.Success) {
+                    # this craziness makes one extra scope that is bound to the user session state
+                    # and inside of it the Invoke-Block is called recursively. Ultimately this invokes all blocks
+                    # in their own scope like this:
+                    # & { # block 1
+                    #     . block 1 setup
+                    #     & { # block 2
+                    #         . block 2 setup
+                    #         & { # block 3
+                    #             . block 3 setup
+                    #             & { # test one
+                    #                 . test 1 setup
+                    #                 . test1
+                    #             }
+                    #         }
+                    #     }
+                    # }
+
+                    $sb = {
+                        param($______pester_invoke_block_parameters)
+                        & $______pester_invoke_block_parameters.Invoke_Block -previousBlock $______pester_invoke_block_parameters.Block
+                    }
+
+                    function Set-SessionStateFromScriptBlock ($OriginScriptBlock, $ScriptBlock) {
+                        $flags = [Reflection.BindingFlags]'Instance,NonPublic'
+
+                        # $sessionStateInternal = $ScriptBlock.SessionStateInternal
+                        $sessionStateInternal = [ScriptBlock].GetProperty(
+                            'SessionStateInternal', $flags).GetValue($OriginScriptBlock, $null)
+
+                        # $ScriptBlock.SessionStateInternal = $sessionStateInternal
+                        [ScriptBlock].GetProperty(
+                            'SessionStateInternal', $flags).SetValue(
+                                $ScriptBlock, $SessionStateInternal)
+                    }
+
+                    Set-SessionStateFromScriptBlock -OriginScriptBlock $block.ScriptBlock -ScriptBlock $sb
+
+                    $result = Invoke-ScriptBlock `
+                        -ScriptBlock $sb `
+                        -OuterSetup $( if (-not (Is-Discovery)) {
+                            combineNonNull @(
+                                $previousBlock.EachBlockSetup
+                                $block.OneTimeTestSetup
+                            )
+                        }) `
+                        -OuterTeardown $( if (-not (Is-Discovery)) {
+                            combineNonNull @(
+                                $block.OneTimeTestTeardown
+                                $previousBlock.EachBlockTeardown
+                            )
+                        } ) `
+                        -Context @{
+                            ______pester_invoke_block_parameters = @{
+                                Invoke_Block = ${function:Invoke-Block}
+                                Block = $block
+                            }
+                        } `
+                        -ReduceContextToInnerScope `
+                        -MoveBetweenScopes `
+                        -OnUserScopeTransition { Switch-Timer -Scope UserCode } `
+                        -OnFrameworkScopeTransition { Switch-Timer -Scope Framework }
+
+                    $block.Passed = $result.Success
+                    $block.StandardOutput = $result.StandardOutput
+
+                    $block.ErrorRecord = $result.ErrorRecord
+                    if ($PesterDebugPreference.WriteDebugMessages) {
+                        Write-PesterDebugMessage -Scope Runtime "Finished executing body of block $Name"
+                    }
+                }
+
+                $frameworkEachBlockTeardowns = @( selectNonNull $state.Plugin.EachBlockTeardownEnd )
+                $frameworkOneTimeBlockTeardowns = @( if ($block.Last) { selectNonNull $state.Plugin.OneTimeBlockTeardownEnd } )
+                # reverse the teardowns so they run in opposite order to setups
+                [Array]::Reverse($frameworkEachBlockTeardowns)
+                [Array]::Reverse($frameworkOneTimeBlockTeardowns)
+
+
+                # setting those values here so they are available for the teardown
+                # BUT they are then set again at the end of the block to make them accurate
+                # so the value on the screen vs the value in the object is slightly different
+                # with the value in the result being the correct one
+                $block.Duration = $state.UserCodeStopWatch.Elapsed - $blockStartTime
+                $block.FrameworkDuration = $state.FrameworkStopWatch.Elapsed - $overheadStartTime
+                $frameworkTeardownResult = Invoke-ScriptBlock `
+                    -ScriptBlock { } `
+                    -Teardown $frameworkEachBlockTeardowns `
+                    -OuterTeardown $frameworkOneTimeBlockTeardowns `
+                    -Context @{
+                    Context = @{
+                        # context that is visible to plugins
+                        Block         = $block
+                        Test          = $null
+                        Configuration = $state.PluginConfiguration
+                    }
+                }
+
+                if (-not $frameworkSetupResult.Success -or -not $frameworkTeardownResult.Success) {
+                    Assert-Success -InvocationResult @($frameworkSetupResult, $frameworkTeardownResult) -Message "Framework failed"
+                }
             }
-        }
-
-        if ($frameworkSetupResult.Success) {
-            $result = Invoke-ScriptBlock `
-                -ScriptBlock $ScriptBlock `
-                -OuterSetup $( if (-not (Is-Discovery)) {
-                    combineNonNull @(
-                        $previousBlock.EachBlockSetup
-                        $block.OneTimeTestSetup
-                    )
-                }) `
-                -OuterTeardown $( if (-not (Is-Discovery)) {
-                    combineNonNull @(
-                        $block.OneTimeTestTeardown
-                        $previousBlock.EachBlockTeardown
-                    )
-                } ) `
-                -Context @{
-                # context that is visible in user code
-                Context = foreach ($b in $block) { $b.Name }
-            } `
-                -ReduceContextToInnerScope `
-                -MoveBetweenScopes `
-                -OnUserScopeTransition { Switch-Timer -Scope UserCode } `
-                -OnFrameworkScopeTransition { Switch-Timer -Scope Framework }
-
-            $block.Passed = $result.Success
-            $block.StandardOutput = $result.StandardOutput
-
-            $block.ErrorRecord = $result.ErrorRecord
-            if ($PesterDebugPreference.WriteDebugMessages) {
-                Write-PesterDebugMessage -Scope Runtime "Finished executing body of block $Name"
+            finally {
+                Set-CurrentBlock -Block $previousBlock
+                if ($PesterDebugPreference.WriteDebugMessages) {
+                    Write-PesterDebugMessage -Scope Runtime "Left block $Name"
+                }
+                $block.Duration = $state.UserCodeStopWatch.Elapsed - $blockStartTime
+                $block.FrameworkDuration = $state.FrameworkStopWatch.Elapsed - $overheadStartTime
+                if ($PesterDebugPreference.WriteDebugMessages) {
+                    Write-PesterDebugMessage -Scope Timing "Block duration $($block.Duration.TotalMilliseconds)ms"
+                    Write-PesterDebugMessage -Scope Timing "Block framework duration $($block.FrameworkDuration.TotalMilliseconds)ms"
+                    Write-PesterDebugMessage -Scope Runtime "Leaving path $($path -join '.')"
+                }
             }
-        }
-
-        $frameworkEachBlockTeardowns = @( selectNonNull $state.Plugin.EachBlockTeardownEnd )
-        $frameworkOneTimeBlockTeardowns = @( if ($block.Last) { selectNonNull $state.Plugin.OneTimeBlockTeardownEnd } )
-        # reverse the teardowns so they run in opposite order to setups
-        [Array]::Reverse($frameworkEachBlockTeardowns)
-        [Array]::Reverse($frameworkOneTimeBlockTeardowns)
-
-
-        # setting those values here so they are available for the teardown
-        # BUT they are then set again at the end of the block to make them accurate
-        # so the value on the screen vs the value in the object is slightly different
-        # with the value in the result being the correct one
-        $block.Duration = $state.UserCodeStopWatch.Elapsed - $blockStartTime
-        $block.FrameworkDuration = $state.FrameworkStopWatch.Elapsed - $overheadStartTime
-        $frameworkTeardownResult = Invoke-ScriptBlock `
-            -ScriptBlock { } `
-            -Teardown $frameworkEachBlockTeardowns `
-            -OuterTeardown $frameworkOneTimeBlockTeardowns `
-            -Context @{
-            Context = @{
-                # context that is visible to plugins
-                Block         = $block
-                Test          = $null
-                Configuration = $state.PluginConfiguration
-            }
-        }
-
-        if (-not $frameworkSetupResult.Success -or -not $frameworkTeardownResult.Success) {
-            Assert-Success -InvocationResult @($frameworkSetupResult, $frameworkTeardownResult) -Message "Framework failed"
-        }
-    }
-    finally {
-        Set-CurrentBlock -Block $previousBlock
-        $null = Pop-Scope
-        if ($PesterDebugPreference.WriteDebugMessages) {
-            Write-PesterDebugMessage -Scope Runtime "Left block $Name"
-        }
-        $block.Duration = $state.UserCodeStopWatch.Elapsed - $blockStartTime
-        $block.FrameworkDuration = $state.FrameworkStopWatch.Elapsed - $overheadStartTime
-        if ($PesterDebugPreference.WriteDebugMessages) {
-            Write-PesterDebugMessage -Scope Timing "Block duration $($block.Duration.TotalMilliseconds)ms"
-            Write-PesterDebugMessage -Scope Timing "Block framework duration $($block.FrameworkDuration.TotalMilliseconds)ms"
-            Write-PesterDebugMessage -Scope Runtime "Leaving path $($path -join '.')"
         }
     }
 }
@@ -436,137 +472,12 @@ function New-Test {
             $Id = Get-Id -ScriptBlock $ScriptBlock -Previous $PreviouslyGeneratedTests
         }
 
-        # do this setup when we are running discovery
-        if (Is-Discovery) {
+        $test = New-TestObject -Name $Name -ScriptBlock $ScriptBlock -Tag $Tag -Data $Data -Id $Id -Path $path -Focus:$Focus
+        $test.FrameworkData.Runtime.Phase = 'Discovery'
 
-            $test = New-TestObject -Name $Name -ScriptBlock $ScriptBlock -Tag $Tag -Data $Data -Id $Id -Path $path -Focus:$Focus
-            $test.FrameworkData.Runtime.Phase = 'Discovery'
-
-            Add-Test -Test $test
-            if ($PesterDebugPreference.WriteDebugMessages) {
-                Write-PesterDebugMessage -Scope DiscoveryCore "Added test '$Name'"
-            }
-        }
-        else {
-            $test = Find-CurrentTest -Name $Name -ScriptBlock $ScriptBlock -Id $Id
-            $test.FrameworkData.Runtime.Phase = 'Execution'
-            Set-CurrentTest -Test $test
-
-            if (-not $test.ShouldRun) {
-                if ($PesterDebugPreference.WriteDebugMessages) {
-                    Write-PesterDebugMessage -Scope Runtime "Test is excluded from run, returning"
-                }
-                return
-            }
-
-            $test.ExecutedAt = [DateTime]::Now
-            $test.Executed = $true
-
-            # TODO: overwrite the data captured during discovery with the data,
-            # captured during execution, to make time sensitive data closer to the execution
-            # this should be a good choice because even though the data should not generally change
-            # when we for example do @{ Time = (Get-Date) } or load some counter, we should get the
-            # data from the moment of execution, not from the moment of test discovery, which can
-            # potentially be few seconds earlier. This also means that we should never identify tests
-            # based on their names + data because the data can change. And also that we should not show
-            # the data from the discovery when execution will follow (so it's not just a call to Find-Test)
-            # This choice might need to be revisited
-            $test.Data = $Data
-
-            $test.ExpandedName = & $state.ExpandName -Name $test.Name -Data $Data
-
-            $block = Get-CurrentBlock
-            if ($PesterDebugPreference.WriteDebugMessages) {
-                Write-PesterDebugMessage -Scope Runtime "Running test '$Name'."
-            }
-
-            # no callbacks are provided because we are not transitioning between any states
-            $frameworkSetupResult = Invoke-ScriptBlock `
-                -OuterSetup @(
-                if ($test.First) { selectNonNull $state.Plugin.OneTimeTestSetupStart }
-            ) `
-                -Setup @( selectNonNull $state.Plugin.EachTestSetupStart ) `
-                -ScriptBlock { } `
-                -Context @{
-                Context = @{
-                    # context visible to Plugins
-                    Block         = $block
-                    Test          = $test
-                    Configuration = $state.PluginConfiguration
-                }
-            }
-
-            if ($frameworkSetupResult.Success) {
-                # invokes the body of the test
-                $testInfo = @(foreach ($t in $test) { [PSCustomObject]@{ Name = $t.Name; Path = $t.Path }
-                    })
-                # user provided data are merged with Pester provided context
-                # TODO: use PesterContext as the name, or some other better reserved name to avoid conflicts
-                $context = @{
-                    # context visible in test
-                    Context = $testInfo
-                }
-                Merge-Hashtable -Source $test.Data -Destination $context
-
-                $eachTestSetups = CombineNonNull (Recurse-Up $Block { param ($b) $b.EachTestSetup } )
-                $eachTestTeardowns = CombineNonNull (Recurse-Up $Block { param ($b) $b.EachTestTeardown } )
-
-                $result = Invoke-ScriptBlock `
-                    -Setup @(
-                    if (any $eachTestSetups) {
-                        # we collect the child first but want the parent to run first
-                        [Array]::Reverse($eachTestSetups)
-                        @( { $test.FrameworkData.Runtime.ExecutionStep = 'EachTestSetup' }) + @($eachTestSetups)
-                    }
-                    # setting the execution info here so I don't have to invoke change the
-                    # contract of Invoke-ScriptBlock to accept multiple -ScriptBlock, because
-                    # that is not needed, and would complicate figuring out in which session
-                    # state we should run.
-                    # this should run every time.
-                    { $test.FrameworkData.Runtime.ExecutionStep = 'Test' }
-                ) `
-                    -ScriptBlock $ScriptBlock `
-                    -Teardown @(
-                    if (any $eachTestTeardowns) {
-                        @( { $test.FrameworkData.Runtime.ExecutionStep = 'EachTestTeardown' }) + @($eachTestTeardowns)
-                    } ) `
-                    -Context $context `
-                    -ReduceContextToInnerScope `
-                    -MoveBetweenScopes `
-                    -OnUserScopeTransition { Switch-Timer -Scope UserCode } `
-                    -OnFrameworkScopeTransition { Switch-Timer -Scope Framework } `
-                    -NoNewScope
-
-                $test.FrameworkData.Runtime.ExecutionStep = 'Finished'
-                $test.Passed = $result.Success
-                $test.StandardOutput = $result.StandardOutput
-                $test.ErrorRecord = $result.ErrorRecord
-            }
-
-            # setting those values here so they are available for the teardown
-            # BUT they are then set again at the end of the block to make them accurate
-            # so the value on the screen vs the value in the object is slightly different
-            # with the value in the result being the correct one
-            $test.Duration = $state.UserCodeStopWatch.Elapsed - $testStartTime
-            $test.FrameworkDuration = $state.FrameworkStopWatch.Elapsed - $overheadStartTime
-            $frameworkTeardownResult = Invoke-ScriptBlock `
-                -ScriptBlock { } `
-                -Teardown @( selectNonNull $state.Plugin.EachTestTeardownEnd ) `
-                -OuterTeardown @(
-                if ($test.Last) { selectNonNull $state.Plugin.OneTimeTestTeardownEnd }
-            ) `
-                -Context @{
-                Context = @{
-                    # context visible to Plugins
-                    Test          = $test
-                    Block         = $block
-                    Configuration = $state.PluginConfiguration
-                }
-            }
-
-            if (-not $frameworkTeardownResult.Success -or -not $frameworkTeardownResult.Success) {
-                throw $frameworkTeardownResult.ErrorRecord[-1]
-            }
+        Add-Test -Test $test
+        if ($PesterDebugPreference.WriteDebugMessages) {
+            Write-PesterDebugMessage -Scope DiscoveryCore "Added test '$Name'"
         }
     }
     finally {
@@ -585,6 +496,153 @@ function New-Test {
         if ($PesterDebugPreference.WriteDebugMessages) {
             Write-PesterDebugMessage -Scope Timing -Message "Test duration $($test.Duration.TotalMilliseconds)ms"
             Write-PesterDebugMessage -Scope Timing -Message "Framework duration $($test.FrameworkDuration.TotalMilliseconds)ms"
+        }
+    }
+}
+
+function Invoke-TestItem {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true)]
+        $Test
+    )
+    # keep this at the top so we report as much time
+    # of the actual test run as possible
+    $overheadStartTime = $state.FrameworkStopWatch.Elapsed
+    $testStartTime = $state.UserCodeStopWatch.Elapsed
+    Switch-Timer -Scope Framework
+
+    if ($PesterDebugPreference.WriteDebugMessages) {
+        Write-PesterDebugMessage -Scope Runtime "Entering test $($Test.Name)"
+    }
+
+    try {
+        if ($PesterDebugPreference.WriteDebugMessages) {
+            Write-PesterDebugMessage -Scope Runtime "Entering path $($Test.Path -join '.')"
+        }
+
+        $Test.FrameworkData.Runtime.Phase = 'Execution'
+        Set-CurrentTest -Test $Test
+
+        if (-not $Test.ShouldRun) {
+            if ($PesterDebugPreference.WriteDebugMessages) {
+                Write-PesterDebugMessage -Scope Runtime "Test is excluded from run, returning"
+            }
+            return
+        }
+
+        $Test.ExecutedAt = [DateTime]::Now
+        $Test.Executed = $true
+
+        $Test.ExpandedName = & $state.ExpandName -Name $Test.Name -Data $Test.Data
+
+        $block = $Test.Block
+        if ($PesterDebugPreference.WriteDebugMessages) {
+            Write-PesterDebugMessage -Scope Runtime "Running test '$($Test.Name)'."
+        }
+
+        # no callbacks are provided because we are not transitioning between any states
+        $frameworkSetupResult = Invoke-ScriptBlock `
+            -OuterSetup @(
+            if ($Test.First) { selectNonNull $state.Plugin.OneTimeTestSetupStart }
+        ) `
+            -Setup @( selectNonNull $state.Plugin.EachTestSetupStart ) `
+            -ScriptBlock { } `
+            -Context @{
+            Context = @{
+                # context visible to Plugins
+                Block         = $block
+                Test          = $Test
+                Configuration = $state.PluginConfiguration
+            }
+        }
+
+        if ($frameworkSetupResult.Success) {
+            $testInfo = @(foreach ($t in $Test) { [PSCustomObject]@{ Name = $t.Name; Path = $t.Path }})
+            # TODO: use PesterContext as the name, or some other better reserved name to avoid conflicts
+            $context = @{
+                # context visible in test
+                Context = $testInfo
+            }
+            # user provided data are merged with Pester provided context
+            Merge-Hashtable -Source $Test.Data -Destination $context
+
+            $eachTestSetups = CombineNonNull (Recurse-Up $Block { param ($b) $b.EachTestSetup } )
+            $eachTestTeardowns = CombineNonNull (Recurse-Up $Block { param ($b) $b.EachTestTeardown } )
+
+            $result = Invoke-ScriptBlock `
+                -Setup @(
+                if (any $eachTestSetups) {
+                    # we collect the child first but want the parent to run first
+                    [Array]::Reverse($eachTestSetups)
+                    @( { $Test.FrameworkData.Runtime.ExecutionStep = 'EachTestSetup' }) + @($eachTestSetups)
+                }
+                # setting the execution info here so I don't have to invoke change the
+                # contract of Invoke-ScriptBlock to accept multiple -ScriptBlock, because
+                # that is not needed, and would complicate figuring out in which session
+                # state we should run.
+                # this should run every time.
+                { $Test.FrameworkData.Runtime.ExecutionStep = 'Test' }
+            ) `
+                -ScriptBlock $Test.ScriptBlock `
+                -Teardown @(
+                if (any $eachTestTeardowns) {
+                    @( { $Test.FrameworkData.Runtime.ExecutionStep = 'EachTestTeardown' }) + @($eachTestTeardowns)
+                } ) `
+                -Context $context `
+                -ReduceContextToInnerScope `
+                -MoveBetweenScopes `
+                -OnUserScopeTransition { Switch-Timer -Scope UserCode } `
+                -OnFrameworkScopeTransition { Switch-Timer -Scope Framework } `
+                -NoNewScope
+
+            $Test.FrameworkData.Runtime.ExecutionStep = 'Finished'
+            $Test.Passed = $result.Success
+            $Test.StandardOutput = $result.StandardOutput
+            $Test.ErrorRecord = $result.ErrorRecord
+        }
+
+        # setting those values here so they are available for the teardown
+        # BUT they are then set again at the end of the block to make them accurate
+        # so the value on the screen vs the value in the object is slightly different
+        # with the value in the result being the correct one
+        $Test.Duration = $state.UserCodeStopWatch.Elapsed - $testStartTime
+        $Test.FrameworkDuration = $state.FrameworkStopWatch.Elapsed - $overheadStartTime
+        $frameworkTeardownResult = Invoke-ScriptBlock `
+            -ScriptBlock { } `
+            -Teardown @( selectNonNull $state.Plugin.EachTestTeardownEnd ) `
+            -OuterTeardown @(
+            if ($Test.Last) { selectNonNull $state.Plugin.OneTimeTestTeardownEnd }
+        ) `
+            -Context @{
+            Context = @{
+                # context visible to Plugins
+                Test          = $Test
+                Block         = $block
+                Configuration = $state.PluginConfiguration
+            }
+        }
+
+        if (-not $frameworkTeardownResult.Success -or -not $frameworkTeardownResult.Success) {
+            throw $frameworkTeardownResult.ErrorRecord[-1]
+        }
+
+    }
+    finally {
+        if ($PesterDebugPreference.WriteDebugMessages) {
+            Write-PesterDebugMessage -Scope Runtime "Leaving path $($Test.Path -join '.')"
+        }
+        $state.CurrentTest = $null
+        if ($PesterDebugPreference.WriteDebugMessages) {
+            Write-PesterDebugMessage -Scope Runtime "Left test $($Test.Name)"
+        }
+
+        # keep this at the end so we report even the test teardown in the framework overhead for the test
+        $Test.Duration = $state.UserCodeStopWatch.Elapsed - $testStartTime
+        $Test.FrameworkDuration = $state.FrameworkStopWatch.Elapsed - $overheadStartTime
+        if ($PesterDebugPreference.WriteDebugMessages) {
+            Write-PesterDebugMessage -Scope Timing -Message "Test duration $($Test.Duration.TotalMilliseconds)ms"
+            Write-PesterDebugMessage -Scope Timing -Message "Framework duration $($Test.FrameworkDuration.TotalMilliseconds)ms"
         }
     }
 }
@@ -1063,8 +1121,7 @@ function Run-Test {
                 & $SafeCommands["Write-Error"] -ErrorRecord $rootSetupResult.ErrorRecord[0] -ErrorAction 'Stop'
             }
 
-            $null = Invoke-BlockContainer -BlockContainer $rootBlock.BlockContainer -SessionState $SessionState
-            # todo: invoke block
+            $null = Invoke-Block -previousBlock $rootBlock
 
             $rootBlock.Passed = $true
         }

--- a/new-runtimepoc/Pester.Runtime.ts.ps1
+++ b/new-runtimepoc/Pester.Runtime.ts.ps1
@@ -513,34 +513,6 @@ i -PassThru:$PassThru {
     }
 
     b "executing each setup & teardown on test" {
-        t "given a test with setup it executes the setup right before the test and makes the variables avaliable to test" {
-            $actual = Invoke-Test -SessionState $ExecutionContext.SessionState -BlockContainer (New-BlockContainerObject -ScriptBlock {
-                    # $s is set to 'block' here
-                    $s = "block"
-                    New-Block 'block1' {
-                        # $s will still be 'block' here so if we invoke the setup on the
-                        # start of the block then $s would be 'block'
-                        $s = "test"
-                        # if the test does not run then this value will stay in $g
-                        $g = "setup did not run"
-                        # here $s is 'test', and here is where we want to invoke the script
-                        New-Test 'test1' {
-                            # $g should be test here, because we run the setup right before
-                            # this scriptblock and kept the changed value of $g in scope
-                            $g
-                        }
-                        New-EachTestSetup {
-                            # setup runs on top of test and in the same scope
-                            # so $g is modifiable and becomes the value of $s
-                            # test then reports the $s value not the original $g value
-                            $g = $s
-                        }
-                    }
-                })
-
-            $actual.Blocks[0].Tests[0].StandardOutput | Verify-Equal "test"
-        }
-
         t "given a test with setups and teardowns they run in correct scopes" {
 
             # what I want here is that the test runs in this fashion
@@ -620,39 +592,70 @@ i -PassThru:$PassThru {
     }
 
     b "executing all test and teardown" {
-        t "given a test with all setup it executes the setup right before the start of the block and keeps the variables in upper scope" {
+        t "given a test with one time setup it executes the setup inside of the block and does not bleed variables to the next block" {
             $actual = Invoke-Test -SessionState $ExecutionContext.SessionState -BlockContainer (New-BlockContainerObject -ScriptBlock {
-                    # $s is set to 'block' here
-                    $s = "block"
                     New-Block 'block1' {
-                        # one time test setup is invoked here
+                        # one time test setup is runs here
                         New-Test 'test1' {
-                            # each setup technically runs here
-
-                            # $g should be test here, because we run the setup right before
-                            # this scriptblock and kept the changed value of $g in scope
-                            if ($g -ne '') { throw "setup did not run ($g)" }
+                            if ($g -eq '') { throw "one time setup did not run" }
                             # $g should be one scope below one time setup so this change
                             # should not be visible in the teardown
                             $g = 10
 
                         }
                         New-OneTimeTestSetup {
-                            if (-not $s) {
-                                throw "`$s is not defined are we running in the correct scope? $($executionContext.SessionState.Module)"
-                            }
                             $g = "from setup"
                         }
                         New-OneTimeTestTeardown {
                             # teardown runs in the scope after the test scope dies so
                             # g should be 'from setup', to which the code after setup set it
                             # set it
-                            $g
+                            $g | Verify-Equal "from setup"
+                        }
+                    }
+
+                    New-Block 'block2' {
+                        New-Test 'test1' {
+                            $err = { Get-Variable g } | Verify-Throw
+                            $err.FullyQualifiedErrorId | Verify-Equal 'VariableNotFound,Microsoft.PowerShell.Commands.GetVariableCommand'
                         }
                     }
                 })
 
+            $actual.Blocks[1].Tests[0].Passed | Verify-True
             $actual.Blocks[0].StandardOutput | Verify-Equal "from setup"
+        }
+
+        t "given a test with each time setup it executes the setup inside of the test and does not affect the whole block" {
+            $actual = Invoke-Test -SessionState $ExecutionContext.SessionState -BlockContainer (New-BlockContainerObject -ScriptBlock {
+                    New-Block 'block1' {
+                        # one time test setup is runs here
+                        New-Test 'test1' {
+                            if ($g -eq '') { throw "one time setup did not run" }
+                            # $g should be one scope below one time setup so this change
+                            # should not be visible in the teardown
+                            $g = "changed"
+
+                        }
+                        New-EachTestSetup {
+                            $g = "from setup"
+                        }
+                        New-EachTestTeardown {
+                            # teardown runs in the scope after the test scope dies so
+                            # g should be 'from setup', to which the code after setup set it
+                            # set it
+                            $g | Verify-Equal "changed"
+                        }
+
+                        New-OneTimeTestTeardown {
+                            $err = { Get-Variable g } | Verify-Throw
+                            $err.FullyQualifiedErrorId | Verify-Equal 'VariableNotFound,Microsoft.PowerShell.Commands.GetVariableCommand'
+                        }
+                    }
+                })
+
+            $actual.Blocks[0].Passed | Verify-True
+            $actual.Blocks[0].Tests[0].Passed | Verify-True
         }
 
         t "setups and teardowns don't run if there are no tests" {
@@ -1111,53 +1114,6 @@ i -PassThru:$PassThru {
                     Remove-Item $tempPath -Force
                 }
             }
-        }
-    }
-
-    b "interpolated variables in names" {
-        t "using variable in test name that changes between discovery and run does not fail" {
-            $actual = Invoke-Test -SessionState $ExecutionContext.SessionState -BlockContainer (
-                New-BlockContainerObject -ScriptBlock {
-                    $var = "'discovery'"
-                    New-Block -Name "block1" {
-                        New-OneTimeTestSetup {
-                            $var = "'run'"
-                        }
-
-                        New-Test "test 1 $var" {
-                            # the one time setup runs before the
-                            # script block, but AFTER the name is evaluated
-                            # so the first test runs just fine,
-                            # because the name is the same during discovery
-                            # and run
-                        }
-
-                        New-Test "test 2 $var" {
-                            # if the name of the test is used as identifier
-                            # then the discovery phase name and run phase name differ
-                            # because the interpolated variable has changed
-                            # because of the one time setup
-                        }
-                    }
-                }
-            )
-
-            $actual.Blocks[0].Tests[0].Passed | Verify-True
-            $actual.Blocks[0].Tests[1].Passed | Verify-True
-        }
-
-        t "using variable in test name that changes between discovery and run does not fail" {
-            $container = @{ Iteration = 0 }
-            $actual = Invoke-Test -SessionState $ExecutionContext.SessionState -BlockContainer (
-                New-BlockContainerObject -ScriptBlock {
-                    New-Block -Name "block $($container.Iteration++)" {
-                        New-Test "test 1" { }
-                    }
-                }
-            )
-
-            $container.Iteration | Verify-Equal 2
-            $actual.Blocks[0].Tests[0].Passed | Verify-True
         }
     }
 
@@ -1661,8 +1617,8 @@ i -PassThru:$PassThru {
 
         t "total time is roughly the same as time measured externally" {
             $container = @{
-                Test = $null
-                Block = $null
+                # Test = $null
+                # Block = $null
                 Total = $null
                 Result = $null
             }
@@ -1670,42 +1626,38 @@ i -PassThru:$PassThru {
             $container.Total = Measure-Command {
                 $container.Result = Invoke-Test -SessionState $ExecutionContext.SessionState -BlockContainer (
                     New-BlockContainerObject -ScriptBlock {
-
-                        $container.Block = (Measure-Command {
-                            New-Block -Name "b1" {
-                                $container.Test = (Measure-Command {
-                                    New-Test "t1" {
-                                        $true | Verify-False
-                                    }
-                                })
+                        New-Block -Name "b1" {
+                            New-Test "t1" {
+                                $true | Verify-False
                             }
-                        })
-                    }
-                )
+                        }
+                    })
             }
-
+            # some of the code is commented out here because before changing the runtime to the new-new runtime
+            # I was able to measure the block and the test execution time and so if I come up with a way again
+            # I don't want to write the same code one more time
             $actual = $container.Result
             $testReported = $actual.Blocks[0].Tests[0].Duration + $actual.Blocks[0].Tests[0].FrameworkDuration
-            $testDifference = $container.Test - $testReported
+            #$testDifference = $container.Test - $testReported
             Write-Host Reported test duration $actual.Blocks[0].Tests[0].Duration.TotalMilliseconds
             Write-Host Reported test overhead $actual.Blocks[0].Tests[0].FrameworkDuration.TotalMilliseconds
             Write-Host Reported test total $testReported.TotalMilliseconds
-            Write-Host Measured test total $container.Test.TotalMilliseconds
-            Write-Host Test difference $testDifference.TotalMilliseconds
+            #Write-Host Measured test total $container.Test.TotalMilliseconds
+            #Write-Host Test difference $testDifference.TotalMilliseconds
             # the difference here is actually <1ms but let's make this less finicky
-            $testDifference.TotalMilliseconds -lt 5 | Verify-True
+           # $testDifference.TotalMilliseconds -lt 5 | Verify-True
 
             # so the block non aggregated time is mostly correct (to get the total time we need to add total blockduration + total test duration), but the overhead is accounted twice because we have only one timer running so the child overhead is included in the child and the parent ( that is the FrameworkDuration on Block is actually Aggregated framework duration),
             $blockReported =  $actual.Blocks[0].Duration + $actual.Blocks[0].FrameworkDuration
-            $blockDifference = $container.Block - $blockReported
+            #$blockDifference = $container.Block - $blockReported
             Write-Host Reported block duration $actual.Blocks[0].Duration.TotalMilliseconds
             Write-Host Reported block overhead $actual.Blocks[0].FrameworkDuration.TotalMilliseconds
             Write-Host Reported block total $blockReported.TotalMilliseconds
-            Write-Host Measured block total $container.Block.TotalMilliseconds
-            Write-Host Block difference $blockDifference.TotalMilliseconds
+            #Write-Host Measured block total $container.Block.TotalMilliseconds
+            #Write-Host Block difference $blockDifference.TotalMilliseconds
 
             # the difference here is actually <1ms but let's make this less finicky
-            $blockDifference.TotalMilliseconds -lt 5 | Verify-True
+            #$blockDifference.TotalMilliseconds -lt 5 | Verify-True
 
             $totalReported = $actual.Duration + $actual.FrameworkDuration + $actual.DiscoveryDuration
             $totalDifference = $container.Total - $totalReported
@@ -1738,42 +1690,39 @@ i -PassThru:$PassThru {
                     New-BlockContainerObject -ScriptBlock {
                         New-Block "b1" {
                         }
-                        $container.Block = (Measure-Command {
-                            New-Block -Name "b2" {
-                                New-Test "t1" { $true }
-                                $container.Test = (Measure-Command {
-                                    New-Test "t2" {
-                                        $true | Verify-False
-                                    }
-                                })
+
+                        New-Block -Name "b2" {
+                            New-Test "t1" { $true }
+                            New-Test "t2" {
+                                $true | Verify-False
                             }
-                        })
+                        }
                     }
                 )
             }
 
             $actual = $container.Result
             $testReported = $actual.Blocks[1].Tests[1].Duration + $actual.Blocks[1].Tests[1].FrameworkDuration
-            $testDifference = $container.Test - $testReported
+            # $testDifference = $container.Test - $testReported
             Write-Host Reported test duration $actual.Blocks[1].Tests[1].Duration.TotalMilliseconds
             Write-Host Reported test overhead $actual.Blocks[1].Tests[1].FrameworkDuration.TotalMilliseconds
             Write-Host Reported test total $testReported.TotalMilliseconds
-            Write-Host Measured test total $container.Test.TotalMilliseconds
-            Write-Host Test difference $testDifference.TotalMilliseconds
+            # Write-Host Measured test total $container.Test.TotalMilliseconds
+            # Write-Host Test difference $testDifference.TotalMilliseconds
             # the difference here is actually <1ms but let's make this less finicky
-            $testDifference.TotalMilliseconds -lt 5 | Verify-True
+            # $testDifference.TotalMilliseconds -lt 5 | Verify-True
 
             # so the block non aggregated time is mostly correct (to get the total time we need to add total blockduration + total test duration), but the overhead is accounted twice because we have only one timer running so the child overhead is included in the child and the parent ( that is the FrameworkDuration on Block is actually Aggregated framework duration),
             $blockReported =  $actual.Blocks[1].Duration + $actual.Blocks[1].FrameworkDuration
-            $blockDifference = $container.Block - $blockReported
+            # $blockDifference = $container.Block - $blockReported
             Write-Host Reported block duration $actual.Blocks[1].Duration.TotalMilliseconds ms
             Write-Host Reported block overhead $actual.Blocks[1].FrameworkDuration.TotalMilliseconds ms
             Write-Host Reported block total $blockReported.TotalMilliseconds ms
-            Write-Host Measured block total $container.Block.TotalMilliseconds ms
-            Write-Host Block difference $blockDifference.TotalMilliseconds ms
+            # Write-Host Measured block total $container.Block.TotalMilliseconds ms
+            # Write-Host Block difference $blockDifference.TotalMilliseconds ms
 
             # the difference here is actually <1ms but let's make this less finicky
-            $blockDifference.TotalMilliseconds -lt 5 | Verify-True
+            # $blockDifference.TotalMilliseconds -lt 5 | Verify-True
 
             $totalReported = $actual.Duration + $actual.FrameworkDuration + $actual.DiscoveryDuration
             $totalDifference = $container.Total - $totalReported
@@ -1788,6 +1737,60 @@ i -PassThru:$PassThru {
             # this needs to be done over all blocks at the same time because of the focused tests
             # the difference here is actually <10ms but let's make this less finicky
             $totalDifference.TotalMilliseconds -lt 50 | Verify-True
+        }
+
+        dt "total time is roughly the same as time measured externally (on many tests)" {
+            # this is the same as above, if I add one time setups then the framework time should grow
+            # but not the user code time
+            $container = @{
+                Test = $null
+                Block = $null
+                Total = $null
+                Result = $null
+            }
+
+            $bs = 1..10
+            $ts = 1..10
+            $container.Total = Measure-Command {
+                $container.Result = Invoke-Test -SessionState $ExecutionContext.SessionState -BlockContainer (
+                    New-BlockContainerObject -ScriptBlock {
+                        foreach ($b in $bs) {
+
+                            New-Block -Name "b$b" {
+                                foreach ($t in $ts) {
+                                    New-Test "b$b-t$t" {
+                                        $true | Verify-True
+                                    }
+                                }
+                            }
+                        }
+                    }
+                )
+            }
+
+            $actual = $container.Result
+
+            $totalReported = $actual.Duration + $actual.FrameworkDuration + $actual.DiscoveryDuration
+            $totalDifference = $container.Total - $totalReported
+            $testCount = $bs.Count * $ts.Count
+            Write-Host Test count $testCount
+            Write-Host Per test $([int]($container.Total.TotalMilliseconds / $testCount)) ms
+            Write-Host Per test without discovery $([int](($actual.Duration + $actual.FrameworkDuration).TotalMilliseconds / $testCount)) ms
+            Write-Host Reported discovery duration $actual.DiscoveryDuration.TotalMilliseconds ms
+            Write-Host Reported total duration $actual.Duration.TotalMilliseconds ms
+            Write-Host Reported total overhead $actual.FrameworkDuration.TotalMilliseconds ms
+            Write-Host Reported total $totalReported.TotalMilliseconds ms
+            Write-Host Measured total $container.Total.TotalMilliseconds ms
+            Write-Host Total difference $totalDifference.TotalMilliseconds ms
+
+
+            # the difference here is because of the code that is running after all tests have been discovered
+            # such as figuring out if there are focused tests, setting filters and determining which tests to run
+            # this needs to be done over all blocks at the same time because of the focused tests
+            # the difference here is actually <10ms but let's make this less finicky
+            $totalDifference.TotalMilliseconds -lt 50 | Verify-True
+
+            # TODO: revisit the difference on many tests, it is still missing some parts of the common discovery processing I guess (replicates on 10k tests)
         }
     }
 

--- a/new-runtimepoc/Pester.Runtime.ts.ps1
+++ b/new-runtimepoc/Pester.Runtime.ts.ps1
@@ -1766,22 +1766,22 @@ i -PassThru:$PassThru {
             # so the block non aggregated time is mostly correct (to get the total time we need to add total blockduration + total test duration), but the overhead is accounted twice because we have only one timer running so the child overhead is included in the child and the parent ( that is the FrameworkDuration on Block is actually Aggregated framework duration),
             $blockReported =  $actual.Blocks[1].Duration + $actual.Blocks[1].FrameworkDuration
             $blockDifference = $container.Block - $blockReported
-            Write-Host Reported block duration $actual.Blocks[1].Duration.TotalMilliseconds
-            Write-Host Reported block overhead $actual.Blocks[1].FrameworkDuration.TotalMilliseconds
-            Write-Host Reported block total $blockReported.TotalMilliseconds
-            Write-Host Measured block total $container.Block.TotalMilliseconds
-            Write-Host Block difference $blockDifference.TotalMilliseconds
+            Write-Host Reported block duration $actual.Blocks[1].Duration.TotalMilliseconds ms
+            Write-Host Reported block overhead $actual.Blocks[1].FrameworkDuration.TotalMilliseconds ms
+            Write-Host Reported block total $blockReported.TotalMilliseconds ms
+            Write-Host Measured block total $container.Block.TotalMilliseconds ms
+            Write-Host Block difference $blockDifference.TotalMilliseconds ms
 
             # the difference here is actually <1ms but let's make this less finicky
             $blockDifference.TotalMilliseconds -lt 5 | Verify-True
 
             $totalReported = $actual.Duration + $actual.FrameworkDuration + $actual.DiscoveryDuration
             $totalDifference = $container.Total - $totalReported
-            Write-Host Reported total duration $actual.Duration.TotalMilliseconds
-            Write-Host Reported total overhead $actual.FrameworkDuration.TotalMilliseconds
-            Write-Host Reported total $totalReported.TotalMilliseconds
-            Write-Host Measured total $container.Total.TotalMilliseconds
-            Write-Host Total difference $totalDifference.TotalMilliseconds
+            Write-Host Reported total duration $actual.Duration.TotalMilliseconds ms
+            Write-Host Reported total overhead $actual.FrameworkDuration.TotalMilliseconds ms
+            Write-Host Reported total $totalReported.TotalMilliseconds ms
+            Write-Host Measured total $container.Total.TotalMilliseconds ms
+            Write-Host Total difference $totalDifference.TotalMilliseconds ms
 
             # the difference here is because of the code that is running after all tests have been discovered
             # such as figuring out if there are focused tests, setting filters and determining which tests to run

--- a/new-runtimepoc/ReloadAndInvokePester.ps1
+++ b/new-runtimepoc/ReloadAndInvokePester.ps1
@@ -17,7 +17,7 @@ $excludePath = "*/demo/*"
  #$excludePath = ""
 $excludeTags = "Help", "VersionChecks", "Formatting"
 
-$path = "C:\Projects\Pester_main"
+$path = "~/Projects/pester_main"
 #$path = "./Functions/Assertions/PesterThrow.Tests.ps1"
 #$path = "C:\projects\pester_main\demo\mocking\CountingMocks.Tests.ps1"
 # $path = "C:\Projects\pester_main\Examples\Validator\"
@@ -25,15 +25,21 @@ $path = "C:\Projects\Pester_main"
 #$path  = "C:\Users\nohwnd\Desktop\mock.tests.ps1"
 
 
-$script:r = $null
-[Math]::Round((Measure-Command {
-    if ($v5) {
-        Write-Host -ForegroundColor Cyan Running in Version 5
-        $script:r = Invoke-Pester -Path $path -ExcludePath $excludePath -ExcludeTag $excludeTags -PassThru -Output Normal
-    }
-    else {
-        Write-Host -ForegroundColor Cyan Running in Version 4
-        $script:r = Invoke-Pester -Path $path -ExcludeTag $excludeTags -PassThru
-    }
-}).TotalMilliseconds, 2)
-# $r
+Set-StrictMode -Version Latest
+$r = Get-ChildItem *.ts.ps1 -Recurse | foreach { & $_.FullName -PassThru } ; if ([bool]($r | Where-Object { $_.Failed -gt 0 })) { exit 1 }
+# $global:PesterDebugPreference_ShowFullErrors = $true
+# Import-Module ./Pester.psd1
+# Invoke-Pester -ExcludeTag VersionChecks, StyleRules, Help -ExcludePath '*/demo/*' -CI
+
+# $script:r = $null
+# [Math]::Round((Measure-Command {
+#     if ($v5) {
+#         Write-Host -ForegroundColor Cyan Running in Version 5
+#         $script:r = Invoke-Pester -Path $path -ExcludePath $excludePath -ExcludeTag $excludeTags -PassThru -Output Normal
+#     }
+#     else {
+#         Write-Host -ForegroundColor Cyan Running in Version 4
+#         $script:r = Invoke-Pester -Path $path -ExcludeTag $excludeTags -PassThru
+#     }
+# }).TotalMilliseconds, 2)
+# # $r


### PR DESCRIPTION
The original runtime executed the file twice and tried to match the code based on positions, this allows for code that is scattered among the tests to still run and have effects. This is the only upside. The downsides are that you need to make sure that block generators, test generators and test case generator functions run twice in the same way, because otherwise you'd get different amount of tests, and so on. In this PR I move from the file based execution to the generate and run execution (the first model). 

This also isolates the discovery and run code better because now they don't need to share the same function and same scoping concerns. 
