### PR TITLE
Add Pester.Format.ps1xml

### DIFF
--- a/Pester.Format.ps1xml
+++ b/Pester.Format.ps1xml
@@ -64,7 +64,6 @@
           <CustomEntry>
             <CustomItem>
               <Frame>
-                <LeftIndent>0</LeftIndent>
                 <CustomItem>
                   <NewLine />
                   <NewLine />
@@ -73,7 +72,6 @@
                     <PropertyName>FullName</PropertyName>
                   </ExpressionBinding>
                   <Text>'</Text>
-                  <NewLine />
                   <NewLine />
                 </CustomItem>
               </Frame>
@@ -161,8 +159,26 @@
                   <Text> </Text>
                   <ExpressionBinding>
                     <PropertyName>Duration</PropertyName>
+                    <ItemSelectionCondition>
+                      <ScriptBlock>-not $_.FrameworkDuration</ScriptBlock>
+                    </ItemSelectionCondition>
                     <CustomControlName>PesterDurationControl</CustomControlName>
                   </ExpressionBinding>
+                  <ExpressionBinding>
+                    <ScriptBlock>$_.Duration + $_.FrameworkDuration</ScriptBlock>
+                    <ItemSelectionCondition>
+                      <ScriptBlock>$_.FrameworkDuration</ScriptBlock>
+                    </ItemSelectionCondition>
+                    <CustomControlName>PesterDurationControl</CustomControlName>
+                  </ExpressionBinding>
+                  <ExpressionBinding>
+                    <ScriptBlock>$_</ScriptBlock>
+                    <ItemSelectionCondition>
+                      <PropertyName>FrameworkDuration</PropertyName>
+                    </ItemSelectionCondition>
+                    <CustomControlName>PesterFrameworkControl</CustomControlName>
+                  </ExpressionBinding>
+                  <NewLine />
                   <ExpressionBinding>
                     <PropertyName>ErrorRecord</PropertyName>
                     <ItemSelectionCondition>
@@ -170,7 +186,6 @@
                     </ItemSelectionCondition>
                     <CustomControlName>PesterErrorControl</CustomControlName>
                   </ExpressionBinding>
-                  <NewLine />
                 </CustomItem>
               </Frame>
             </CustomItem>
@@ -184,15 +199,51 @@
         <CustomEntries>
           <CustomEntry>
             <CustomItem>
-              <NewLine />
               <Frame>
-                <LeftIndent>4</LeftIndent>
+                <LeftIndent>1</LeftIndent>
                 <CustomItem>
                   <ExpressionBinding>
-                    <ScriptBlock>$_</ScriptBlock>
+                    <ScriptBlock>$_.DisplayErrorMessage</ScriptBlock>
                   </ExpressionBinding>
+                  <NewLine />
+                  <ExpressionBinding>
+                    <ScriptBlock>$_.DisplayStackTrace</ScriptBlock>
+                  </ExpressionBinding>
+                  <NewLine />
                 </CustomItem>
               </Frame>
+            </CustomItem>
+          </CustomEntry>
+        </CustomEntries>
+      </CustomControl>
+    </Control>
+    <Control>
+      <Name>PesterFrameworkControl</Name>
+      <CustomControl>
+        <CustomEntries>
+          <CustomEntry>
+            <CustomItem>
+              <ExpressionBinding>
+                <CustomControl>
+                  <CustomEntries>
+                    <CustomEntry>
+                      <CustomItem>
+                        <Text> (</Text>
+                        <ExpressionBinding>
+                          <PropertyName>Duration</PropertyName>
+                          <CustomControlName>PesterDurationControl</CustomControlName>
+                        </ExpressionBinding>
+                        <Text>|</Text>
+                        <ExpressionBinding>
+                          <PropertyName>FrameworkDuration</PropertyName>
+                          <CustomControlName>PesterDurationControl</CustomControlName>
+                        </ExpressionBinding>
+                        <Text>)</Text>
+                      </CustomItem>
+                    </CustomEntry>
+                  </CustomEntries>
+                </CustomControl>
+              </ExpressionBinding>
             </CustomItem>
           </CustomEntry>
         </CustomEntries>

