### PR TITLE
Fixed incorrect variable used for hooks with tags in Invoke-GherkinHook.

### DIFF
--- a/Examples/Gherkin/HookTag.Steps.ps1
+++ b/Examples/Gherkin/HookTag.Steps.ps1
@@ -1,0 +1,11 @@
+BeforeEachFeature -Tags FeatureHookTag {
+    # NOOP
+}
+
+BeforeEachFeature -Tags ScenarioHookTag {
+    # NOOP
+}
+
+Then "not much is going on" {
+    # NOOP
+}

--- a/Examples/Gherkin/HookTag.feature
+++ b/Examples/Gherkin/HookTag.feature
@@ -1,0 +1,6 @@
+@FeatureHookTag
+Feature: A test feature that has a tag
+
+  @ScenarioHookTag
+  Scenario: A scenario that has another tag
+    Then not much is going on

--- a/Functions/Gherkin.ps1
+++ b/Functions/Gherkin.ps1
@@ -36,7 +36,7 @@ function Invoke-GherkinHook {
                 :tags foreach ($hookTag in $GherkinHook.Tags) {
                     foreach ($testTag in $Tags) {
                         if ($testTag -match "^($hookTag)$") {
-                            & $hook.Script $Name
+                            & $GherkinHook.Script $Name
                             break :tags
                         }
                     }


### PR DESCRIPTION
## 1. General summary of the pull request

There was an incorrect variable used in `Invoke-GherkinHook` function (in `Gherkin.ps1`) for accessing hook's script - instead of an actual hook object (`$GherkinHook`), a hook's name was given (`$hook`).

This only happened for hooks with tags.

This has now been fixed and a unit test was added.

I don't believe there was any issue reported for this.