### PR TITLE
Fix basic scoping of BeforeAll

### DIFF
--- a/src/Pester.Runtime.psm1
+++ b/src/Pester.Runtime.psm1
@@ -946,7 +946,7 @@ function Run-Test {
             $script:ScriptBlockSessionStateInternalProperty.SetValue($rootBlock.ScriptBlock, $SessionStateInternal, $null)
 
             $parent = [Pester.Block]::Create()
-            $parent.Name = "Parent"
+            $parent.Name = "ParentBlock"
             $parent.Path = "Path"
 
             $parent.First = $false

--- a/src/Pester.Runtime.psm1
+++ b/src/Pester.Runtime.psm1
@@ -945,16 +945,16 @@ function Run-Test {
             $SessionStateInternal = $script:SessionStateInternalProperty.GetValue($SessionState, $null)
             $script:ScriptBlockSessionStateInternalProperty.SetValue($rootBlock.ScriptBlock, $SessionStateInternal, $null)
 
-            $parent = [Pester.Block]::Create()
-            $parent.Name = "ParentBlock"
-            $parent.Path = "Path"
+            $private:parent = [Pester.Block]::Create()
+            $private:parent.Name = "ParentBlock"
+            $private:parent.Path = "Path"
 
-            $parent.First = $false
-            $parent.Last = $false
+            $private:parent.First = $false
+            $private:parent.Last = $false
 
-            $parent.Order.Add($rootBlock)
+            $private:parent.Order.Add($rootBlock)
 
-            $null = Invoke-Block -previousBlock $parent
+            $null = Invoke-Block -previousBlock $private:parent
         }
         catch {
             $rootBlock.ErrorRecord.Add($_)

--- a/src/Pester.Runtime.psm1
+++ b/src/Pester.Runtime.psm1
@@ -939,34 +939,24 @@ function Run-Test {
                 throw "Teardowns are not supported in root (directly in the block container)."
             }
 
-            $rootSetupResult = $null
-            if ($null -ne $rootBlock.OneTimeTestSetup) {
-                if ($PesterPreference.Debug.WriteDebugMessages.Value) {
-                    Write-PesterDebugMessage -Scope Runtime "One time setup from root block is executing"
-                }
+            # we add one more artificial block so the root can run
+            # all of it's setups and teardowns
+            $rootBlock.ScriptBlock = {}
+            $SessionStateInternal = $script:SessionStateInternalProperty.GetValue($SessionState, $null)
+            $script:ScriptBlockSessionStateInternalProperty.SetValue($rootBlock.ScriptBlock, $SessionStateInternal, $null)
 
-                $rootSetupResult = Invoke-ScriptBlock `
-                    -OuterSetup @(
-                    # if ($rootBlock.ShouldRun) {
-                    # todo: should this always run?
-                    $rootBlock.OneTimeTestSetup
-                    # }
-                ) `
-                    -ReduceContextToInnerScope `
-                    -MoveBetweenScopes
-            }
+            $parent = [Pester.Block]::Create()
+            $parent.Name = "Parent"
+            $parent.Path = "Path"
 
+            $parent.First = $false
+            $parent.Last = $false
 
-            if ($null -ne $rootSetupResult -and -not $rootSetupResult.Success) {
-                & $SafeCommands["Write-Error"] -ErrorRecord $rootSetupResult.ErrorRecord[0] -ErrorAction 'Stop'
-            }
+            $parent.Order.Add($rootBlock)
 
-            $null = Invoke-Block -previousBlock $rootBlock
-
-            $rootBlock.OwnPassed = $true
+            $null = Invoke-Block -previousBlock $parent
         }
         catch {
-            $rootBlock.OwnPassed = $false
             $rootBlock.ErrorRecord.Add($_)
         }
 
@@ -1103,21 +1093,24 @@ function Assert-Success {
 
     $rc = 0
     $anyFailed = $false
+    $err = ""
     foreach ($r in $InvocationResult) {
         $ec = 0
         if ($null -ne $r.ErrorRecord -and $r.ErrorRecord.Length -gt 0) {
-            & $SafeCommands["Write-Host"] -ForegroundColor Red "Result $($rc++):"
+            $err += "Result $($rc++):"
             $anyFailed = $true
             foreach ($e in $r.ErrorRecord) {
-                & $SafeCommands["Write-Host"] -ForegroundColor Red "Error $($ec++):"
-                & $SafeCommands["Write-Host"] -ForegroundColor Red (Out-String -InputObject $e )
-                & $SafeCommands["Write-Host"] -ForegroundColor Red (Out-String -InputObject $e.ScriptStackTrace)
+                $err += "Error $($ec++):"
+                $err += & $SafeCommands["Out-String"] -InputObject $e
+                $err += & $SafeCommands["Out-String"] -InputObject $e.ScriptStackTrace
             }
         }
+    }
 
-        if ($anyFailed) {
-            throw $Message
-        }
+    if ($anyFailed) {
+        $Message = $Message + ":`n$err"
+        & $SafeCommands["Write-Host"] -ForegroundColor Red $Message
+        throw $Message
     }
 }
 

--- a/src/functions/Output.ps1
+++ b/src/functions/Output.ps1
@@ -532,6 +532,10 @@ function Get-WriteScreenPlugin ($Verbosity) {
             # the $context does not mean Context block, it's just a generic name
             # for the invocation context of this callback
 
+            if ($Context.Block.IsRoot) {
+                return
+            }
+
             $commandUsed = $Context.Block.FrameworkData.CommandUsed
 
             $block = $Context.Block
@@ -655,6 +659,11 @@ function Get-WriteScreenPlugin ($Verbosity) {
 
     $p.EachBlockTeardownEnd = {
         param ($Context)
+
+        if ($Context.Block.IsRoot) {
+            return
+        }
+
         if (-not $Context.Block.OwnPassed) {
             if ($PesterPreference.Output.Verbosity.Value -in 'Detailed', 'Diagnostic') {
                 $level = $Context.Block.Path.Count

--- a/tst/Pester.Runtime.ts.ps1
+++ b/tst/Pester.Runtime.ts.ps1
@@ -1135,8 +1135,10 @@ i -PassThru:$PassThru {
                     }
                 }) -Plugin $p
 
-            $container.OneTimeBlockSetup | Verify-Equal 1
-            $container.EachBlockSetup | Verify-Equal 2
+            # we invoke the actual block and Root block as well,
+            # so each block related count is 1 higher than what is visible
+            $container.OneTimeBlockSetup | Verify-Equal 2
+            $container.EachBlockSetup | Verify-Equal 3
 
             $container.OneTimeTestSetup | Verify-Equal 2
             $container.EachTestSetup | Verify-Equal 3
@@ -1144,8 +1146,8 @@ i -PassThru:$PassThru {
             $container.EachTestTeardown | Verify-Equal 3
             $container.OneTimeTestTeardown | Verify-Equal 2
 
-            $container.EachBlockTeardown | Verify-Equal 2
-            $container.OneTimeBlockTeardown | Verify-Equal 1
+            $container.EachBlockTeardown | Verify-Equal 3
+            $container.OneTimeBlockTeardown | Verify-Equal 2
         }
 
         t "Given multiple plugins the teardowns are called in opposite order than the setups" {
@@ -1192,8 +1194,11 @@ i -PassThru:$PassThru {
                     }
                 }) -Plugin $p
 
-            $container.OneTimeBlockSetup | Verify-Equal "ab"
-            $container.EachBlockSetup | Verify-Equal "abab"
+            # we are running root block as a normal block so
+            # there is one more execution of every block related setup / tardown
+            # than what is visible
+            $container.OneTimeBlockSetup | Verify-Equal "abab"
+            $container.EachBlockSetup | Verify-Equal "ababab"
 
             $container.OneTimeTestSetup | Verify-Equal "abab"
             $container.EachTestSetup | Verify-Equal "ababab"
@@ -1201,8 +1206,8 @@ i -PassThru:$PassThru {
             $container.EachTestTeardown | Verify-Equal "bababa"
             $container.OneTimeTestTeardown | Verify-Equal "baba"
 
-            $container.EachBlockTeardown | Verify-Equal "baba"
-            $container.OneTimeBlockTeardown | Verify-Equal "ba"
+            $container.EachBlockTeardown | Verify-Equal "bababa"
+            $container.OneTimeBlockTeardown | Verify-Equal "baba"
         }
 
         t "Plugin has access to test info" {

--- a/tst/functions/GlobalMock-B.Tests.ps1
+++ b/tst/functions/GlobalMock-B.Tests.ps1
@@ -4,11 +4,10 @@ Set-StrictMode -Version Latest
 # is that global functions that have been mocked are still properly set up even after the test
 # script exits its scope.
 
-$functionName = '01c1a57716fe4005ac1a7bf216f38ad0'
-
 try {
     Describe 'Mocking Global Functions - Part Two' {
         It 'Restored the global function properly' {
+            $functionName = '01c1a57716fe4005ac1a7bf216f38ad0'
             $globalFunctionExists = Test-Path Function:\global:$functionName
             $globalFunctionExists | Should -Be $true
             & $functionName | Should -Be 'Original Function'
@@ -16,6 +15,7 @@ try {
     }
 }
 finally {
+    $functionName = '01c1a57716fe4005ac1a7bf216f38ad0'
     if (Test-Path Function:\$functionName) {
         Remove-Item Function:\$functionName -Force
     }


### PR DESCRIPTION
Push the whole execution one scope down to cleanup the variables and functions defined in BeforeAll correctly.

Fix #1624
Fix #1596
Fix #1579 