### PR TITLE
Filter what Context and It blocks run

### DIFF
--- a/Functions/Context.Tests.ps1
+++ b/Functions/Context.Tests.ps1
@@ -20,3 +20,61 @@ Describe 'Testing Context' {
         }| should -Throw  'No test fixture is provided. (Have you put the open curly brace on the next line?)'
     }
 }
+
+Describe 'Filtering Context' {
+    It 'should only run filtered contexts' {
+        InModuleScope 'Pester' {
+            Mock -CommandName 'DescribeImpl' -ModuleName 'Pester' -ParameterFilter { $CommandUsed -eq 'Context' }
+
+            $currentFilter = $Pester.ContextFilter
+            $Pester.ContextFilter = @( 'one', 'tw*' )
+            try
+            {
+                Context 'One' {
+                }
+
+                Context 'Two' {
+                }
+
+                Context 'Three' {
+                }
+
+                Assert-MockCalled -CommandName 'DescribeImpl' -ModuleName 'Pester' -Times 2 -Exactly
+                Assert-MockCalled -CommandName 'DescribeImpl' -ModuleName 'Pester' -Times 1 -ParameterFilter { $Name -eq 'One' }
+                Assert-MockCalled -CommandName 'DescribeImpl' -ModuleName 'Pester' -Times 1 -ParameterFilter { $Name -eq 'Two' }
+                Assert-MockCalled -CommandName 'DescribeImpl' -ModuleName 'Pester' -Times 0 -ParameterFilter { $Name -eq 'Three' }
+            }
+            finally
+            {
+                $Pester.ContextFilter = $currentFilter
+            }
+        }
+    }
+    It 'should run all contexts if not filtering' {
+        InModuleScope 'Pester' {
+            Mock -CommandName 'DescribeImpl' -ModuleName 'Pester' -ParameterFilter { $CommandUsed -eq 'Context' }
+
+            $currentFilter = $Pester.ContextFilter
+            $Pester.ContextFilter = $null
+            try
+            {
+                Context 'Four' {
+                }
+
+                Context 'Five' {
+                }
+
+                Context 'Six' {
+                }
+
+                Assert-MockCalled -CommandName 'DescribeImpl' -ModuleName 'Pester' -Times 1 -ParameterFilter { $Name -eq 'Four' }
+                Assert-MockCalled -CommandName 'DescribeImpl' -ModuleName 'Pester' -Times 1 -ParameterFilter { $Name -eq 'Five' }
+                Assert-MockCalled -CommandName 'DescribeImpl' -ModuleName 'Pester' -Times 1 -ParameterFilter { $Name -eq 'Six' }
+            }
+            finally
+            {
+                $Pester.ContextFilter = $currentFilter
+            }
+        }
+    }
+}

--- a/Functions/Context.ps1
+++ b/Functions/Context.ps1
@@ -78,5 +78,9 @@ about_TestDrive
         $script:mockTable = @{}
     }
 
+    if ($Pester.ContextFilter -and -not (Contain-AnyStringLike -Filter $Pester.ContextFilter -Collection $Name)) {
+        return
+    }
+
     DescribeImpl @PSBoundParameters -CommandUsed 'Context' -Pester $Pester -DescribeOutputBlock ${function:Write-Describe} -TestOutputBlock ${function:Write-PesterResult} -NoTestRegistry:('Windows' -ne (GetPesterOs))
 }

--- a/Functions/It.Tests.ps1
+++ b/Functions/It.Tests.ps1
@@ -154,4 +154,32 @@ InModuleScope Pester {
             comment#> code' | Should -Be 'code  code'
         }
     }
