### PR TITLE
Make OutputPath of NUnit not mandatory

### DIFF
--- a/src/Pester.ps1
+++ b/src/Pester.ps1
@@ -311,7 +311,7 @@ function Invoke-Pester {
         [Parameter(ParameterSetName = "Legacy")] # Legacy set for v4 compatibility during migration - deprecated
         [Switch]$Strict,
 
-        [Parameter(Mandatory = $true, ParameterSetName = "Legacy")] # Legacy set for v4 compatibility during migration - deprecated
+        [Parameter(ParameterSetName = "Legacy")] # Legacy set for v4 compatibility during migration - deprecated
         [string] $OutputFile,
 
         [Parameter(ParameterSetName = "Legacy")] # Legacy set for v4 compatibility during migration - deprecated


### PR DESCRIPTION
This used to be part of another parameter set. It should not be mandatory in Legacy parameter set.