### PR TITLE
fix formatting for Nunit parameterrized tests

### DIFF
--- a/src/Pester.Runtime.psm1
+++ b/src/Pester.Runtime.psm1
@@ -448,7 +448,7 @@ function Invoke-TestItem {
 
         $Test.ExpandedName = & $state.ExpandName -Name $Test.Name -Data $Test.Data
 
-        $test.ExpandedPath = & $state.ExpandName -Name ($Test.Path -join '.') -Data $Test.Data
+        $test.ExpandedPath = "$($Test.Block.Path -join '.').$($Test.ExpandedName)"
 
         $block = $Test.Block
         if ($PesterPreference.Debug.WriteDebugMessages.Value) {

--- a/src/Pester.Runtime.psm1
+++ b/src/Pester.Runtime.psm1
@@ -448,6 +448,8 @@ function Invoke-TestItem {
 
         $Test.ExpandedName = & $state.ExpandName -Name $Test.Name -Data $Test.Data
 
+        $test.ExpandedPath = & $state.ExpandName -Name ($Test.Path -join '.') -Data $Test.Data
+
         $block = $Test.Block
         if ($PesterPreference.Debug.WriteDebugMessages.Value) {
             Write-PesterDebugMessage -Scope Runtime "Running test '$($Test.Name)'."

--- a/src/csharp/Pester/Test.cs
+++ b/src/csharp/Pester/Test.cs
@@ -30,6 +30,7 @@ namespace Pester
         public List<string> Path { get; set; }
         public IDictionary Data { get; set; }
         public string ExpandedName { get; set; }
+        public string ExpandedPath { get; set; }
 
         public string Result { get; set; }
         public List<object> ErrorRecord { get; set; }

--- a/src/functions/Output.ps1
+++ b/src/functions/Output.ps1
@@ -574,7 +574,7 @@ function Get-WriteScreenPlugin ($Verbosity) {
             $level = 0
             $margin = ''
             $error_margin = $ReportStrings.Margin
-            $out = "$($_test.Block.Path -join '.').$($_test.ExpandedName)"
+            $out = $_test.ExpandedPath
         }
         else {
             throw "Unsupported level out output '$($PesterPreference.Output.Verbosity.Value)'"

--- a/src/functions/TestResults.ps1
+++ b/src/functions/TestResults.ps1
@@ -592,15 +592,7 @@ function Write-NUnitTestCaseElement($TestResult, [System.Xml.XmlWriter] $XmlWrit
 }
 
 function Write-NUnitTestCaseAttributes($TestResult, [System.Xml.XmlWriter] $XmlWriter, [string] $ParameterizedSuiteName, [string] $Path) {
-    $testName = $TestResult.Path -join '.'
-
-    foreach ($testParameterName in $TestResult.Data.Keys){
-        $matchString = [regex]::Escape("<$testParameterName>")
-        if ($testName -match $matchString){
-            $testName = $testName -replace $matchString, [string]$TestResult.Data[$testParameterName]
-            $paramsUsedInTestName = $true
-        }
-    }
+    $testName = $TestResult.ExpandedPath
 
     # todo: this comparison would fail if the test name would contain $(Get-Date) or something similar that changes all the time
     if ($testName -eq $ParameterizedSuiteName) {
@@ -632,7 +624,7 @@ function Write-NUnitTestCaseAttributes($TestResult, [System.Xml.XmlWriter] $XmlW
         }
     }
 
-    $XmlWriter.WriteAttributeString('description', $TestResult.Name)
+    $XmlWriter.WriteAttributeString('description', $TestResult.ExpandedName)
 
     $XmlWriter.WriteAttributeString('name', $testName)
     $XmlWriter.WriteAttributeString('time', (Convert-TimeSpan $TestResult.Duration))

--- a/src/functions/TestResults.ps1
+++ b/src/functions/TestResults.ps1
@@ -594,31 +594,43 @@ function Write-NUnitTestCaseElement($TestResult, [System.Xml.XmlWriter] $XmlWrit
 function Write-NUnitTestCaseAttributes($TestResult, [System.Xml.XmlWriter] $XmlWriter, [string] $ParameterizedSuiteName, [string] $Path) {
     $testName = $TestResult.Path -join '.'
 
+    foreach ($testParameterName in $TestResult.Data.Keys){
+        $matchString = [regex]::Escape("<$testParameterName>")
+        if ($testName -match $matchString){
+            $testName = $testName -replace $matchString, [string]$TestResult.Data.$testParameterName
+            $paramsUsedInTestName = $true
+        }
+    }
+
     # todo: this comparison would fail if the test name would contain $(Get-Date) or something similar that changes all the time
     if ($testName -eq $ParameterizedSuiteName) {
         $paramString = ''
         if ($null -ne $TestResult.Data) {
-            $params = @(
-                foreach ($value in $TestResult.Data.Values) {
-                    if ($null -eq $value) {
-                        'null'
-                    }
-                    elseif ($value -is [string]) {
-                        '"{0}"' -f $value
-                    }
-                    else {
-                        #do not use .ToString() it uses the current culture settings
-                        #and we need to use en-US culture, which [string] or .ToString([Globalization.CultureInfo]'en-us') uses
-                        [string]$value
-                    }
-                }
-            )
+            $paramsUsedInTestName =$false
 
-            $paramString = "($($params -join ','))"
+            if (-not $paramsUsedInTestName) {
+                $params = @(
+                    foreach ($value in $TestResult.Data.Values) {
+                        if ($null -eq $value) {
+                            'null'
+                        }
+                        elseif ($value -is [string]) {
+                            '"{0}"' -f $value
+                        }
+                        else {
+                            #do not use .ToString() it uses the current culture settings
+                            #and we need to use en-US culture, which [string] or .ToString([Globalization.CultureInfo]'en-us') uses
+                            [string]$value
+                        }
+                    }
+                )
+
+                $paramString = "($($params -join ','))"
+        
+                $testName = "$testName$paramString"
+            }
         }
     }
-
-    $testName = "$testName$paramString"
 
     $XmlWriter.WriteAttributeString('description', $TestResult.Name)
 
@@ -719,6 +731,7 @@ function Write-NUnitTestCaseAttributes($TestResult, [System.Xml.XmlWriter] $XmlW
         }
     }
 }
+
 function Get-RunTimeEnvironment() {
     # based on what we found during startup, use the appropriate cmdlet
     $computerName = $env:ComputerName

--- a/src/functions/TestResults.ps1
+++ b/src/functions/TestResults.ps1
@@ -618,7 +618,6 @@ function Write-NUnitTestCaseAttributes($TestResult, [System.Xml.XmlWriter] $XmlW
                 )
 
                 $paramString = "($($params -join ','))"
-        
                 $testName = "$testName$paramString"
             }
         }

--- a/src/functions/TestResults.ps1
+++ b/src/functions/TestResults.ps1
@@ -597,7 +597,7 @@ function Write-NUnitTestCaseAttributes($TestResult, [System.Xml.XmlWriter] $XmlW
     foreach ($testParameterName in $TestResult.Data.Keys){
         $matchString = [regex]::Escape("<$testParameterName>")
         if ($testName -match $matchString){
-            $testName = $testName -replace $matchString, [string]$TestResult.Data.$testParameterName
+            $testName = $testName -replace $matchString, [string]$TestResult.Data[$testParameterName]
             $paramsUsedInTestName = $true
         }
     }

--- a/tst/Pester.RSpec.Nunit.TestResults.ts.ps1
+++ b/tst/Pester.RSpec.Nunit.TestResults.ts.ps1
@@ -268,7 +268,7 @@ i -PassThru:$PassThru {
         t 'should write parameterized test results correctly' {
             $sb = {
                 Describe "Mocked Describe" {
-                    It "Parameterized Testcase <value>" -TestCases @(
+                    It "Parameterized Testcase" -TestCases @(
                         @{ Value = 1 }
                         [ordered] @{ Value = 2; StringParameter = "two"; NullParameter = $null; NumberParameter = -42.67 }
                     ) {
@@ -281,8 +281,8 @@ i -PassThru:$PassThru {
 
             $xmlResult = $r | ConvertTo-NUnitReport
             $xmlTestSuite = $xmlResult.'test-results'.'test-suite'.'results'.'test-suite'.'results'.'test-suite'.'results'.'test-suite'
-            $xmlTestSuite.name | Verify-Equal 'Mocked Describe.Parameterized Testcase <value>'
-            $xmlTestSuite.description | Verify-Equal 'Parameterized Testcase <value>'
+            $xmlTestSuite.name | Verify-Equal 'Mocked Describe.Parameterized Testcase'
+            $xmlTestSuite.description | Verify-Equal 'Parameterized Testcase'
             $xmlTestSuite.type | Verify-Equal 'ParameterizedTest'
             $xmlTestSuite.result | Verify-Equal 'Failure'
             $xmlTestSuite.success | Verify-Equal 'False'
@@ -293,10 +293,50 @@ i -PassThru:$PassThru {
             $testCase1 = $xmlTestSuite.results.'test-case'[0]
             $testCase2 = $xmlTestSuite.results.'test-case'[1]
 
-            $testCase1.Name | Verify-Equal 'Mocked Describe.Parameterized Testcase <value>(1)'
+            $testCase1.Name | Verify-Equal 'Mocked Describe.Parameterized Testcase(1)'
             $testCase1.Time | Verify-XmlTime $r.Containers[0].Blocks[0].Tests[0].Duration
 
-            $testCase2.Name | Verify-Equal 'Mocked Describe.Parameterized Testcase <value>(2,"two",null,-42.67)'
+            $testCase2.Name | Verify-Equal 'Mocked Describe.Parameterized Testcase(2,"two",null,-42.67)'
+            $testCase2.Time | Verify-XmlTime $r.Containers[0].Blocks[0].Tests[1].Duration
+
+            # verify against schema
+            $schemaPath = (Get-Module -Name Pester).Path | Split-Path | Join-Path -ChildPath "nunit_schema_2.5.xsd"
+            $null = $xmlResult.Schemas.Add($null, $schemaPath)
+            $xmlResult.Validate( { throw $args[1].Exception })
+        }
+
+        t 'should write parameterized test results correctly if <parameter> tags are used' {
+            $sb = {
+                Describe "Mocked Describe" {
+                    It "Parameterized Testcase Value: <value>" -TestCases @(
+                        @{ Value = 1 }
+                        [ordered] @{ Value = 2; StringParameter = "two"; NullParameter = $null; NumberParameter = -42.67 }
+                    ) {
+                        param ($Value)
+                        $Value | Should -Be 1
+                    }
+                }
+            }
+            $r = Invoke-Pester -Configuration ([PesterConfiguration]@{ Run = @{ ScriptBlock = $sb; PassThru = $true }; Output = @{ Verbosity = 'None' } })
+
+            $xmlResult = $r | ConvertTo-NUnitReport
+            $xmlTestSuite = $xmlResult.'test-results'.'test-suite'.'results'.'test-suite'.'results'.'test-suite'.'results'.'test-suite'
+            $xmlTestSuite.name | Verify-Equal 'Mocked Describe.Parameterized Testcase Value: <value>'
+            $xmlTestSuite.description | Verify-Equal 'Parameterized Testcase Value: <value>'
+            $xmlTestSuite.type | Verify-Equal 'ParameterizedTest'
+            $xmlTestSuite.result | Verify-Equal 'Failure'
+            $xmlTestSuite.success | Verify-Equal 'False'
+            $xmlTestSuite.time | Verify-XmlTime (
+                $r.Containers[0].Blocks[0].Tests[0].Duration +
+                $r.Containers[0].Blocks[0].Tests[1].Duration)
+
+            $testCase1 = $xmlTestSuite.results.'test-case'[0]
+            $testCase2 = $xmlTestSuite.results.'test-case'[1]
+
+            $testCase1.Name | Verify-Equal 'Mocked Describe.Parameterized Testcase Value: 1'
+            $testCase1.Time | Verify-XmlTime $r.Containers[0].Blocks[0].Tests[0].Duration
+
+            $testCase2.Name | Verify-Equal 'Mocked Describe.Parameterized Testcase Value: 2'
             $testCase2.Time | Verify-XmlTime $r.Containers[0].Blocks[0].Tests[1].Duration
 
             # verify against schema

--- a/tst/Pester.RSpec.Nunit.TestResults.ts.ps1
+++ b/tst/Pester.RSpec.Nunit.TestResults.ts.ps1
@@ -265,7 +265,7 @@ i -PassThru:$PassThru {
     }
 
     b 'Exporting Parameterized Tests (Newer format)' {
-        t 'should write parameterized test results correctly' {
+        t 'should write parameterized test results without <value> tags expanded with parameter set values' {
             $sb = {
                 Describe "Mocked Describe" {
                     It "Parameterized Testcase" -TestCases @(
@@ -293,11 +293,11 @@ i -PassThru:$PassThru {
             $testCase1 = $xmlTestSuite.results.'test-case'[0]
             $testCase2 = $xmlTestSuite.results.'test-case'[1]
 
-            $testCase1.Name | Verify-Equal 'Mocked Describe.Parameterized Testcase(1)'
-            $testCase1.Time | Verify-XmlTime $r.Containers[0].Blocks[0].Tests[0].Duration
+            $testCase1.name | Verify-Equal 'Mocked Describe.Parameterized Testcase(1)'
+            $testCase1.time | Verify-XmlTime $r.Containers[0].Blocks[0].Tests[0].Duration
 
-            $testCase2.Name | Verify-Equal 'Mocked Describe.Parameterized Testcase(2,"two",null,-42.67)'
-            $testCase2.Time | Verify-XmlTime $r.Containers[0].Blocks[0].Tests[1].Duration
+            $testCase2.name | Verify-Equal 'Mocked Describe.Parameterized Testcase(2,"two",null,-42.67)'
+            $testCase2.time | Verify-XmlTime $r.Containers[0].Blocks[0].Tests[1].Duration
 
             # verify against schema
             $schemaPath = (Get-Module -Name Pester).Path | Split-Path | Join-Path -ChildPath "nunit_schema_2.5.xsd"
@@ -333,11 +333,13 @@ i -PassThru:$PassThru {
             $testCase1 = $xmlTestSuite.results.'test-case'[0]
             $testCase2 = $xmlTestSuite.results.'test-case'[1]
 
-            $testCase1.Name | Verify-Equal 'Mocked Describe.Parameterized Testcase Value: 1'
-            $testCase1.Time | Verify-XmlTime $r.Containers[0].Blocks[0].Tests[0].Duration
+            $testCase1.name | Verify-Equal 'Mocked Describe.Parameterized Testcase Value: 1'
+            $testCase1.description | Verify-Equal 'Parameterized Testcase Value: 1'
+            $testCase1.time | Verify-XmlTime $r.Containers[0].Blocks[0].Tests[0].Duration
 
-            $testCase2.Name | Verify-Equal 'Mocked Describe.Parameterized Testcase Value: 2'
-            $testCase2.Time | Verify-XmlTime $r.Containers[0].Blocks[0].Tests[1].Duration
+            $testCase2.name | Verify-Equal 'Mocked Describe.Parameterized Testcase Value: 2'
+            $testCase2.description | Verify-Equal 'Parameterized Testcase Value: 2'
+            $testCase2.time | Verify-XmlTime $r.Containers[0].Blocks[0].Tests[1].Duration
 
             # verify against schema
             $schemaPath = (Get-Module -Name Pester).Path | Split-Path | Join-Path -ChildPath "nunit_schema_2.5.xsd"


### PR DESCRIPTION
# 1. General summary of the pull request

Fix #1573 
Fix #1612

It will replace the Parameter tokens in the test names with the parameter values if provided. If no replacement has taken place, the current behavior will take place (put all parameters cast into [string] after the test name.

The current behavior breaks on test builds we are running with parametersets containing a huge array of hash tables, as they will produce test names with "System.Collections.Hashtable System.Collections.Hashtable ..." at the end, making both the result file very big and break the parser eventually. (apart from the fact it makes the results unreadable) 

