### PR TITLE
Should work

### DIFF
--- a/src/Pester.ps1
+++ b/src/Pester.ps1
@@ -77,8 +77,7 @@ function Add-ShouldOperator {
         [string] $InternalName,
 
         [switch] $SupportsArrayInput
-    )
-
+    )    
     $entry = New-Object psobject -Property @{
         Test               = $Test
         SupportsArrayInput = [bool]$SupportsArrayInput
@@ -228,14 +227,70 @@ function Add-AssertionDynamicParameterSet {
 
         $null = $dynamic.Attributes.Add($attribute)
     }
+
+    $script:AssertionDynamicParamsByParameterSet = @{}
 }
 
 function Get-AssertionOperatorEntry([string] $Name) {
     return $script:AssertionOperators[$Name]
 }
 
-function Get-AssertionDynamicParams {
-    return $script:AssertionDynamicParams
+function Get-AssertionDynamicParams([string] $ParameterSet) {
+    if (-not $ParameterSet) {
+        return $script:AssertionDynamicParams
+    }
+    if (-not $script:AssertionDynamicParamsByParameterSet) {
+        $script:AssertionDynamicParamsByParameterSet = @{}
+    }
+    if (-not $script:AssertionDynamicParamsByParameterSet[$ParameterSet]) {
+        $script:AssertionDynamicParamsByParameterSet[$ParameterSet] = [Pester.Factory]::CreateRuntimeDefinedParameterDictionary()
+        $anyFound = $false 
+        :nextParameter foreach ($param in $script:AssertionDynamicParams.Values) {
+            $attributeCollection = New-Object Collections.ObjectModel.Collection[Attribute]
+
+            $includeParameter = $false
+            foreach ($attribute in $param.Attributes) {
+                if ($attribute -is [Management.Automation.ParameterAttribute]) {
+                    if ($attribute.ParameterSetName -ne $ParameterSet) { continue }
+                    if ($param.Name -eq $ParameterSet -and $param.ParameterType -eq [switch]) {
+                        continue nextParameter
+                    }
+                    # Very few parts of PowerShell are case-sensitive.
+                    # Parameter set names are one of them.  
+                    if ($ParameterSet -cne $attribute.ParameterSetName) { # So check the case
+                        $ParameterSet = $attribute.ParameterSetName # and make sure it matches the parameter set name.
+                    }
+
+                    $includeParameter = $true
+                }
+                if ($attribute -is [Management.Automation.AliasAttribute] -and 
+                    $param.ParameterType -eq [switch] -and 
+                    $attribute.ValidValues -contains $ParameterSet) {
+                    continue nextParameter    
+                }
+                $attributeCollection.Add($attribute)
+            }
+            
+            if ($includeParameter) {
+                $anyFound = $true
+                $dynamic = New-Object System.Management.Automation.RuntimeDefinedParameter($param.Name, $param.ParameterType, $attributeCollection)
+                $script:AssertionDynamicParamsByParameterSet[$ParameterSet].Add($param.Name, $dynamic)
+            }
+        }
+        if ($anyFound) {
+            $attribute = New-Object Management.Automation.ParameterAttribute
+            $attribute.ParameterSetName = $ParameterSet
+            $attribute.Mandatory = $true
+            $attribute.Position = 0 
+
+            $attributeCollection = New-Object Collections.ObjectModel.Collection[Attribute]
+            $null = $attributeCollection.Add($attribute)
+
+            $dynamic = New-Object System.Management.Automation.RuntimeDefinedParameter('ShouldOperator', [string], $attributeCollection)
+            $null = $script:AssertionDynamicParamsByParameterSet[$ParameterSet].Add('ShouldOperator', $dynamic)           
+        }
+    }
+    return $script:AssertionDynamicParamsByParameterSet[$ParameterSet]
 }
 
 function Has-Flag {

--- a/src/functions/assertions/Should.ps1
+++ b/src/functions/assertions/Should.ps1
@@ -53,7 +53,7 @@ function Should {
             $MyInvocation.Line.Substring($MyInvocation.OffsetInLine - 1)
 
         # A bit of Regex lets us know if the line used the old form
-        if ($myLine -match '\s{0,}should\s{1,}(?<Operator>[^\-\s]+)')
+        if ($myLine -match '^\s{0,}should\s{1,}(?<Operator>[^\-\s]+)')
         {
             $operatorDynamicParameters = Get-AssertionDynamicParams $matches.Operator
             if ($operatorDynamicParameters.Count -ge 1) {

--- a/src/functions/assertions/Should.ps1
+++ b/src/functions/assertions/Should.ps1
@@ -1,4 +1,4 @@
-function Get-FailureMessage($assertionEntry, $negate, $value, $expected) {
+﻿function Get-FailureMessage($assertionEntry, $negate, $value, $expected) {
     if ($negate) {
         $failureMessageFunction = $assertionEntry.GetNegativeFailureMessage
     }
@@ -48,7 +48,39 @@ function Should {
     )
 
     dynamicparam {
-        Get-AssertionDynamicParams
+        # Figuring out if we are using the old syntax is 'easy'
+        $myLine = # we can use $myInvocation.Line to get the surrounding context
+            $MyInvocation.Line.Substring($MyInvocation.OffsetInLine - 1)
+
+        # A bit of Regex lets us know if the line used the old form
+        if ($myLine -match '\s{0,}should\s{1,}(?<Operator>[^\-\s]+)')
+        {
+            $operatorDynamicParameters = Get-AssertionDynamicParams $matches.Operator
+            if ($operatorDynamicParameters.Count -ge 1) {
+                return $operatorDynamicParameters
+            }
+            # Now it gets tricky.  This will be called once for each unmapped parameter.
+            # So while we always want to return here, we only want to error once
+            # The message uniqueness can be one part of our error.
+            $shouldErrorMsg =
+                "should operator '$($matches.Operator)' not found."
+
+            # The rest of the uniqueness we can cobble together out of $MyInvocation.
+            $uniqueErrorMsg = $shouldErrorMsg,
+                $MyInvocation.HistoryId, # The history ID is unique per run
+                $MyInvocation.PSCommandPath, # the command path is unique per file
+                $myLine  -join '.' # and the whole line should be.  Join all of these pieces by .
+
+
+            if ($script:lastShouldErrorMsg -ne $uniqueErrorMsg) {
+                $script:lastShouldErrorMsg  = $uniqueErrorMsg
+                Write-Error $shouldErrorMsg
+                return
+            }
+            return
+        } else {
+            Get-AssertionDynamicParams
+        }
     }
 
     begin {
@@ -130,6 +162,7 @@ function Should {
             AddErrorCallback   = $addErrorCallback
         }
 
+        if (-not $entry) { return }
         if ($inputArray.Count -eq 0) {
             Invoke-Assertion @assertionParams -ValueToTest $null
         }


### PR DESCRIPTION
This Pull Request enables most of the syntax for should to maintain backwards compatibility.

e.g.  
~~~PowerShell
1 | should -be 1  # This works
1 | should be 1   # This works!
~~~