### PR TITLE
Fixes Convert-FailureLines for Core vs. Desktop PS

### DIFF
--- a/Functions/Output.ps1
+++ b/Functions/Output.ps1
@@ -279,9 +279,9 @@ function Write-PesterResult {
                     }
                     else {
                         $TestResult.ErrorRecord |
-                        ConvertTo-FailureLines |
-                        ForEach-Object { $_.Message + $_.Trace } |
-                        ForEach-Object { & $SafeCommands['Write-Host'] -ForegroundColor $ReportTheme.Fail $($_ -replace '(?m)^', $error_margin) }
+                            ConvertTo-FailureLines |
+                            ForEach-Object {$_.Message + $_.Trace} |
+                            ForEach-Object { & $SafeCommands['Write-Host'] -ForegroundColor $ReportTheme.Fail $($_ -replace '(?m)^', $error_margin) }
                     }
                     break
                 }
@@ -473,14 +473,7 @@ function ConvertTo-FailureLines {
             $exceptionName = $exception.GetType().Name
             $thisLines = $exception.Message.Split([string[]]($([System.Environment]::NewLine), "\n", "`n"), [System.StringSplitOptions]::RemoveEmptyEntries)
             if ($ErrorRecord.FullyQualifiedErrorId -ne 'PesterAssertionFailed' -and $thisLines.Length -gt 0) {
-                # in powershell 7 format changed from
-                # <Exception Name>: <first message line>
-                # Parameter: <param name>
-                # <Inner Exception Name>: <first inner exn line>
-                # to:
-                # <Exception name>: <first message line> (Parameter '<param name>')
-                # <Inner Exception name>: <first inner exn line>
-                if (7 -le $PSVersionTable.PSVersion.Major) {
+                if ($thisLines[0] -match '(?n)\(Parameter ''(?<param>[^'']+)''\)$') {
                     $thisLines = @(
                         "$exceptionName`: $($thisLines[0] -replace '\s*\(Parameter ''[^'']+''\)$')"
                         "Parameter name: $($Matches.param)"
@@ -552,8 +545,8 @@ function ConvertTo-FailureLines {
         }
         else {
             $lines.Trace += $traceLines |
-            & $SafeCommands['Select-Object'] -First $count |
-            & $SafeCommands['Where-Object'] {
+                & $SafeCommands['Select-Object'] -First $count |
+                & $SafeCommands['Where-Object'] {
                 $_ -notmatch $pattern2 -and
                 $_ -notmatch $pattern3 -and
                 $_ -notmatch $pattern4 -and

--- a/Functions/Output.ps1
+++ b/Functions/Output.ps1
@@ -473,7 +473,16 @@ function ConvertTo-FailureLines {
             $exceptionName = $exception.GetType().Name
             $thisLines = $exception.Message.Split([string[]]($([System.Environment]::NewLine), "\n", "`n"), [System.StringSplitOptions]::RemoveEmptyEntries)
             if ($ErrorRecord.FullyQualifiedErrorId -ne 'PesterAssertionFailed' -and $thisLines.Length -gt 0) {
-                $thisLines[0] = "$exceptionName`: $($thisLines[0])"
+                if ($thisLines[0] -match '(?n)\(Parameter ''(?<param>[^'']+)''\)$') {
+                    $thisLines = @(
+                        "$exceptionName`: $($thisLines[0] -replace '\s*\(Parameter ''[^'']+''\)$')"
+                        "Parameter name: $($Matches.param)"
+                        for ($i = 1; $i -lt $thisLines.Length; $i++) { $thisLines[$i] }
+                    )
+                }
+                else {
+                    $thisLines[0] = "$exceptionName`: $($thisLines[0])"
+                }
             }
             [array]::Reverse($thisLines)
             $exceptionLines += $thisLines

--- a/Functions/Output.ps1
+++ b/Functions/Output.ps1
@@ -279,9 +279,9 @@ function Write-PesterResult {
                     }
                     else {
                         $TestResult.ErrorRecord |
-                            ConvertTo-FailureLines |
-                            ForEach-Object {$_.Message + $_.Trace} |
-                            ForEach-Object { & $SafeCommands['Write-Host'] -ForegroundColor $ReportTheme.Fail $($_ -replace '(?m)^', $error_margin) }
+                        ConvertTo-FailureLines |
+                        ForEach-Object { $_.Message + $_.Trace } |
+                        ForEach-Object { & $SafeCommands['Write-Host'] -ForegroundColor $ReportTheme.Fail $($_ -replace '(?m)^', $error_margin) }
                     }
                     break
                 }
@@ -473,7 +473,14 @@ function ConvertTo-FailureLines {
             $exceptionName = $exception.GetType().Name
             $thisLines = $exception.Message.Split([string[]]($([System.Environment]::NewLine), "\n", "`n"), [System.StringSplitOptions]::RemoveEmptyEntries)
             if ($ErrorRecord.FullyQualifiedErrorId -ne 'PesterAssertionFailed' -and $thisLines.Length -gt 0) {
-                if ($thisLines[0] -match '(?n)\(Parameter ''(?<param>[^'']+)''\)$') {
+                # in powershell 7 format changed from
+                # <Exception Name>: <first message line>
+                # Parameter: <param name>
+                # <Inner Exception Name>: <first inner exn line>
+                # to:
+                # <Exception name>: <first message line> (Parameter '<param name>')
+                # <Inner Exception name>: <first inner exn line>
+                if (7 -le $PSVersionTable.PSVersion.Major) {
                     $thisLines = @(
                         "$exceptionName`: $($thisLines[0] -replace '\s*\(Parameter ''[^'']+''\)$')"
                         "Parameter name: $($Matches.param)"
@@ -545,8 +552,8 @@ function ConvertTo-FailureLines {
         }
         else {
             $lines.Trace += $traceLines |
-                & $SafeCommands['Select-Object'] -First $count |
-                & $SafeCommands['Where-Object'] {
+            & $SafeCommands['Select-Object'] -First $count |
+            & $SafeCommands['Where-Object'] {
                 $_ -notmatch $pattern2 -and
                 $_ -notmatch $pattern3 -and
                 $_ -notmatch $pattern4 -and


### PR DESCRIPTION
For the desktop version of Powershell, when getting the exception
message, there would be 3 lines: the exeception name and message, any
parameter name, and then the inner exception type (and first line
message):

```
<Exception Name>: <first message line>
Parameter: <param name>
<Inner Exception Name>: <first inner exn line>
```

But, in PowerShell Core (7.0?), the output looked like this:

```
<Exception name>: <first message line> (Parameter '<param name>')
<Inner Exception name>: <first inner exn line>
```

This commit detects whether the first message line matches a regex that
matches the parenthesized parameter name in the first message line, and
if so, splits the line into two. This "normalizes" the message lines
between PowerShell Desktop and PowerShell Core.