+
+    Describe 'Filtering' {
+        It 'should only run It blocks that match filter' {
+            $testState = New-PesterState -Path $TestDrive -ItFilter @( 'One', 'Tw*' )
+
+            ItImpl -Pester $testState -Name 'One' { }
+            ItImpl -Pester $testSTate -Name 'Two' { }
+            ItImpl -Pester $testState -Name 'Three' { }
+
+            $testState.TestResult.Count | Should -Be 2 -Because 'one of the tests should not have run'
+            $testState.TestResult[0].Name | Should -Be 'One'
+            $testState.TestResult[1].Name | Should -Be 'Two'
+            $testState.TestResult | Where-Object { $_.Name -eq 'Three' } | Should -BeNullOrEmpty
+        }
+
+        It 'should run all It blocks if no filter' {
+            $testState = New-PesterState -Path $TestDrive
+
+            ItImpl -Pester $testState -Name 'One' { }
+            ItImpl -Pester $testSTate -Name 'Two' { }
+            ItImpl -Pester $testState -Name 'Three' { }
+
+            $testState.TestResult.Count | Should -Be 3 -Because 'all of the tests should have run'
+            $testState.TestResult[0].Name | Should -Be 'One'
+            $testState.TestResult[1].Name | Should -Be 'Two'
+            $testState.TestResult[2].Name | Should -Be 'Three'
+        }
+    }
 }

--- a/Functions/It.ps1
+++ b/Functions/It.ps1
@@ -165,6 +165,10 @@ function ItImpl {
         }
     }
 
