### PR TITLE
Add support for logging the reason if a test is skipped or marked pending

### DIFF
--- a/Functions/TestResults.Tests.ps1
+++ b/Functions/TestResults.Tests.ps1
@@ -39,6 +39,34 @@ InModuleScope Pester {
             $xmlTestCase.failure.'stack-trace'  | Should -Be 'at line: 28 in  C:\Pester\Result.Tests.ps1'
         }
 
+        It "should log the reason for a skipped test when provided" {
+            $message = "skipped for reasons"
+            $TestResults = New-PesterState -Path TestDrive:\
+            $testResults.EnterTestGroup('Mocked Describe', 'Describe')
+            $TestResults.AddTestResult("Successful testcase", 'Skipped', (New-TimeSpan -Seconds 1), $message)
+
+            #export and validate the message
+            [String]$testFile = "$TestDrive{0}Results{0}Tests.xml" -f [System.IO.Path]::DirectorySeparatorChar
+            Export-NunitReport $testResults $testFile
+            $xmlResult = [xml] (Get-Content $testFile)
+            $xmlTestCase = $xmlResult.'test-results'.'test-suite'.'results'.'test-suite'.'results'.'test-case'
+            $xmlTestCase.reason.message   | Should -BeExactly $message
+        }
+
+        It "should log the reason for a pending test when provided" {
+            $message = "pending for reasons"
+            $TestResults = New-PesterState -Path TestDrive:\
+            $testResults.EnterTestGroup('Mocked Describe', 'Describe')
+            $TestResults.AddTestResult("Successful testcase", 'Pending', (New-TimeSpan -Seconds 1), $message)
+
+            #export and validate the message
+            [String]$testFile = "$TestDrive{0}Results{0}Tests.xml" -f [System.IO.Path]::DirectorySeparatorChar
+            Export-NunitReport $testResults $testFile
+            $xmlResult = [xml] (Get-Content $testFile)
+            $xmlTestCase = $xmlResult.'test-results'.'test-suite'.'results'.'test-suite'.'results'.'test-case'
+            $xmlTestCase.reason.message   | Should -BeExactly $message
+        }
+
         It "should write the test summary" {
             #create state
             $TestResults = New-PesterState -Path TestDrive:\

--- a/Functions/TestResults.ps1
+++ b/Functions/TestResults.ps1
@@ -391,19 +391,36 @@ function Write-NUnitTestCaseAttributes($TestResult, [System.Xml.XmlWriter] $XmlW
         Passed {
             $XmlWriter.WriteAttributeString('result', 'Success')
             $XmlWriter.WriteAttributeString('executed', 'True')
+
             break
         }
+
         Skipped {
             $XmlWriter.WriteAttributeString('result', 'Ignored')
             $XmlWriter.WriteAttributeString('executed', 'False')
+
+            if ($TestResult.FailureMessage) {
+                $XmlWriter.WriteStartElement('reason')
+                $xmlWriter.WriteElementString('message', $TestResult.FailureMessage)
+                $XmlWriter.WriteEndElement() # Close reason tag
+            }
+
             break
         }
 
         Pending {
             $XmlWriter.WriteAttributeString('result', 'Inconclusive')
             $XmlWriter.WriteAttributeString('executed', 'True')
+
+            if ($TestResult.FailureMessage) {
+                $XmlWriter.WriteStartElement('reason')
+                $xmlWriter.WriteElementString('message', $TestResult.FailureMessage)
+                $XmlWriter.WriteEndElement() # Close reason tag
+            }
+
             break
         }
+
         Inconclusive {
             $XmlWriter.WriteAttributeString('result', 'Inconclusive')
             $XmlWriter.WriteAttributeString('executed', 'True')


### PR DESCRIPTION
If you create a nunit log, the reason for skipping or a pending test is not persisted, but the schema seems to allow this, and we would like to keep the information in our logs.

## 1. General summary of the pull request

The nunit schema allows for a reason to be associated with a test which is skipped or marked pending (or inconclusive). While the current behavior provides a way to emit a reason for skipping or pending, that is only written to the console and not persisted. This PR ensures that those reasons (if provided) will make it into the nunit log.
