### PR TITLE
Feat: Add a configuration option to suppress per-file Discovery messages

### DIFF
--- a/src/csharp/Pester/Configuration.cs
+++ b/src/csharp/Pester/Configuration.cs
@@ -1006,6 +1006,7 @@ namespace Pester
     public class OutputConfiguration : ConfigurationSection
     {
         private StringOption _verbosity;
+        private BoolOption _summarizeDiscovery;
 
         public static OutputConfiguration Default { get { return new OutputConfiguration(); } }
         public static OutputConfiguration ShallowClone(OutputConfiguration configuration)
@@ -1024,6 +1025,7 @@ namespace Pester
         public OutputConfiguration() : base("Output configuration")
         {
             Verbosity = new StringOption("The verbosity of output, options are None, Minimal, Normal and Diagnostic.", "Minimal");
+            SummarizeDiscovery = new BoolOption("Display only a summary of Discovery, rather than per-file statistics. Default is not enabled", false);
         }
 
         public StringOption Verbosity
@@ -1038,6 +1040,22 @@ namespace Pester
                 else
                 {
                     _verbosity = new StringOption(_verbosity, value?.Value);
+                }
+            }
+        }
+
+        public BoolOption SummarizeDiscovery
+        {
+            get { return _summarizeDiscovery; }
+            set
+            {
+                if (_summarizeDiscovery == null)
+                {
+                    _summarizeDiscovery = value;
+                }
+                else
+                {
+                    _summarizeDiscovery = new BoolOption(_summarizeDiscovery, value.Value);
                 }
             }
         }

--- a/src/functions/Output.ps1
+++ b/src/functions/Output.ps1
@@ -467,7 +467,9 @@ function Get-WriteScreenPlugin ($Verbosity) {
     if ($PesterPreference.Output.Verbosity.Value -in 'Normal', 'Detailed', 'Diagnostic') {
         $p.ContainerDiscoveryStart = {
             param ($Context)
-            & $SafeCommands["Write-Host"] -ForegroundColor Magenta "Discovering in $($Context.BlockContainer.Item)."
+            if (-not $PesterPreference.Output.SummarizeDiscovery.Value) {
+                & $SafeCommands["Write-Host"] -ForegroundColor Magenta "Discovering in $($Context.BlockContainer.Item)."
+            }
         }
     }
 
@@ -475,7 +477,9 @@ function Get-WriteScreenPlugin ($Verbosity) {
         $p.ContainerDiscoveryEnd = {
             param ($Context)
             # todo: this is very very slow because of View-flat
-            & $SafeCommands["Write-Host"] -ForegroundColor Magenta "Found $(@(View-Flat -Block $Context.Block).Count) tests. $(ConvertTo-HumanTime $Context.Duration)"
+            if (-not $PesterPreference.Output.SummarizeDiscovery.Value) {
+                & $SafeCommands["Write-Host"] -ForegroundColor Magenta "Found $(@(View-Flat -Block $Context.Block).Count) tests. $(ConvertTo-HumanTime $Context.Duration)"
+            }
         }
     }
 


### PR DESCRIPTION
<!--

Thank you for contributing to Pester! Please provide a descriptive title of the pull request in the field 'Title'.

-->

## 1. General summary of the pull request

<!--

Please describe what your pull request fixes, or how it improves Pester.

If your pull request resolves a reported issue, please mention it by using  `Fix #<issue_number>` on a new line, this will close the linked issue automatically when this PR is merged. For more info see: [Closing issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/).

If your pull request integrates Pester with another system, please tell us how the change can be tested.

Please remember to update [the Pester wiki](https://github.com/pester/Pester/wiki) if needed.

Before you continue, please review [Contributing to Pester](https://github.com/pester/Pester/wiki/Contributing-to-Pester) and [Development rules - technical](https://github.com/pester/Pester/wiki/Developement-rules---technical).

Our continuous integration system doesn't send any notifications about failed tests. Please return to the opened pull request (after ~60 minutes) to check if is everything OK.

-->

Adds Output.SummarizeDiscovery option

Resolves #1552


## Examples
### Default Behavior
![image](https://user-images.githubusercontent.com/15258962/82155026-f1bb8900-9826-11ea-90ce-e7f08b79bb63.png)

### Enabling SummarizeDiscovery
![image](https://user-images.githubusercontent.com/15258962/82155071-2e878000-9827-11ea-9d02-ac69a865e128.png)
