### PR TITLE
WIP Build module

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -15,6 +15,7 @@ test_script:
       if ( $env:PSEdition -eq 'Desktop' ) {
       Set-StrictMode -Version Latest
       $global:PesterDebugPreference_ShowFullErrors = $true
+      ./build.ps1
       Import-Module ./Pester.psd1
       Invoke-Pester -ExcludeTag VersionChecks, StyleRules, Help -EnableExit -OutputFile TestResults.xml -OutputFormat NUnitXml
       (New-Object 'System.Net.WebClient').UploadFile("https://ci.appveyor.com/api/testresults/nunit/${env:APPVEYOR_JOB_ID}", (Join-Path $PWD 'TestResults.xml')) }
@@ -22,6 +23,7 @@ test_script:
       if ( $env:PSEdition -eq 'Core' ) {
       Set-StrictMode -Version Latest
       $global:PesterDebugPreference_ShowFullErrors = $true
+      ./build.ps1
       Import-Module ./Pester.psd1
       Invoke-Pester -ExcludeTag VersionChecks, StyleRules, Help -EnableExit -OutputFile TestResults.xml -OutputFormat NUnitXml
       (New-Object 'System.Net.WebClient').UploadFile("https://ci.appveyor.com/api/testresults/nunit/${env:APPVEYOR_JOB_ID}", (Join-Path $PWD 'TestResults.xml')) }

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,4 +21,4 @@ matrix:
             - powershell
 
 script:
-  - pwsh -c 'Set-StrictMode -Version Latest; $global:PesterDebugPreference_ShowFullErrors = $true ;Import-Module ./Pester.psd1; Invoke-Pester -ExcludeTag VersionChecks, StyleRules, Help -EnableExit'
+  - pwsh -c 'Set-StrictMode -Version Latest; $global:PesterDebugPreference_ShowFullErrors = $true; ./build.ps1; Import-Module ./Pester.psd1; Invoke-Pester -ExcludeTag VersionChecks, StyleRules, Help -EnableExit'

--- a/Pester.psm1
+++ b/Pester.psm1
@@ -616,16 +616,21 @@ function Get-AssertionDynamicParams {
 }
 
 $Script:PesterRoot = & $SafeCommands['Split-Path'] -Path $MyInvocation.MyCommand.Path
+
+#region Functions
 "$PesterRoot\Functions\*.ps1", "$PesterRoot\Functions\Assertions\*.ps1" |
     & $script:SafeCommands['Resolve-Path'] |
     & $script:SafeCommands['Where-Object'] { -not ($_.ProviderPath.ToLower().Contains(".tests.")) } |
     & $script:SafeCommands['ForEach-Object'] { . $_.ProviderPath }
+#endregion
 
+#region Dependencies
 if (& $script:SafeCommands['Test-Path'] "$PesterRoot\Dependencies") {
     # sub-modules
     & $script:SafeCommands['Get-ChildItem'] "$PesterRoot\Dependencies\*\*.psm1" |
         & $script:SafeCommands['ForEach-Object'] { & $script:SafeCommands['Import-Module'] $_.FullName -Force -DisableNameChecking }
 }
+#endregion
 
 Add-Type -TypeDefinition @"
 using System;

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -24,7 +24,7 @@ jobs:
           rem build in 32-bit version of PowerShell 2 because the 64-bit version
           rem was butchered and replaced with PowerShell 6 to be able to run the
           rem Azure Pipelines agent on Server 2008 R2 with only PowerShell 2
-          C:\Windows\SysWOW64\WindowsPowerShell\v1.0\powershell.exe -c "$errorActionPreference = 'stop'; $global:PesterDebugPreference_ShowFullErrors = $true ; try {$PSVersionTable; Set-StrictMode -Version Latest; ./build.ps1; Import-Module .\Pester.psd1; Invoke-Pester -ExcludeTag VersionChecks, StyleRules, Help -EnableExit} catch { Write-Error $_; exit 9999 }"
+          C:\Windows\SysWOW64\WindowsPowerShell\v1.0\powershell.exe -c "$errorActionPreference = 'stop'; $global:PesterDebugPreference_ShowFullErrors = $true ; try {$PSVersionTable; Set-StrictMode -Version Latest; ./build.ps1; Import-Module .\Pester.psd1 -Verbose; Invoke-Pester -ExcludeTag VersionChecks, StyleRules, Help -EnableExit} catch { Write-Error $_; exit 9999 }"
           exit %errorlevel%
 
   - job: ps3

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -24,7 +24,7 @@ jobs:
           rem build in 32-bit version of PowerShell 2 because the 64-bit version
           rem was butchered and replaced with PowerShell 6 to be able to run the
           rem Azure Pipelines agent on Server 2008 R2 with only PowerShell 2
