### PR TITLE
Fixes #1028 - Code Coverage for proxy functions/steppablePipelines

### DIFF
--- a/Functions/Coverage.ps1
+++ b/Functions/Coverage.ps1
@@ -306,10 +306,7 @@ Function Get-AstTopParent {
         return $Ast
     }
     elseif ($MaxDepth -le 0) {
-        $params = @{
-            Message = "Max depth reached, skipping this check"
-        }
-        & $SafeCommands['Write-Warning'] @params
+        & $SafeCommands['Write-Verbose'] "Max depth reached, moving on"
         return $null
     }
     else {

--- a/Functions/Coverage.ps1
+++ b/Functions/Coverage.ps1
@@ -296,6 +296,26 @@ function New-CoverageBreakpoint {
     }
 }
 
+Function Get-AstTopParent {
+    param(
+        [System.Management.Automation.Language.Ast] $Ast,
+        [int] $MaxDepth = 30
+    )
+    If ([string]::IsNullOrEmpty($Ast.Parent)) {
+        $Ast
+    }
+    ElseIf ($MaxDepth -le 0) {
+        $params = @{
+            Message = "Max depth reached, skipping this check"
+        }
+        & $SafeCommands['Write-Warning'] @params
+    }
+    Else {
+        $MaxDepth--
+        Get-AstTopParent -Ast $Ast.Parent -MaxDepth $MaxDepth
+    }
+}
+
 function IsIgnoredCommand {
     param ([System.Management.Automation.Language.Ast] $Command)
 
@@ -320,6 +340,15 @@ function IsIgnoredCommand {
             # configuration, we'll ignore it so it doesn't clutter up the coverage analysis with useless junk.
             return $true
         }
+    }
+
+    if ($Command.Extent.Text -match '^{?& \$wrappedCmd @PSBoundParameters ?}?$' -and
+        (Get-AstTopParent -Ast $Command) -like '*$steppablePipeline.Begin($PSCmdlet)*$steppablePipeline.Process($_)*$steppablePipeline.End()*' ) {
+        # Fix for proxy function wrapped pipeline command. PowerShell does not increment the hit count when
+        # these functions are executed using the steppable pipeline; further, these checks are redundant, as
+        # all steppable pipeline constituents already get breakpoints set. This checks to ensure the top parent
+        # node of the command contains all three constituents of the steppable pipeline before ignoring it.
+        return $true
     }
 
     if (IsClosingLoopCondition -Command $Command) {

--- a/Functions/Coverage.ps1
+++ b/Functions/Coverage.ps1
@@ -301,16 +301,18 @@ Function Get-AstTopParent {
         [System.Management.Automation.Language.Ast] $Ast,
         [int] $MaxDepth = 30
     )
-    If ([string]::IsNullOrEmpty($Ast.Parent)) {
-        $Ast
+
+    if ([string]::IsNullOrEmpty($Ast.Parent)) {
+        return $Ast
     }
-    ElseIf ($MaxDepth -le 0) {
+    elseif ($MaxDepth -le 0) {
         $params = @{
             Message = "Max depth reached, skipping this check"
         }
         & $SafeCommands['Write-Warning'] @params
+        return $null
     }
-    Else {
+    else {
         $MaxDepth--
         Get-AstTopParent -Ast $Ast.Parent -MaxDepth $MaxDepth
     }


### PR DESCRIPTION
## 1. General summary of the pull request
Pester generates all breakpoints using a combination of line number and column number. PowerShell does not trigger breakpoints on the proxy function constructs described in #1028 when initiated using both line and column number, but it does when using line number only. This appears to be a bug within PowerShell itself, as the behavior can be replicated outside of Pester like so:
```powershell
# Create a new proxy function for Write-Output in a file in the current directory
$ProxyMetadata = New-Object System.Management.Automation.CommandMetaData (Get-Command Write-Output)
@"
Function Write-FancyTestOutput {
$([System.Management.Automation.ProxyCommand]::Create($ProxyMetadata))
}
"@ | Out-File $PWD\Write-FancyTestOutput.ps1

# Get AST for the new function
$ast = [System.Management.Automation.Language.Parser]::ParseFile( `
    "$PWD\Write-FancyTestOutput.ps1", `
    [ref]$null, `
    [ref]$null `
)

# Initialize line number var
$LineNumber = 0

# Use FindAll to loop through all commands, look for the
# '& $wrappedCmd @PSBoundParameters' command, and add a
# breakpoint at line & column for that command -- this is
# what Pester currently does
$ast.FindAll( `
    {$args[0] -is [System.Management.Automation.Language.CommandBaseAst]}, `
    $true `
) | Where-Object {
    $_.Extent.Text -like '*& $wrappedCmd @PSBoundParameters*'
} | ForEach-Object {
    If($LineNumber -le 0) {
        $LineNumber = $_.Extent.StartLineNumber
    }
    Set-PSBreakpoint -Script "$PWD\Write-FancyTestOutput.ps1" `
                     -Action { } `
                     -Line $_.Extent.StartLineNumber `
                     -Column $_.Extent.StartColumnNumber
}

. $PWD\Write-FancyTestOutput.ps1
Write-FancyTestOutput -InputObject "Hello"   # will not trigger any breakpoints

# Add another breakpoint with no column specified for the same line
If($LineNumber -gt 0) {
    Set-PSBreakpoint -Script "$PWD\Write-FancyTestOutput.ps1" `
                     -Action { } `
                     -Line $LineNumber
}

Write-FancyTestOutput -InputObject "Hello again"   # Triggers the last breakpoint
Get-PSBreakpoint | fl
```
...which results in this output:
```text
Id       : 0
Script   : C:\Temp\Write-FancyTestOutput.ps1
Line     : 22
Column   : 22
Enabled  : True
HitCount : 0
Action   :

Id       : 1
Script   : C:\Temp\Write-FancyTestOutput.ps1
Line     : 22
Column   : 23
Enabled  : True
HitCount : 0
Action   :

Id       : 2
Script   : C:\Temp\Write-FancyTestOutput.ps1
Line     : 22
Column   : 0
Enabled  : True
HitCount : 1
Action   :
```
Rather than trying to rewrite Pester to create breakpoints without column specifications, this PR includes proxy functions using steppable pipelines in the `IsIgnoredCommand` private function. I feel this is appropriate because in proxy command situations, the steppable pipeline constituents are already covered by breakpoints.

It does this be validating two criteria:

* The extent text of the command matches `'^{?& \$wrappedCmd @PSBoundParameters ?}?$'`, which matches the specific constructs created when auto-generating a proxy command using `[System.Management.Automation.ProxyCommand]::Create()`.
* The topmost parent of the command is like `'*$steppablePipeline.Begin($PSCmdlet)*$steppablePipeline.Process($_)*$steppablePipeline.End()*'`, which matches when all three of the steppable pipeline steps have been defined in the function or file where this proxy command is defined.

Since there is no out-of-the-box mechanism to recursively iterate through nested AST objects to get to the topmost parent, this PR also includes a new private function, `Get-AstTopParent`, that does exactly that.

Fix #1028 