### PR TITLE
Fix TestDrive and TestRegistry teardowns when already teared down

### DIFF
--- a/src/Pester.RSpec.ps1
+++ b/src/Pester.RSpec.ps1
@@ -191,6 +191,10 @@ function PostProcess-RspecTestRun ($TestRun) {
         }
 
         ## summarize
+        if (0 -lt $b.ErrorRecord.Count) {
+            $TestRun.FailedContainers.Add($b)
+        }
+
         $TestRun.Duration += $b.Duration
         $TestRun.UserDuration += $b.UserDuration
         $TestRun.FrameworkDuration += $b.FrameworkDuration
@@ -205,8 +209,9 @@ function PostProcess-RspecTestRun ($TestRun) {
     $TestRun.TotalCount = $TestRun.Tests.Count
 
     $TestRun.FailedBlocksCount = $TestRun.FailedBlocks.Count
+    $TestRun.FailedContainersCount = $TestRun.FailedContainers.Count
 
-    $TestRun.Result = if (0 -lt ($TestRun.FailedCount + $TestRun.FailedBlocksCount)) {
+    $TestRun.Result = if (0 -lt ($TestRun.FailedCount + $TestRun.FailedBlocksCount + $TestRun.FailedContainersCount)) {
         "Failed"
     }
     else {

--- a/src/Pester.ps1
+++ b/src/Pester.ps1
@@ -565,7 +565,7 @@ function Invoke-Pester {
             }
 
             if ($PesterPreference.Run.Exit.Value -and "failed" -eq $run.Result) {
-                exit ($run.FailedCount + $run.FailedBlocksCount)
+                exit ($run.FailedCount + $run.FailedBlocksCount + $run.FailedContainersCount)
             }
         }
         catch {

--- a/src/csharp/Pester/Run.cs
+++ b/src/csharp/Pester/Run.cs
@@ -17,6 +17,7 @@ namespace Pester
         public string Result { get; set; } = "NotRun";
         public int FailedCount { get; set; }
         public int FailedBlocksCount { get; set; }
+        public int FailedContainersCount { get; set; }
 
         public int PassedCount { get; set; }
         public int SkippedCount { get; set; }
@@ -43,6 +44,7 @@ namespace Pester
 
         public List<Test> Failed { get; set; } = new List<Test>();
         public List<Block> FailedBlocks { get; set; } = new List<Block>();
+        public List<Container> FailedContainers { get; set; } = new List<Container>();
 
         public List<Test> Passed { get; set; } = new List<Test>();
         public List<Test> Skipped { get; set; } = new List<Test>();

--- a/src/csharp/Pester/ToStringConverter.cs
+++ b/src/csharp/Pester/ToStringConverter.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Management.Automation;
 
 namespace Pester
 {
@@ -26,6 +27,15 @@ namespace Pester
             {
                 case "File":
                     path = container.Item.ToString();
+                    break;
+                case "ScriptBlock":
+                    path = $"<ScriptBlock>"; 
+                    if (container.Item is ScriptBlock s) { 
+                        if (!string.IsNullOrWhiteSpace(s.File))
+                        {
+                            path += $":{s.File}:{s.StartPosition.StartLine}";
+                        }
+                    }
                     break;
                 default:
                     path = $"<{container.Type}>";

--- a/src/functions/Output.ps1
+++ b/src/functions/Output.ps1
@@ -268,6 +268,24 @@ function Write-PesterReport {
         & $SafeCommands['Write-Host'] ("BeforeAll \ AfterAll failed: {0}" -f $RunResult.FailedBlocksCount) -Foreground $ReportTheme.Fail
         & $SafeCommands['Write-Host'] ($(foreach ($b in $RunResult.FailedBlocks) { "  - $($b.Path -join '.')" }) -join [Environment]::NewLine) -Foreground $ReportTheme.Fail
     }
+
+    if (0 -lt $RunResult.FailedContainersCount) {
+        $cs = foreach ($container in $RunResult.FailedContainers) {
+            $path = if ("File" -eq $container.Type) {
+                $container.Item.FullName
+            }
+            elseif ("ScriptBlock" -eq $container.Type) {
+                "<ScriptBlock>$($container.Item.File):$($container.Item.StartPosition.StartLine)"
+            }
+            else {
+                throw "Container type '$($container.Type)' is not supported."
+            }
+
+            "  - $path"
+        }
+        & $SafeCommands['Write-Host'] ("Container failed: {0}" -f $RunResult.FailedContainersCount) -Foreground $ReportTheme.Fail
+        & $SafeCommands['Write-Host'] ($cs -join [Environment]::NewLine) -Foreground $ReportTheme.Fail
+    }
         # & $SafeCommands['Write-Host'] ($ReportStrings.TestsPending -f $RunResult.PendingCount) -Foreground $Pending -NoNewLine
         # & $SafeCommands['Write-Host'] ($ReportStrings.TestsInconclusive -f $RunResult.InconclusiveCount) -Foreground $Inconclusive
     # }

--- a/src/functions/Pester.SafeCommands.ps1
+++ b/src/functions/Pester.SafeCommands.ps1
@@ -1,5 +1,3 @@
-$script:IgnoreErrorPreference = 'Ignore' # TODO: get rid of this, it is used in only few places
-
 # Tried using $ExecutionState.InvokeCommand.GetCmdlet() here, but it does not trigger module auto-loading the way
 # Get-Command does.  Since this is at import time, before any mocks have been defined, that's probably acceptable.
 # If someone monkeys with Get-Command before they import Pester, they may break something.

--- a/src/functions/TestDrive.ps1
+++ b/src/functions/TestDrive.ps1
@@ -136,7 +136,7 @@ function Remove-TestDriveSymbolicLinks ([String] $Path) {
 function Remove-TestDrive {
 
     $DriveName = "TestDrive"
-    $Drive = & $SafeCommands['Get-PSDrive'] -Name $DriveName -ErrorAction 'Ignore'
+    $Drive = & $SafeCommands['Get-PSDrive'] -Name $DriveName -ErrorAction Ignore
     $Path = ($Drive).Root
 
 
@@ -157,7 +157,7 @@ function Remove-TestDrive {
         & $SafeCommands['Remove-Item'] -Path $Path -Force -Recurse
     }
 
-    if (& $SafeCommands['Get-Variable'] -Name $DriveName -Scope Global -ErrorAction 'Ignore') {
+    if (& $SafeCommands['Get-Variable'] -Name $DriveName -Scope Global -ErrorAction Ignore) {
         & $SafeCommands['Remove-Variable'] -Scope Global -Name $DriveName -Force
     }
 }

--- a/src/functions/TestDrive.ps1
+++ b/src/functions/TestDrive.ps1
@@ -71,6 +71,15 @@ function New-TestDrive ([Switch]$PassThru, [string] $Path) {
 
 
 function Clear-TestDrive ([String[]]$Exclude) {
+    $drive = & $SafeCommands['Get-PSDrive'] -Name TestDrive -ErrorAction Ignore
+
+    if ($null -eq $drive) {
+        # someone cleared it up before us, maybe a Pester running in a child scope
+        return
+    }
+
+    $Path = $drive.Root
+
     $Path = (& $SafeCommands['Get-PSDrive'] -Name TestDrive).Root
     if (& $SafeCommands['Test-Path'] -Path $Path ) {
 
@@ -127,7 +136,7 @@ function Remove-TestDriveSymbolicLinks ([String] $Path) {
 function Remove-TestDrive {
 
     $DriveName = "TestDrive"
-    $Drive = & $SafeCommands['Get-PSDrive'] -Name $DriveName -ErrorAction $script:IgnoreErrorPreference
+    $Drive = & $SafeCommands['Get-PSDrive'] -Name $DriveName -ErrorAction 'Ignore'
     $Path = ($Drive).Root
 
 
@@ -148,7 +157,7 @@ function Remove-TestDrive {
         & $SafeCommands['Remove-Item'] -Path $Path -Force -Recurse
     }
 
-    if (& $SafeCommands['Get-Variable'] -Name $DriveName -Scope Global -ErrorAction $script:IgnoreErrorPreference) {
+    if (& $SafeCommands['Get-Variable'] -Name $DriveName -Scope Global -ErrorAction 'Ignore') {
         & $SafeCommands['Remove-Variable'] -Scope Global -Name $DriveName -Force
     }
 }

--- a/src/functions/TestRegistry.ps1
+++ b/src/functions/TestRegistry.ps1
@@ -108,7 +108,7 @@ function New-RandomTempRegistry {
 
 function Remove-TestRegistry {
     $DriveName = "TestRegistry"
-    $Drive = & $SafeCommands['Get-PSDrive'] -Name $DriveName -ErrorAction 'Ignore'
+    $Drive = & $SafeCommands['Get-PSDrive'] -Name $DriveName -ErrorAction Ignore
     if ($null -eq $Drive) {
         # the drive does not exist, someone must have removed it instead of us,
         # most likely a test that tests pester itself, so we just hope that the
@@ -132,7 +132,7 @@ function Remove-TestRegistry {
         & $SafeCommands['Remove-Item'] -Path $path -Force -Recurse
     }
 
-    if (& $SafeCommands['Get-Variable'] -Name $DriveName -Scope Global -ErrorAction 'Ignore') {
+    if (& $SafeCommands['Get-Variable'] -Name $DriveName -Scope Global -ErrorAction Ignore) {
         & $SafeCommands['Remove-Variable'] -Scope Global -Name $DriveName -Force
     }
 }

--- a/src/functions/TestRegistry.ps1
+++ b/src/functions/TestRegistry.ps1
@@ -108,7 +108,7 @@ function New-RandomTempRegistry {
 
 function Remove-TestRegistry {
     $DriveName = "TestRegistry"
-    $Drive = & $SafeCommands['Get-PSDrive'] -Name $DriveName -ErrorAction $script:IgnoreErrorPreference
+    $Drive = & $SafeCommands['Get-PSDrive'] -Name $DriveName -ErrorAction 'Ignore'
     if ($null -eq $Drive) {
         # the drive does not exist, someone must have removed it instead of us,
         # most likely a test that tests pester itself, so we just hope that the
@@ -132,7 +132,7 @@ function Remove-TestRegistry {
         & $SafeCommands['Remove-Item'] -Path $path -Force -Recurse
     }
 
-    if (& $SafeCommands['Get-Variable'] -Name $DriveName -Scope Global -ErrorAction $script:IgnoreErrorPreference) {
+    if (& $SafeCommands['Get-Variable'] -Name $DriveName -Scope Global -ErrorAction 'Ignore') {
         & $SafeCommands['Remove-Variable'] -Scope Global -Name $DriveName -Force
     }
 }
@@ -143,7 +143,7 @@ function Get-TestRegistryPlugin {
     # TODO: add OnStart block and put this in it
 
     if (Test-Path TestRegistry:\) {
-        Remove-Item (Get-PSDrive TestRegistry -ErrorAction Stop).Root -Force -Recurse -Confirm:$false
+        Remove-Item (Get-PSDrive TestRegistry -ErrorAction Stop).Root -Force -Recurse -Confirm:$false -ErrorAction Ignore
         Remove-PSDrive TestRegistry
     }
     New-PluginObject -Name "TestRegistry" -EachBlockSetupStart {

--- a/src/functions/TestResults.ps1
+++ b/src/functions/TestResults.ps1
@@ -197,12 +197,12 @@ function Write-NUnitTestResultChildNodes($RunResult, [System.Xml.XmlWriter] $Xml
     $cwdReplacement = [regex]::Escape($pwd.Path)
     foreach ($container in $Result.Containers) {
         if ("File" -eq $container.Type) {
-            $path = ($action.Path -replace "$cwdReplacement[\\/](.*)", '.\$1')
+            $path = ($container.Item.FullName -replace "$cwdReplacement[\\/](.*)", '.\$1')
         }
         elseif ("ScriptBlock" -eq $container.Type) {
             $path = "<ScriptBlock>$($container.Item.File):$($container.Item.StartPosition.StartLine)"
         }
-        else  {
+        else {
             throw "Container type '$($container.Type)' is not supported."
         }
         Write-NUnitTestSuiteElements -XmlWriter $XmlWriter -Node $container -Path $path

--- a/tst/functions/Pester.TestDrive.ts.ps1
+++ b/tst/functions/Pester.TestDrive.ts.ps1
@@ -1,15 +1,9 @@
 param ([switch] $PassThru)
 
-
 Get-Module Pester.Runtime, Pester.Utility, P, Pester, Axiom, Stack | Remove-Module
 
 Import-Module $PSScriptRoot\..\p.psm1 -DisableNameChecking
 Import-Module $PSScriptRoot\..\axiom\Axiom.psm1 -DisableNameChecking
-
-if ($PSVersionTable.PSVersion.Major -le 5 -or -not $IsWindows) {
-    Write-Host "Not on Windows skipping TestRegistry tests." -ForegroundColor Yellow
-    return (i -PassThru:$PassThru { })
-}
 
 Import-Module $PSScriptRoot\..\..\bin\Pester.psd1
 
@@ -23,13 +17,13 @@ $global:PesterPreference = @{
 }
 
 i -PassThru:$PassThru {
-    b "Test registry clean up" {
-        t "TestRegistry is removed after execution" {
+    b "Test drive clean up" {
+        t "TestDrive is removed after execution" {
             $c = @{ DrivePath = $null}
             $sb = {
                 Describe "a" {
                     It "i" {
-                        $c.DrivePath = (Get-PSDrive "TestRegistry").Root -replace "HKEY_CURRENT_USER", "HKCU:"
+                        $c.DrivePath = (Get-PSDrive "TestDrive").Root
                     }
                 }
             }
@@ -42,12 +36,12 @@ i -PassThru:$PassThru {
 
             $registryKeyWasRemoved | Verify-True
 
-            $testRegistryDriveWasRemoved = -not (Test-Path "TestRegistry:\")
-            $testRegistryDriveWasRemoved | Verify-True
+            $TestDriveDriveWasRemoved = -not (Test-Path "TestDrive:\")
+            $TestDriveDriveWasRemoved | Verify-True
 
         }
 
-        t "TestRegistry removal does not fail when Pester is invoked in Pester" {
+        t "TestDrive removal does not fail when Pester is invoked in Pester" {
             $innerSb = {
                 Describe "d" {
                     It "i" {


### PR DESCRIPTION
Teardown TestDrive and TestRegistry only when they still exist, but don't fail when someone else already removed them, possibly a child Invoke-Pester running inside of this test.


Fixes #1524 