--- a/Pester.Format.ps1xml
+++ b/Pester.Format.ps1xml
@@ -1,0 +1,252 @@
+<Configuration>
+  <Controls>
+    <Control>
+      <Name>PesterContainersControl</Name>
+      <CustomControl>
+        <CustomEntries>
+          <CustomEntry>
+            <CustomItem>
+              <ExpressionBinding>
+                <PropertyName>Content</PropertyName>
+                <CustomControlName>PesterContentControl</CustomControlName>
+              </ExpressionBinding>
+              <ExpressionBinding>
+                <PropertyName>Blocks</PropertyName>
+                <EnumerateCollection />
+                <CustomControlName>PesterBlocksControl</CustomControlName>
+              </ExpressionBinding>
+            </CustomItem>
+          </CustomEntry>
+        </CustomEntries>
+      </CustomControl>
+    </Control>
+    <Control>
+      <Name>PesterSummaryControl</Name>
+      <CustomControl>
+        <CustomEntries>
+          <CustomEntry>
+            <CustomItem>
+              <Text>Tests completed in </Text>
+              <ExpressionBinding>
+                <PropertyName>Duration</PropertyName>
+                <CustomControlName>PesterDurationControl</CustomControlName>
+              </ExpressionBinding>
+              <NewLine />
+              <Text>Tests Passed: </Text>
+              <ExpressionBinding>
+                <PropertyName>PassedCount</PropertyName>
+              </ExpressionBinding>
+              <Text>, Failed: </Text>
+              <ExpressionBinding>
+                <PropertyName>FailedCount</PropertyName>
+              </ExpressionBinding>
+              <Text>, Skipped: </Text>
+              <ExpressionBinding>
+                <PropertyName>SkippedCount</PropertyName>
+              </ExpressionBinding>
+              <Text>, Total: </Text>
+              <ExpressionBinding>
+                <PropertyName>TestsCount</PropertyName>
+              </ExpressionBinding>
+              <Text>, NotRun: </Text>
+              <ExpressionBinding>
+                <PropertyName>NotRunCount</PropertyName>
+              </ExpressionBinding>
+            </CustomItem>
+          </CustomEntry>
+        </CustomEntries>
+      </CustomControl>
+    </Control>
+    <Control>
+      <Name>PesterContentControl</Name>
+      <CustomControl>
+        <CustomEntries>
+          <CustomEntry>
+            <CustomItem>
+              <Frame>
+                <LeftIndent>0</LeftIndent>
+                <CustomItem>
+                  <NewLine />
+                  <NewLine />
+                  <Text>Tests from: '</Text>
+                  <ExpressionBinding>
+                    <PropertyName>FullName</PropertyName>
+                  </ExpressionBinding>
+                  <Text>'</Text>
+                  <NewLine />
+                  <NewLine />
+                </CustomItem>
+              </Frame>
+            </CustomItem>
+          </CustomEntry>
+        </CustomEntries>
+      </CustomControl>
+    </Control>
+    <Control>
+      <Name>PesterBlocksControl</Name>
+      <CustomControl>
+        <CustomEntries>
+          <CustomEntry>
+            <CustomItem>
+              <Frame>
+                <LeftIndent>2</LeftIndent>
+                <CustomItem>
+                  <ExpressionBinding>
+                    <ScriptBlock>$_</ScriptBlock>
+                    <CustomControlName>PesterBlockHeaderControl</CustomControlName>
+                  </ExpressionBinding>
+                  <ExpressionBinding>
+                    <PropertyName>Blocks</PropertyName>
+                    <EnumerateCollection />
+                    <CustomControlName>PesterBlocksControl</CustomControlName>
+                  </ExpressionBinding>
+                  <ExpressionBinding>
+                    <PropertyName>Tests</PropertyName>
+                    <EnumerateCollection />
+                    <CustomControlName>PesterTestsControl</CustomControlName>
+                  </ExpressionBinding>
+                </CustomItem>
+              </Frame>
+            </CustomItem>
+          </CustomEntry>
+        </CustomEntries>
+      </CustomControl>
+    </Control>
+    <Control>
+      <Name>PesterBlockHeaderControl</Name>
+      <CustomControl>
+        <CustomEntries>
+          <CustomEntry>
+            <CustomItem>
+              <ExpressionBinding>
+                <ScriptBlock>
+                  if ($_.Path.Count -eq 1) { 'Describing ' } else { 'Context ' }
+                </ScriptBlock>
+              </ExpressionBinding>
+              <ExpressionBinding>
+                <PropertyName>Name</PropertyName>
+              </ExpressionBinding>
+              <NewLine />
+            </CustomItem>
+          </CustomEntry>
+        </CustomEntries>
+      </CustomControl>
+    </Control>
+    <Control>
+      <Name>PesterTestsControl</Name>
+      <CustomControl>
+        <CustomEntries>
+          <CustomEntry>
+            <CustomItem>
+              <Frame>
+                <LeftIndent>2</LeftIndent>
+                <CustomItem>
+                  <Text>[</Text>
+                  <ExpressionBinding>
+                    <ScriptBlock>
+                      switch ($_.result) {
+                        'Passed' { '+' }
+                        'Failed' { '-' }
+                        'Skipped' { '!' }
+                        'Pending' { '?' }
+                        'Inconclusive' { '?' }
+                        default { '?' }
+                      }
+                    </ScriptBlock>
+                  </ExpressionBinding>
+                  <Text>] </Text>
+                  <ExpressionBinding>
+                    <PropertyName>Name</PropertyName>
+                  </ExpressionBinding>
+                  <Text> </Text>
+                  <ExpressionBinding>
+                    <PropertyName>Duration</PropertyName>
+                    <CustomControlName>PesterDurationControl</CustomControlName>
+                  </ExpressionBinding>
+                  <ExpressionBinding>
+                    <PropertyName>ErrorRecord</PropertyName>
+                    <ItemSelectionCondition>
+                      <ScriptBlock>$_.ErrorRecord</ScriptBlock>
+                    </ItemSelectionCondition>
+                    <CustomControlName>PesterErrorControl</CustomControlName>
+                  </ExpressionBinding>
+                  <NewLine />
+                </CustomItem>
+              </Frame>
+            </CustomItem>
+          </CustomEntry>
+        </CustomEntries>
+      </CustomControl>
+    </Control>
+    <Control>
+      <Name>PesterErrorControl</Name>
+      <CustomControl>
+        <CustomEntries>
+          <CustomEntry>
+            <CustomItem>
+              <NewLine />
+              <Frame>
+                <LeftIndent>4</LeftIndent>
+                <CustomItem>
+                  <ExpressionBinding>
+                    <ScriptBlock>$_</ScriptBlock>
+                  </ExpressionBinding>
+                </CustomItem>
+              </Frame>
+            </CustomItem>
+          </CustomEntry>
+        </CustomEntries>
+      </CustomControl>
+    </Control>
+    <Control>
+      <Name>PesterDurationControl</Name>
+      <CustomControl>
+        <CustomEntries>
+          <CustomEntry>
+            <CustomItem>
+              <ExpressionBinding>
+                <ScriptBlock>
+                  if ($_.Ticks -lt [TimeSpan]::TicksPerSecond) {
+                      $time = [int]($_.TotalMilliseconds)
+                      $unit = "ms"
+                  }
+                  else {
+                      $time = [Math]::Round($_.TotalSeconds, 2)
+                      $unit = 's'
+                  }
+
+                  "$time$unit"
+                </ScriptBlock>
+              </ExpressionBinding>
+            </CustomItem>
+          </CustomEntry>
+        </CustomEntries>
+      </CustomControl>
+    </Control>
+  </Controls>
+  <ViewDefinitions>
+    <View>
+      <Name>Default</Name>
+      <ViewSelectedBy>
+        <TypeName>PesterRSpecTestRun</TypeName>
+      </ViewSelectedBy>
+      <CustomControl>
+        <CustomEntries>
+          <CustomEntry>
+            <CustomItem>
+              <ExpressionBinding>
+                <PropertyName>Containers</PropertyName>
+                <EnumerateCollection />
+                <CustomControlName>PesterContainersControl</CustomControlName>
+              </ExpressionBinding>
+              <ExpressionBinding>
+                <ScriptBlock>$_</ScriptBlock>
+                <CustomControlName>PesterSummaryControl</CustomControlName>
+              </ExpressionBinding>
+            </CustomItem>
+          </CustomEntry>
+        </CustomEntries>
+      </CustomControl>
+    </View>
+  </ViewDefinitions>
+</Configuration>

