### PR TITLE
Make StringArrayOption property perform object[] to string[] transformation automatically in a similar way how PowerShell would do it

### DIFF
--- a/src/csharp/Pester/Configuration.cs
+++ b/src/csharp/Pester/Configuration.cs
@@ -220,7 +220,7 @@ namespace Pester
 
         }
 
-        public StringArrayOption(object[] value) : base("", new string[0], value.Cast<string>().ToArray())
+        public StringArrayOption(object[] value) : base("", new string[0], value.Select(oneValue => oneValue.ToString()).ToArray())
         {
 
         }

--- a/tst/Pester.RSpec.Configuration.ts.ps1
+++ b/tst/Pester.RSpec.Configuration.ts.ps1
@@ -186,7 +186,7 @@ i -PassThru:$PassThru {
         }
         t "StringArrayOption can be assigned an array of Objects that don't directly cast to a string" {
             $config = [PesterConfiguration]::Default
-            $path = (Join-Path $PWD "foo"), (Join-Path $PWD "bar")
+            $path = (Join-Path $PWD 'foo'), (Join-Path $PWD 'bar')
             $config.Run.Path = $path
 
             Verify-Same $path[0] -Actual $config.Run.Path.Value[0]

--- a/tst/Pester.RSpec.Configuration.ts.ps1
+++ b/tst/Pester.RSpec.Configuration.ts.ps1
@@ -184,6 +184,14 @@ i -PassThru:$PassThru {
             Verify-Same $path[0] -Actual $config.Run.Path.Value[0]
             Verify-Same $path[1] -Actual $config.Run.Path.Value[1]
         }
+        t "StringArrayOption can be assigned an array of Objects that don't directly cast to a string" {
+            $config = [PesterConfiguration]::Default
+            $path = (Join-Path $PWD "foo"), (Join-Path $PWD "bar")
+            $config.Run.Path = $path
+
+            Verify-Same $path[0] -Actual $config.Run.Path.Value[0]
+            Verify-Same $path[1] -Actual $config.Run.Path.Value[1]
+        }
     }
 
     b "Cloning" {


### PR DESCRIPTION
Fixes #1548

As described in the issue, there are cases where  the cast fails for a valid object array. Since very object has to implement `.ToString()`, we can do the conversion ourselves. This way the behaviour will be more PowerShell-y.

Can you point me at a good place for a unit test for that? The xunit test project don't seem to be run in CI btw.