+    if ( $Pester.ItFilter -and -not (Contain-AnyStringLike -Filter $Pester.ItFilter -Collection $Name)) {
+        return
+    }
+
     #the function is called with Pending or Skipped set the script block if needed
     if ($null -eq $Test) {
         $Test = {}

--- a/Functions/Mock.ps1
+++ b/Functions/Mock.ps1
@@ -711,7 +711,7 @@ function Test-MockCallScope {
     }
 
     $testGroups = $pester.TestGroups
-    [Array]::Reverse($testGroups)
+    [Array]::Reverse([object[]]$testGroups)
 
     $target = 0
     $isNumberedScope = [int]::TryParse($DesiredScope, [ref] $target)

--- a/Functions/PesterState.ps1
+++ b/Functions/PesterState.ps1
@@ -3,6 +3,7 @@ function New-PesterState {
         [String[]]$TagFilter,
         [String[]]$ExcludeTagFilter,
         [String[]]$TestNameFilter,
+        [string[]]$ItFilter,
         [System.Management.Automation.SessionState]$SessionState,
         [Switch]$Strict,
         [Pester.OutputTypes]$Show = 'All',
@@ -27,11 +28,12 @@ function New-PesterState {
         }
     }
 
-    & $SafeCommands['New-Module'] -Name PesterState -AsCustomObject -ArgumentList $TagFilter, $ExcludeTagFilter, $TestNameFilter, $SessionState, $Strict, $Show, $PesterOption, $RunningViaInvokePester -ScriptBlock {
+    & $SafeCommands['New-Module'] -Name PesterState -AsCustomObject -ArgumentList $TagFilter, $ExcludeTagFilter, $TestNameFilter, $ItFilter, $SessionState, $Strict, $Show, $PesterOption, $RunningViaInvokePester -ScriptBlock {
         param (
             [String[]]$_tagFilter,
             [String[]]$_excludeTagFilter,
             [String[]]$_testNameFilter,
+            [string[]]$_itFilter,
             [System.Management.Automation.SessionState]$_sessionState,
             [Switch]$Strict,
             [Pester.OutputTypes]$Show,
@@ -43,7 +45,7 @@ function New-PesterState {
         $TagFilter = $_tagFilter
         $ExcludeTagFilter = $_excludeTagFilter
         $TestNameFilter = $_testNameFilter
-
+        $ItFilter = $_itFilter
 
         $script:SessionState = $_sessionState
         $script:Stopwatch = [System.Diagnostics.Stopwatch]::StartNew()
@@ -330,6 +332,7 @@ function New-PesterState {
         $ExportedVariables = "TagFilter",
         "ExcludeTagFilter",
         "TestNameFilter",
+        "ItFilter",
         "ScriptBlockFilter",
         "TestResult",
         "SessionState",

--- a/Functions/PesterState.ps1
+++ b/Functions/PesterState.ps1
@@ -28,11 +28,12 @@ function New-PesterState {
         }
     }
 
-    & $SafeCommands['New-Module'] -Name PesterState -AsCustomObject -ArgumentList $TagFilter, $ExcludeTagFilter, $TestNameFilter, $ItFilter, $SessionState, $Strict, $Show, $PesterOption, $RunningViaInvokePester -ScriptBlock {
+    & $SafeCommands['New-Module'] -Name PesterState -AsCustomObject -ArgumentList $TagFilter, $ExcludeTagFilter, $TestNameFilter, $ContextFilter, $ItFilter, $SessionState, $Strict, $Show, $PesterOption, $RunningViaInvokePester -ScriptBlock {
         param (
             [String[]]$_tagFilter,
             [String[]]$_excludeTagFilter,
             [String[]]$_testNameFilter,
+            [string[]]$_contextFilter,
             [string[]]$_itFilter,
             [System.Management.Automation.SessionState]$_sessionState,
             [Switch]$Strict,
@@ -45,6 +46,7 @@ function New-PesterState {
         $TagFilter = $_tagFilter
         $ExcludeTagFilter = $_excludeTagFilter
         $TestNameFilter = $_testNameFilter
+        $ContextFilter = $_contextFilter
         $ItFilter = $_itFilter
 
         $script:SessionState = $_sessionState
@@ -332,6 +334,7 @@ function New-PesterState {
         $ExportedVariables = "TagFilter",
         "ExcludeTagFilter",
         "TestNameFilter",
+        "ContextFilter",
         "ItFilter",
         "ScriptBlockFilter",
         "TestResult",

--- a/Pester.psm1
+++ b/Pester.psm1
@@ -744,6 +744,15 @@ function Invoke-Pester {
     If you specify multiple TestName values, Invoke-Pester runs tests that have any
     of the values in the Describe name (it ORs the TestName values).
 
+    .PARAMETER ContextFilter
+    Runs only Context blocks that have the specified name or name pattern. Wildcard
+    characters are supported. Anything not in a Context block will still run. Use
+    the TestName and ItFilter parameters to filter the Describe and It blocks you
+    want to run.
+
+    If you specify multiple ContextFilter values, Invoke-Pester runs tests that have
+    any of the values in the Context name (it ORs the ContextFilter values).
+
     .PARAMETER ItFilter
     Runs only tests in It blocks that have the specified name or name pattern.
     Wildcard characters are supported.
@@ -929,6 +938,11 @@ function Invoke-Pester {
     This command runs only the tests in the Describe block named "Add Numbers".
 
     .Example
+    Invoke-Pester -ContextFilter '*dev'
+
+    This command only runs Context blocks whose name match the wildcard pattern "*dev".
+
+    .Example
     Invoke-Pester -ItFilter '*comments'
 
     This command only runs It blocks whose name match the wildcard pattern "*comments".
@@ -1032,6 +1046,8 @@ function Invoke-Pester {
         [Alias("Name")]
         [string[]]$TestName,
 
+        [string[]]$ContextFilter,
+
         [string[]]$ItFilter,
 
         [Parameter(Position = 2, Mandatory = 0)]
@@ -1092,7 +1108,7 @@ function Invoke-Pester {
         $script:mockTable = @{ }
         Remove-MockFunctionsAndAliases
         $sessionState = Set-SessionStateHint -PassThru  -Hint "Caller - Captured in Invoke-Pester" -SessionState $PSCmdlet.SessionState
-        $pester = New-PesterState -TestNameFilter $TestName -ItFilter $ItFilter -TagFilter $Tag -ExcludeTagFilter $ExcludeTag -SessionState $SessionState -Strict:$Strict -Show:$Show -PesterOption $PesterOption -RunningViaInvokePester
+        $pester = New-PesterState -TestNameFilter $TestName -ContextFilter $ContextFilter -ItFilter $ItFilter -TagFilter $Tag -ExcludeTagFilter $ExcludeTag -SessionState $SessionState -Strict:$Strict -Show:$Show -PesterOption $PesterOption -RunningViaInvokePester
 
         try {
             Enter-CoverageAnalysis -CodeCoverage $CodeCoverage -PesterState $pester

--- a/Pester.psm1
+++ b/Pester.psm1
@@ -744,6 +744,13 @@ function Invoke-Pester {
     If you specify multiple TestName values, Invoke-Pester runs tests that have any
     of the values in the Describe name (it ORs the TestName values).
 
+    .PARAMETER ItFilter
+    Runs only tests in It blocks that have the specified name or name pattern.
+    Wildcard characters are supported.
+
+    If you specify multiple ItFilter values, Invoke-Pester runs tests that have any
+    of the values in the It name (it ORs the ItFilter values).
+
     .PARAMETER EnableExit
     Will cause Invoke-Pester to exit with a exit code equal to the number of failed
     tests once all tests have been run. Use this to "fail" a build when any tests fail.
@@ -921,6 +928,11 @@ function Invoke-Pester {
 
     This command runs only the tests in the Describe block named "Add Numbers".
 
+    .Example
+    Invoke-Pester -ItFilter '*comments'
+
+    This command only runs It blocks whose name match the wildcard pattern "*comments".
+
     .EXAMPLE
     $results = Invoke-Pester -Script D:\MyModule -PassThru -Show None
     $failed = $results.TestResult | where Result -eq 'Failed'
@@ -1020,6 +1032,8 @@ function Invoke-Pester {
         [Alias("Name")]
         [string[]]$TestName,
 
+        [string[]]$ItFilter,
+
         [Parameter(Position = 2, Mandatory = 0)]
         [switch]$EnableExit,
 
@@ -1078,7 +1092,7 @@ function Invoke-Pester {
         $script:mockTable = @{ }
         Remove-MockFunctionsAndAliases
         $sessionState = Set-SessionStateHint -PassThru  -Hint "Caller - Captured in Invoke-Pester" -SessionState $PSCmdlet.SessionState
-        $pester = New-PesterState -TestNameFilter $TestName -TagFilter $Tag -ExcludeTagFilter $ExcludeTag -SessionState $SessionState -Strict:$Strict -Show:$Show -PesterOption $PesterOption -RunningViaInvokePester
+        $pester = New-PesterState -TestNameFilter $TestName -ItFilter $ItFilter -TagFilter $Tag -ExcludeTagFilter $ExcludeTag -SessionState $SessionState -Strict:$Strict -Show:$Show -PesterOption $PesterOption -RunningViaInvokePester
 
         try {
             Enter-CoverageAnalysis -CodeCoverage $CodeCoverage -PesterState $pester


### PR DESCRIPTION
Pester wants test fixtures to have one (or just a few) `Describe` blocks with many `It` blocks representing specific tests. Unfortunately, the `TestName` parameter only applies to `Describe` blocks. If you have all your `It` blocks in a single `Describe` (as most everybody and Pester examples do), then you can't run individual tests. If these `It` blocks take a long time and one of them is failing, it can be very painful to debug them. You can comment out the tests you don't want to run, or re-arrange, or add `return` statements. Or, you use a pattern where you have a single `It` block in each `Describe` block.

As a developer, I'd like parameters on `Invoke-Pester` that allow me to filter `It` blocks so I don't have to go through all the steps I currently have to just to run a single `It` block.

This PR adds `ContextFilter` and `ItFilter` parameters to `Invoke-Pester` that allows this level of control.

This should address issue #292, although without the special formatting to the `TestName` parameter described in that issue.

I would also like to rename the `TestName` parameter to `DescribeFilter` (with a backwards-compatible alias) along with renaming internal parameters and Pester state property names. That's a big refactor and didn't want to do it without permission.

Also, maybe in Pester 5, we can make `ItFilter` the second  positional parameter instead of `TestName` because it just makes more sense to filter `It` blocks my default than `Describe` blocks.
