### PR TITLE
Handle when exceptions have no error messages.

### DIFF
--- a/Functions/Output.Tests.ps1
+++ b/Functions/Output.Tests.ps1
@@ -369,20 +369,34 @@ InModuleScope -ModuleName Pester -ScriptBlock {
             }
 
             Context 'Exceptions with no error message property set' {
+                $powershellVersion = $($PSVersionTable.PSVersion.Major)
                 try {
-                    throw [System.Exception]::new($null)
+                    $exceptionWithNullMessage = New-Object -TypeName "System.Management.Automation.ParentContainsErrorRecordException"
+                    throw $exceptionWithNullMessage
                 }
                 catch {
                     $exception = $_
                 }
                 $result = $exception | ConvertTo-FailureLines
 
-                It 'produces correct message lines' {
-                    $result.Message.Count | Should -Be 0
-                }
+                if ($powershellVersion -lt 5) {
+                    # Necessary because Microsoft changed the behaviour of System.Management.Automation.ParentContainsErrorRecordException at this point.
+                    It 'produces correct message lines' {
+                        $result.Message.Length | Should -Be 2
+                    }
 
-                It 'produces correct trace line' {
-                    $result.Trace.Count | Should -Be 1
+                    It 'produces correct trace line' {
+                        $result.Trace.Count | Should -Be 1
+                    }
+                }
+                else {
+                    It 'produces correct message lines' {
+                        $result.Message.Length | Should -Be 0
+                    }
+
+                    It 'produces correct trace line' {
+                        $result.Trace.Count | Should -Be 1
+                    }
                 }
             }
 

--- a/Functions/Output.Tests.ps1
+++ b/Functions/Output.Tests.ps1
@@ -1,4 +1,4 @@
-﻿Set-StrictMode -Version Latest
+Set-StrictMode -Version Latest
 
 InModuleScope -ModuleName Pester -ScriptBlock {
     Describe 'Has-Flag' -Fixture {
@@ -367,6 +367,25 @@ InModuleScope -ModuleName Pester -ScriptBlock {
                     }
                 }
             }
+
+            Context 'Exceptions with no error message property set' {
+                try {
+                    throw [System.Exception]::new($null)
+                }
+                catch {
+                    $exception = $_
+                }
+                $result = $exception | ConvertTo-FailureLines
+
+                It 'produces correct message lines' {
+                    $result.Message.Count | Should -Be 0
+                }
+
+                It 'produces correct trace line' {
+                    $result.Trace.Count | Should -Be 1
+                }
+            }
+
         }
     }
 }

--- a/Functions/Output.Tests.ps1
+++ b/Functions/Output.Tests.ps1
@@ -379,7 +379,7 @@ InModuleScope -ModuleName Pester -ScriptBlock {
                 }
                 $result = $exception | ConvertTo-FailureLines
 
-                if ($powershellVersion -lt 5) {
+                if ($powershellVersion -lt 3) {
                     # Necessary because Microsoft changed the behaviour of System.Management.Automation.ParentContainsErrorRecordException at this point.
                     It 'produces correct message lines' {
                         $result.Message.Length | Should -Be 2

--- a/Functions/Output.ps1
+++ b/Functions/Output.ps1
@@ -479,7 +479,7 @@ function ConvertTo-FailureLines {
         while ($exception) {
             $exceptionName = $exception.GetType().Name
             $thisLines = $exception.Message.Split([string[]]($([System.Environment]::NewLine), "\n", "`n"), [System.StringSplitOptions]::RemoveEmptyEntries)
-            if ($ErrorRecord.FullyQualifiedErrorId -ne 'PesterAssertionFailed') {
+            if ($ErrorRecord.FullyQualifiedErrorId -ne 'PesterAssertionFailed' -and $thisLines.Length -gt 0) {
                 $thisLines[0] = "$exceptionName`: $($thisLines[0])"
             }
             [array]::Reverse($thisLines)


### PR DESCRIPTION
## 1. General summary of the pull request
Pester crashes on exceptions with null error messages. This PR fixes the problem by adding an additional check in the code that "unwinds" the stack trace and error messages.

I do not believe there is an open issue for this problem on github.