### PR TITLE
Add FullNameFilter and PassThru parameters to Simple interface parameter list

### DIFF
--- a/README.md
+++ b/README.md
@@ -471,8 +471,10 @@ Invoke-Pester -Path <String[]>
               -ExcludePath <String[]>
               -Tag <String[]>
               -ExcludeTag <String[]>
+              -FullNameFilter <String[]>
               -Output <String>
               -CI
+              -PassThru
 ```
 
 And the Advanced interface that takes just Pester configuration object and nothing else:
@@ -483,15 +485,16 @@ Invoke-Pester -Configuration <PesterConfiguration>
 
 A mapping of the parameters of the simple interface to the configuration object properties on the advanced interface is:
 
-| Parameter   | Configuration Object Property                                              |
-| ----------- | -------------------------------------------------------------------------- |
-| Path        | Run.Path                                                                   |
-| ExcludePath | Run.ExcludePath                                                            |
-| Tag         | Filter.Tag                                                                 |
-| ExcludeTag  | Filter.ExcludeTag                                                          |
-| Output      | Output.Verbosity                                                           |
-| CI          | CodeCoverage.Enabled, TestResult.Enabled and Run.Exit (all set to `$true`) |
-| PassThru    | Run.PassThru                                                               |
+| Parameter      | Configuration Object Property                                              |
+| -----------    | -------------------------------------------------------------------------- |
+| Path           | Run.Path                                                                   |
+| ExcludePath    | Run.ExcludePath                                                            |
+| Tag            | Filter.Tag                                                                 |
+| ExcludeTag     | Filter.ExcludeTag                                                          |
+| FullNameFilter | Filter.FullName                                                            |
+| Output         | Output.Verbosity                                                           |
+| CI             | CodeCoverage.Enabled, TestResult.Enabled and Run.Exit (all set to `$true`) |
+| PassThru       | Run.PassThru                                                               |
 
 #### Simple interface
 
@@ -561,7 +564,6 @@ The following table shows a mapping of v4 Legacy parameters (those which have no
 
 | Parameter                       | Configuration Object Property                          |
 | ------------------------------- | ------------------------------------------------------ |
-| FullNameFilter                  | Filter.FullName                                        |
 | EnableExit                      | Run.Exit                                               |
 | CodeCoverage                    | CodeCoverage.Path                                      |
 | CodeCoverageOutputFile          | CodeCoverage.CodeCoverageOutputFile                    |


### PR DESCRIPTION
<!--

Thank you for contributing to Pester! Please provide a descriptive title of the pull request in the field 'Title'.

-->

## 1. General summary of the pull request

Add `FullNameFilter` and `PassThru` parameters to Simple interface parameter list in README.md

It seems from the code, that `FullNameFilter` is a Simple Interface parameter, so added it to the list and table.
Also `PassThru` is added to the list.

<!--

Please describe what your pull request fixes, or how it improves Pester.

If your pull request resolves a reported issue, please mention it by using  `Fix #<issue_number>` on a new line, this will close the linked issue automatically when this PR is merged. For more info see: [Closing issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/).

If your pull request integrates Pester with another system, please tell us how the change can be tested.

Please remember to update [the Pester wiki](https://github.com/pester/Pester/wiki) if needed.

Before you continue, please review [Contributing to Pester](https://github.com/pester/Pester/wiki/Contributing-to-Pester) and [Development rules - technical](https://github.com/pester/Pester/wiki/Developement-rules---technical).

Our continuous integration system doesn't send any notifications about failed tests. Please return to the opened pull request (after ~60 minutes) to check if is everything OK.

-->
