### PR TITLE
Handle the case when the failure message contains an escape sequence

### DIFF
--- a/Functions/TestResults.Tests.ps1
+++ b/Functions/TestResults.Tests.ps1
@@ -45,7 +45,7 @@ InModuleScope Pester {
                 $TestResults = New-PesterState -Path TestDrive:\
                 $testResults.EnterTestGroup('Mocked Describe', 'Describe')
                 $time = [TimeSpan]25000000 #2.5 seconds
-                $TestResults.AddTestResult("Failed testcase", 'Failed', $time, "Assert failed: ""Expected: `e[34mTest`e[0m. But was: Testing""", 'at line: 28 in  C:\Pester\Result.Tests.ps1')
+                $TestResults.AddTestResult("Failed testcase", 'Failed', $time, "Assert failed: ""Expected: ``[34mTest``[0m. But was: Testing""", 'at line: 28 in  C:\Pester\Result.Tests.ps1')
 
                 #export and validate the file
                 [String]$testFile = "$TestDrive{0}Results{0}Tests.xml" -f [System.IO.Path]::DirectorySeparatorChar

--- a/Functions/TestResults.Tests.ps1
+++ b/Functions/TestResults.Tests.ps1
@@ -40,6 +40,25 @@ InModuleScope Pester {
                 $xmlTestCase.failure.'stack-trace' | Should -Be 'at line: 28 in  C:\Pester\Result.Tests.ps1'
             }
 
+            It "should write a failed test result when the failure message has an escape character" {
+                #create state
+                $TestResults = New-PesterState -Path TestDrive:\
+                $testResults.EnterTestGroup('Mocked Describe', 'Describe')
+                $time = [TimeSpan]25000000 #2.5 seconds
+                $TestResults.AddTestResult("Failed testcase", 'Failed', $time, "Assert failed: ""Expected: `e[34mTest`e[0m. But was: Testing""", 'at line: 28 in  C:\Pester\Result.Tests.ps1')
+
+                #export and validate the file
+                [String]$testFile = "$TestDrive{0}Results{0}Tests.xml" -f [System.IO.Path]::DirectorySeparatorChar
+                Export-XmlReport $testResults $testFile 'NUnitXml'
+                $xmlResult = [xml] (Get-Content $testFile)
+                $xmlTestCase = $xmlResult.'test-results'.'test-suite'.'results'.'test-suite'.'results'.'test-case'
+                $xmlTestCase.name | Should -Be "Mocked Describe.Failed testcase"
+                $xmlTestCase.result | Should -Be "Failure"
+                $xmlTestCase.time | Should -Be "2.5"
+                $xmlTestCase.failure.message | Should -Be 'Assert failed: "Expected: &27;[34mTest&27;[0m. But was: Testing"'
+                $xmlTestCase.failure.'stack-trace' | Should -Be 'at line: 28 in  C:\Pester\Result.Tests.ps1'
+            }
+
             It "should log the reason for a skipped test when provided" {
                 $message = "skipped for reasons"
                 $TestResults = New-PesterState -Path TestDrive:\

--- a/Functions/TestResults.Tests.ps1
+++ b/Functions/TestResults.Tests.ps1
@@ -45,7 +45,8 @@ InModuleScope Pester {
                 $TestResults = New-PesterState -Path TestDrive:\
                 $testResults.EnterTestGroup('Mocked Describe', 'Describe')
                 $time = [TimeSpan]25000000 #2.5 seconds
-                $TestResults.AddTestResult("Failed testcase", 'Failed', $time, "Assert failed: ""Expected: ``[34mTest``[0m. But was: Testing""", 'at line: 28 in  C:\Pester\Result.Tests.ps1')
+                $escape = [string][char]27 # escape, also `e in PowerShell 6+
+                $TestResults.AddTestResult("Failed testcase", 'Failed', $time, "Assert failed: ""Expected: $escape[34mTest$escape[0m. But was: Testing""", 'at line: 28 in  C:\Pester\Result.Tests.ps1')
 
                 #export and validate the file
                 [String]$testFile = "$TestDrive{0}Results{0}Tests.xml" -f [System.IO.Path]::DirectorySeparatorChar

--- a/Functions/TestResults.ps1
+++ b/Functions/TestResults.ps1
@@ -588,9 +588,9 @@ function Write-NUnitTestCaseAttributes($TestResult, [System.Xml.XmlWriter] $XmlW
             $XmlWriter.WriteAttributeString('result', 'Failure')
             $XmlWriter.WriteAttributeString('executed', 'True')
             $XmlWriter.WriteStartElement('failure')
-            # manually replace ` with &27 to avoid breaking output when error contains escape sign
-            # for example in powershell 7
-            $xmlWriter.WriteElementString('message', $TestResult.FailureMessage.Replace('`','&27;'))
+            # manually replace Escape character (escape meaning "Escape key", not escape sequence "`")
+            # with &27 to avoid breaking serialized output when error contains it
+            $xmlWriter.WriteElementString('message', $TestResult.FailureMessage.Replace([string][char]27,'&27;'))
             $XmlWriter.WriteElementString('stack-trace', $TestResult.StackTrace)
             $XmlWriter.WriteEndElement() # Close failure tag
             break

--- a/Functions/TestResults.ps1
+++ b/Functions/TestResults.ps1
@@ -588,7 +588,7 @@ function Write-NUnitTestCaseAttributes($TestResult, [System.Xml.XmlWriter] $XmlW
             $XmlWriter.WriteAttributeString('result', 'Failure')
             $XmlWriter.WriteAttributeString('executed', 'True')
             $XmlWriter.WriteStartElement('failure')
-            $xmlWriter.WriteElementString('message', $TestResult.FailureMessage)
+            $xmlWriter.WriteElementString('message', $TestResult.FailureMessage.Replace("`e",'&27;'))
             $XmlWriter.WriteElementString('stack-trace', $TestResult.StackTrace)
             $XmlWriter.WriteEndElement() # Close failure tag
             break

--- a/Functions/TestResults.ps1
+++ b/Functions/TestResults.ps1
@@ -588,7 +588,9 @@ function Write-NUnitTestCaseAttributes($TestResult, [System.Xml.XmlWriter] $XmlW
             $XmlWriter.WriteAttributeString('result', 'Failure')
             $XmlWriter.WriteAttributeString('executed', 'True')
             $XmlWriter.WriteStartElement('failure')
-            $xmlWriter.WriteElementString('message', $TestResult.FailureMessage.Replace("`e",'&27;'))
+            # manually replace ` with &27 to avoid breaking output when error contains escape sign
+            # for example in powershell 7
+            $xmlWriter.WriteElementString('message', $TestResult.FailureMessage.Replace('`','&27;'))
             $XmlWriter.WriteElementString('stack-trace', $TestResult.StackTrace)
             $XmlWriter.WriteEndElement() # Close failure tag
             break


### PR DESCRIPTION

…which may occur with PowerShell 7

<!--

Thank you for contributing to Pester! Please provide a descriptive title of the pull request in the field 'Title'.

-->

## 1. General summary of the pull request

If the failure message contains an escape sequence (which can happen with PowerShell 7, and the results are going to be serialized to an Nunit file, you may see something like this:
```
MethodInvocationException: /Users/jimtru/src/github/forks/JamesWTruher/Pester/Functions/TestResults.ps1
Line |
 591 |             $xmlWriter.WriteElementString('message', $TestResult.FailureMessage)
     |             ^ Exception calling "WriteElementString" with "2" argument(s): "', hexadecimal value 0x1B, is an invalid character."

```

and the xml file created is partial. The escape in the message is not valid for serialization
<!--

Please describe what your pull request fixes, or how it improves Pester.

If your pull request resolves a reported issue, please mention it by using  `Fix #<issue_number>` on a new line, this will close the linked issue automatically when this PR is merged. For more info see: [Closing issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/).

If your pull request integrates Pester with another system, please tell us how the change can be tested.

Please remember to update [the Pester wiki](https://github.com/pester/Pester/wiki) if needed.

Before you continue, please review [Contributing to Pester](https://github.com/pester/Pester/wiki/Contributing-to-Pester) and [Development rules - technical](https://github.com/pester/Pester/wiki/Developement-rules---technical).

Our continuous integration system doesn't send any notifications about failed tests. Please return to the opened pull request (after ~60 minutes) to check if is everything OK.

-->

This escapes the escape character ([char]27) to `&27;`