-          C:\Windows\SysWOW64\WindowsPowerShell\v1.0\powershell.exe -c "$errorActionPreference = 'stop'; $global:PesterDebugPreference_ShowFullErrors = $true ; try {$PSVersionTable; Set-StrictMode -Version Latest; Import-Module .\Pester.psd1; Invoke-Pester -ExcludeTag VersionChecks, StyleRules, Help -EnableExit} catch { Write-Error $_; exit 9999 }"
+          C:\Windows\SysWOW64\WindowsPowerShell\v1.0\powershell.exe -c "$errorActionPreference = 'stop'; $global:PesterDebugPreference_ShowFullErrors = $true ; try {$PSVersionTable; Set-StrictMode -Version Latest; ./build.ps1; Import-Module .\Pester.psd1; Invoke-Pester -ExcludeTag VersionChecks, StyleRules, Help -EnableExit} catch { Write-Error $_; exit 9999 }"
           exit %errorlevel%
 
   - job: ps3
@@ -42,5 +42,6 @@ jobs:
           $global:PesterDebugPreference_ShowFullErrors = $true
           $errorActionPreference = 'stop'
           Set-StrictMode -Version Latest
+          ./build.ps1
           Import-Module .\Pester.psd1
           Invoke-Pester -ExcludeTag VersionChecks, StyleRules, Help -EnableExit

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -18,7 +18,7 @@ jobs:
         - ps2
     workspace:
       clean: all
-    timeoutInMinutes: 3
+    timeoutInMinutes: 4
     steps:
       - script: |
           rem build in 32-bit version of PowerShell 2 because the 64-bit version
@@ -36,7 +36,7 @@ jobs:
         - ps3
     workspace:
       clean: all
-    timeoutInMinutes: 3
+    timeoutInMinutes: 4
     steps:
       - powershell: |
           $global:PesterDebugPreference_ShowFullErrors = $true

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -18,7 +18,7 @@ jobs:
         - ps2
     workspace:
       clean: all
-    timeoutInMinutes: 4
+    timeoutInMinutes: 5
     steps:
       - script: |
           rem build in 32-bit version of PowerShell 2 because the 64-bit version
@@ -36,7 +36,7 @@ jobs:
         - ps3
     workspace:
       clean: all
-    timeoutInMinutes: 4
+    timeoutInMinutes: 5
     steps:
       - powershell: |
           $global:PesterDebugPreference_ShowFullErrors = $true

--- a/build.ps1
+++ b/build.ps1
@@ -1,0 +1,16 @@
+$PowerShellScriptsToBeMerged = Get-ChildItem -Path (Join-Path $PSScriptRoot Functions) -Filter '*.ps1' -Exclude '*.Tests.ps1' -Recurse
+$mergedContent = ''
+foreach ($powerShellScriptToBeMerged in $PowerShellScriptsToBeMerged) {
+    $scriptContentToBeMerged = Get-Content -Path $powerShellScriptToBeMerged.FullName -Raw
+    $mergedContent += @"
+#region $($powerShellScriptToBeMerged.BaseName)
+$scriptContentToBeMerged
+#endregion
+
+"@
+}
+
+$mainModulePath = Join-Path $PSScriptRoot 'Pester.psm1'
+$contentOfMainModule = Get-Content -Path $mainModulePath
+$contentOfMainModule = $contentOfMainModule.Replace('# Functions', $mergedContent)
+Set-Content -Path $mainModulePath -Value $contentOfMainModule

