### PR TITLE
Feature: Allow Output Status Character Customization

### DIFF
--- a/src/csharp/Pester/Configuration.cs
+++ b/src/csharp/Pester/Configuration.cs
@@ -1006,6 +1006,10 @@ namespace Pester
     public class OutputConfiguration : ConfigurationSection
     {
         private StringOption _verbosity;
+        private StringOption _passedChar;
+        private StringOption _failedChar;
+        private StringOption _skippedChar;
+        private StringOption _unknownChar;
 
         public static OutputConfiguration Default { get { return new OutputConfiguration(); } }
         public static OutputConfiguration ShallowClone(OutputConfiguration configuration)
@@ -1024,6 +1028,10 @@ namespace Pester
         public OutputConfiguration() : base("Output configuration")
         {
             Verbosity = new StringOption("The verbosity of output, options are None, Minimal, Normal and Diagnostic.", "Minimal");
+            PassedChar = new StringOption("The character to use to represent passed tests in console output.", "+");
+            FailedChar = new StringOption("The character to use to represent failed tests in console output.", "-");
+            SkippedChar = new StringOption("The character to use to represent skipped tests in console output.", "!");
+            UnknownChar = new StringOption("The character to use to represent unknown tests in console output.", "?");
         }
 
         public StringOption Verbosity
@@ -1038,6 +1046,66 @@ namespace Pester
                 else
                 {
                     _verbosity = new StringOption(_verbosity, value?.Value);
+                }
+            }
+        }
+        public StringOption PassedChar
+        {
+            get { return _passedChar; }
+            set
+            {
+                if (_passedChar == null)
+                {
+                    _passedChar = value;
+                }
+                else
+                {
+                    _passedChar = new StringOption(_passedChar, value?.Value);
+                }
+            }
+        }
+        public StringOption FailedChar
+        {
+            get { return _failedChar; }
+            set
+            {
+                if (_failedChar == null)
+                {
+                    _failedChar = value;
+                }
+                else
+                {
+                    _failedChar = new StringOption(_failedChar, value?.Value);
+                }
+            }
+        }
+        public StringOption SkippedChar
+        {
+            get { return _skippedChar; }
+            set
+            {
+                if (_skippedChar == null)
+                {
+                    _skippedChar = value;
+                }
+                else
+                {
+                    _skippedChar = new StringOption(_skippedChar, value?.Value);
+                }
+            }
+        }
+        public StringOption UnknownChar
+        {
+            get { return _unknownChar; }
+            set
+            {
+                if (_unknownChar == null)
+                {
+                    _unknownChar = value;
+                }
+                else
+                {
+                    _unknownChar = new StringOption(_unknownChar, value?.Value);
                 }
             }
         }

