### PR TITLE
Upgrade AppVeyor image for PS Core test to 'Visual Studio 2019' to upgrade PS Core version used in tests from 6.1 to 6.2

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,6 +1,6 @@
 environment:
   matrix:
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
       PSEdition: Core
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
       PSEdition: Desktop


### PR DESCRIPTION
## 1. General summary of the pull request

This new image has PS 6.2 in it, in contrast to the old image that had PS 6.1 in it.
Since PS 6.1 is going out of support this month, there is no point keeping the old image as well, therefore it's just a replacement.

Unfortunately, it seems 1 test does not work in PS 6.2, it errors out on this line of code and can be reproduced locally:
https://github.com/pester/Pester/blob/c300092040f837666cd98de919f187920f387cae/Functions/TestDrive.Tests.ps1#L231
```pwsh
$null = New-Item -Type SymbolicLink -Path TestDrive:/test/link1 -Target TestDrive:/d1

New-Item : The filename, directory name, or volume label syntax is incorrect : 'C:\windows\system32\TestDrive:\d1'
At C:\Users\christoph.bergmeiste\git\Pester\Functions\TestDrive.Tests.ps1:231 char:21
+ ...     $null = New-Item -Type SymbolicLink -Path TestDrive:/test/link1 - ...
+                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ CategoryInfo          : PermissionDenied: (TestDrive:/d1:String) [New-Item], IOException
+ FullyQualifiedErrorId : AccessException,Microsoft.PowerShell.Commands.NewItemCommand

```

I would appreciate some help in debugging this, but it seems it was a breaking change in PS 6.2