--- a/Pester.psd1
+++ b/Pester.psd1
@@ -26,6 +26,9 @@
 
     # TypesToProcess    = @('.\Functions\Gherkin.types.ps1xml')
 
+    # Format files (.ps1xml) to be loaded when importing this module
+    FormatsToProcess = @('.\Pester.Format.ps1xml')
+
     # Functions to export from this module
     FunctionsToExport = @(
         'Invoke-Pester'


### PR DESCRIPTION
## 1. General summary of the pull request

This PR comes from the discussion on #1480 to add a format definition to the `PesterRSpecTestRun` object. The format definition replicates the existing interactive host output.

Notes:

* Currently does not have color but can be added easily when https://github.com/PowerShell/PowerShell/issues/11890 is complete.
*  Does not have breakdown of framework time and execution time because the object does not contain it
* Does not display script code and line during error. Might need to create an alias or hidden alias property to get that information
* Does not support localization but can be added
* Can add additional views based on user feedback. For example, a summary view, pass/fail per describe/context, etc



### Current Output

```
C:\> $pester

ExecutedAt        : 4/10/2020 9:01:56 AM
Containers        : {@{PassedCount=12; Skip=False; Executed=True; ErrorRecord=System.Collections.Generic.List`1[System.Object]; Blocks=System.Collections.Generic.List`1[System.Object]; ScriptBlock=; ShouldRun=True; ExecutedAt=4/10/2020
                    9:01:57 AM; Content=C:\Users\Thomas\Documents\GitHub\TypeExtension\tests\CustomControl.Tests.ps1; TotalCount=13; Type=File; Tests=System.Collections.Generic.List`1[System.Object]; FailedCount=1; NotRunCount=0;
                    SkippedCount=0; Result=Failed; Duration=00:00:01.0711344}, @{PassedCount=9; Skip=False; Executed=True; ErrorRecord=System.Collections.Generic.List`1[System.Object];
                    Blocks=System.Collections.Generic.List`1[System.Object]; ScriptBlock=; ShouldRun=True; ExecutedAt=4/10/2020 9:01:58 AM; Content=C:\Users\Thomas\Documents\GitHub\TypeExtension\tests\ListControl.Tests.ps1;
                    TotalCount=11; Type=File; Tests=System.Collections.Generic.List`1[System.Object]; FailedCount=2; NotRunCount=0; SkippedCount=0; Result=Failed; Duration=00:00:00.3994711}, @{PassedCount=18; Skip=False; Executed=True;
                    ErrorRecord=System.Collections.Generic.List`1[System.Object]; Blocks=System.Collections.Generic.List`1[System.Object]; ScriptBlock=; ShouldRun=True; ExecutedAt=4/10/2020 9:01:58 AM;
                    Content=C:\Users\Thomas\Documents\GitHub\TypeExtension\tests\TableContol.Tests.ps1; TotalCount=19; Type=File; Tests=System.Collections.Generic.List`1[System.Object]; FailedCount=1; NotRunCount=0; SkippedCount=0;
                    Result=Failed; Duration=00:00:00.6495279}, @{PassedCount=1; Skip=False; Executed=True; ErrorRecord=System.Collections.Generic.List`1[System.Object]; Blocks=System.Collections.Generic.List`1[System.Object];
                    ScriptBlock=; ShouldRun=True; ExecutedAt=4/10/2020 9:01:59 AM; Content=C:\Users\Thomas\Documents\GitHub\TypeExtension\tests\TypeExtension.Tests.ps1; TotalCount=1; Type=File;
                    Tests=System.Collections.Generic.List`1[System.Object]; FailedCount=0; NotRunCount=0; SkippedCount=0; Result=Passed; Duration=00:00:00.2065382}…}
PSBoundParameters : {}
Configuration     : PesterConfiguration
PassedCount       : 52
FailedCount       : 4
SkippedCount      : 0
NotRunCount       : 0
TestsCount        : 56
FailedBlocksCount : 0
Result            : Failed
Duration          : 00:00:02.8003846
```

### New View

```
C:\> $pester



Tests from: 'C:\Users\Thomas\Documents\GitHub\TypeExtension\tests\CustomControl.Tests.ps1'

  Describing CustomControl
    Context Basic
      [+] Is the correct type 137ms
      [+] OutOfBand is true 19ms
      [+] ItemGroupBy Name property 53ms
    Context CustomItem
      [+] Name property 27ms
      [-] Scriptblock property 86ms
      Expected strings to be the same, but they were different.
      Expected length: 7
      Actual length:   9
      Strings differ at index 0.
      Expected: '$_.Name'
      But was:  ' $_.Name '
      [+] NewLine 20ms
      [+] Text 17ms
      [+] SelectedByTypeName 24ms
    Context CustomItemFrame
      [+] Empty CustomItemFrame 29ms
      [+] CustomItemFrame with property 31ms
      [+] CustomItem 33ms
      [+] Entry 31ms
      [+] CmdletHelp 48ms


Tests from: 'C:\Users\Thomas\Documents\GitHub\TypeExtension\tests\ListControl.Tests.ps1'

  Describing ListControl
    Context Basic
      [+] Is the correct type 20ms
      [+] OutOfBand is true 12ms
      [+] ItemGroupBy Name property 18ms
    Context ListItem
      [+] Name property 25ms
      [-] Script block property 29ms
      Expected strings to be the same, but they were different.
      Expected length: 7
      Actual length:   9
      Strings differ at index 0.
      Expected: '$_.Name'
      But was:  ' $_.Name '
      [+] Multiple properties items 20ms
      [-] Multiple script block items 22ms
      Expected strings to be the same, but they were different.
      Expected length: 7
      Actual length:   9
      Strings differ at index 0.
      Expected: '$_.Name'
      But was:  ' $_.Name '
    Context EntrySelectedBy
      [+] Type name condition in entry 28ms
      [+] Multiple items in same entry without entry keyword 28ms
      [+] Multiple entries with different conditions 32ms
      [+] Multiple entries with different conditions 2 25ms


Tests from: 'C:\Users\Thomas\Documents\GitHub\TypeExtension\tests\TableContol.Tests.ps1'

  Describing TableControl
    Context Basic
      [+] Is the correct type 22ms
      [+] AutoSize is true 13ms
      [+] HideTableHeaders is true 13ms
      [+] OutOfBand is true 15ms
      [+] ItemGroupBy Name property 16ms
    Context TableHeader
      [+] Single header 26ms
      [+] Multiple headers 23ms
      [+] Width 18ms
      [+] Alignment 29ms
    Context TableItem
      [+] Single column 30ms
      [+] Multiple columns 22ms
      [+] Alignment 19ms
      [+] FormatString 21ms
    Context Entry
      [+] Wrap 29ms
      [+] Multiple columns 11ms
    Context EntrySelectedBy
      [+] Property condition in Entry 43ms
      [-] Script block condition in Entry 34ms
      Expected strings to be the same, but they were different.
      Expected length: 7
      Actual length:   9
      Strings differ at index 0.
      Expected: '$_.Name'
      But was:  ' $_.Name '
      [+] Type name condition in Entry 31ms
      [+] Entry condition and root property 27ms


Tests from: 'C:\Users\Thomas\Documents\GitHub\TypeExtension\tests\TypeExtension.Tests.ps1'

  Describing TypeExtension
    Context ListControl
      [+] PassThru should not be null or empty 127ms


Tests from: 'C:\Users\Thomas\Documents\GitHub\TypeExtension\tests\ViewDefintion.Tests.ps1'

  Describing ViewDefinition
    Context ListControl
      [+] Is correct type 33ms
      [+] Has correct name 22ms
      [+] Single control 31ms
      [+] Multiple controls 49ms


Tests from: 'C:\Users\Thomas\Documents\GitHub\TypeExtension\tests\WideControl.Tests.ps1'

  Describing WideControl
    Context Basic
      [+] Is the correct type 18ms
      [+] AutoSize is true 15ms
      [+] Columns can be set 11ms
      [+] OutOfBand is true 11ms
      [+] ItemGroupBy Name property 15ms
    Context WideItem
      [+] Single item 19ms
    Context EntrySelectedBy
      [+] Condition in entry 24ms
      [+] Condition in entry and none in root 24ms
Tests completed in 2.8s
Tests Passed: 52, Failed: 4, Skipped: 0, Total: 56, NotRun: 0
```