--- a/src/functions/Output.ps1
+++ b/src/functions/Output.ps1
@@ -575,14 +575,14 @@ function Get-WriteScreenPlugin ($Verbosity) {
         switch ($result) {
             Passed {
                 if ($PesterPreference.Output.Verbosity.Value -in 'Normal', 'Detailed', 'Diagnostic') {
-                    & $SafeCommands['Write-Host'] -ForegroundColor $ReportTheme.Pass "$margin[+] $out" -NoNewLine
+                    & $SafeCommands['Write-Host'] -ForegroundColor $ReportTheme.Pass "$margin[$($PesterPreference.Output.PassedChar.Value)] $out" -NoNewLine
                     & $SafeCommands['Write-Host'] -ForegroundColor $ReportTheme.PassTime " $humanTime"
                 }
                 break
             }
 
             Failed {
-                & $SafeCommands['Write-Host'] -ForegroundColor $ReportTheme.Fail "$margin[-] $out" -NoNewLine
+                & $SafeCommands['Write-Host'] -ForegroundColor $ReportTheme.Fail "$margin[$($PesterPreference.Output.FailedChar.Value)] $out" -NoNewLine
                 & $SafeCommands['Write-Host'] -ForegroundColor $ReportTheme.FailTime " $humanTime"
 
                 # review how we should write errors for VS code based on https://github.com/PowerShell/vscode-powershell/pull/2447
@@ -599,7 +599,7 @@ function Get-WriteScreenPlugin ($Verbosity) {
 
             Skipped {
                 if ($PesterPreference.Output.Verbosity.Value -in 'Normal', 'Detailed', 'Diagnostic') {
-                    & $SafeCommands['Write-Host'] -ForegroundColor $ReportTheme.Skipped "$margin[!] $out" -NoNewLine
+                    & $SafeCommands['Write-Host'] -ForegroundColor $ReportTheme.Skipped "$margin[$($PesterPreference.Output.SkippedChar.Value)] $out" -NoNewLine
                     & $SafeCommands['Write-Host'] -ForegroundColor $ReportTheme.SkippedTime " $humanTime"
                 }
                 break
@@ -608,7 +608,7 @@ function Get-WriteScreenPlugin ($Verbosity) {
             Pending {
                 if ($PesterPreference.Output.Verbosity.Value -in 'Normal', 'Detailed', 'Diagnostic') {
                     $because = if ($_test.FailureMessage) { ", because $($_test.FailureMessage)" } else { $null }
-                    & $SafeCommands['Write-Host'] -ForegroundColor $ReportTheme.Pending "$margin[?] $out" -NoNewLine
+                    & $SafeCommands['Write-Host'] -ForegroundColor $ReportTheme.Pending "$margin[$($PesterPreference.Output.SkippedChar.Value)] $out" -NoNewLine
                     & $SafeCommands['Write-Host'] -ForegroundColor $ReportTheme.Pending ", is pending$because" -NoNewLine
                     & $SafeCommands['Write-Host'] -ForegroundColor $ReportTheme.PendingTime " $humanTime"
                 }
@@ -618,7 +618,7 @@ function Get-WriteScreenPlugin ($Verbosity) {
             Inconclusive {
                 if ($PesterPreference.Output.Verbosity.Value -in 'Normal', 'Detailed', 'Diagnostic') {
                     $because = if ($_test.FailureMessage) { ", because $($_test.FailureMessage)" } else { $null }
-                    & $SafeCommands['Write-Host'] -ForegroundColor $ReportTheme.Inconclusive "$margin[?] $out" -NoNewLine
+                    & $SafeCommands['Write-Host'] -ForegroundColor $ReportTheme.Inconclusive "$margin[$($PesterPreference.Output.UnknownChar.Value)] $out" -NoNewLine
                     & $SafeCommands['Write-Host'] -ForegroundColor $ReportTheme.Inconclusive ", is inconclusive$because" -NoNewLine
                     & $SafeCommands['Write-Host'] -ForegroundColor $ReportTheme.InconclusiveTime " $humanTime"
                 }
@@ -630,7 +630,7 @@ function Get-WriteScreenPlugin ($Verbosity) {
                 if ($PesterPreference.Output.Verbosity.Value -in 'Normal', 'Detailed', 'Diagnostic') {
                     # TODO:  Add actual Incomplete status as default rather than checking for null time.
                     if ($null -eq $_test.Duration) {
-                        & $SafeCommands['Write-Host'] -ForegroundColor $ReportTheme.Incomplete "$margin[?] $out" -NoNewLine
+                        & $SafeCommands['Write-Host'] -ForegroundColor $ReportTheme.Incomplete "$margin[$($PesterPreference.Output.UnknownChar.Value)] $out" -NoNewLine
                         & $SafeCommands['Write-Host'] -ForegroundColor $ReportTheme.IncompleteTime " $humanTime"
                     }
                 }


### PR DESCRIPTION
<!--

Thank you for contributing to Pester! Please provide a descriptive title of the pull request in the field 'Title'.

-->

## 1. General summary of the pull request

Adds properties to the PesterConfiguration object and modifies appropriate output items to allow for status symbol customization, such as displaying "PASS/FAIL" or displaying emojis.

![Capture](https://user-images.githubusercontent.com/15258962/81578047-25963a80-935f-11ea-8ef4-59b98606bc45.gif)

<!--

Please describe what your pull request fixes, or how it improves Pester.

If your pull request resolves a reported issue, please mention it by using  `Fix #<issue_number>` on a new line, this will close the linked issue automatically when this PR is merged. For more info see: [Closing issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/).

If your pull request integrates Pester with another system, please tell us how the change can be tested.

Please remember to update [the Pester wiki](https://github.com/pester/Pester/wiki) if needed.

Before you continue, please review [Contributing to Pester](https://github.com/pester/Pester/wiki/Contributing-to-Pester) and [Development rules - technical](https://github.com/pester/Pester/wiki/Developement-rules---technical).

Our continuous integration system doesn't send any notifications about failed tests. Please return to the opened pull request (after ~60 minutes) to check if is everything OK.

-->
