### PR TITLE
Fix Should behavior

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -23,6 +23,7 @@ test_script:
   - pwsh: |
       if ( $env:PSEdition -eq 'Core' ) {
       Set-StrictMode -Version Latest
+      $ErrorActionPreference = 'Stop'
       $env:CI = 1
       $r = Get-ChildItem *.ts.ps1 -Recurse | foreach { & $_.FullName -PassThru } ; if ([bool]($r | Where-Object { $_.Failed -gt 0 })) { exit 1 }
       $global:PesterDebugPreference = @{ ShowFullErrors = $true }

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,4 +21,4 @@ matrix:
             - powershell
 
 script:
-  - pwsh -c 'Set-StrictMode -Version Latest; $env:CI = 1; $r = Get-ChildItem *.ts.ps1 -Recurse | foreach { & $_.FullName -PassThru } ; if ([bool]($r | Where-Object { $_.Failed -gt 0 })) { exit 1 }; $global:PesterDebugPreference = @{ ShowFullErrors = $true } ;Import-Module ./Pester.psd1; Invoke-Pester -ExcludeTag VersionChecks, StyleRules, Help -ExcludePath '*/demo/*', '*/examples/*', '*/Gherkin*' -Path . -CI | Out-Null'
+  - pwsh -c 'Set-StrictMode -Version Latest; $ErrorActionPreference = 'Stop'; $env:CI = 1; $r = Get-ChildItem *.ts.ps1 -Recurse | foreach { & $_.FullName -PassThru } ; if ([bool]($r | Where-Object { $_.Failed -gt 0 })) { exit 1 }; $global:PesterDebugPreference = @{ ShowFullErrors = $true } ;Import-Module ./Pester.psd1; Invoke-Pester -ExcludeTag VersionChecks, StyleRules, Help -ExcludePath '*/demo/*', '*/examples/*', '*/Gherkin*' -Path . -CI | Out-Null'

--- a/Functions/Assertions/Be.Tests.ps1
+++ b/Functions/Assertions/Be.Tests.ps1
@@ -1,7 +1,7 @@
 Set-StrictMode -Version Latest
 
 BeforeAll {
-    $ErrorActionPreference = 'Stop'
+    $PSDefaultParameterValues = @{ 'Should:ErrorAction' = 'Stop' }
 }
 
 InModuleScope Pester {

--- a/Functions/Assertions/Be.Tests.ps1
+++ b/Functions/Assertions/Be.Tests.ps1
@@ -1,10 +1,12 @@
 Set-StrictMode -Version Latest
 
-BeforeAll {
-    $PSDefaultParameterValues = @{ 'Should:ErrorAction' = 'Stop' }
-}
-
 InModuleScope Pester {
+
+    BeforeAll {
+        $PSDefaultParameterValues = @{ 'Should:ErrorAction' = 'Stop' }
+    }
+
+
     Describe "Should -Be" {
         It "returns true if the 2 arguments are equal" {
             1 | Should -Be 1

--- a/Functions/Assertions/BeGreaterThan.Tests.ps1
+++ b/Functions/Assertions/BeGreaterThan.Tests.ps1
@@ -1,7 +1,7 @@
 Set-StrictMode -Version Latest
 
 BeforeAll {
-    $ErrorActionPreference = 'Stop'
+    $PSDefaultParameterValues = @{ 'Should:ErrorAction' = 'Stop' }
 }
 
 InModuleScope Pester {

--- a/Functions/Assertions/BeGreaterThan.Tests.ps1
+++ b/Functions/Assertions/BeGreaterThan.Tests.ps1
@@ -1,10 +1,11 @@
 Set-StrictMode -Version Latest
 
-BeforeAll {
-    $PSDefaultParameterValues = @{ 'Should:ErrorAction' = 'Stop' }
-}
-
 InModuleScope Pester {
+    
+    BeforeAll {
+        $PSDefaultParameterValues = @{ 'Should:ErrorAction' = 'Stop' }
+    }
+
     Describe "Should -BeGreaterThan" {
         It "passes if value greater than expected" {
             2 | Should -BeGreaterThan 1

--- a/Functions/Assertions/BeIn.Tests.ps1
+++ b/Functions/Assertions/BeIn.Tests.ps1
@@ -1,7 +1,7 @@
 Set-StrictMode -Version Latest
 
 BeforeAll {
-    $ErrorActionPreference = 'Stop'
+    $PSDefaultParameterValues = @{ 'Should:ErrorAction' = 'Stop' }
 }
 
 InModuleScope Pester {

--- a/Functions/Assertions/BeIn.Tests.ps1
+++ b/Functions/Assertions/BeIn.Tests.ps1
@@ -1,10 +1,11 @@
 Set-StrictMode -Version Latest
 
-BeforeAll {
-    $PSDefaultParameterValues = @{ 'Should:ErrorAction' = 'Stop' }
-}
-
 InModuleScope Pester {
+
+    BeforeAll {
+        $PSDefaultParameterValues = @{ 'Should:ErrorAction' = 'Stop' }
+    }
+
     Describe "Should -BeIn" {
         It "passes if value is in the collection" {
             'a' | Should -BeIn @(1, 'a', 3)

--- a/Functions/Assertions/BeLessThan.Tests.ps1
+++ b/Functions/Assertions/BeLessThan.Tests.ps1
@@ -1,7 +1,7 @@
 Set-StrictMode -Version Latest
 
 BeforeAll {
-    $ErrorActionPreference = 'Stop'
+    $PSDefaultParameterValues = @{ 'Should:ErrorAction' = 'Stop' }
 }
 
 InModuleScope Pester {

--- a/Functions/Assertions/BeLessThan.Tests.ps1
+++ b/Functions/Assertions/BeLessThan.Tests.ps1
@@ -1,10 +1,11 @@
 Set-StrictMode -Version Latest
 
-BeforeAll {
-    $PSDefaultParameterValues = @{ 'Should:ErrorAction' = 'Stop' }
-}
-
 InModuleScope Pester {
+
+    BeforeAll {
+        $PSDefaultParameterValues = @{ 'Should:ErrorAction' = 'Stop' }
+    }
+
     Describe "Should -BeLessThan" {
         It "passes if value is less than expected" {
             0 | Should -BeLessThan 1

--- a/Functions/Assertions/BeLike.Tests.ps1
+++ b/Functions/Assertions/BeLike.Tests.ps1
@@ -1,7 +1,7 @@
 Set-StrictMode -Version Latest
 
 BeforeAll {
-    $ErrorActionPreference = 'Stop'
+    $PSDefaultParameterValues = @{ 'Should:ErrorAction' = 'Stop' }
 }
 
 InModuleScope Pester {

--- a/Functions/Assertions/BeLike.Tests.ps1
+++ b/Functions/Assertions/BeLike.Tests.ps1
@@ -1,10 +1,11 @@
 Set-StrictMode -Version Latest
 
-BeforeAll {
-    $PSDefaultParameterValues = @{ 'Should:ErrorAction' = 'Stop' }
-}
-
 InModuleScope Pester {
+
+    BeforeAll {
+        $PSDefaultParameterValues = @{ 'Should:ErrorAction' = 'Stop' }
+    }
+
     Describe "Should -BeLike" {
         It "passes for things that are like wildcard" {
             "foobar" | Should -BeLike "*ob*"

--- a/Functions/Assertions/BeLikeExactly.Tests.ps1
+++ b/Functions/Assertions/BeLikeExactly.Tests.ps1
@@ -1,7 +1,7 @@
 Set-StrictMode -Version Latest
 
 BeforeAll {
-    $ErrorActionPreference = 'Stop'
+    $PSDefaultParameterValues = @{ 'Should:ErrorAction' = 'Stop' }
 }
 
 InModuleScope Pester {

--- a/Functions/Assertions/BeLikeExactly.Tests.ps1
+++ b/Functions/Assertions/BeLikeExactly.Tests.ps1
@@ -1,10 +1,11 @@
 Set-StrictMode -Version Latest
 
-BeforeAll {
-    $PSDefaultParameterValues = @{ 'Should:ErrorAction' = 'Stop' }
-}
-
 InModuleScope Pester {
+
+    BeforeAll {
+        $PSDefaultParameterValues = @{ 'Should:ErrorAction' = 'Stop' }
+    }
+
     Describe "Should -BeLikeExactly" {
         It "passes for things that are like wildcard" {
             "foobar" | Should -BeLikeExactly "*ob*"

--- a/Functions/Assertions/BeNullOrEmpty.Tests.ps1
+++ b/Functions/Assertions/BeNullOrEmpty.Tests.ps1
@@ -1,7 +1,7 @@
 Set-StrictMode -Version Latest
 
 BeforeAll {
-    $ErrorActionPreference = 'Stop'
+    $PSDefaultParameterValues = @{ 'Should:ErrorAction' = 'Stop' }
 }
 
 InModuleScope Pester {

--- a/Functions/Assertions/BeNullOrEmpty.Tests.ps1
+++ b/Functions/Assertions/BeNullOrEmpty.Tests.ps1
@@ -1,10 +1,11 @@
 Set-StrictMode -Version Latest
 
-BeforeAll {
-    $PSDefaultParameterValues = @{ 'Should:ErrorAction' = 'Stop' }
-}
-
 InModuleScope Pester {
+
+    BeforeAll {
+        $PSDefaultParameterValues = @{ 'Should:ErrorAction' = 'Stop' }
+    }
+
     Describe "Should -BeNullOrEmpty" {
         It "should return true if null" {
             $null | Should -BeNullOrEmpty

--- a/Functions/Assertions/BeOfType.Tests.ps1
+++ b/Functions/Assertions/BeOfType.Tests.ps1
@@ -1,10 +1,11 @@
 Set-StrictMode -Version Latest
 
-BeforeAll {
-    $PSDefaultParameterValues = @{ 'Should:ErrorAction' = 'Stop' }
-}
-
 InModuleScope Pester {
+
+    BeforeAll {
+        $PSDefaultParameterValues = @{ 'Should:ErrorAction' = 'Stop' }
+    }
+
     Describe "Should -BeOfType" {
         It "passes if value is of the expected type" {
             1 | Should -BeOfType Int

--- a/Functions/Assertions/BeOfType.Tests.ps1
+++ b/Functions/Assertions/BeOfType.Tests.ps1
@@ -1,7 +1,7 @@
 Set-StrictMode -Version Latest
 
 BeforeAll {
-    $ErrorActionPreference = 'Stop'
+    $PSDefaultParameterValues = @{ 'Should:ErrorAction' = 'Stop' }
 }
 
 InModuleScope Pester {

--- a/Functions/Assertions/BeTrueOrFalse.Tests.ps1
+++ b/Functions/Assertions/BeTrueOrFalse.Tests.ps1
@@ -1,7 +1,7 @@
 Set-StrictMode -Version Latest
 
 BeforeAll {
-    $ErrorActionPreference = 'Stop'
+    $PSDefaultParameterValues = @{ 'Should:ErrorAction' = 'Stop' }
 }
 
 InModuleScope Pester {

--- a/Functions/Assertions/BeTrueOrFalse.Tests.ps1
+++ b/Functions/Assertions/BeTrueOrFalse.Tests.ps1
@@ -1,10 +1,11 @@
 Set-StrictMode -Version Latest
 
-BeforeAll {
-    $PSDefaultParameterValues = @{ 'Should:ErrorAction' = 'Stop' }
-}
-
 InModuleScope Pester {
+
+    BeforeAll {
+        $PSDefaultParameterValues = @{ 'Should:ErrorAction' = 'Stop' }
+    }
+
     Describe "Should -BeTrue" {
         Context "Basic functionality" {
             It "given true it passes" {

--- a/Functions/Assertions/Contain.Tests.ps1
+++ b/Functions/Assertions/Contain.Tests.ps1
@@ -1,10 +1,11 @@
 Set-StrictMode -Version Latest
 
-BeforeAll {
-    $PSDefaultParameterValues = @{ 'Should:ErrorAction' = 'Stop' }
-}
-
 InModuleScope Pester {
+
+    BeforeAll {
+        $PSDefaultParameterValues = @{ 'Should:ErrorAction' = 'Stop' }
+    }
+
     Describe "Should -Contain" {
         It "passes if collection contains the value" {
             @(1, 'a', 3) | Should -Contain 'a'

--- a/Functions/Assertions/Contain.Tests.ps1
+++ b/Functions/Assertions/Contain.Tests.ps1
@@ -1,7 +1,7 @@
 Set-StrictMode -Version Latest
 
 BeforeAll {
-    $ErrorActionPreference = 'Stop'
+    $PSDefaultParameterValues = @{ 'Should:ErrorAction' = 'Stop' }
 }
 
 InModuleScope Pester {

--- a/Functions/Assertions/Exist.Tests.ps1
+++ b/Functions/Assertions/Exist.Tests.ps1
@@ -1,10 +1,11 @@
 Set-StrictMode -Version Latest
 
-BeforeAll {
-    $PSDefaultParameterValues = @{ 'Should:ErrorAction' = 'Stop' }
-}
-
 InModuleScope Pester {
+
+    BeforeAll {
+        $PSDefaultParameterValues = @{ 'Should:ErrorAction' = 'Stop' }
+    }
+
     Describe "Should -Exist" {
         It "returns true for paths that exist" {
             "TestDrive:\" | Should -Exist

--- a/Functions/Assertions/Exist.Tests.ps1
+++ b/Functions/Assertions/Exist.Tests.ps1
@@ -1,7 +1,7 @@
 Set-StrictMode -Version Latest
 
 BeforeAll {
-    $ErrorActionPreference = 'Stop'
+    $PSDefaultParameterValues = @{ 'Should:ErrorAction' = 'Stop' }
 }
 
 InModuleScope Pester {

--- a/Functions/Assertions/FileContentMatch.Tests.ps1
+++ b/Functions/Assertions/FileContentMatch.Tests.ps1
@@ -1,10 +1,11 @@
 ﻿Set-StrictMode -Version Latest
 
-BeforeAll {
-    $PSDefaultParameterValues = @{ 'Should:ErrorAction' = 'Stop' }
-}
-
 InModuleScope Pester {
+
+    BeforeAll {
+        $PSDefaultParameterValues = @{ 'Should:ErrorAction' = 'Stop' }
+    }
+
     Describe "Should -FileContentMatch" {
         Context "when testing file contents" {
             BeforeAll {

--- a/Functions/Assertions/FileContentMatch.Tests.ps1
+++ b/Functions/Assertions/FileContentMatch.Tests.ps1
@@ -1,7 +1,7 @@
 ﻿Set-StrictMode -Version Latest
 
 BeforeAll {
-    $ErrorActionPreference = 'Stop'
+    $PSDefaultParameterValues = @{ 'Should:ErrorAction' = 'Stop' }
 }
 
 InModuleScope Pester {

--- a/Functions/Assertions/FileContentMatchExactly.Tests.ps1
+++ b/Functions/Assertions/FileContentMatchExactly.Tests.ps1
@@ -1,7 +1,7 @@
 ﻿Set-StrictMode -Version Latest
 
 BeforeAll {
-    $ErrorActionPreference = 'Stop'
+    $PSDefaultParameterValues = @{ 'Should:ErrorAction' = 'Stop' }
 }
 
 InModuleScope Pester {

--- a/Functions/Assertions/FileContentMatchExactly.Tests.ps1
+++ b/Functions/Assertions/FileContentMatchExactly.Tests.ps1
@@ -1,10 +1,11 @@
 ﻿Set-StrictMode -Version Latest
 
-BeforeAll {
-    $PSDefaultParameterValues = @{ 'Should:ErrorAction' = 'Stop' }
-}
-
 InModuleScope Pester {
+
+    BeforeAll {
+        $PSDefaultParameterValues = @{ 'Should:ErrorAction' = 'Stop' }
+    }
+
     Describe "Should -FileContentMatchExactly" {
         Context "when testing file contents" {
             BeforeAll {

--- a/Functions/Assertions/FileContentMatchMultiline.Tests.ps1
+++ b/Functions/Assertions/FileContentMatchMultiline.Tests.ps1
@@ -1,7 +1,7 @@
 Set-StrictMode -Version Latest
 
 BeforeAll {
-    $ErrorActionPreference = 'Stop'
+    $PSDefaultParameterValues = @{ 'Should:ErrorAction' = 'Stop' }
 }
 
 InModuleScope Pester {

--- a/Functions/Assertions/FileContentMatchMultiline.Tests.ps1
+++ b/Functions/Assertions/FileContentMatchMultiline.Tests.ps1
@@ -1,10 +1,11 @@
 Set-StrictMode -Version Latest
 
-BeforeAll {
-    $PSDefaultParameterValues = @{ 'Should:ErrorAction' = 'Stop' }
-}
-
 InModuleScope Pester {
+
+    BeforeAll {
+        $PSDefaultParameterValues = @{ 'Should:ErrorAction' = 'Stop' }
+    }
+
     Describe "Should -FileContentMatchMultiline" {
         Context "when testing file contents" {
             BeforeAll {

--- a/Functions/Assertions/HaveCount.Tests.ps1
+++ b/Functions/Assertions/HaveCount.Tests.ps1
@@ -1,7 +1,7 @@
 Set-StrictMode -Version Latest
 
 BeforeAll {
-    $ErrorActionPreference = 'Stop'
+    $PSDefaultParameterValues = @{ 'Should:ErrorAction' = 'Stop' }
 }
 
 InModuleScope Pester {

--- a/Functions/Assertions/HaveCount.Tests.ps1
+++ b/Functions/Assertions/HaveCount.Tests.ps1
@@ -1,10 +1,11 @@
 Set-StrictMode -Version Latest
 
-BeforeAll {
-    $PSDefaultParameterValues = @{ 'Should:ErrorAction' = 'Stop' }
-}
-
 InModuleScope Pester {
+
+    BeforeAll {
+        $PSDefaultParameterValues = @{ 'Should:ErrorAction' = 'Stop' }
+    }
+
     Describe "Should -HaveCount" {
         It "passes if collection has the expected amount of items" {
             @(1, 'a', 3) | Should -HaveCount 3

--- a/Functions/Assertions/HaveParameter.Tests.ps1
+++ b/Functions/Assertions/HaveParameter.Tests.ps1
@@ -1,10 +1,10 @@
 Set-StrictMode -Version Latest
 
-BeforeAll {
-    $PSDefaultParameterValues = @{ 'Should:ErrorAction' = 'Stop' }
-}
-
 InModuleScope Pester {
+
+    BeforeAll {
+        $PSDefaultParameterValues = @{ 'Should:ErrorAction' = 'Stop' }
+    }
 
     BeforeAll {
         $functionsBlock = {

--- a/Functions/Assertions/HaveParameter.Tests.ps1
+++ b/Functions/Assertions/HaveParameter.Tests.ps1
@@ -1,7 +1,7 @@
 Set-StrictMode -Version Latest
 
 BeforeAll {
-    $ErrorActionPreference = 'Stop'
+    $PSDefaultParameterValues = @{ 'Should:ErrorAction' = 'Stop' }
 }
 
 InModuleScope Pester {

--- a/Functions/Assertions/Match.Tests.ps1
+++ b/Functions/Assertions/Match.Tests.ps1
@@ -1,7 +1,7 @@
 Set-StrictMode -Version Latest
 
 BeforeAll {
-    $ErrorActionPreference = 'Stop'
+    $PSDefaultParameterValues = @{ 'Should:ErrorAction' = 'Stop' }
 }
 
 InModuleScope Pester {

--- a/Functions/Assertions/Match.Tests.ps1
+++ b/Functions/Assertions/Match.Tests.ps1
@@ -1,10 +1,11 @@
 Set-StrictMode -Version Latest
 
-BeforeAll {
-    $PSDefaultParameterValues = @{ 'Should:ErrorAction' = 'Stop' }
-}
-
 InModuleScope Pester {
+
+    BeforeAll {
+        $PSDefaultParameterValues = @{ 'Should:ErrorAction' = 'Stop' }
+    }
+
     Describe "Should -Match" {
         It "returns true for things that match" {
             'foobar' | Should -Match 'ob'

--- a/Functions/Assertions/MatchExactly.Tests.ps1
+++ b/Functions/Assertions/MatchExactly.Tests.ps1
@@ -1,7 +1,7 @@
 Set-StrictMode -Version Latest
 
 BeforeAll {
-    $ErrorActionPreference = 'Stop'
+    $PSDefaultParameterValues = @{ 'Should:ErrorAction' = 'Stop' }
 }
 
 InModuleScope Pester {

--- a/Functions/Assertions/MatchExactly.Tests.ps1
+++ b/Functions/Assertions/MatchExactly.Tests.ps1
@@ -1,10 +1,11 @@
 Set-StrictMode -Version Latest
 
-BeforeAll {
-    $PSDefaultParameterValues = @{ 'Should:ErrorAction' = 'Stop' }
-}
-
 InModuleScope Pester {
+
+    BeforeAll {
+        $PSDefaultParameterValues = @{ 'Should:ErrorAction' = 'Stop' }
+    }
+
     Describe "Should -MatchExactly" {
         It "returns true for things that match exactly" {
             'foobar' | Should -MatchExactly 'ob'

--- a/Functions/Assertions/PesterThrow.Tests.ps1
+++ b/Functions/Assertions/PesterThrow.Tests.ps1
@@ -1,7 +1,7 @@
 Set-StrictMode -Version Latest
 
 BeforeAll {
-    $ErrorActionPreference = 'Stop'
+    $PSDefaultParameterValues = @{ 'Should:ErrorAction' = 'Stop' }
 }
 
 InModuleScope Pester {

--- a/Functions/Assertions/PesterThrow.Tests.ps1
+++ b/Functions/Assertions/PesterThrow.Tests.ps1
@@ -1,10 +1,11 @@
 Set-StrictMode -Version Latest
 
-BeforeAll {
-    $PSDefaultParameterValues = @{ 'Should:ErrorAction' = 'Stop' }
-}
-
 InModuleScope Pester {
+
+    BeforeAll {
+        $PSDefaultParameterValues = @{ 'Should:ErrorAction' = 'Stop' }
+    }
+
     Describe "Should -Throw" {
         Context "Basic functionality" {
             It "given scriptblock that throws an exception it passes" {

--- a/Functions/Mock.Tests.ps1
+++ b/Functions/Mock.Tests.ps1
@@ -1,6 +1,6 @@
 ﻿Set-StrictMode -Version Latest
 BeforeAll {
-    $ErrorActionPreference = 'Stop'
+    $PSDefaultParameterValues = @{ 'Should:ErrorAction' = 'Stop' }
     function FunctionUnderTest {
         [CmdletBinding()]
         param (

--- a/Functions/Output.Tests.ps1
+++ b/Functions/Output.Tests.ps1
@@ -1,7 +1,7 @@
 ﻿Set-StrictMode -Version Latest
 
 BeforeAll {
-    $ErrorActionPreference = 'Stop'
+    $PSDefaultParameterValues = @{ 'Should:ErrorAction' = 'Stop' }
 }
 
 InModuleScope -ModuleName Pester -ScriptBlock {

--- a/Pester.psd1
+++ b/Pester.psd1
@@ -51,6 +51,7 @@
         'Get-ShouldOperator'
         'Export-NUnitReport'
         'ConvertTo-NUnitReport'
+        'New-PesterConfiguration'
 
 
         # Gherkin Support:

--- a/Pester.psm1
+++ b/Pester.psm1
@@ -661,9 +661,23 @@ function Invoke-Pester {
         $Output = 'Normal',
 
         [Parameter(ParameterSetName = "Simple")]
-        [ScriptBlock[]] $ScriptBlock
+        [ScriptBlock[]] $ScriptBlock,
+
+        [Parameter(ParameterSetName = "Simple")] #TODO, move this to Advanced and make sure that everything from the simple parameter set is translated to the Configuration object
+        $Configuration
     )
     begin {
+        $defaultConfig = New-PesterConfiguration
+        $Configuration = if (-not $Configuration) {
+            $defaultConfig
+        }
+        else {
+            #TODO: merge the user provided config with ours, but for the moment we can assume the user provided the whole object and just modified what they like
+            ## Merge-Configuration -DefaultConfiguration $defaultConfig -Configuration $Configuration
+            $Configuration
+        }
+
+
         $start = [DateTime]::Now
         if ($CI) {
             $EnableExit = $true
@@ -745,7 +759,7 @@ function Invoke-Pester {
                 return
             }
 
-            $r = Pester.Runtime\Invoke-Test -BlockContainer $containers -Plugin $plugins -PluginConfiguration $pluginConfiguration -SessionState $sessionState -Filter $filter
+            $r = Pester.Runtime\Invoke-Test -BlockContainer $containers -Plugin $plugins -PluginConfiguration $pluginConfiguration -SessionState $sessionState -Filter $filter -Configuration $Configuration
 
             foreach ($c in $r) {
                 Fold-Container -Container $c  -OnTest { param($t) Add-RSpecTestObjectProperties $t }
@@ -1084,4 +1098,4 @@ $SafeCommands['Set-DynamicParameterVariable'] = $ExecutionContext.SessionState.I
 & $script:SafeCommands['Export-ModuleMember'] New-PesterOptions
 # & $script:SafeCommands['Export-ModuleMember'] Invoke-Gherkin, Find-GherkinStep, BeforeEachFeature, BeforeEachScenario, AfterEachFeature, AfterEachScenario, GherkinStep -Alias Given, When, Then, And, But
 & $script:SafeCommands['Export-ModuleMember'] New-MockObject, Add-ShouldOperator, Get-ShouldOperator
-& $script:SafeCommands['Export-ModuleMember'] Export-NunitReport, ConvertTo-NUnitReport
+& $script:SafeCommands['Export-ModuleMember'] Export-NunitReport, ConvertTo-NUnitReport, New-PesterConfiguration

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
       - powershell: |
           $global:PesterDebugPreference = @{ ShowFullErrors = $true }
-          $errorActionPreference = 'stop'
+          $ErrorActionPreference = 'Stop'
           Set-StrictMode -Version Latest
           $env:CI = 1
           $r = Get-ChildItem *.ts.ps1 -Recurse | foreach { & $_.FullName -PassThru }

--- a/new-runtimepoc/Pester.RSpec.ps1
+++ b/new-runtimepoc/Pester.RSpec.ps1
@@ -183,6 +183,9 @@ function Get-RSpecObjectDecoratorPlugin () {
 }
 
 function New-PesterConfiguration {
+    [CmdletBinding()]
+    param()
+
     New_PSObject -Type "PesterConfiguration" @{
         Should = New_PSObject -Type "PesterShouldConfiguration" @{
             ErrorAction = 'Continue'

--- a/new-runtimepoc/Pester.RSpec.ps1
+++ b/new-runtimepoc/Pester.RSpec.ps1
@@ -181,3 +181,11 @@ function Get-RSpecObjectDecoratorPlugin () {
         Add-RSpecTestObjectProperties $Context.Test
     }
 }
+
+function New-PesterConfiguration {
+    New_PSObject -Type "PesterConfiguration" @{
+        Should = New_PSObject -Type "PesterShouldConfiguration" @{
+            ErrorAction = 'Continue'
+        }
+    }
+}

--- a/new-runtimepoc/Pester.RSpec.ts.ps1
+++ b/new-runtimepoc/Pester.RSpec.ts.ps1
@@ -229,31 +229,31 @@ i -PassThru:$PassThru {
                 $result | Verify-NotNull
             }
 
-            t "CI generates code coverage and xml output" {
-                $temp = [IO.Path]::GetTempPath()
-                $path = "$temp/$([Guid]::NewGuid().Guid)"
-                $pesterPath = (Get-Module Pester).Path
+            # t "CI generates code coverage and xml output" {
+            #     $temp = [IO.Path]::GetTempPath()
+            #     $path = "$temp/$([Guid]::NewGuid().Guid)"
+            #     $pesterPath = (Get-Module Pester).Path
 
-                try {
-                    New-Item -Path $path -ItemType Container | Out-Null
+            #     try {
+            #         New-Item -Path $path -ItemType Container | Out-Null
 
-                    $job = Start-Job {
-                        param ($PesterPath, $File, $Path)
-                        Import-Module $PesterPath
-                        Set-Location $Path
-                        Invoke-Pester $File -CI -Output None
-                    } -ArgumentList $pesterPath, $file1, $path
+            #         $job = Start-Job {
+            #             param ($PesterPath, $File, $Path)
+            #             Import-Module $PesterPath
+            #             Set-Location $Path
+            #             Invoke-Pester $File -CI -Output None
+            #         } -ArgumentList $pesterPath, $file1, $path
 
-                    $job | Wait-Job
+            #         $job | Wait-Job
 
 
-                    Test-Path "$path/testResults.xml" | Verify-True
-                    Test-Path "$path/coverage.xml" | Verify-True
-                }
-                finally {
-                    Remove-Item -Recurse -Force $path
-                }
-            }
+            #         Test-Path "$path/testResults.xml" | Verify-True
+            #         Test-Path "$path/coverage.xml" | Verify-True
+            #     }
+            #     finally {
+            #         Remove-Item -Recurse -Force $path
+            #     }
+            # }
         }
         finally {
             cd $path

--- a/new-runtimepoc/Pester.RSpec.ts.ps1
+++ b/new-runtimepoc/Pester.RSpec.ts.ps1
@@ -229,7 +229,7 @@ i -PassThru:$PassThru {
                 $result | Verify-NotNull
             }
 
-            d "CI generates code coverage and xml output" {
+            t "CI generates code coverage and xml output" {
                 $temp = [IO.Path]::GetTempPath()
                 $path = "$temp/$([Guid]::NewGuid().Guid)"
                 $pesterPath = (Get-Module Pester).Path

--- a/new-runtimepoc/Pester.Runtime.ResultObject.ts.ps1
+++ b/new-runtimepoc/Pester.Runtime.ResultObject.ts.ps1
@@ -20,7 +20,7 @@ $global:PesterDebugPreference = @{
 
 
 Set-StrictMode -Version Latest
-$ErrorActionPreference = 'stop'
+$ErrorActionPreference = 'Stop'
 
 i -PassThru:$PassThru {
     b "Counting tests" {

--- a/new-runtimepoc/Pester.Runtime.ts.ps1
+++ b/new-runtimepoc/Pester.Runtime.ts.ps1
@@ -50,7 +50,7 @@ function Verify-TestFailed {
 
 
 Set-StrictMode -Version Latest
-$ErrorActionPreference = 'stop'
+$ErrorActionPreference = 'Stop'
 
 i -PassThru:$PassThru {
 

--- a/new-runtimepoc/ReloadAndInvokePester.ps1
+++ b/new-runtimepoc/ReloadAndInvokePester.ps1
@@ -23,7 +23,7 @@ $path = "~/Pester"
 # $path = "C:\projects\pester_main\Functions\Coverage.Tests.ps1"
 $path = "C:\projects\pester_main\Functions\Output.Tests.ps1"
 cd c:\temp\cc
-$path = "C:\projects\pester_main\Functions\Assertions"
+$path = "C:\projects\pester_main\Functions\Mock.Tests.ps1"
 
 
 Set-StrictMode -Version Latest

--- a/new-runtimepoc/ReloadAndInvokePester.ps1
+++ b/new-runtimepoc/ReloadAndInvokePester.ps1
@@ -23,7 +23,7 @@ $path = "~/Pester"
 # $path = "C:\projects\pester_main\Functions\Coverage.Tests.ps1"
 $path = "C:\projects\pester_main\Functions\Output.Tests.ps1"
 cd c:\temp\cc
-$path = "C:\temp\cc"
+$path = "C:\projects\pester_main\Functions\Assertions"
 
 
 Set-StrictMode -Version Latest


### PR DESCRIPTION

Stop using the global ErrorActionPreference to force Should to fail, use
default parameter value instead to give us flexibility to only fail Should 
and not all remaining code. 

Add some basic configuration to Pester.

Fixes #1404

