### PR TITLE
Fixes #1631 - Updated docs Planets example to work with Pester v5

### DIFF
--- a/docs/Examples/Planets/Get-Planet.Tests.ps1
+++ b/docs/Examples/Planets/Get-Planet.Tests.ps1
@@ -30,8 +30,8 @@ BeforeAll {
     # the current path, but replace the ".Tests.ps1" occurences with ".ps1".
     # . $PSCommandPath.Replace('.Tests.ps1', '.ps1')
     #
-    # We could even replace all the ".Tests" occurences with "" and end up
-    # with the right filename.Get-
+    # We could even replace all the ".Tests" occurences in the current path
+    # with "" and end up with the right filename.
     # . $PSCommandPath.Replace('.Tests', '')
 }
 

--- a/docs/Examples/Planets/Get-Planet.Tests.ps1
+++ b/docs/Examples/Planets/Get-Planet.Tests.ps1
@@ -18,17 +18,22 @@
 #      [+] Given invalid parameter -Name 'Alpha Centauri', it returns $null 22ms
 
 
-# First we need to import the Get-Planet.ps1 file to make the function
-# Get-Planet available to our test. Notice the . at the start
-# of the line.
-$here = (Split-Path -Parent $MyInvocation.MyCommand.Path)
-. $here\Get-Planet.ps1
+# Put the initialization code in a seperate `BeforeAll` block,
+# where you can perform i.e. your imports.
+BeforeAll {
+    # First we need to import the Get-Planet.ps1 file to make the function
+    # Get-Planet available to our test. Notice the . at the start
+    # of the line.
+    . $PSScriptRoot/Get-Planet.ps1
 
-# Normally we would use this PowerShell 3 and newer compatible
-# version of the same code, but we need to keep our examples
-# compatible with PowerShell v2.
-# . $PSScriptRoot\Get-Planet.ps1
-
+    # Normally we can use a more platform agnostic and generic approach where we import
+    # the current path, but replace the ".Tests.ps1" occurences with ".ps1".
+    # . $PSCommandPath.Replace('.Tests.ps1', '.ps1')
+    #
+    # We could even replace all the ".Tests" occurences with "" and end up
+    # with the right filename.Get-
+    # . $PSCommandPath.Replace('.Tests', '')
+}
 
 # Describe groups tests for easy navigation and overview.
 # Usually we use the name of the function we are testing as description

--- a/docs/Examples/Planets/Get-Planet.Tests.ps1
+++ b/docs/Examples/Planets/Get-Planet.Tests.ps1
@@ -106,11 +106,7 @@ Describe 'Get-Planet' {
             $planets = Get-Planet -Name $Filter
             # We validate that the returned name is equal to $Expected.
             # That is Neptune, in our second test.
-            $planets | Select -ExpandProperty Name | Should -Be $Expected
-
-            # again we are jumping thru hoops to keep PowerShell v2 compatibility
-            # in PowerShell v3 you would just do this, as seen in readme:
-            # $planets.Name | Should -Be $Expected
+            $planets.Name | Should -Be $Expected
         }
 
         # Testing just the positive cases is usually not enough. Our tests

--- a/docs/Examples/Planets/Get-Planet.ps1
+++ b/docs/Examples/Planets/Get-Planet.ps1
@@ -1,7 +1,6 @@
 # This is not the best file to start from,
 # open Get-Planet.Tests.ps1 as well :)
 
-
 function Get-Planet ([string]$Name = '*') {
     $planets = @(
         @{ Name = 'Mercury' }
@@ -12,11 +11,7 @@ function Get-Planet ([string]$Name = '*') {
         @{ Name = 'Saturn'  }
         @{ Name = 'Uranus'  }
         @{ Name = 'Neptune' }
-    ) | foreach { New-Object -TypeName PSObject -Property $_ }
+    ) | foreach { [PSCustomObject] $_ }
 
     $planets | where { $_.Name -like $Name }
 }
-
-# The code above uses New-Object instead of the [PSCustomObject]
-# you saw in the readme file. This is only to keep the example
-# compatible with PowerShell version 2.

--- a/docs/Examples/Planets/Get-Planet.ps1
+++ b/docs/Examples/Planets/Get-Planet.ps1
@@ -11,7 +11,7 @@ function Get-Planet ([string]$Name = '*') {
         @{ Name = 'Saturn'  }
         @{ Name = 'Uranus'  }
         @{ Name = 'Neptune' }
-    ) | foreach { [PSCustomObject] $_ }
+    ) | ForEach-Object { [PSCustomObject] $_ }
 
-    $planets | where { $_.Name -like $Name }
+    $planets | Where-Object { $_.Name -like $Name }
 }


### PR DESCRIPTION
<!--

Thank you for contributing to Pester! Please provide a descriptive title of the pull request in the field 'Title'.

-->

## 1. General summary of the pull request
Fixed the `Get-Planet` example to use a `BeforeAll` block where we dot-source the `Get-Planet.ps1` script, by following the examples provided over here https://jakubjares.com/2020/04/11/pester5-importing-ps-files/ . Also removed the PowerShell v2 comparability part, since from version 5 onwards only PowerShell v3 and higher is supported. 

This one was a bit of a pain as a **Pester** beginner, to get the first example up and running.

Fixes #1631 