### PR TITLE
sessionstate variable is not being passed correctly in Context.ps1

### DIFF
--- a/Functions/Context.ps1
+++ b/Functions/Context.ps1
@@ -85,7 +85,7 @@ https://pester.dev/docs/usage/testdrive
     if ($null -eq (& $SafeCommands['Get-Variable'] -Name Pester -ValueOnly -ErrorAction $script:IgnoreErrorPreference)) {
         # User has executed a test script directly instead of calling Invoke-Pester
         $sessionState = Set-SessionStateHint -PassThru -Hint "Caller - Captured in Context" -SessionState $PSCmdlet.SessionState
-        $Pester = New-PesterState -Path (& $SafeCommands['Resolve-Path'] .) -TestNameFilter $null -TagFilter @() -SessionState SessionState
+        $Pester = New-PesterState -Path (& $SafeCommands['Resolve-Path'] .) -TestNameFilter $null -TagFilter @() -SessionState $sessionState
         $script:mockTable = @{ }
     }
 


### PR DESCRIPTION
I recently upgraded to the latest version of Pester and while debugging some of my tests were failing with below

New-PesterState : Cannot process argument transformation on parameter 'SessionState'. Cannot convert the "SessionState" value of type "System.String" to type "System.Management.Automation.SessionState".
At C:\Program Files\WindowsPowerShell\Modules\pester\4.10.1\Functions\Context.ps1:88 char:128
 ... '] .) -TestNameFilter $null -TagFilter @() -SessionState SessionState

                                                            
It seems that a bug was introduced with Session state hints (#1169) in the change to Context.ps1 (   https://github.com/pester/Pester/commit/d25ff9f34b1fb160df096cc7101efdd8a06cbd43#diff-d4fc7a10c374cf6c159f443304feb3e4)
