### PR TITLE
Fix unused variable build warning

### DIFF
--- a/src/csharp/Pester/Configuration.cs
+++ b/src/csharp/Pester/Configuration.cs
@@ -788,7 +788,6 @@ namespace Pester
         private ScriptBlockArrayOption _scriptBlock;
         private StringOption _testExtension;
         private BoolOption _exit;
-        private BoolOption _strict;
         private BoolOption _passThru;
 
         public static RunConfiguration Default { get { return new RunConfiguration(); } }


### PR DESCRIPTION
## 1. General summary of the pull request

A clean build of the c# Pester project returns a warning due to an unused variable.
`Configuration.cs(791,28): warning CS0169: The field 'RunConfiguration._strict' is never used [/workspaces/Pester/src/csharp/Pester/Pester.csproj`

This PR removes the unused variable.
