### PR TITLE
Add advanced tag filtering options

### DIFF
--- a/Functions/Describe.Tests.ps1
+++ b/Functions/Describe.Tests.ps1
@@ -227,6 +227,14 @@ InModuleScope Pester {
                     Assert-MockCalled MockMe -Scope It -Exactly $case.Runs
                 }
             }
+            $testState = New-PesterState -Path $TestDrive -AdvancedTagFilter { throw "pester" }
+            It "Given an advanced filter { throw 'pester' } and a test with advanced tags the test throws, because the filter threw an exception" {
+                # figuring out what this test does is a bit difficult. Internally the tags to be used
+                # are stored in Pester state tag filter. So here we have a static  filter and
+                # we throw tests on it to see if they would run. Then we assert that a mock in the
+                # test case was called, to see if the test was executed.
+                { DescribeImpl -Name 'Name' -AdvancedTag @{key1 = "value1" } -Pester $testState -Fixture $testBlock -NoTestDrive -NoTestRegistry } | Should -Throw "pester"
+            }
 
             # Testing nested Describe is probably not necessary here; that's covered by PesterState.Tests.ps1 and $pester.EnterDescribe().
         }

--- a/Functions/Describe.ps1
+++ b/Functions/Describe.ps1
@@ -80,6 +80,8 @@ https://pester.dev/docs/usage/testdrive
         [Alias('Tags')]
         [string[]] $Tag = @(),
 
+        [hashtable] $AdvancedTag = @{ },
+
         [Parameter(Position = 1)]
         [ValidateNotNull()]
         [ScriptBlock] $Fixture
