### PR TITLE
Added parameter for Alias in HaveParameter

### DIFF
--- a/Functions/Assertions/HaveParameter.Tests.ps1
+++ b/Functions/Assertions/HaveParameter.Tests.ps1
@@ -6,6 +6,7 @@ InModuleScope Pester {
         function Invoke-DummyFunction {
             param(
                 [Parameter(Mandatory = $true)]
+                [Alias('First')]
                 $MandatoryParam,
 
                 [ValidateNotNullOrEmpty()]
@@ -37,8 +38,8 @@ InModuleScope Pester {
                     {
                         param($commandName, $parameterName, $wordToComplete, $commandAst, $fakeBoundParameter)
                         & Get-ChildItem |
-                            Where-Object { $_.Name -like "$wordToComplete*" } |
-                            ForEach-Object { [System.Management.Automation.CompletionResult]::new( $_.Name, $_.Name, [System.Management.Automation.CompletionResultType]::ParameterValue, $_.Name ) }
+                        Where-Object { $_.Name -like "$wordToComplete*" } |
+                        ForEach-Object { [System.Management.Automation.CompletionResult]::new( $_.Name, $_.Name, [System.Management.Automation.CompletionResultType]::ParameterValue, $_.Name ) }
                     }
                 )]
                 [String]$ParamWithArgumentCompleter = "./.git"
@@ -49,6 +50,7 @@ InModuleScope Pester {
         function Invoke-DummyFunction {
             param(
                 [Parameter(Mandatory = $true)]
+                [Alias('First')]
                 $MandatoryParam,
 
                 [ValidateNotNullOrEmpty()]
@@ -85,11 +87,11 @@ InModuleScope Pester {
     Describe "Should -HaveParameter" {
 
         It "passes if the parameter <ParameterName> exists" -TestCases @(
-            @{ParameterName = "MandatoryParam"}
-            @{ParameterName = "ParamWithNotNullOrEmptyValidation"}
-            @{ParameterName = "ParamWithScriptValidation"}
+            @{ParameterName = "MandatoryParam" }
+            @{ParameterName = "ParamWithNotNullOrEmptyValidation" }
+            @{ParameterName = "ParamWithScriptValidation" }
             if ($PSVersionTable.PSVersion.Major -ge 5) {
-                @{ParameterName = "ParamWithArgumentCompleter"}
+                @{ParameterName = "ParamWithArgumentCompleter" }
             }
         ) {
             param($ParameterName)
@@ -97,18 +99,18 @@ InModuleScope Pester {
         }
 
         It "passes if the parameter <ParameterName> is mandatory" -TestCases @(
-            @{ParameterName = "MandatoryParam"}
+            @{ParameterName = "MandatoryParam" }
         ) {
             param($ParameterName)
             Get-Command "Invoke-DummyFunction" | Should -HaveParameter $ParameterName -Mandatory
         }
 
         It "passes if the parameter <ParameterName> is of type <ExpectedType>" -TestCases @(
-            @{ParameterName = "MandatoryParam"; ExpectedType = [System.Object]}
-            @{ParameterName = "ParamWithNotNullOrEmptyValidation"; ExpectedType = [DateTime]}
-            @{ParameterName = "ParamWithScriptValidation"; ExpectedType = "String"}
+            @{ParameterName = "MandatoryParam"; ExpectedType = [System.Object] }
+            @{ParameterName = "ParamWithNotNullOrEmptyValidation"; ExpectedType = [DateTime] }
+            @{ParameterName = "ParamWithScriptValidation"; ExpectedType = "String" }
             if ($PSVersionTable.PSVersion.Major -ge 5) {
-                @{ParameterName = "ParamWithArgumentCompleter"; ExpectedType = "String"}
+                @{ParameterName = "ParamWithArgumentCompleter"; ExpectedType = "String" }
             }
         ) {
             param($ParameterName, $ExpectedType)
@@ -117,7 +119,7 @@ InModuleScope Pester {
 
         if ($PSVersionTable.PSVersion.Major -ge 5) {
             It "passes if the parameter <ParameterName> has an ArgumentCompleter" -TestCases @(
-                @{ParameterName = "ParamWithArgumentCompleter"}
+                @{ParameterName = "ParamWithArgumentCompleter" }
             ) {
                 param($ParameterName)
                 Get-Command "Invoke-DummyFunction" | Should -HaveParameter $ParameterName -HasArgumentCompleter
@@ -125,11 +127,11 @@ InModuleScope Pester {
         }
 
         It "passes if the parameter <ParameterName> has a default value '<ExpectedValue>'" -TestCases @(
-            @{ParameterName = "MandatoryParam"; ExpectedValue = ""}
-            @{ParameterName = "ParamWithNotNullOrEmptyValidation"; ExpectedValue = "(Get-Date)"}
-            @{ParameterName = "ParamWithScriptValidation"; ExpectedValue = "."}
+            @{ParameterName = "MandatoryParam"; ExpectedValue = "" }
+            @{ParameterName = "ParamWithNotNullOrEmptyValidation"; ExpectedValue = "(Get-Date)" }
+            @{ParameterName = "ParamWithScriptValidation"; ExpectedValue = "." }
             if ($PSVersionTable.PSVersion.Major -ge 5) {
-                @{ParameterName = "ParamWithArgumentCompleter"; ExpectedValue = "./.git"}
+                @{ParameterName = "ParamWithArgumentCompleter"; ExpectedValue = "./.git" }
             }
         ) {
             param($ParameterName, $ExpectedValue)
@@ -137,19 +139,23 @@ InModuleScope Pester {
         }
 
         It "passes if the parameter <ParameterName> exists, is of type <ExpectedType> and has a default value '<ExpectedValue>'" -TestCases @(
-            @{ParameterName = "ParamWithNotNullOrEmptyValidation"; ExpectedType = [DateTime]; ExpectedValue = "(Get-Date)"}
-            @{ParameterName = "ParamWithScriptValidation"; ExpectedType = [String]; ExpectedValue = "."}
+            @{ParameterName = "ParamWithNotNullOrEmptyValidation"; ExpectedType = [DateTime]; ExpectedValue = "(Get-Date)" }
+            @{ParameterName = "ParamWithScriptValidation"; ExpectedType = [String]; ExpectedValue = "." }
             if ($PSVersionTable.PSVersion.Major -ge 5) {
-                @{ParameterName = "ParamWithArgumentCompleter"; ExpectedType = "String"; ExpectedValue = "./.git"}
+                @{ParameterName = "ParamWithArgumentCompleter"; ExpectedType = "String"; ExpectedValue = "./.git" }
             }
         ) {
             param($ParameterName, $ExpectedType, $ExpectedValue)
             Get-Command "Invoke-DummyFunction" | Should -HaveParameter $ParameterName -Type $ExpectedType -DefaultValue $ExpectedValue
         }
 
+        It "passes if the parameter MandatoryParam has an alias 'First'" {
+            Get-Command "Invoke-DummyFunction" | Should -HaveParameter MandatoryParam -Alias First
+        }
+
         if ($PSVersionTable.PSVersion.Major -ge 5) {
             It "passes if the parameter <ParameterName> exists, is of type <ExpectedType>, has a default value '<ExpectedValue>' and has an ArgumentCompleter" -TestCases @(
-                @{ParameterName = "ParamWithArgumentCompleter"; ExpectedType = [String]; ExpectedValue = "./.git"}
+                @{ParameterName = "ParamWithArgumentCompleter"; ExpectedType = [String]; ExpectedValue = "./.git" }
             ) {
                 param($ParameterName, $ExpectedType, $ExpectedValue)
                 Get-Command "Invoke-DummyFunction" | Should -HaveParameter $ParameterName -Type $ExpectedType -DefaultValue $ExpectedValue -HasArgumentCompleter
@@ -161,34 +167,34 @@ InModuleScope Pester {
         }
 
         It "fails if the parameter <ParameterName> does not exists" -TestCases @(
-            @{ParameterName = "InputObject"}
-            @{ParameterName = "Date"}
-            @{ParameterName = "Path"}
+            @{ParameterName = "InputObject" }
+            @{ParameterName = "Date" }
+            @{ParameterName = "Path" }
         ) {
             param($ParameterName)
             { Get-Command "Invoke-DummyFunction" | Should -HaveParameter $ParameterName } | Verify-AssertionFailed
         }
 
         It "fails if the parameter <ParameterName> is not mandatory or does not exist" -TestCases @(
-            @{ParameterName = "ParamWithNotNullOrEmptyValidation"}
-            @{ParameterName = "ParamWithScriptValidation"}
+            @{ParameterName = "ParamWithNotNullOrEmptyValidation" }
+            @{ParameterName = "ParamWithScriptValidation" }
             if ($PSVersionTable.PSVersion.Major -ge 5) {
-                @{ParameterName = "ParamWithArgumentCompleter"}
+                @{ParameterName = "ParamWithArgumentCompleter" }
             }
-            @{ParameterName = "InputObject"}
+            @{ParameterName = "InputObject" }
         ) {
             param($ParameterName)
             { Get-Command "Invoke-DummyFunction" | Should -HaveParameter $ParameterName -Mandatory } | Verify-AssertionFailed
         }
 
         It "fails if the parameter <ParameterName> is not of type <ExpectedType> or does not exist" -TestCases @(
-            @{ParameterName = "MandatoryParam"; ExpectedType = [Int32]}
-            @{ParameterName = "ParamWithNotNullOrEmptyValidation"; ExpectedType = [Int32]}
-            @{ParameterName = "ParamWithScriptValidation"; ExpectedType = [DateTime]}
+            @{ParameterName = "MandatoryParam"; ExpectedType = [Int32] }
+            @{ParameterName = "ParamWithNotNullOrEmptyValidation"; ExpectedType = [Int32] }
+            @{ParameterName = "ParamWithScriptValidation"; ExpectedType = [DateTime] }
             if ($PSVersionTable.PSVersion.Major -ge 5) {
-                @{ParameterName = "ParamWithArgumentCompleter"; ExpectedType = "DateTime"}
+                @{ParameterName = "ParamWithArgumentCompleter"; ExpectedType = "DateTime" }
             }
-            @{ParameterName = "InputObject"; ExpectedType = [String]}
+            @{ParameterName = "InputObject"; ExpectedType = [String] }
         ) {
             param($ParameterName, $ExpectedType)
             { Get-Command "Invoke-DummyFunction" | Should -HaveParameter $ParameterName -Type $ExpectedType } | Verify-AssertionFailed
@@ -196,10 +202,10 @@ InModuleScope Pester {
 
         if ($PSVersionTable.PSVersion.Major -ge 5) {
             It "fails if the parameter <ParameterName> has not an ArgumentCompleter or does not exist" -TestCases @(
-                @{ParameterName = "MandatoryParam"}
-                @{ParameterName = "ParamWithNotNullOrEmptyValidation"}
-                @{ParameterName = "ParamWithScriptValidation"}
-                @{ParameterName = "InputObject"}
+                @{ParameterName = "MandatoryParam" }
+                @{ParameterName = "ParamWithNotNullOrEmptyValidation" }
+                @{ParameterName = "ParamWithScriptValidation" }
+                @{ParameterName = "InputObject" }
             ) {
                 param($ParameterName)
                 { Get-Command "Invoke-DummyFunction" | Should -HaveParameter $ParameterName -HasArgumentCompleter } | Verify-AssertionFailed
@@ -207,38 +213,42 @@ InModuleScope Pester {
         }
 
         It "fails if the parameter <ParameterName> has a default value other than '<ExpectedValue>' or does not exist" -TestCases @(
-            @{ParameterName = "MandatoryParam"; ExpectedValue = "."}
-            @{ParameterName = "ParamWithNotNullOrEmptyValidation"; ExpectedValue = "(Get-Item)"}
-            @{ParameterName = "ParamWithScriptValidation"; ExpectedValue = ""}
+            @{ParameterName = "MandatoryParam"; ExpectedValue = "." }
+            @{ParameterName = "ParamWithNotNullOrEmptyValidation"; ExpectedValue = "(Get-Item)" }
+            @{ParameterName = "ParamWithScriptValidation"; ExpectedValue = "" }
             if ($PSVersionTable.PSVersion.Major -ge 5) {
-                @{ParameterName = "ParamWithArgumentCompleter"; ExpectedValue = "."}
+                @{ParameterName = "ParamWithArgumentCompleter"; ExpectedValue = "." }
             }
-            @{ParameterName = "InputObject"; ExpectedValue = ""}
+            @{ParameterName = "InputObject"; ExpectedValue = "" }
         ) {
             param($ParameterName, $ExpectedValue)
             { Get-Command "Invoke-DummyFunction" | Should -HaveParameter $ParameterName -DefaultValue $ExpectedValue } | Verify-AssertionFailed
         }
 
         It "fails if the parameter <ParameterName> does not exist, is not of type <ExpectedType> or has a default value other than '<ExpectedValue>'" -TestCases @(
-            @{ParameterName = "MandatoryParam"; ExpectedType = [DateTime]; ExpectedValue = "(Get-Item)"}
-            @{ParameterName = "ParamWithNotNullOrEmptyValidation"; ExpectedType = [DateTime]; ExpectedValue = "(Get-Item)"}
-            @{ParameterName = "ParamWithScriptValidation"; ExpectedType = [DateTime]; ExpectedValue = "."}
+            @{ParameterName = "MandatoryParam"; ExpectedType = [DateTime]; ExpectedValue = "(Get-Item)" }
+            @{ParameterName = "ParamWithNotNullOrEmptyValidation"; ExpectedType = [DateTime]; ExpectedValue = "(Get-Item)" }
+            @{ParameterName = "ParamWithScriptValidation"; ExpectedType = [DateTime]; ExpectedValue = "." }
             if ($PSVersionTable.PSVersion.Major -ge 5) {
-                @{ParameterName = "ParamWithArgumentCompleter"; ExpectedType = "String"; ExpectedValue = ""}
+                @{ParameterName = "ParamWithArgumentCompleter"; ExpectedType = "String"; ExpectedValue = "" }
             }
-            @{ParameterName = "InputObject"; ExpectedType = [String]; ExpectedValue = ""}
+            @{ParameterName = "InputObject"; ExpectedType = [String]; ExpectedValue = "" }
         ) {
             param($ParameterName, $ExpectedType, $ExpectedValue)
             { Get-Command "Invoke-DummyFunction" | Should -HaveParameter $ParameterName -Type $ExpectedType -DefaultValue $ExpectedValue } | Verify-AssertionFailed
         }
 
+        It "passes if the parameter MandatoryParam has no alias 'Second'" {
+            { Get-Command "Invoke-DummyFunction" | Should -HaveParameter MandatoryParam -Alias Second } | Verify-AssertionFailed
+        }
+
         if ($PSVersionTable.PSVersion.Major -ge 5) {
             It "fails if the parameter <ParameterName> does not exist, is not of type <ExpectedType>, has a default value other than '<ExpectedValue>' or has not an ArgumentCompleter" -TestCases @(
-                @{ParameterName = "MandatoryParam"; ExpectedType = [Object]; ExpectedValue = ""}
-                @{ParameterName = "ParamWithNotNullOrEmptyValidation"; ExpectedType = [DateTime]; ExpectedValue = "."}
-                @{ParameterName = "ParamWithScriptValidation"; ExpectedType = [String]; ExpectedValue = "."}
-                @{ParameterName = "ParamWithArgumentCompleter"; ExpectedType = [String]; ExpectedValue = "."}
-                @{ParameterName = "InputObject"; ExpectedType = [String]; ExpectedValue = "."}
+                @{ParameterName = "MandatoryParam"; ExpectedType = [Object]; ExpectedValue = "" }
+                @{ParameterName = "ParamWithNotNullOrEmptyValidation"; ExpectedType = [DateTime]; ExpectedValue = "." }
+                @{ParameterName = "ParamWithScriptValidation"; ExpectedType = [String]; ExpectedValue = "." }
+                @{ParameterName = "ParamWithArgumentCompleter"; ExpectedType = [String]; ExpectedValue = "." }
+                @{ParameterName = "InputObject"; ExpectedType = [String]; ExpectedValue = "." }
             ) {
                 param($ParameterName, $ExpectedType, $ExpectedValue)
                 { Get-Command "Invoke-DummyFunction" | Should -HaveParameter $ParameterName -Type $ExpectedType -DefaultValue $ExpectedValue -HasArgumentCompleter } | Verify-AssertionFailed
@@ -271,45 +281,45 @@ InModuleScope Pester {
     Describe "Should -Not -HavePameter" {
 
         It "passes if the parameter <ParameterName> does not exists" -TestCases @(
-            @{ParameterName = "FirstParam"}
-            @{ParameterName = "InputObject"}
+            @{ParameterName = "FirstParam" }
+            @{ParameterName = "InputObject" }
         ) {
             param($ParameterName)
             Get-Command "Invoke-DummyFunction" | Should -Not -HaveParameter $ParameterName
         }
 
         It "passes if the parameter <ParameterName> does not exist or is not mandatory" -TestCases @(
-            @{ParameterName = "ParamWithNotNullOrEmptyValidation"}
-            @{ParameterName = "ParamWithScriptValidation"}
+            @{ParameterName = "ParamWithNotNullOrEmptyValidation" }
+            @{ParameterName = "ParamWithScriptValidation" }
             if ($PSVersionTable.PSVersion.Major -ge 5) {
-                @{ParameterName = "ParamWithArgumentCompleter"}
+                @{ParameterName = "ParamWithArgumentCompleter" }
             }
-            @{ParameterName = "InputObject"}
+            @{ParameterName = "InputObject" }
         ) {
             param($ParameterName)
             Get-Command "Invoke-DummyFunction" | Should -Not -HaveParameter $ParameterName -Mandatory
         }
 
         It "passes if the parameter <ParameterName> does not exist, is not mandatory or is not of type <ExpectedType>"-TestCases @(
-            @{ParameterName = "ParamWithNotNullOrEmptyValidation"; ExpectedType = "[TimeSpan]"}
-            @{ParameterName = "ParamWithScriptValidation"; ExpectedType = "[TimeSpan]"}
+            @{ParameterName = "ParamWithNotNullOrEmptyValidation"; ExpectedType = "[TimeSpan]" }
+            @{ParameterName = "ParamWithScriptValidation"; ExpectedType = "[TimeSpan]" }
             if ($PSVersionTable.PSVersion.Major -ge 5) {
-                @{ParameterName = "ParamWithArgumentCompleter"; ExpectedType = [TimeSpan]}
+                @{ParameterName = "ParamWithArgumentCompleter"; ExpectedType = [TimeSpan] }
             }
-            @{ParameterName = "InputObject"; ExpectedType = "[Object]"}
+            @{ParameterName = "InputObject"; ExpectedType = "[Object]" }
         ) {
             param($ParameterName, $ExpectedType)
             Get-Command "Invoke-DummyFunction" | Should -Not -HaveParameter $ParameterName -Mandatory -Type $ExpectedType
         }
 
         It "passes if the parameter <ParameterName> does not exist, is not mandatory, is not of type <ExpectedType> or the default value is not <ExpectedValue>"-TestCases @(
-            @{ParameterName = "MandatoryParam"; ExpectedType = "[TimeSpan]"; ExpectedValue = "wrong"}
-            @{ParameterName = "ParamWithNotNullOrEmptyValidation"; ExpectedType = "[TimeSpan]"; ExpectedValue = ""}
-            @{ParameterName = "ParamWithScriptValidation"; ExpectedType = "[Int32]"; ExpectedValue = ".."}
+            @{ParameterName = "MandatoryParam"; ExpectedType = "[TimeSpan]"; ExpectedValue = "wrong" }
+            @{ParameterName = "ParamWithNotNullOrEmptyValidation"; ExpectedType = "[TimeSpan]"; ExpectedValue = "" }
+            @{ParameterName = "ParamWithScriptValidation"; ExpectedType = "[Int32]"; ExpectedValue = ".." }
             if ($PSVersionTable.PSVersion.Major -ge 5) {
-                @{ParameterName = "ParamWithArgumentCompleter"; ExpectedType = [TimeSpan]; ExpectedValue = "."}
+                @{ParameterName = "ParamWithArgumentCompleter"; ExpectedType = [TimeSpan]; ExpectedValue = "." }
             }
-            @{ParameterName = "InputObject"; ExpectedType = "[Object]"; ExpectedValue = ""}
+            @{ParameterName = "InputObject"; ExpectedType = "[Object]"; ExpectedValue = "" }
         ) {
             param($ParameterName, $ExpectedType, $ExpectedValue)
             Get-Command "Invoke-DummyFunction" | Should -Not -HaveParameter $ParameterName -Type $ExpectedType -DefaultValue $ExpectedValue
@@ -317,10 +327,10 @@ InModuleScope Pester {
 
         if ($PSVersionTable.PSVersion.Major -ge 5) {
             It "passes if the parameter <ParameterName> does not exist, has not an ArgumentCompleter" -TestCases @(
-                @{ParameterName = "MandatoryParam"}
-                @{ParameterName = "ParamWithNotNullOrEmptyValidation"}
-                @{ParameterName = "ParamWithScriptValidation"}
-                @{ParameterName = "InputObject"}
+                @{ParameterName = "MandatoryParam" }
+                @{ParameterName = "ParamWithNotNullOrEmptyValidation" }
+                @{ParameterName = "ParamWithScriptValidation" }
+                @{ParameterName = "InputObject" }
             ) {
                 param($ParameterName)
                 Get-Command "Invoke-DummyFunction" | Should -Not -HaveParameter -HasArgumentCompleter
@@ -328,11 +338,11 @@ InModuleScope Pester {
         }
 
         It "fails if the parameter <ParameterName> exists" -TestCases @(
-            @{ParameterName = "MandatoryParam"}
-            @{ParameterName = "ParamWithNotNullOrEmptyValidation"}
-            @{ParameterName = "ParamWithScriptValidation"}
+            @{ParameterName = "MandatoryParam" }
+            @{ParameterName = "ParamWithNotNullOrEmptyValidation" }
+            @{ParameterName = "ParamWithScriptValidation" }
             if ($PSVersionTable.PSVersion.Major -ge 5) {
-                @{ParameterName = "ParamWithArgumentCompleter"}
+                @{ParameterName = "ParamWithArgumentCompleter" }
             }
         ) {
             param($ParameterName)
@@ -340,18 +350,18 @@ InModuleScope Pester {
         }
 
         It "fails if the parameter <ParameterName> is mandatory" -TestCases @(
-            @{ParameterName = "MandatoryParam"}
+            @{ParameterName = "MandatoryParam" }
         ) {
             param($ParameterName)
             { Get-Command "Invoke-DummyFunction" | Should -Not -HaveParameter $ParameterName -Mandatory } | Verify-AssertionFailed
         }
 
         It "fails if the parameter <ParameterName> is of type <ExpectedType>" -TestCases @(
-            @{ParameterName = "MandatoryParam"; ExpectedType = [Object]}
-            @{ParameterName = "ParamWithNotNullOrEmptyValidation"; ExpectedType = [DateTime]}
-            @{ParameterName = "ParamWithScriptValidation"; ExpectedType = [String]}
+            @{ParameterName = "MandatoryParam"; ExpectedType = [Object] }
+            @{ParameterName = "ParamWithNotNullOrEmptyValidation"; ExpectedType = [DateTime] }
+            @{ParameterName = "ParamWithScriptValidation"; ExpectedType = [String] }
             if ($PSVersionTable.PSVersion.Major -ge 5) {
-                @{ParameterName = "ParamWithArgumentCompleter"; ExpectedType = "String"}
+                @{ParameterName = "ParamWithArgumentCompleter"; ExpectedType = "String" }
             }
         ) {
             param($ParameterName, $ExpectedType)
@@ -359,11 +369,11 @@ InModuleScope Pester {
         }
 
         It "fails if the parameter <ParameterName> is of type <ExpectedType> or the default value is <ExpectedValue>"-TestCases @(
-            @{ParameterName = "MandatoryParam"; ExpectedType = "[Object]"; ExpectedValue = ""}
-            @{ParameterName = "ParamWithNotNullOrEmptyValidation"; ExpectedType = "[DateTime]"; ExpectedValue = ""}
-            @{ParameterName = "ParamWithScriptValidation"; ExpectedType = "[String]"; ExpectedValue = ".."}
+            @{ParameterName = "MandatoryParam"; ExpectedType = "[Object]"; ExpectedValue = "" }
+            @{ParameterName = "ParamWithNotNullOrEmptyValidation"; ExpectedType = "[DateTime]"; ExpectedValue = "" }
+            @{ParameterName = "ParamWithScriptValidation"; ExpectedType = "[String]"; ExpectedValue = ".." }
             if ($PSVersionTable.PSVersion.Major -ge 5) {
-                @{ParameterName = "ParamWithArgumentCompleter"; ExpectedType = [String]; ExpectedValue = "."}
+                @{ParameterName = "ParamWithArgumentCompleter"; ExpectedType = [String]; ExpectedValue = "." }
             }
         ) {
             param($ParameterName, $ExpectedType, $ExpectedValue)
@@ -372,7 +382,7 @@ InModuleScope Pester {
 
         if ($PSVersionTable.PSVersion.Major -ge 5) {
             It "fails if the parameter <ParameterName> has an ArgumentCompleter" -TestCases @(
-                @{ParameterName = "ParamWithArgumentCompleter"}
+                @{ParameterName = "ParamWithArgumentCompleter" }
             ) {
                 param($ParameterName)
                 { Get-Command "Invoke-DummyFunction" | Should -Not -HaveParameter $ParameterName -HasArgumentCompleter } | Verify-AssertionFailed
@@ -380,11 +390,11 @@ InModuleScope Pester {
         }
 
         It "fails if the parameter <ParameterName> has a default value of '<ExpectedValue>'" -TestCases @(
-            @{ParameterName = "MandatoryParam"; ExpectedValue = ""}
-            @{ParameterName = "ParamWithNotNullOrEmptyValidation"; ExpectedValue = "(Get-Date)"}
-            @{ParameterName = "ParamWithScriptValidation"; ExpectedValue = "."}
+            @{ParameterName = "MandatoryParam"; ExpectedValue = "" }
+            @{ParameterName = "ParamWithNotNullOrEmptyValidation"; ExpectedValue = "(Get-Date)" }
+            @{ParameterName = "ParamWithScriptValidation"; ExpectedValue = "." }
             if ($PSVersionTable.PSVersion.Major -ge 5) {
-                @{ParameterName = "ParamWithArgumentCompleter"; ExpectedValue = "./.git"}
+                @{ParameterName = "ParamWithArgumentCompleter"; ExpectedValue = "./.git" }
             }
         ) {
             param($ParameterName, $ExpectedValue)
@@ -392,11 +402,11 @@ InModuleScope Pester {
         }
 
         It "fails if the parameter <ParameterName> is of type <ExpectedType> or has a default value of '<ExpectedValue>'" -TestCases @(
-            @{ParameterName = "MandatoryParam"; ExpectedType = [Object]; ExpectedValue = ""}
-            @{ParameterName = "ParamWithNotNullOrEmptyValidation"; ExpectedType = [DateTime]; ExpectedValue = "(Get-Date)"}
-            @{ParameterName = "ParamWithScriptValidation"; ExpectedType = [String]; ExpectedValue = "."}
+            @{ParameterName = "MandatoryParam"; ExpectedType = [Object]; ExpectedValue = "" }
+            @{ParameterName = "ParamWithNotNullOrEmptyValidation"; ExpectedType = [DateTime]; ExpectedValue = "(Get-Date)" }
+            @{ParameterName = "ParamWithScriptValidation"; ExpectedType = [String]; ExpectedValue = "." }
             if ($PSVersionTable.PSVersion.Major -ge 5) {
-                @{ParameterName = "ParamWithArgumentCompleter"; ExpectedType = "String"; ExpectedValue = "./.git"}
+                @{ParameterName = "ParamWithArgumentCompleter"; ExpectedType = "String"; ExpectedValue = "./.git" }
             }
         ) {
             param($ParameterName, $ExpectedType, $ExpectedValue)
@@ -405,9 +415,9 @@ InModuleScope Pester {
 
         if ($PSVersionTable.PSVersion.Major -ge 5) {
             It "fails if the parameter <ParameterName> is of type <ExpectedType>, has a default value of '<ExpectedValue>' or has an ArgumentCompleter" -TestCases @(
-                @{ParameterName = "ParamWithArgumentCompleter"; ExpectedType = [String]; ExpectedValue = "./.git"}
-                @{ParameterName = "ParamWithArgumentCompleter"; ExpectedType = [DateTime]; ExpectedValue = "./.git"}
-                @{ParameterName = "ParamWithArgumentCompleter"; ExpectedType = [DateTime]; ExpectedValue = ""}
+                @{ParameterName = "ParamWithArgumentCompleter"; ExpectedType = [String]; ExpectedValue = "./.git" }
+                @{ParameterName = "ParamWithArgumentCompleter"; ExpectedType = [DateTime]; ExpectedValue = "./.git" }
+                @{ParameterName = "ParamWithArgumentCompleter"; ExpectedType = [DateTime]; ExpectedValue = "" }
 
             ) {
                 param($ParameterName, $ExpectedType, $ExpectedValue)

--- a/Functions/Assertions/HaveParameter.ps1
+++ b/Functions/Assertions/HaveParameter.ps1
@@ -5,6 +5,7 @@ function Should-HaveParameter (
     [String]$DefaultValue,
     [Switch]$Mandatory,
     [Switch]$HasArgumentCompleter,
+    [String]$Alias,
     [Switch]$Negate,
     [String]$Because ) {
     <#
@@ -197,7 +198,7 @@ function Should-HaveParameter (
         }
 
         if ($HasArgumentCompleter) {
-            $testArgumentCompleter = $attributes | Where-Object {$_ -is [ArgumentCompleter]}
+            $testArgumentCompleter = $attributes | Where-Object { $_ -is [ArgumentCompleter] }
             $filters += "has ArgumentCompletion"
 
             if (-not $Negate -and -not $testArgumentCompleter) {
@@ -205,6 +206,18 @@ function Should-HaveParameter (
             }
             elseif ($Negate -and $testArgumentCompleter) {
                 $buts += "has ArgumentCompletion"
+            }
+        }
+
+        if ($Alias) {
+            $testPresenceOfAlias = $ActualValue.Parameters[$ParameterName].Aliases -contains $Alias
+            $filters += "to$(if ($Negate) {" not"}) have an alias '$Alias'"
+
+            if (-not $Negate -and -not $testPresenceOfAlias) {
+                $buts += "it didn't have an alias '$Alias'"
+            }
+            elseif ($Negate -and $testPresenceOfAlias) {
+                $buts += "it had an alias '$Alias'"
             }
         }
     }


### PR DESCRIPTION
## 1. General summary of the pull request

Added `-Alias` to `| Should -HaveParameter`

This will check if the list of aliases of the parameter contain the string the test is trying to assert