### PR TITLE
Throw on should failure in mock parameter filter

### DIFF
--- a/Functions/Assertions/Should.ps1
+++ b/Functions/Assertions/Should.ps1
@@ -98,8 +98,12 @@ function Should {
             }
             else {
                 if ($null -eq $shouldThrow) {
-                    # ErrorAction was not specified explictily, figure out what to do from the configuration
-                    $shouldThrow = 'Stop' -eq $pesterRuntimeInvocationContext.Configuration.Should.ErrorAction.Value
+                    if ($null -ne $PSCmdlet.SessionState.PSVariable.GetValue('______isInMockParameterFilter')) {
+                        $shouldThrow = $true
+                    } else {
+                        # ErrorAction was not specified explictily, figure out what to do from the configuration
+                        $shouldThrow = 'Stop' -eq $pesterRuntimeInvocationContext.Configuration.Should.ErrorAction.Value
+                    }
                 }
 
                 # here the $ShouldThrow is set from one of multiple places, either as override from -ErrorAction or
@@ -152,8 +156,6 @@ function Invoke-Assertion {
         [System.Collections.IDictionary]
         $BoundParameters,
 
-        [Parameter(Mandatory)]
-        [ValidateNotNullOrEmpty()]
         [string]
         $File,
 

--- a/Functions/Mock.ps1
+++ b/Functions/Mock.ps1
@@ -1066,8 +1066,10 @@ function Test-ParameterFilter {
 
     $paramBlock = Get-ParamBlockFromBoundParameters -BoundParameters $BoundParameters -Metadata $Metadata
 
+    #TODO: a hacky solution to make Should throw on failure in Mock ParameterFilter, to make it good enough for the first release $______isInMockParameterFilter
     $scriptBlockString = "
         $paramBlock
+        `$______isInMockParameterFilter = `$true
 
         Set-StrictMode -Off
         $ScriptBlock


### PR DESCRIPTION
Forces should to fail on assertion failure when in mock param filter irrespective of Should preference to keep scenario that throws in ParameterFilters working.

Partial fix #1409