### PR TITLE
[v5] Repair Set-ItResult

### DIFF
--- a/README.md
+++ b/README.md
@@ -789,11 +789,9 @@ You can specify verbosity in VSCode, to see normal or minimal output, or to take
 -  `Assert-MockCalled` is deprecated, it is recommended to use [Should -Invoke](#should--invoke)
 -  `Assert-VerifiableMock` is deprecated, it is recommended to use [Should -InvokeVerifiable](#should--invoke)
 
-
 ### Additional issues to be solved in 5.1
-- `Set-ItResult` is published but does not work
 - `-Strict` switch is not available
-- Inconclusive and Pending states are not available, `-Pending` is translated to `-Skip`
+- Inconclusive and Pending states are currently no longer available, `-Pending` and `-Inconclusive` are translated to `-Skip` both on test blocks and when using `Set-ItResult`
 - Code coverage report is not available.
 - Automatic Code coverage via -CI switch is largely untested.
 - Generating tests during using foreach during discovery time works mostly, generating them from BeforeAll, to postpone expensive work till it is needed in case the test is filtered out also works, but is hacky. Get in touch if you need it and help me refine it.

--- a/src/Pester.Runtime.psm1
+++ b/src/Pester.Runtime.psm1
@@ -546,7 +546,7 @@ function Invoke-TestItem {
 
                 $Test.FrameworkData.Runtime.ExecutionStep = 'Finished'
 
-                if ($Test.Result -eq 'Skipped') {
+                if ($Result.ErrorRecord.FullyQualifiedErrorId -eq 'PesterTestSkipped') {
                     #Same logic as when setting a test block to skip
                     if ($PesterPreference.Debug.WriteDebugMessages.Value) {
                         $path = $Test.Path -join '.'

--- a/src/Pester.Runtime.psm1
+++ b/src/Pester.Runtime.psm1
@@ -552,8 +552,8 @@ function Invoke-TestItem {
                         $path = $Test.Path -join '.'
                         Write-PesterDebugMessage -Scope Skip "($path) Test is skipped."
                     }
-                    $test.Passed = $true
-                    $test.Skipped = $true
+                    $Test.Passed = $true
+                    $Test.Skipped = $true
                 } else {
                     $Test.Passed = $result.Success
                 }

--- a/src/Pester.Runtime.psm1
+++ b/src/Pester.Runtime.psm1
@@ -545,7 +545,19 @@ function Invoke-TestItem {
                     -Configuration $state.Configuration
 
                 $Test.FrameworkData.Runtime.ExecutionStep = 'Finished'
-                $Test.Passed = $result.Success
+
+                if ($Test.Result -eq 'Skipped') {
+                    #Same logic as when setting a test block to skip
+                    if ($PesterPreference.Debug.WriteDebugMessages.Value) {
+                        $path = $Test.Path -join '.'
+                        Write-PesterDebugMessage -Scope Skip "($path) Test is skipped."
+                    }
+                    $test.Passed = $true
+                    $test.Skipped = $true
+                } else {
+                    $Test.Passed = $result.Success
+                }
+
                 $Test.StandardOutput = $result.StandardOutput
                 $Test.ErrorRecord = $result.ErrorRecord
             }

--- a/src/csharp/Pester/Factory.cs
+++ b/src/csharp/Pester/Factory.cs
@@ -22,7 +22,7 @@ namespace Pester
             return new System.Management.Automation.RuntimeDefinedParameterDictionary();
         }
 
-        public static ErrorRecord CreateErrorRecord(string message, string file, string line, string lineText, bool terminating)
+        public static ErrorRecord CreateShouldErrorRecord(string message, string file, string line, string lineText, bool terminating)
         {
             return CreateErrorRecord("PesterAssertionFailed", message, file, line, lineText, terminating);
         }

--- a/src/csharp/Pester/Factory.cs
+++ b/src/csharp/Pester/Factory.cs
@@ -22,10 +22,13 @@ namespace Pester
             return new System.Management.Automation.RuntimeDefinedParameterDictionary();
         }
 
-        public static ErrorRecord CreateShouldErrorRecord(string message, string file, string line, string lineText, bool terminating)
+        public static ErrorRecord CreateErrorRecord(string message, string file, string line, string lineText, bool terminating)
+        {
+            return CreateErrorRecord("PesterAssertionFailed", message, file, line, lineText, terminating);
+        }
+        public static ErrorRecord CreateErrorRecord(string errorId, string message, string file, string line, string lineText, bool terminating)
         {
             var exception = new Exception(message);
-            var errorId = "PesterAssertionFailed";
             var errorCategory = ErrorCategory.InvalidResult;
             // we use ErrorRecord.TargetObject to pass structured information about the error to a reporting system.
             var targetObject = new Dictionary<string, object> { };

--- a/src/functions/Output.ps1
+++ b/src/functions/Output.ps1
@@ -532,6 +532,10 @@ function Get-WriteScreenPlugin ($Verbosity) {
             $margin = $ReportStrings.Margin * ($level)
             $error_margin = $margin + $ReportStrings.Margin
             $out = $_test.ExpandedName
+            if ($_test.ErrorRecord.FullyQualifiedErrorId -eq 'PesterTestSkipped') {
+                $skippedMessage = [String]$_Test.ErrorRecord
+                [String]$out += " $skippedMessage"
+            }
         }
         elseif ('Minimal' -eq $PesterPreference.Output.Verbosity.Value) {
             $level = 0
@@ -578,11 +582,6 @@ function Get-WriteScreenPlugin ($Verbosity) {
             Skipped {
                 if ($PesterPreference.Output.Verbosity.Value -in 'Normal', 'Detailed', 'Diagnostic') {
                     & $SafeCommands['Write-Host'] -ForegroundColor $ReportTheme.Skipped "$margin[!] $out" -NoNewLine
-                    & $SafeCommands['Write-Host'] -ForegroundColor $ReportTheme.Skipped " is skipped" -NoNewLine
-                    $because = $_test.Data.Because
-                    if ($because) {
-                        & $SafeCommands['Write-Host'] -ForegroundColor $ReportTheme.Skipped ", because $because" -NoNewLine
-                    }
                     & $SafeCommands['Write-Host'] -ForegroundColor $ReportTheme.SkippedTime " $humanTime"
                 }
                 break

--- a/src/functions/Output.ps1
+++ b/src/functions/Output.ps1
@@ -577,9 +577,12 @@ function Get-WriteScreenPlugin ($Verbosity) {
 
             Skipped {
                 if ($PesterPreference.Output.Verbosity.Value -in 'Normal', 'Detailed', 'Diagnostic') {
-                    $because = if ($_test.FailureMessage) { ", because $($_test.FailureMessage)" } else { $null }
                     & $SafeCommands['Write-Host'] -ForegroundColor $ReportTheme.Skipped "$margin[!] $out" -NoNewLine
-                    & $SafeCommands['Write-Host'] -ForegroundColor $ReportTheme.Skipped ", is skipped$because" -NoNewLine
+                    & $SafeCommands['Write-Host'] -ForegroundColor $ReportTheme.Skipped " is skipped" -NoNewLine
+                    $because = $_Test.Data.Because
+                    if ($Because) {
+                        & $SafeCommands['Write-Host'] -ForegroundColor $ReportTheme.Skipped ", because $Because" -NoNewLine
+                    }
                     & $SafeCommands['Write-Host'] -ForegroundColor $ReportTheme.SkippedTime " $humanTime"
                 }
                 break

--- a/src/functions/Output.ps1
+++ b/src/functions/Output.ps1
@@ -579,9 +579,9 @@ function Get-WriteScreenPlugin ($Verbosity) {
                 if ($PesterPreference.Output.Verbosity.Value -in 'Normal', 'Detailed', 'Diagnostic') {
                     & $SafeCommands['Write-Host'] -ForegroundColor $ReportTheme.Skipped "$margin[!] $out" -NoNewLine
                     & $SafeCommands['Write-Host'] -ForegroundColor $ReportTheme.Skipped " is skipped" -NoNewLine
-                    $because = $_Test.Data.Because
-                    if ($Because) {
-                        & $SafeCommands['Write-Host'] -ForegroundColor $ReportTheme.Skipped ", because $Because" -NoNewLine
+                    $because = $_test.Data.Because
+                    if ($because) {
+                        & $SafeCommands['Write-Host'] -ForegroundColor $ReportTheme.Skipped ", because $because" -NoNewLine
                     }
                     & $SafeCommands['Write-Host'] -ForegroundColor $ReportTheme.SkippedTime " $humanTime"
                 }

--- a/src/functions/Set-ItResult.ps1
+++ b/src/functions/Set-ItResult.ps1
@@ -71,7 +71,7 @@ function Set-ItResult {
             [String]$Line = $MyInvocation.ScriptLineNumber
         }
         $LineText {
-            $LineText = [String]$MyInvocation.Line.trim()
+            [String]$LineText = $MyInvocation.Line.trim()
         }
     }
 

--- a/src/functions/Set-ItResult.ps1
+++ b/src/functions/Set-ItResult.ps1
@@ -9,11 +9,15 @@ function Set-ItResult {
     Using Set-ItResult it is possible to set the result from the inside of the It script
     block to either inconclusive, pending or skipped.
 
+    As of Pester 5, there is no "Inconclusive" or "Pending" test state, so all tests will now go to state skipped,
+    however the test result notes will include information about being inconclusive or testing to keep this command
+    backwards compatible
+
     .PARAMETER Inconclusive
-    Sets the test result to inconclusive. Cannot be used at the same time as -Pending or -Skipped
+    **DEPRECATED** Sets the test result to inconclusive. Cannot be used at the same time as -Pending or -Skipped
 
     .PARAMETER Pending
-    Sets the test result to pending. Cannot be used at the same time as -Inconclusive or -Skipped
+    **DEPRECATED** Sets the test result to pending. Cannot be used at the same time as -Inconclusive or -Skipped
 
     .PARAMETER Skipped
     Sets the test result to skipped. Cannot be used at the same time as -Inconclusive or -Pending
@@ -21,23 +25,6 @@ function Set-ItResult {
     .PARAMETER Because
     Similarily to failing tests, skipped and inconclusive tests should have reason. It allows
     to provide information to the user why the test is neither successful nor failed.
-
-    .EXAMPLE
-    ```ps
-    Describe "Example" {
-        It "Inconclusive result test" {
-            Set-ItResult -Inconclusive -Because "we want it to be inconclusive"
-        }
-    }
-    ```
-
-    the output should be
-
-    ```
-    [?] Inconclusive result test, is inconclusive, because we want it to be inconclusive
-    Tests completed in 0ms
-    Tests Passed: 0, Failed: 0, Skipped: 0, Pending: 0, Inconclusive 1
-    ```
 
     .EXAMPLE
     ```ps
@@ -51,7 +38,7 @@ function Set-ItResult {
     the output should be
 
     ```
-    [!] Skipped test, is skipped, because we want it to be skipped
+    [!] Skipped test is skipped, because we want it to be skipped
     Tests completed in 0ms
     Tests Passed: 0, Failed: 0, Skipped: 0, Pending: 0, Inconclusive 1
     ```
@@ -67,60 +54,14 @@ function Set-ItResult {
     Assert-DescribeInProgress -CommandName Set-ItResult
 
     $result = $PSCmdlet.ParameterSetName
-    $message = "It result set to $result$(if ($Because) { ", $Because" })"
-    $data = @{
-        Result  = $result
-        Because = $Because
-    }
-    $errorRecord = New-PesterErrorRecord -Result $result  -Message $message -Data $data
-    throw $errorRecord
-}
 
-function New-PesterErrorRecord {
-    [CmdletBinding()]
-    param(
-        [Parameter(Mandatory = $true)]
-        [string]$Result,
-        [Parameter(Mandatory = $true)]
-        [string]$Message,
-        [string]$File,
-        [string]$Line,
-        [string]$LineText,
-        [hashtable]$Data
-    )
-
-    $exception = [Exception]$Message
-    $errorID = "PesterTest$Result"
-    $errorCategory = [Management.Automation.ErrorCategory]::InvalidResult
-
-    # we use ErrorRecord.TargetObject to pass structured information about the error to a reporting system.
-    $targetObject = @{
-        Message  = $Message
-        Data     = $Data
-        File     = $(if ($File -ne $null) {
-                $File
-            }
-            else {
-                $MyInvocation.ScriptName
-            })
-        Line     = $(if ($Line -ne $null) {
-                $Line
-            }
-            else {
-                $MyInvocation.ScriptLineNumber
-            })
-        LineText = $(if ($LineText -ne $null) {
-                $LineText
-            }
-            else {
-                $MyInvocation.Line
-            }).TrimEnd($([System.Environment]::NewLine))
+    #TODO: Remove in Pester 6
+    if ($result -in 'Inconclusive','Pending') {
+        Write-Host -Fore Yellow 'DEPRECATION WARNING: Inconclusive and Pending states are deprecated in Pester 5. You should update Set-ItResult in your tests to use -Skipped only'
+        [String]$Because = $result.toUpper() + ': ' + $Because
     }
 
-    & $SafeCommands['New-Object'] Management.Automation.ErrorRecord $exception, $errorID, $errorCategory, $targetObject@{
-        exception     = $exception
-        errorId       = $errorID
-        errorCategory = $errorCategory
-        targetObject  = $targetObject
-    }
+    $test.Result = 'Skipped'
+    $test.Data.Because = $Because
+    throw [Management.Automation.RuntimeException]'Skipped'
 }

--- a/src/functions/Set-ItResult.ps1
+++ b/src/functions/Set-ItResult.ps1
@@ -61,7 +61,7 @@ function Set-ItResult {
         [String]$Because = $result.toUpper() + ': ' + $Because
     }
 
-    $test.Result = 'Skipped'
-    $test.Data.Because = $Because
+    $Test.Result = 'Skipped'
+    $Test.Data.Because = $Because
     throw [Management.Automation.RuntimeException]'Skipped'
 }


### PR DESCRIPTION
<!--

Thank you for contributing to Pester! Please provide a descriptive title of the pull request in the field 'Title'.

-->

## Summary

Resolves Set-ItResult not working correctly

## To-Do Checklist Prior to Merge

- [x] Fixes improper hashtable format
- [x] Treat Pending and Inconclusive as "skipped" for now
- [x] Fix Because Message in output
<!--

Please describe what your pull request fixes, or how it improves Pester.

If your pull request resolves a reported issue, please mention it by using  `Fix #<issue_number>` on a new line, this will close the linked issue automatically when this PR is merged. For more info see: [Closing issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/).

If your pull request integrates Pester with another system, please tell us how the change can be tested.

Please remember to update [the Pester wiki](https://github.com/pester/Pester/wiki) if needed.

Before you continue, please review [Contributing to Pester](https://github.com/pester/Pester/wiki/Contributing-to-Pester) and [Development rules - technical](https://github.com/pester/Pester/wiki/Developement-rules---technical).

Our continuous integration system doesn't send any notifications about failed tests. Please return to the opened pull request (after ~60 minutes) to check if is everything OK.

-->