@@ -112,6 +114,8 @@ function DescribeImpl {
 
         [Alias('Tags')]
         $Tag = @(),
+
+        $AdvancedTag = @{ },
 
         [Parameter(Position = 1)]
         [ValidateNotNull()]
@@ -165,6 +169,13 @@ function DescribeImpl {
 
         if ($Pester.ExcludeTagFilter) {
             if (Contain-AnyStringLike -Filter $Pester.ExcludeTagFilter -Collection $Tag) {
+                return
+            }
+        }
+        if ($Pester.AdvancedTagFilter) {
+            $variables = [System.Collections.Generic.List[PSVariable]]::new()
+            $variables.Add([PSVariable]::new("tags", $AdvancedTag))
+            if (-not ($Pester.AdvancedTagFilter.InvokeWithContext($null, $variables))) {
                 return
             }
         }

--- a/Functions/Describe.ps1
+++ b/Functions/Describe.ps1
@@ -173,8 +173,8 @@ function DescribeImpl {
             }
         }
         if ($Pester.AdvancedTagFilter) {
-            $variables = New-Object -TypeName "System.Collections.Generic.List[PSVariable]"
-            $tags = New-Object -TypeName "PSVariable" -ArgumentList @("tags", $AdvancedTag)
+            $variables = New-Object -TypeName "System.Collections.Generic.List[System.Management.Automation.PSVariable]"
+            $tags = New-Object -TypeName "System.Management.Automation.PSVariable" -ArgumentList @("tags", $AdvancedTag)
             $variables.Add($tags)
             if (-not ($Pester.AdvancedTagFilter.InvokeWithContext($null, $variables))) {
                 return

--- a/Functions/Describe.ps1
+++ b/Functions/Describe.ps1
@@ -173,8 +173,9 @@ function DescribeImpl {
             }
         }
         if ($Pester.AdvancedTagFilter) {
-            $variables = [System.Collections.Generic.List[PSVariable]]::new()
-            $variables.Add([PSVariable]::new("tags", $AdvancedTag))
+            $variables = New-Object -TypeName "System.Collections.Generic.List[PSVariable]"
+            $tags = New-Object -TypeName "PSVariable" -ArgumentList @("tags", $AdvancedTag)
+            $variables.Add($tags)
             if (-not ($Pester.AdvancedTagFilter.InvokeWithContext($null, $variables))) {
                 return
             }

--- a/Functions/Describe.ps1
+++ b/Functions/Describe.ps1
@@ -173,10 +173,9 @@ function DescribeImpl {
             }
         }
         if ($Pester.AdvancedTagFilter) {
-            $variables = New-Object -TypeName "System.Collections.Generic.List[System.Management.Automation.PSVariable]"
-            $tags = New-Object -TypeName "System.Management.Automation.PSVariable" -ArgumentList @("tags", $AdvancedTag)
-            $variables.Add($tags)
-            if (-not ($Pester.AdvancedTagFilter.InvokeWithContext($null, $variables))) {
+            $tags = $AdvancedTag
+            Set-ScriptBlockScope -ScriptBlock $Pester.AdvancedTagFilter -SessionState $PSCmdlet.SessionState
+            if (-not (Invoke-Command -ScriptBlock $Pester.AdvancedTagFilter)) {
                 return
             }
         }

--- a/Functions/PesterState.Tests.ps1
+++ b/Functions/PesterState.Tests.ps1
@@ -5,53 +5,60 @@ InModuleScope Pester {
         Context "TestNameFilter parameter is set" {
             $p = new-pesterstate -TestNameFilter "filter"
 
-            it "sets the TestNameFilter property" {
-                $p.TestNameFilter | should -be "filter"
+            It "sets the TestNameFilter property" {
+                $p.TestNameFilter | Should -be "filter"
             }
 
         }
         Context "TagFilter parameter is set" {
             $p = new-pesterstate -TagFilter "tag", "tag2"
 
-            it "sets the TestNameFilter property" {
-                $p.TagFilter | should -be ("tag", "tag2")
+            It "sets the TestNameFilter property" {
+                $p.TagFilter | Should -be ("tag", "tag2")
             }
         }
 
         Context "ExcludeTagFilter parameter is set" {
             $p = new-pesterstate -ExcludeTagFilter "tag3", "tag"
 
-            it "sets the ExcludeTagFilter property" {
-                $p.ExcludeTagFilter | should -be ("tag3", "tag")
+            It "sets the ExcludeTagFilter property" {
+                $p.ExcludeTagFilter | Should -be ("tag3", "tag")
             }
         }
 
         Context "TagFilter and ExcludeTagFilter parameter are set" {
             $p = new-pesterstate -TagFilter "tag", "tag2" -ExcludeTagFilter "tag3"
 
-            it "sets the TestNameFilter property" {
-                $p.TagFilter | should -be ("tag", "tag2")
+            It "sets the TestNameFilter property" {
+                $p.TagFilter | Should -be ("tag", "tag2")
             }
 
-            it "sets the ExcludeTagFilter property" {
-                $p.ExcludeTagFilter | should -be ("tag3")
+            It "sets the ExcludeTagFilter property" {
+                $p.ExcludeTagFilter | Should -be ("tag3")
             }
         }
         Context "TestNameFilter and TagFilter parameter is set" {
             $p = new-pesterstate -TagFilter "tag", "tag2" -testnamefilter "filter"
 
-            it "sets the TagFilter property" {
-                $p.TagFilter | should -be ("tag", "tag2")
+            It "sets the TagFilter property" {
+                $p.TagFilter | Should -be ("tag", "tag2")
             }
 
-            it "sets the TestNameFilter property" {
-                $p.TestNameFilter | should -be "Filter"
+            It "sets the TestNameFilter property" {
+                $p.TestNameFilter | Should -be "Filter"
+            }
+        }
+        Context "AdvancedTagFilter parameter is set" {
+            $p = new-pesterstate -AdvancedTagFilter { $true }
+
+            It "sets the AdvancedTagFilter property" {
+                $p.AdvancedTagFilter | Should -BeOfType [scriptblock]
             }
         }
 
         Context "ScritpBlockFilter is set" {
-            it "sets the ScriptBlockFilter property" {
-                $o = New-PesterOption -ScriptBlockFilter @(@{Path = "C:\Tests"; Line = 293})
+            It "sets the ScriptBlockFilter property" {
+                $o = New-PesterOption -ScriptBlockFilter @(@{Path = "C:\Tests"; Line = 293 })
                 $p = New-PesterState -PesterOption $o
                 $p.ScriptBlockFilter | Should -Not -BeNullOrEmpty
                 $p.ScriptBlockFilter[0].Path | Should -Be "C:\Tests"
@@ -78,7 +85,7 @@ InModuleScope Pester {
             }
         }
 
-        context "adding test result" {
+        Context "adding test result" {
             $p.EnterTestGroup('Describe', 'Describe')
 
             #region TIMING TESTS ###########
@@ -89,7 +96,7 @@ InModuleScope Pester {
             #   3. TestSuite - Time between the start and finish of all test groups
             #
             #################################
-            it "times test accurately within 10 milliseconds" {
+            It "times test accurately within 10 milliseconds" {
 
                 # Simulating the start of a test
                 $p.EnterTest()
@@ -160,11 +167,11 @@ InModuleScope Pester {
 
             #     # The time recorded as taken during the test should be within + or - 15 milliseconds of the time we
             #     #   recorded using Measure-Command
-            #     $result.time.TotalMilliseconds | Should -BeGreaterOrEqual ($Time.Milliseconds - 15)
-            #     $result.time.TotalMilliseconds | Should -BeLessOrEqual ($Time.Milliseconds + 15)
+            #     $result.time.TotalMilliseconds | should -BeGreaterOrEqual ($Time.Milliseconds - 15)
+            #     $result.time.TotalMilliseconds | should -BeLessOrEqual ($Time.Milliseconds + 15)
             # }
 
-            it "accurately increments total testsuite time within 10 milliseconds" {
+            It "accurately increments total testsuite time within 10 milliseconds" {
                 # Initial time for the current testsuite
                 $TotalTimeStart = $p.time;
 
@@ -219,50 +226,50 @@ InModuleScope Pester {
 
             #endregion TIMING TESTS
 
-            it "adds passed test" {
+            It "adds passed test" {
                 $p.AddTestResult("result", "Passed", 100)
                 $result = $p.TestResult[-1]
-                $result.Name | should -be "result"
-                $result.passed | should -be $true
+                $result.Name | Should -be "result"
+                $result.passed | Should -be $true
                 $result.Result | Should -be "Passed"
-                $result.time.ticks | should -be 100
+                $result.time.ticks | Should -be 100
             }
-            it "adds failed test" {
+            It "adds failed test" {
                 try {
                     throw 'message'
                 }
                 catch {
                     $e = $_
                 }
-                $p.AddTestResult("result", "Failed", 100, "fail", "stack", "suite name", @{param = 'eters'}, $e)
+                $p.AddTestResult("result", "Failed", 100, "fail", "stack", "suite name", @{param = 'eters' }, $e)
                 $result = $p.TestResult[-1]
-                $result.Name | should -be "result"
-                $result.passed | should -be $false
+                $result.Name | Should -be "result"
+                $result.passed | Should -be $false
                 $result.Result | Should -be "Failed"
-                $result.time.ticks | should -be 100
-                $result.FailureMessage | should -be "fail"
-                $result.StackTrace | should -be "stack"
-                $result.ParameterizedSuiteName | should -be "suite name"
-                $result.Parameters['param'] | should -be 'eters'
-                $result.ErrorRecord.Exception.Message | should -be 'message'
+                $result.time.ticks | Should -be 100
+                $result.FailureMessage | Should -be "fail"
+                $result.StackTrace | Should -be "stack"
+                $result.ParameterizedSuiteName | Should -be "suite name"
+                $result.Parameters['param'] | Should -be 'eters'
+                $result.ErrorRecord.Exception.Message | Should -be 'message'
             }
 
-            it "adds skipped test" {
+            It "adds skipped test" {
                 $p.AddTestResult("result", "Skipped", 100)
                 $result = $p.TestResult[-1]
-                $result.Name | should -be "result"
-                $result.passed | should -be $true
+                $result.Name | Should -be "result"
+                $result.passed | Should -be $true
                 $result.Result | Should -be "Skipped"
-                $result.time.ticks | should -be 100
+                $result.time.ticks | Should -be 100
             }
 
-            it "adds Pending test" {
+            It "adds Pending test" {
                 $p.AddTestResult("result", "Pending", 100)
                 $result = $p.TestResult[-1]
-                $result.Name | should -be "result"
-                $result.passed | should -be $true
+                $result.Name | Should -be "result"
+                $result.passed | Should -be $true
                 $result.Result | Should -be "Pending"
-                $result.time.ticks | should -be 100
+                $result.time.ticks | Should -be 100
             }
 
             $p.LeaveTestGroup('Describe', 'Describe')
@@ -275,7 +282,7 @@ InModuleScope Pester {
                 $strict.AddTestResult("test", "Passed")
                 $result = $strict.TestResult[-1]
 
-                $result.passed | should -be $true
+                $result.passed | Should -be $true
                 $result.Result | Should -be "Passed"
             }
 
@@ -283,7 +290,7 @@ InModuleScope Pester {
                 $strict.AddTestResult("test", "Failed")
                 $result = $strict.TestResult[-1]
 
-                $result.passed | should -be $false
+                $result.passed | Should -be $false
                 $result.Result | Should -be "Failed"
             }
 
@@ -291,7 +298,7 @@ InModuleScope Pester {
                 $strict.AddTestResult("test", "Pending")
                 $result = $strict.TestResult[-1]
 
-                $result.passed | should -be $false
+                $result.passed | Should -be $false
                 $result.Result | Should -be "Failed"
             }
 
@@ -299,7 +306,7 @@ InModuleScope Pester {
                 $strict.AddTestResult("test", "Skipped")
                 $result = $strict.TestResult[-1]
 
-                $result.passed | should -be $false
+                $result.passed | Should -be $false
                 $result.Result | Should -be "Failed"
             }
 
@@ -307,7 +314,7 @@ InModuleScope Pester {
                 $strict.AddTestResult("test", "Inconclusive")
                 $result = $strict.TestResult[-1]
 
-                $result.passed | should -be $false
+                $result.passed | Should -be $false
                 $result.Result | Should -be "Failed"
             }
         }

--- a/Functions/PesterState.ps1
+++ b/Functions/PesterState.ps1
@@ -2,6 +2,7 @@ function New-PesterState {
     param (
         [String[]]$TagFilter,
         [String[]]$ExcludeTagFilter,
+        [scriptblock]$AdvancedTagFilter,
         [String[]]$TestNameFilter,
         [System.Management.Automation.SessionState]$SessionState,
         [Switch]$Strict,
@@ -27,10 +28,11 @@ function New-PesterState {
         }
     }
 
-    & $SafeCommands['New-Module'] -Name PesterState -AsCustomObject -ArgumentList $TagFilter, $ExcludeTagFilter, $TestNameFilter, $SessionState, $Strict, $Show, $PesterOption, $RunningViaInvokePester -ScriptBlock {
+    & $SafeCommands['New-Module'] -Name PesterState -AsCustomObject -ArgumentList $TagFilter, $ExcludeTagFilter, $AdvancedTagFilter, $TestNameFilter, $SessionState, $Strict, $Show, $PesterOption, $RunningViaInvokePester -ScriptBlock {
         param (
             [String[]]$_tagFilter,
             [String[]]$_excludeTagFilter,
+            [scriptblock]$_advancedTagFilter,
             [String[]]$_testNameFilter,
             [System.Management.Automation.SessionState]$_sessionState,
             [Switch]$Strict,
@@ -42,6 +44,7 @@ function New-PesterState {
         #public read-only
         $TagFilter = $_tagFilter
         $ExcludeTagFilter = $_excludeTagFilter
+        $AdvancedTagFilter = $_advancedTagFilter
         $TestNameFilter = $_testNameFilter
 
 
@@ -329,6 +332,7 @@ function New-PesterState {
 
         $ExportedVariables = "TagFilter",
         "ExcludeTagFilter",
+        "AdvancedTagFilter",
         "TestNameFilter",
         "ScriptBlockFilter",
         "TestResult",

--- a/Pester.psm1
+++ b/Pester.psm1
@@ -1058,9 +1058,13 @@ function Invoke-Pester {
         [Switch]$Strict,
 
         [Parameter(Mandatory = $true, ParameterSetName = 'NewOutputSet')]
+        [Parameter(ParameterSetName = 'Tag')]
+        [Parameter(ParameterSetName = 'TagFilter')]
         [string] $OutputFile,
 
         [Parameter(ParameterSetName = 'NewOutputSet')]
+        [Parameter(ParameterSetName = 'Tag')]
+        [Parameter(ParameterSetName = 'TagFilter')]
         [ValidateSet('NUnitXml', 'JUnitXml')]
         [string] $OutputFormat = 'NUnitXml',
 

--- a/Pester.psm1
+++ b/Pester.psm1
@@ -1033,13 +1033,16 @@ function Invoke-Pester {
         [switch]$EnableExit,
 
         [Parameter(Position = 4, Mandatory = 0, ParameterSetName = 'Tag')]
+        [Parameter(ParameterSetName = 'NewOutputSet')]
         [Alias('Tags')]
         [string[]]$Tag,
 
         [Parameter(ParameterSetName = 'Tag')]
+        [Parameter(ParameterSetName = 'NewOutputSet')]
         [string[]]$ExcludeTag,
 
         [Parameter(ParameterSetName = 'TagFilter')]
+        [Parameter(ParameterSetName = 'NewOutputSet')]
         [scriptblock]$TagFilter,
 
         [switch]$PassThru,
@@ -1058,13 +1061,9 @@ function Invoke-Pester {
         [Switch]$Strict,
 
         [Parameter(Mandatory = $true, ParameterSetName = 'NewOutputSet')]
-        [Parameter(ParameterSetName = 'Tag')]
-        [Parameter(ParameterSetName = 'TagFilter')]
         [string] $OutputFile,
 
         [Parameter(ParameterSetName = 'NewOutputSet')]
-        [Parameter(ParameterSetName = 'Tag')]
-        [Parameter(ParameterSetName = 'TagFilter')]
         [ValidateSet('NUnitXml', 'JUnitXml')]
         [string] $OutputFormat = 'NUnitXml',
 

--- a/Pester.psm1
+++ b/Pester.psm1
@@ -93,7 +93,7 @@ $script:SafeCommands = @{
 if ( Get-Command -ea SilentlyContinue Get-CimInstance ) {
     $script:SafeCommands['Get-CimInstance'] = Get-Command -Name Get-CimInstance -Module CimCmdlets @safeCommandLookupParameters
 }
-elseif ( Get-command -ea SilentlyContinue Get-WmiObject ) {
+elseif ( Get-Command -ea SilentlyContinue Get-WmiObject ) {
     $script:SafeCommands['Get-WmiObject'] = Get-Command -Name Get-WmiObject   -Module Microsoft.PowerShell.Management @safeCommandLookupParameters
 }
 elseif ( Get-Command -ea SilentlyContinue uname -Type Application ) {
@@ -484,7 +484,7 @@ function Add-AssertionOperator {
 
     $script:AssertionOperators[$Name] = $entry
 
-    foreach ($string in $Alias | Where { -not (Test-NullOrWhiteSpace $_) }) {
+    foreach ($string in $Alias | Where-Object { -not (Test-NullOrWhiteSpace $_) }) {
         Assert-ValidAssertionAlias -Alias $string
         $script:AssertionAliases[$string] = $Name
     }
@@ -511,7 +511,7 @@ function Assert-AssertionOperatorNameIsUnique {
         [string[]] $Name
     )
 
-    foreach ($string in $name | Where { -not (Test-NullOrWhiteSpace $_) }) {
+    foreach ($string in $name | Where-Object { -not (Test-NullOrWhiteSpace $_) }) {
         Assert-ValidAssertionName -Name $string
 
         if ($script:AssertionOperators.ContainsKey($string)) {
@@ -1032,11 +1032,15 @@ function Invoke-Pester {
         [Parameter(Position = 2, Mandatory = 0)]
         [switch]$EnableExit,
 
-        [Parameter(Position = 4, Mandatory = 0)]
+        [Parameter(Position = 4, Mandatory = 0, ParameterSetName = 'Tag')]
         [Alias('Tags')]
         [string[]]$Tag,
 
+        [Parameter(ParameterSetName = 'Tag')]
         [string[]]$ExcludeTag,
+
+        [Parameter(ParameterSetName = 'TagFilter')]
+        [scriptblock]$TagFilter,
 
         [switch]$PassThru,
 
@@ -1091,7 +1095,7 @@ function Invoke-Pester {
         $script:mockTable = @{ }
         Remove-MockFunctionsAndAliases
         $sessionState = Set-SessionStateHint -PassThru  -Hint "Caller - Captured in Invoke-Pester" -SessionState $PSCmdlet.SessionState
-        $pester = New-PesterState -TestNameFilter $TestName -TagFilter $Tag -ExcludeTagFilter $ExcludeTag -SessionState $SessionState -Strict:$Strict -Show:$Show -PesterOption $PesterOption -RunningViaInvokePester
+        $pester = New-PesterState -TestNameFilter $TestName -TagFilter $Tag -ExcludeTagFilter $ExcludeTag -AdvancedTagFilter $TagFilter -SessionState $SessionState -Strict:$Strict -Show:$Show -PesterOption $PesterOption -RunningViaInvokePester
 
         try {
             Enter-CoverageAnalysis -CodeCoverage $CodeCoverage -PesterState $pester


### PR DESCRIPTION
## 1. General summary of the pull request

Adds a new parameter AdvancedTag to Describe to specify tags as a hashtable and a corresponding TagFilter parameter to Invoke-Pester that allows for granular filtering of tags using a scriptblock

Fix #608 

### TODO
- [ ] Documentation