--- a/build.ps1
+++ b/build.ps1
@@ -1,4 +1,4 @@
-$PowerShellScriptsToBeMerged = Get-ChildItem -Path (Join-Path $PSScriptRoot Functions) -Filter '*.ps1' -Exclude '*.Tests.ps1' -Recurse
+$PowerShellScriptsToBeMerged = Get-ChildItem -Path (Join-Path $PSScriptRoot Functions) -Filter '*.ps1' -Exclude '*.Tests.ps1', '*.ps1xml' -Recurse
 $mergedContent = ''
 foreach ($powerShellScriptToBeMerged in $PowerShellScriptsToBeMerged) {
     $scriptContentToBeMerged = Get-Content -Path $powerShellScriptToBeMerged.FullName -Raw
@@ -42,7 +42,7 @@ Edit-Region -Path $mainModulePath -RegionName 'Functions' -ReplacementText $merg
 function Get-ContentOfMergedFolder($DirectoryPath) {
     [array] $mainModulePath = Get-ChildItem -Path $DirectoryPath -Filter '*.psm1'
     if ($mainModulePath.Length -ne 1) { throw "We assumed there is only one psm1 file in directory '$DirectoryPath'" }
-    $mainModuleContent = Get-Content $mainModulePath[0] -Raw
+    $mainModuleContent = Get-Content $mainModulePath[0].FullName -Raw
     $PowerShellScriptsToBeMerged = Get-ChildItem -Path $DirectoryPath -Filter '*.ps1'
     foreach ($powerShellScriptToBeMerged in $PowerShellScriptsToBeMerged) {
         $NameOfScriptToBeMerged = $powerShellScriptToBeMerged.Name
@@ -67,8 +67,8 @@ function Get-ContentOfMergedFolder($DirectoryPath) {
 $dependenciesFolder = Join-Path $PSScriptRoot 'Dependencies'
 $axiomsCode = Get-ContentOfMergedFolder -DirectoryPath (Join-Path $dependenciesFolder 'Axiom')
 # Format module dependes on TypeClass module, hence why the TypeClass code has to go first
-$typeClassCode = Get-Content -Path (Join-Path $dependenciesFolder 'TypeClass' 'TypeClass.psm1') -Raw
-$formatCode = Get-Content -Path (Join-Path $dependenciesFolder 'Format' 'Format.psm1') -Raw
+$typeClassCode = Get-Content -Path (Join-Path $dependenciesFolder 'TypeClass\TypeClass.psm1') -Raw
+$formatCode = Get-Content -Path (Join-Path $dependenciesFolder 'Format\Format.psm1') -Raw
 $typeClassImport = 'Import-Module $PSScriptRoot\..\TypeClass\TypeClass.psm1 -DisableNameChecking'
 if (-not $formatCode.Contains($typeClassImport)) {
     throw "Expected the following string to be present in Format.psm1 for replacement '$typeClassImport'"

--- a/build.ps1
+++ b/build.ps1
@@ -12,5 +12,5 @@ $scriptContentToBeMerged
 
 $mainModulePath = Join-Path $PSScriptRoot 'Pester.psm1'
 $contentOfMainModule = Get-Content -Path $mainModulePath
-$contentOfMainModule = $contentOfMainModule.Replace('# Functions', $mergedContent)
+$contentOfMainModule = $contentOfMainModule.Replace('#region Functions', "$([System.Environment]::Newline)$mergedContent")
 Set-Content -Path $mainModulePath -Value $contentOfMainModule

--- a/build.ps1
+++ b/build.ps1
@@ -1,5 +1,6 @@
 $PSScriptRoot = Split-Path $MyInvocation.MyCommand.Path -Parent
-$PowerShellScriptsToBeMerged = Get-ChildItem -Path (Join-Path $PSScriptRoot Functions) -File -Filter '*.ps1' -Exclude '*.Tests.ps1', '*.ps1xml' -Recurse
+$PowerShellScriptsToBeMerged = Get-ChildItem -Path (Join-Path $PSScriptRoot Functions) -File -Filter '*.ps1' -Exclude '*.Tests.ps1', '*.ps1xml' -Recurse |
+    Where-Object { -not $_.PSIsContainer }
 foreach ($powerShellScriptToBeMerged in $PowerShellScriptsToBeMerged) {
     $scriptContentToBeMerged = [System.IO.File]::ReadAllText($powerShellScriptToBeMerged.FullName)
     $mergedContent += @"

--- a/build.ps1
+++ b/build.ps1
@@ -1,6 +1,7 @@
 $PSScriptRoot = Split-Path $MyInvocation.MyCommand.Path -Parent
 $PowerShellScriptsToBeMerged = Get-ChildItem -Path (Join-Path $PSScriptRoot Functions) -Filter '*.ps1' -Exclude '*.Tests.ps1', '*.ps1xml' -Recurse |
     Where-Object { -not $_.PSIsContainer }
+$mergedContent = ''
 foreach ($powerShellScriptToBeMerged in $PowerShellScriptsToBeMerged) {
     $scriptContentToBeMerged = [System.IO.File]::ReadAllText($powerShellScriptToBeMerged.FullName)
     $mergedContent += @"

--- a/build.ps1
+++ b/build.ps1
@@ -41,7 +41,7 @@ Edit-Region -Path $mainModulePath -RegionName 'Functions' -ReplacementText $merg
 # Takes in a directory (Dependencies/Axiom)
 function Get-ContentOfMergedFolder($DirectoryPath) {
     [array] $mainModulePath = Get-ChildItem -Path $DirectoryPath -Filter '*.psm1'
-    $mainModulePath.Length | Should -Be 1 -Because "we assumed there is only one psm1 file in directory '$DirectoryPath'"
+    if ($mainModulePath.Length -ne 1) { throw "We assumed there is only one psm1 file in directory '$DirectoryPath'" }
     $mainModuleContent = Get-Content $mainModulePath[0] -Raw
     $PowerShellScriptsToBeMerged = Get-ChildItem -Path $DirectoryPath -Filter '*.ps1'
     foreach ($powerShellScriptToBeMerged in $PowerShellScriptsToBeMerged) {

--- a/build.ps1
+++ b/build.ps1
@@ -1,6 +1,5 @@
 $PSScriptRoot = Split-Path $MyInvocation.MyCommand.Path -Parent
-$PowerShellScriptsToBeMerged = Get-ChildItem -Path (Join-Path $PSScriptRoot Functions) -Filter '*.ps1' -Exclude '*.Tests.ps1', '*.ps1xml' -Recurse
-$mergedContent = ''
+$PowerShellScriptsToBeMerged = Get-ChildItem -Path (Join-Path $PSScriptRoot Functions) -File -Filter '*.ps1' -Exclude '*.Tests.ps1', '*.ps1xml' -Recurse
 foreach ($powerShellScriptToBeMerged in $PowerShellScriptsToBeMerged) {
     $scriptContentToBeMerged = [System.IO.File]::ReadAllText($powerShellScriptToBeMerged.FullName)
     $mergedContent += @"

--- a/build.ps1
+++ b/build.ps1
@@ -2,7 +2,7 @@ $PSScriptRoot = Split-Path $MyInvocation.MyCommand.Path -Parent
 $PowerShellScriptsToBeMerged = Get-ChildItem -Path (Join-Path $PSScriptRoot Functions) -Filter '*.ps1' -Exclude '*.Tests.ps1', '*.ps1xml' -Recurse
 $mergedContent = ''
 foreach ($powerShellScriptToBeMerged in $PowerShellScriptsToBeMerged) {
-    $scriptContentToBeMerged = Get-Content -Path $powerShellScriptToBeMerged.FullName -Raw
+    $scriptContentToBeMerged = [System.IO.File]::ReadAllText($powerShellScriptToBeMerged)
     $mergedContent += @"
 #region $($powerShellScriptToBeMerged.BaseName)
 $scriptContentToBeMerged
@@ -43,11 +43,11 @@ Edit-Region -Path $mainModulePath -RegionName 'Functions' -ReplacementText $merg
 function Get-ContentOfMergedFolder($DirectoryPath) {
     [array] $mainModulePath = Get-ChildItem -Path $DirectoryPath -Filter '*.psm1'
     if ($mainModulePath.Length -ne 1) { throw "We assumed there is only one psm1 file in directory '$DirectoryPath'" }
-    $mainModuleContent = Get-Content $mainModulePath[0].FullName -Raw
+    $mainModuleContent = [System.IO.File]::ReadAllText($mainModulePath[0].FullName)
     $PowerShellScriptsToBeMerged = Get-ChildItem -Path $DirectoryPath -Filter '*.ps1'
     foreach ($powerShellScriptToBeMerged in $PowerShellScriptsToBeMerged) {
         $NameOfScriptToBeMerged = $powerShellScriptToBeMerged.Name
-        $scriptContentToBeMerged = Get-Content -Path $powerShellScriptToBeMerged.FullName -Raw
+        $scriptContentToBeMerged = [System.IO.File]::ReadAllText($powerShellScriptToBeMerged.FullName)
         $replaceSearchText = ". `$PSScriptRoot\$NameOfScriptToBeMerged"
         if (-not $mainModuleContent.Contains($replaceSearchText)) {
             continue
@@ -68,8 +68,8 @@ function Get-ContentOfMergedFolder($DirectoryPath) {
 $dependenciesFolder = Join-Path $PSScriptRoot 'Dependencies'
 $axiomsCode = Get-ContentOfMergedFolder -DirectoryPath (Join-Path $dependenciesFolder 'Axiom')
 # Format module dependes on TypeClass module, hence why the TypeClass code has to go first
-$typeClassCode = Get-Content -Path (Join-Path $dependenciesFolder 'TypeClass\TypeClass.psm1') -Raw
-$formatCode = Get-Content -Path (Join-Path $dependenciesFolder 'Format\Format.psm1') -Raw
+$typeClassCode = [System.IO.File]::ReadAllText((Join-Path $dependenciesFolder 'TypeClass\TypeClass.psm1'))
+$formatCode = [System.IO.File]::ReadAllText((Join-Path $dependenciesFolder 'Format\Format.psm1'))
 $typeClassImport = 'Import-Module $PSScriptRoot\..\TypeClass\TypeClass.psm1 -DisableNameChecking'
 if (-not $formatCode.Contains($typeClassImport)) {
     throw "Expected the following string to be present in Format.psm1 for replacement '$typeClassImport'"

--- a/build.ps1
+++ b/build.ps1
@@ -2,7 +2,7 @@ $PSScriptRoot = Split-Path $MyInvocation.MyCommand.Path -Parent
 $PowerShellScriptsToBeMerged = Get-ChildItem -Path (Join-Path $PSScriptRoot Functions) -Filter '*.ps1' -Exclude '*.Tests.ps1', '*.ps1xml' -Recurse
 $mergedContent = ''
 foreach ($powerShellScriptToBeMerged in $PowerShellScriptsToBeMerged) {
-    $scriptContentToBeMerged = [System.IO.File]::ReadAllText($powerShellScriptToBeMerged)
+    $scriptContentToBeMerged = [System.IO.File]::ReadAllText($powerShellScriptToBeMerged.FullName)
     $mergedContent += @"
 #region $($powerShellScriptToBeMerged.BaseName)
 $scriptContentToBeMerged

--- a/build.ps1
+++ b/build.ps1
@@ -1,3 +1,4 @@
+$PSScriptRoot = Split-Path $MyInvocation.MyCommand.Path -Parent
 $PowerShellScriptsToBeMerged = Get-ChildItem -Path (Join-Path $PSScriptRoot Functions) -Filter '*.ps1' -Exclude '*.Tests.ps1', '*.ps1xml' -Recurse
 $mergedContent = ''
 foreach ($powerShellScriptToBeMerged in $PowerShellScriptsToBeMerged) {

--- a/build.ps1
+++ b/build.ps1
@@ -1,5 +1,5 @@
 $PSScriptRoot = Split-Path $MyInvocation.MyCommand.Path -Parent
-$PowerShellScriptsToBeMerged = Get-ChildItem -Path (Join-Path $PSScriptRoot Functions) -File -Filter '*.ps1' -Exclude '*.Tests.ps1', '*.ps1xml' -Recurse |
+$PowerShellScriptsToBeMerged = Get-ChildItem -Path (Join-Path $PSScriptRoot Functions) -Filter '*.ps1' -Exclude '*.Tests.ps1', '*.ps1xml' -Recurse |
     Where-Object { -not $_.PSIsContainer }
 foreach ($powerShellScriptToBeMerged in $PowerShellScriptsToBeMerged) {
     $scriptContentToBeMerged = [System.IO.File]::ReadAllText($powerShellScriptToBeMerged.FullName)


### PR DESCRIPTION
Fixes #1365

Adds a `build.ps1` file to merge all dot sourced dependencies into `Pester.psm1` for faster import speed.

Outstanding work:
- Investigate failing tests: On PowerShell 5/6 there are 2 failing tests due to the error stack trace suddenly being 11 lines long somehow, on PowerShell 3/4 there are 4 failures in total
- PowerShell 2: The` Invoke-Pester` cmdlet does not get exported
- Instead of merging into the `Pester.psm1` in source control, create everything in a new folder
- Add some unit tests for `build.ps1` to test the internal functions

Question: What about the Travis? I cannot update their build to see if there would be breaking changes there? The PS v2 build is broken because there is no `-Raw` parameter on `Get-Content`, I really do not understand the need to support deprecated technology.