### PR TITLE
Add an Example of Should Be with an Array

### DIFF
--- a/Functions/Assertions/Be.Tests.ps1
+++ b/Functions/Assertions/Be.Tests.ps1
@@ -36,6 +36,15 @@ InModuleScope Pester {
             $array | Should -EQ $arrayWithCaps
         }
 
+        It 'Compares arrays with similar values in different order' {
+            [int32[]]$array = (1..10)
+            $arrayoutoforder = (1, 10, 2, 3, 4, 5, 6, 7, 8, 9)
+
+            $array | Should Not Be $arrayOutOfOrder
+            $array | Should -Not -Be $arrayOutOfOrder
+            $array | Should -Not -EQ $arrayOutOfOrder
+        }
+
         It 'Handles reference types properly' {
             $object1 = New-Object psobject -Property @{ Value = 'Test' }
             $object2 = New-Object psobject -Property @{ Value = 'Test' }
@@ -74,15 +83,15 @@ InModuleScope Pester {
         }
 
         It "returns true if the actual value can be cast to the expected value and they are the same value" {
-            {abc} | Should Be "aBc"
-            {abc} | Should -Be "aBc"
-            {abc} | Should -EQ "aBc"
+            { abc } | Should Be "aBc"
+            { abc } | Should -Be "aBc"
+            { abc } | Should -EQ "aBc"
         }
 
         It "returns true if the actual value can be cast to the expected value and they are the same value (case sensitive)" {
-            {abc} | Should BeExactly "abc"
-            {abc} | Should -BeExactly "abc"
-            {abc} | Should -CEQ "abc"
+            { abc } | Should BeExactly "abc"
+            { abc } | Should -BeExactly "abc"
+            { abc } | Should -CEQ "abc"
         }
 
         It 'Does not overflow on IEnumerable' {

--- a/Functions/Assertions/Be.Tests.ps1
+++ b/Functions/Assertions/Be.Tests.ps1
@@ -83,15 +83,15 @@ InModuleScope Pester {
         }
 
         It "returns true if the actual value can be cast to the expected value and they are the same value" {
-            { abc } | Should Be "aBc"
-            { abc } | Should -Be "aBc"
-            { abc } | Should -EQ "aBc"
+            {abc} | Should Be "aBc"
+            {abc} | Should -Be "aBc"
+            {abc} | Should -EQ "aBc"
         }
 
         It "returns true if the actual value can be cast to the expected value and they are the same value (case sensitive)" {
-            { abc } | Should BeExactly "abc"
-            { abc } | Should -BeExactly "abc"
-            { abc } | Should -CEQ "abc"
+            {abc} | Should BeExactly "abc"
+            {abc} | Should -BeExactly "abc"
+            {abc} | Should -CEQ "abc"
         }
 
         It 'Does not overflow on IEnumerable' {

--- a/en-US/about_Should.help.txt
+++ b/en-US/about_Should.help.txt
@@ -25,6 +25,22 @@ SHOULD MEMBERS
         $actual | Should -Be "actual value" # Test will pass
         $actual | Should -Be "not actual value"  # Test will fail
 
+        Also compares an entire array for equality and throws if the array is not the same.
+
+        $array = @(1, 2, 3, 4, 'I am a string', (New-Object psobject -Property @{ IAm = 'An Object' }))
+        $array | Should -Be $array # Test will pass
+
+        $string = 'I am a string'
+        $array = @(1, 2, 3, 4, $string)
+        $arrayWithCaps = @(1, 2, 3, 4, $string.ToUpper())
+        $array | Should -Be $arrayWithCaps # Test will pass
+
+        Comparisons will fail if the arrays have the same values, but not the same order.
+
+        [int32[]]$array = (1..10)
+        $arrayoutoforder = (1,10,2,3,4,5,6,7,8,9)
+        $array | Should -Be $arrayOutOfOrder # Test will fail
+
     BeExactly
         Compares one object with another for equality and throws if the two objects are not the same.  This comparison is case sensitive.
 


### PR DESCRIPTION
<!--

Thank you for contributing to Pester! Please provide a descriptive title of the pull request in the field 'Title'.

-->

## 1. General summary of the pull request

Adding documentation about existing support for array comparison in the `-Be` operator.
This PR fixes the `about_Should.help.txt` as requested in #1157. 
This also includes a pester test of the specific example added, showing that arrays with similar values will not pass assertion if the values are in different indexes .

If this PR is accepted the [corresponding Wiki page](https://github.com/pester/Pester/wiki/Should#be) will be updated for this change to the Help.

<!--

Please describe what your pull request fixes, or how it improves Pester.

If your pull request resolves a reported issue, please mention it by using  `Fix #<issue_number>` on a new line, this will close the linked issue automatically when this PR is merged. For more info see: [Closing issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/).

If your pull request integrates Pester with another system, please tell us how the change can be tested.

Please remember to update [the Pester wiki](https://github.com/pester/Pester/wiki) if needed.

Before you continue, please review [Contributing to Pester](https://github.com/pester/Pester/wiki/Contributing-to-Pester) and [Development rules - technical](https://github.com/pester/Pester/wiki/Developement-rules---technical).

Our continuous integration system doesn't send any notifications about failed tests. Please return to the opened pull request (after ~60 minutes) to check if is everything OK.

-->
