### PR TITLE
Fix Get-Help links

### DIFF
--- a/Functions/Assertions/Set-TestInconclusive.ps1
+++ b/Functions/Assertions/Set-TestInconclusive.ps1
@@ -30,7 +30,7 @@ function Set-TestInconclusive {
     ```
 
     .LINK
-    https://github.com/pester/Pester/wiki/Set%E2%80%90TestInconclusive
+    https://pester.dev/docs/commands/Set-TestInconclusive
 #>
     [CmdletBinding()]
     param (

--- a/Functions/Assertions/Set-TestInconclusive.ps1
+++ b/Functions/Assertions/Set-TestInconclusive.ps1
@@ -29,8 +29,6 @@ function Set-TestInconclusive {
         [?] My test, is inconclusive because we forced it to be inconclusive 58ms
     ```
 
-    .LINK
-    https://pester.dev/docs/commands/Set-TestInconclusive
 #>
     [CmdletBinding()]
     param (

--- a/Functions/Assertions/Should.ps1
+++ b/Functions/Assertions/Should.ps1
@@ -66,14 +66,6 @@ function Should {
     need to be verified. Each Should keywords need to be located in a new line.
     Test will be passed only when all assertion will be met (logical conjuction).
 
-    .LINK
-    https://pester.dev/docs/commands/Should
-
-    .LINK
-    about_Should
-
-	.LINK
-    about_Pester
 #>
 
     [CmdletBinding(DefaultParameterSetName = 'Legacy')]

--- a/Functions/Assertions/Should.ps1
+++ b/Functions/Assertions/Should.ps1
@@ -67,10 +67,12 @@ function Should {
     Test will be passed only when all assertion will be met (logical conjuction).
 
     .LINK
-    https://github.com/pester/Pester/wiki/Should
+    https://pester.dev/docs/commands/Should
 
     .LINK
     about_Should
+
+	.LINK
     about_Pester
 #>
 

--- a/Functions/Context.ps1
+++ b/Functions/Context.ps1
@@ -43,28 +43,25 @@ Describe "Add-Numbers" {
 ```
 
 .LINK
-https://pester.dev/docs/commands/Context
+https://pester.dev/docs/commands/Describe
 
 .LINK
-Describe
+https://pester.dev/docs/commands/It
 
 .LINK
-It
+https://pester.dev/docs/commands/BeforeEach
 
 .LINK
-BeforeEach
+https://pester.dev/docs/commands/AfterEach
 
 .LINK
-AfterEach
+https://pester.dev/docs/commands/Should
 
 .LINK
-about_Should
+https://pester.dev/docs/usage/mocking
 
 .LINK
-about_Mocking
-
-.LINK
-about_TestDrive
+https://pester.dev/docs/usage/testdrive
 
 #>
     param(

--- a/Functions/Context.ps1
+++ b/Functions/Context.ps1
@@ -43,15 +43,27 @@ Describe "Add-Numbers" {
 ```
 
 .LINK
-https://github.com/pester/Pester/wiki/Context
+https://pester.dev/docs/commands/Context
 
 .LINK
 Describe
+
+.LINK
 It
+
+.LINK
 BeforeEach
+
+.LINK
 AfterEach
+
+.LINK
 about_Should
+
+.LINK
 about_Mocking
+
+.LINK
 about_TestDrive
 
 #>

--- a/Functions/Describe.ps1
+++ b/Functions/Describe.ps1
@@ -54,25 +54,22 @@ Describe "Add-Numbers" {
 ```
 
 .LINK
-https://pester.dev/docs/commands/Describe
+https://pester.dev/docs/commands/It
 
 .LINK
-It
+https://pester.dev/docs/commands/Context
 
 .LINK
-Context
+https://pester.dev/docs/commands/Invoke-Pester
 
 .LINK
-Invoke-Pester
+https://pester.dev/docs/commands/Should
 
 .LINK
-about_Should
+https://pester.dev/docs/usage/mocking
 
 .LINK
-about_Mocking
-
-.LINK
-about_TestDrive
+https://pester.dev/docs/usage/testdrive
 
 #>
 

--- a/Functions/Describe.ps1
+++ b/Functions/Describe.ps1
@@ -54,11 +54,24 @@ Describe "Add-Numbers" {
 ```
 
 .LINK
+https://pester.dev/docs/commands/Describe
+
+.LINK
 It
+
+.LINK
 Context
+
+.LINK
 Invoke-Pester
+
+.LINK
 about_Should
+
+.LINK
 about_Mocking
+
+.LINK
 about_TestDrive
 
 #>

--- a/Functions/Get-ShouldOperator.ps1
+++ b/Functions/Get-ShouldOperator.ps1
@@ -26,7 +26,9 @@ function Get-ShouldOperator {
     -Name is a dynamic parameter that tab completes all available options.
 
     .LINK
-    https://github.com/Pester/Pester
+    https://pester.dev/docs/commands/Get-ShouldOperator
+
+	.LINK
     about_Should
     #>
     [CmdletBinding()]

--- a/Functions/Get-ShouldOperator.ps1
+++ b/Functions/Get-ShouldOperator.ps1
@@ -24,12 +24,10 @@ function Get-ShouldOperator {
     Get-ShouldOperator -Name Be
     Return help examples for the Be assertion operator.
     -Name is a dynamic parameter that tab completes all available options.
-
-    .LINK
-    https://pester.dev/docs/commands/Get-ShouldOperator
-
+	    
 	.LINK
-    about_Should
+    https://pester.dev/docs/commands/Should
+
     #>
     [CmdletBinding()]
     param ()

--- a/Functions/Gherkin.ps1
+++ b/Functions/Gherkin.ps1
@@ -182,6 +182,8 @@ function Invoke-Gherkin {
         .LINK
             Invoke-Pester
             https://kevinmarquette.github.io/2017-03-17-Powershell-Gherkin-specification-validation/
+
+		.LINK
             https://kevinmarquette.github.io/2017-04-30-Powershell-Gherkin-advanced-features/
     #>
     [CmdletBinding(DefaultParameterSetName = 'Default')]

--- a/Functions/GherkinHook.ps1
+++ b/Functions/GherkinHook.ps1
@@ -17,7 +17,11 @@ function BeforeEachFeature {
 
         .LINK
         AfterEachFeature
+
+		.LINK
         BeforeEachScenario
+
+		.LINK
         AfterEachScenario
     #>
     [CmdletBinding(DefaultParameterSetName = "All")]
@@ -58,9 +62,13 @@ function AfterEachFeature {
         The ScriptBlock to run for the hook
 
         .LINK
-            BeforeEachFeature
-            BeforeEachScenario
-            AfterEachScenario
+        BeforeEachFeature
+
+		.LINK
+        BeforeEachScenario
+
+		.LINK
+        AfterEachScenario
     #>
     [CmdletBinding(DefaultParameterSetName = "All")]
     param(
@@ -103,7 +111,11 @@ function BeforeEachScenario {
 
         .LINK
         AfterEachFeature
+
+		.LINK
         BeforeEachScenario
+
+		.LINK
         AfterEachScenario
     #>
     [CmdletBinding(DefaultParameterSetName = "All")]
@@ -144,9 +156,13 @@ function AfterEachScenario {
         The ScriptBlock to run for the hook
 
         .LINK
-            BeforeEachFeature
-            BeforeEachScenario
-            AfterEachScenario
+        BeforeEachFeature
+            
+		.LINK
+		BeforeEachScenario
+
+		.LINK
+        AfterEachScenario
     #>
     [CmdletBinding(DefaultParameterSetName = "All")]
     param(

--- a/Functions/GherkinHook.ps1
+++ b/Functions/GherkinHook.ps1
@@ -16,13 +16,13 @@ function BeforeEachFeature {
         The ScriptBlock to run for the hook
 
         .LINK
-        AfterEachFeature
+        https://pester.dev/docs/commands/AfterEachFeature
 
 		.LINK
-        BeforeEachScenario
+        https://pester.dev/docs/commands/BeforeEachScenario
 
 		.LINK
-        AfterEachScenario
+        https://pester.dev/docs/commands/AfterEachScenario
     #>
     [CmdletBinding(DefaultParameterSetName = "All")]
     param(
@@ -62,13 +62,13 @@ function AfterEachFeature {
         The ScriptBlock to run for the hook
 
         .LINK
-        BeforeEachFeature
+        https://pester.dev/docs/commands/BeforeEachFeature
 
 		.LINK
-        BeforeEachScenario
+        https://pester.dev/docs/commands/BeforeEachScenario
 
 		.LINK
-        AfterEachScenario
+        https://pester.dev/docs/commands/AfterEachScenario
     #>
     [CmdletBinding(DefaultParameterSetName = "All")]
     param(
@@ -109,14 +109,15 @@ function BeforeEachScenario {
         .PARAMETER Script
         The ScriptBlock to run for the hook
 
+		.LINK
+        https://pester.dev/docs/commands/AfterEachScenario
+
+		.LINK
+        https://pester.dev/docs/commands/BeforeEachFeature
+
         .LINK
-        AfterEachFeature
+        https://pester.dev/docs/commands/AfterEachFeature
 
-		.LINK
-        BeforeEachScenario
-
-		.LINK
-        AfterEachScenario
     #>
     [CmdletBinding(DefaultParameterSetName = "All")]
     param(
@@ -155,14 +156,14 @@ function AfterEachScenario {
         .PARAMETER Script
         The ScriptBlock to run for the hook
 
-        .LINK
-        BeforeEachFeature
-            
 		.LINK
-		BeforeEachScenario
+		https://pester.dev/docs/commands/BeforeEachScenario
+
+        .LINK
+        https://pester.dev/docs/commands/BeforeEachFeature
 
 		.LINK
-        AfterEachScenario
+        https://pester.dev/docs/commands/AfterEachFeature
     #>
     [CmdletBinding(DefaultParameterSetName = "All")]
     param(

--- a/Functions/GherkinStep.ps1
+++ b/Functions/GherkinStep.ps1
@@ -71,7 +71,10 @@ Scenario: basic feature support
 
 .LINK
 about_gherkin
+
+.LINK
 Invoke-GherkinStep
+
 https://sites.google.com/site/unclebobconsultingllc/the-truth-about-bdd
 
 #>

--- a/Functions/GherkinStep.ps1
+++ b/Functions/GherkinStep.ps1
@@ -70,11 +70,6 @@ Scenario: basic feature support
 ```
 
 .LINK
-about_gherkin
-
-.LINK
-Invoke-GherkinStep
-
 https://sites.google.com/site/unclebobconsultingllc/the-truth-about-bdd
 
 #>

--- a/Functions/In.ps1
+++ b/Functions/In.ps1
@@ -16,7 +16,7 @@ function In {
     The script to be executed in the path provided.
 
     .LINK
-    https://github.com/pester/Pester/wiki/In
+    https://pester.dev/docs/commands/In
 
     #>
     [CmdletBinding()]

--- a/Functions/In.ps1
+++ b/Functions/In.ps1
@@ -15,9 +15,6 @@ function In {
     .PARAMETER execute
     The script to be executed in the path provided.
 
-    .LINK
-    https://pester.dev/docs/commands/In
-
     #>
     [CmdletBinding()]
     param(

--- a/Functions/It.ps1
+++ b/Functions/It.ps1
@@ -99,13 +99,20 @@ Describe "Add-Numbers" {
 ```
 
 .LINK
-https://github.com/pester/Pester/wiki/It
+https://pester.dev/docs/commands/It
 
 .LINK
 Describe
+
+.LINK
 Context
+
+.LINK
 Set-TestInconclusive
+
+.LINK
 about_should
+
 #>
     [CmdletBinding(DefaultParameterSetName = 'Normal')]
     param(

--- a/Functions/It.ps1
+++ b/Functions/It.ps1
@@ -99,19 +99,16 @@ Describe "Add-Numbers" {
 ```
 
 .LINK
-https://pester.dev/docs/commands/It
+https://pester.dev/docs/commands/Describe
 
 .LINK
-Describe
+https://pester.dev/docs/commands/Context
 
 .LINK
-Context
+https://pester.dev/docs/commands/Set-TestInconclusive
 
 .LINK
-Set-TestInconclusive
-
-.LINK
-about_should
+https://pester.dev/docs/commands/Should
 
 #>
     [CmdletBinding(DefaultParameterSetName = 'Normal')]

--- a/Functions/Mock.ps1
+++ b/Functions/Mock.ps1
@@ -176,13 +176,29 @@ This example shows how calls to commands made from inside a module can be
 mocked by using the -ModuleName parameter.
 
 .LINK
+https://pester.dev/docs/commands/Mock
+
+.LINK
 Assert-MockCalled
+
+.LINK
 Assert-VerifiableMock
+
+.LINK
 Describe
+
+.LINK
 Context
+
+.LINK
 It
+
+.LINK
 about_Should
+
+.LINK
 about_Mocking
+
 #>
     [CmdletBinding()]
     param(

--- a/Functions/Mock.ps1
+++ b/Functions/Mock.ps1
@@ -176,28 +176,25 @@ This example shows how calls to commands made from inside a module can be
 mocked by using the -ModuleName parameter.
 
 .LINK
-https://pester.dev/docs/commands/Mock
+https://pester.dev/docs/commands/Assert-MockCalled
 
 .LINK
-Assert-MockCalled
+https://pester.dev/docs/commands/Assert-VerifiableMock
 
 .LINK
-Assert-VerifiableMock
+https://pester.dev/docs/commands/Describe
 
 .LINK
-Describe
+https://pester.dev/docs/commands/Context
 
 .LINK
-Context
+https://pester.dev/docs/commands/It
 
 .LINK
-It
+https://pester.dev/docs/commands/Should
 
 .LINK
-about_Should
-
-.LINK
-about_Mocking
+https://pester.dev/docs/usage/mocking
 
 #>
     [CmdletBinding()]

--- a/Functions/New-Fixture.ps1
+++ b/Functions/New-Fixture.ps1
@@ -53,12 +53,24 @@ function New-Fixture {
 
     Creates a new folder named Cleaner in the current directory and creates the scripts in it.
 
+	.LINK
+	https://pester.dev/docs/commands/New-Fixture
+
     .LINK
     Describe
+
+	.LINK
     Context
+
+	.LINK
     It
-    about_Pester
-    about_Should
+    
+	.LINK
+	about_Pester
+
+	.LINK
+	about_Should
+
     #>
 
     param (

--- a/Functions/New-Fixture.ps1
+++ b/Functions/New-Fixture.ps1
@@ -53,23 +53,17 @@ function New-Fixture {
 
     Creates a new folder named Cleaner in the current directory and creates the scripts in it.
 
-	.LINK
-	https://pester.dev/docs/commands/New-Fixture
-
     .LINK
-    Describe
+    https://pester.dev/docs/commands/Describe
 
 	.LINK
-    Context
+    https://pester.dev/docs/commands/Context
 
 	.LINK
-    It
+    https://pester.dev/docs/commands/It
     
 	.LINK
-	about_Pester
-
-	.LINK
-	about_Should
+	https://pester.dev/docs/commands/Should
 
     #>
 

--- a/Functions/SetupTeardown.ps1
+++ b/Functions/SetupTeardown.ps1
@@ -12,10 +12,8 @@ function BeforeEach {
         with each other, please refer to the about_BeforeEach_AfterEach help file.
 
     .LINK
-        https://github.com/pester/Pester/wiki/BeforeEach-and-AfterEach
+        https://pester.dev/docs/commands/BeforeEach
 
-    .LINK
-        about_BeforeEach_AfterEach
     #>
     [CmdletBinding()]
     param
@@ -43,10 +41,8 @@ function AfterEach {
         with each other, please refer to the about_BeforeEach_AfterEach help file.
 
     .LINK
-        https://github.com/pester/Pester/wiki/BeforeEach-and-AfterEach
+        https://pester.dev/docs/commands/AfterEach
 
-    .LINK
-        about_BeforeEach_AfterEach
     #>
     [CmdletBinding()]
     param
@@ -71,11 +67,9 @@ function BeforeAll {
         to the entire Context or Describe block, regardless of the order of the
         statements in the Context or Describe.
 
-    .LINK
-        https://github.com/pester/Pester/wiki/BeforeEach-and-AfterEach
+        .LINK
+        https://pester.dev/docs/commands/BeforeAll
 
-    .LINK
-        about_BeforeEach_AfterEach
     #>
     [CmdletBinding()]
     param
@@ -100,11 +94,8 @@ function AfterAll {
     to the entire Context or Describe block, regardless of the order of the
     statements in the Context or Describe.
 
-    .LINK
-        https://github.com/pester/Pester/wiki/BeforeEach-and-AfterEach
-
-    .LINK
-    about_BeforeEach_AfterEach
+.LINK
+    https://pester.dev/docs/commands/AfterAll
 #>
     [CmdletBinding()]
     param

--- a/Functions/SetupTeardown.ps1
+++ b/Functions/SetupTeardown.ps1
@@ -12,7 +12,7 @@ function BeforeEach {
         with each other, please refer to the about_BeforeEach_AfterEach help file.
 
     .LINK
-        https://pester.dev/docs/commands/BeforeEach
+        https://pester.dev/docs/commands/AfterEach
 
     #>
     [CmdletBinding()]
@@ -41,7 +41,7 @@ function AfterEach {
         with each other, please refer to the about_BeforeEach_AfterEach help file.
 
     .LINK
-        https://pester.dev/docs/commands/AfterEach
+        https://pester.dev/docs/commands/BeforeEach
 
     #>
     [CmdletBinding()]
@@ -68,7 +68,7 @@ function BeforeAll {
         statements in the Context or Describe.
 
         .LINK
-        https://pester.dev/docs/commands/BeforeAll
+        https://pester.dev/docs/commands/AfterAll
 
     #>
     [CmdletBinding()]
@@ -95,7 +95,7 @@ function AfterAll {
     statements in the Context or Describe.
 
 .LINK
-    https://pester.dev/docs/commands/AfterAll
+    https://pester.dev/docs/commands/BeforeAll
 #>
     [CmdletBinding()]
     param

--- a/Functions/TestDrive.ps1
+++ b/Functions/TestDrive.ps1
@@ -79,7 +79,9 @@ function Get-TestDriveItem {
     what is located under TestDrive.
 
     .LINK
-    https://github.com/pester/Pester/wiki/TestDrive
+    https://pester.dev/docs/usage/testdrive
+
+	.LINK
     about_TestDrive
 #>
 

--- a/Functions/TestDrive.ps1
+++ b/Functions/TestDrive.ps1
@@ -81,8 +81,6 @@ function Get-TestDriveItem {
     .LINK
     https://pester.dev/docs/usage/testdrive
 
-	.LINK
-    about_TestDrive
 #>
 
     #moved here from Pester.psm1

--- a/Pester.psm1
+++ b/Pester.psm1
@@ -1520,7 +1520,7 @@ function Assert-VerifiableMocks {
     The function will be removed finally in the next major version of Pester.
 
     .LINK
-    https://github.com/pester/Pester/wiki/Migrating-from-Pester-3-to-Pester-4
+    https://pester.dev/docs/migrations/v3-to-v4
 
     .LINK
     https://github.com/pester/Pester/issues/880
@@ -1530,7 +1530,7 @@ function Assert-VerifiableMocks {
     [CmdletBinding()]
     param()
 
-    Throw "This command has been renamed to 'Assert-VerifiableMock' (without the 's' at the end), please update your code. For more information see: https://github.com/pester/Pester/wiki/Migrating-from-Pester-3-to-Pester-4"
+    Throw "This command has been renamed to 'Assert-VerifiableMock' (without the 's' at the end), please update your code. For more information see: https://pester.dev/docs/migrations/v3-to-v4"
 
 }
 

--- a/Pester.psm1
+++ b/Pester.psm1
@@ -1014,9 +1014,6 @@ function Invoke-Pester {
     also has a Bug tag.
 
     .LINK
-    https://pester.dev/docs/commands/Invoke-Pester
-
-    .LINK
     https://pester.dev/docs/commands/Describe
 
     .LINK
@@ -1233,8 +1230,6 @@ function New-PesterOption {
 
         The result of commands will be execution of tests and saving results of them in a NUnitMXL file where the root "test-suite"
         will be named "Tests - Set A".
-    .LINK
-    https://pester.dev/docs/commands/New-PesterOption
 
     .LINK
     https://pester.dev/docs/commands/Invoke-Pester


### PR DESCRIPTION
Comment based help in source has several .LINK problems. 

- URLs point to old pester wiki
- Several lines of commands under one .LINK entry leading to incorrect formatting
- Some commands are missing .LINK entries for their online version of help. 

See discussion https://github.com/pester/docs/issues/8

Not sure if this is finished. Unsure if each .LINK entry under a command should be to the online resource or left as plain text. Eg: 

.LINK 
Context

.LINK
https://pester.dev/docs/commands/Context
