### PR TITLE
Fix line-based filter for tests with multiline testcases

### DIFF
--- a/src/Pester.Runtime.psm1
+++ b/src/Pester.Runtime.psm1
@@ -369,10 +369,10 @@ function New-Test {
         [String] $Name,
         [Parameter(Mandatory = $true, Position = 1)]
         [ScriptBlock] $ScriptBlock,
+        [int] $StartLine,
         [String[]] $Tag = @(),
         [System.Collections.IDictionary] $Data = @{ },
         [String] $Id,
-        [int] $StartLine,
         [Switch] $Focus,
         [Switch] $Skip
     )
@@ -2348,12 +2348,12 @@ function New-ParametrizedTest () {
         [String] $Name,
         [Parameter(Mandatory = $true, Position = 1)]
         [ScriptBlock] $ScriptBlock,
+        [int] $StartLine,
         [String[]] $Tag = @(),
         # do not use [hashtable[]] because that throws away the order if user uses [ordered] hashtable
         [System.Collections.IDictionary[]] $Data = @{ },
         [Switch] $Focus,
-        [Switch] $Skip,
-        [int] $StartLine
+        [Switch] $Skip
     )
 
     # we don't need to switch the timer, all the code that runs during discovery is "overhead"
@@ -2365,7 +2365,7 @@ function New-ParametrizedTest () {
     $id = $ScriptBlock.StartPosition.StartLine
     foreach ($d in $Data) {
         #    $innerId = if (-not $hasExternalId) { $null } else { "$Id-$(($counter++))" }
-        New-Test -Id $id -Name $Name -Tag $Tag -ScriptBlock $ScriptBlock -Data $d -Focus:$Focus -Skip:$Skip -StartLine $StartLine
+        New-Test -Id $id -Name $Name -Tag $Tag -ScriptBlock $ScriptBlock -StartLine $StartLine -Data $d -Focus:$Focus -Skip:$Skip
     }
 }
 

--- a/src/Pester.Runtime.psm1
+++ b/src/Pester.Runtime.psm1
@@ -154,6 +154,7 @@ function New-Block {
         [String] $Name,
         [Parameter(Mandatory = $true)]
         [ScriptBlock] $ScriptBlock,
+        [int] $StartLine,
         [String[]] $Tag = @(),
         [HashTable] $FrameworkData = @{ },
         [Switch] $Focus,
@@ -184,6 +185,7 @@ function New-Block {
     $block.Path = $Path
     $block.Tag = $Tag
     $block.ScriptBlock = $ScriptBlock
+    $block.StartLine = $StartLine
     $block.FrameworkData = $FrameworkData
     $block.Focus = $Focus
     $block.Id = $Id

--- a/src/Pester.Runtime.psm1
+++ b/src/Pester.Runtime.psm1
@@ -372,6 +372,7 @@ function New-Test {
         [String] $Name,
         [Parameter(Mandatory = $true, Position = 1)]
         [ScriptBlock] $ScriptBlock,
+        [Parameter(Mandatory = $true)]
         [int] $StartLine,
         [String[]] $Tag = @(),
         [System.Collections.IDictionary] $Data = @{ },

--- a/src/Pester.Runtime.psm1
+++ b/src/Pester.Runtime.psm1
@@ -154,6 +154,7 @@ function New-Block {
         [String] $Name,
         [Parameter(Mandatory = $true)]
         [ScriptBlock] $ScriptBlock,
+        [Parameter(Mandatory = $true)]
         [int] $StartLine,
         [String[]] $Tag = @(),
         [HashTable] $FrameworkData = @{ },

--- a/src/Pester.Runtime.psm1
+++ b/src/Pester.Runtime.psm1
@@ -1553,7 +1553,7 @@ function Test-ShouldRun {
     # in one place and check if parent was included after this one to short circuit the other
     # filters in case parent already knows that it will run
 
-    # using $StartLine property in Item of type Test when available due to TestsCase support in VSCode
+    # using StartLine property in Item-object for Tests when available to target It startline when using testcases with multiple lines
     $line = "$(if ($Item.ScriptBlock.File) { $Item.ScriptBlock.File } else { $Item.ScriptBlock.Id }):$(if($Item.StartLine) { $Item.Startline } else { $Item.ScriptBlock.StartPosition.StartLine })" -replace '\\', '/'
     if ($lineFilter -and 0 -ne $lineFilter.Count) {
         $anyIncludeFilters = $true

--- a/src/Pester.Runtime.psm1
+++ b/src/Pester.Runtime.psm1
@@ -371,7 +371,6 @@ function New-Test {
         [String] $Name,
         [Parameter(Mandatory = $true, Position = 1)]
         [ScriptBlock] $ScriptBlock,
-        [Parameter(Mandatory = $true)]
         [int] $StartLine,
         [String[]] $Tag = @(),
         [System.Collections.IDictionary] $Data = @{ },

--- a/src/Pester.Runtime.psm1
+++ b/src/Pester.Runtime.psm1
@@ -1555,8 +1555,7 @@ function Test-ShouldRun {
     # in one place and check if parent was included after this one to short circuit the other
     # filters in case parent already knows that it will run
 
-    # using StartLine property in Item-object for Tests when available to target It startline when using testcases with multiple lines
-    $line = "$(if ($Item.ScriptBlock.File) { $Item.ScriptBlock.File } else { $Item.ScriptBlock.Id }):$(if($Item.StartLine) { $Item.Startline } else { $Item.ScriptBlock.StartPosition.StartLine })" -replace '\\', '/'
+    $line = "$(if ($Item.ScriptBlock.File) { $Item.ScriptBlock.File } else { $Item.ScriptBlock.Id }):$($Item.StartLine)" -replace '\\', '/'
     if ($lineFilter -and 0 -ne $lineFilter.Count) {
         $anyIncludeFilters = $true
         foreach ($l in $lineFilter -replace '\\', '/') {

--- a/src/Pester.Runtime.psm1
+++ b/src/Pester.Runtime.psm1
@@ -372,6 +372,7 @@ function New-Test {
         [String[]] $Tag = @(),
         [System.Collections.IDictionary] $Data = @{ },
         [String] $Id,
+        [int] $StartLine,
         [Switch] $Focus,
         [Switch] $Skip
     )
@@ -397,6 +398,7 @@ function New-Test {
     $test.ScriptBlock = $ScriptBlock
     $test.Name = $Name
     $test.Path = $path
+    $test.StartLine = $StartLine
     $test.Tag = $Tag
     $test.Focus = $Focus
     $test.Skip = $Skip
@@ -1550,7 +1552,9 @@ function Test-ShouldRun {
     # the test even if it is marked as skipped run this include as first so we figure it out
     # in one place and check if parent was included after this one to short circuit the other
     # filters in case parent already knows that it will run
-    $line = "$(if ($Item.ScriptBlock.File) { $Item.ScriptBlock.File } else { $Item.ScriptBlock.Id }):$($Item.ScriptBlock.StartPosition.StartLine)" -replace '\\', '/'
+
+    # using $StartLine property in Item of type Test when available due to TestsCase support in VSCode
+    $line = "$(if ($Item.ScriptBlock.File) { $Item.ScriptBlock.File } else { $Item.ScriptBlock.Id }):$(if($Item.StartLine) { $Item.Startline } else { $Item.ScriptBlock.StartPosition.StartLine })" -replace '\\', '/'
     if ($lineFilter -and 0 -ne $lineFilter.Count) {
         $anyIncludeFilters = $true
         foreach ($l in $lineFilter -replace '\\', '/') {
@@ -2348,7 +2352,8 @@ function New-ParametrizedTest () {
         # do not use [hashtable[]] because that throws away the order if user uses [ordered] hashtable
         [System.Collections.IDictionary[]] $Data = @{ },
         [Switch] $Focus,
-        [Switch] $Skip
+        [Switch] $Skip,
+        [int] $StartLine
     )
 
     # we don't need to switch the timer, all the code that runs during discovery is "overhead"
@@ -2360,7 +2365,7 @@ function New-ParametrizedTest () {
     $id = $ScriptBlock.StartPosition.StartLine
     foreach ($d in $Data) {
         #    $innerId = if (-not $hasExternalId) { $null } else { "$Id-$(($counter++))" }
-        New-Test -Id $id -Name $Name -Tag $Tag -ScriptBlock $ScriptBlock -Data $d -Focus:$Focus -Skip:$Skip
+        New-Test -Id $id -Name $Name -Tag $Tag -ScriptBlock $ScriptBlock -Data $d -Focus:$Focus -Skip:$Skip -StartLine $StartLine
     }
 }
 

--- a/src/Pester.Runtime.psm1
+++ b/src/Pester.Runtime.psm1
@@ -154,7 +154,6 @@ function New-Block {
         [String] $Name,
         [Parameter(Mandatory = $true)]
         [ScriptBlock] $ScriptBlock,
-        [Parameter(Mandatory = $true)]
         [int] $StartLine,
         [String[]] $Tag = @(),
         [HashTable] $FrameworkData = @{ },

--- a/src/csharp/Pester/Block.cs
+++ b/src/csharp/Pester/Block.cs
@@ -74,6 +74,7 @@ namespace Pester
         public TimeSpan OwnDuration { get; set; }
 
         public ScriptBlock ScriptBlock { get; set; }
+        public int StartLine { get; set; }
         public Hashtable FrameworkData { get; set; } = new Hashtable();
         public Hashtable PluginData { get; set; } = new Hashtable();
 
@@ -88,6 +89,7 @@ namespace Pester
         public int OwnPendingCount { get; set; }
         public int OwnNotRunCount { get; set; }
         public int OwnInconclusiveCount { get; set; }
+
         public override string ToString()
         {
             return ToStringConverter.BlockToString(this);

--- a/src/csharp/Pester/Test.cs
+++ b/src/csharp/Pester/Test.cs
@@ -40,6 +40,7 @@ namespace Pester
         public string ItemType { get; private set; }
         public string Id { get; set; }
         public ScriptBlock ScriptBlock { get; set; }
+        public int StartLine { get; set; }
         public List<string> Tag { get; set; }
         public bool Focus { get; set; }
         public bool Skip { get; set; }

--- a/src/csharp/Pester/Test.cs
+++ b/src/csharp/Pester/Test.cs
@@ -40,7 +40,6 @@ namespace Pester
         public string ItemType { get; private set; }
         public string Id { get; set; }
         public ScriptBlock ScriptBlock { get; set; }
-        public int StartLine { get; set; }
         public List<string> Tag { get; set; }
         public bool Focus { get; set; }
         public bool Skip { get; set; }
@@ -54,6 +53,8 @@ namespace Pester
         public bool Exclude { get; set; }
         public bool Explicit { get; set; }
         public bool ShouldRun { get; set; }
+
+        public int StartLine { get; set; }
 
         public bool Executed { get; set; }
         public DateTime? ExecutedAt { get; set; }

--- a/src/functions/Context.ps1
+++ b/src/functions/Context.ps1
@@ -90,7 +90,7 @@ https://pester.dev/docs/usage/testdrive
     }
 
     if ($ExecutionContext.SessionState.PSVariable.Get("invokedViaInvokePester")) {
-        New-Block -Name $Name -ScriptBlock $Fixture -Tag $Tag -FrameworkData @{ CommandUsed = "Context" } -Focus:$Focus -Skip:$Skip
+        New-Block -Name $Name -ScriptBlock $Fixture -StartLine $MyInvocation.ScriptLineNumber -Tag $Tag -FrameworkData @{ CommandUsed = "Context" } -Focus:$Focus -Skip:$Skip
     }
     else {
         if ($invokedInteractively) {

--- a/src/functions/Describe.ps1
+++ b/src/functions/Describe.ps1
@@ -88,7 +88,7 @@ about_TestDrive
 
 
     if ($ExecutionContext.SessionState.PSVariable.Get('invokedViaInvokePester')) {
-        New-Block -Name $Name -ScriptBlock $Fixture -Tag $Tag -FrameworkData @{ CommandUsed = 'Describe' } -Focus:$Focus -Skip:$Skip
+        New-Block -Name $Name -ScriptBlock $Fixture -StartLine $MyInvocation.ScriptLineNumber -Tag $Tag -FrameworkData @{ CommandUsed = 'Describe' } -Focus:$Focus -Skip:$Skip
     }
     else {
         Invoke-Interactively -CommandUsed 'Describe' -ScriptName $PSCmdlet.MyInvocation.ScriptName -SessionState $PSCmdlet.SessionState -BoundParameters $PSCmdlet.MyInvocation.BoundParameters

--- a/src/functions/It.ps1
+++ b/src/functions/It.ps1
@@ -136,9 +136,9 @@ about_should
     }
 
     if (any $TestCases) {
-        New-ParametrizedTest -Name $Name -ScriptBlock $Test -Data $TestCases -Tag $Tag -Focus:$Focus -Skip:$Skip
+        New-ParametrizedTest -Name $Name -ScriptBlock $Test -Data $TestCases -Tag $Tag -Focus:$Focus -Skip:$Skip -StartLine $MyInvocation.ScriptLineNumber
     }
     else {
-        New-Test -Name $Name -ScriptBlock $Test -Tag $Tag -Focus:$Focus -Skip:$Skip
+        New-Test -Name $Name -ScriptBlock $Test -Tag $Tag -Focus:$Focus -Skip:$Skip -StartLine $MyInvocation.ScriptLineNumber
     }
 }

--- a/src/functions/It.ps1
+++ b/src/functions/It.ps1
@@ -136,9 +136,9 @@ about_should
     }
 
     if (any $TestCases) {
-        New-ParametrizedTest -Name $Name -ScriptBlock $Test -Data $TestCases -Tag $Tag -Focus:$Focus -Skip:$Skip -StartLine $MyInvocation.ScriptLineNumber
+        New-ParametrizedTest -Name $Name -ScriptBlock $Test -StartLine $MyInvocation.ScriptLineNumber -Data $TestCases -Tag $Tag -Focus:$Focus -Skip:$Skip
     }
     else {
-        New-Test -Name $Name -ScriptBlock $Test -Tag $Tag -Focus:$Focus -Skip:$Skip -StartLine $MyInvocation.ScriptLineNumber
+        New-Test -Name $Name -ScriptBlock $Test -StartLine $MyInvocation.ScriptLineNumber -Tag $Tag -Focus:$Focus -Skip:$Skip
     }
 }

--- a/src/functions/Output.ps1
+++ b/src/functions/Output.ps1
@@ -546,7 +546,7 @@ function Get-WriteScreenPlugin ($Verbosity) {
             $text = $ReportStrings.$commandUsed -f $block.Name
 
             if ($PesterPreference.Debug.ShowNavigationMarkers.Value) {
-                $text += ", $($block.ScriptBlock.File):$($block.ScriptBlock.StartPosition.StartLine)"
+                $text += ", $($block.ScriptBlock.File):$($block.StartLine)"
             }
 
             if (0 -eq $level -and -not $block.First) {
@@ -587,7 +587,7 @@ function Get-WriteScreenPlugin ($Verbosity) {
         $humanTime = "$(Get-HumanTime ($_test.Duration)) ($(Get-HumanTime $_test.UserDuration)|$(Get-HumanTime $_test.FrameworkDuration))"
 
         if ($PesterPreference.Debug.ShowNavigationMarkers.Value) {
-            $out += ", $($_test.ScriptBlock.File):$($_Test.ScriptBlock.StartPosition.StartLine)"
+            $out += ", $($_test.ScriptBlock.File):$($_Test.StartLine)"
         }
 
         $result = $_test.Result

--- a/tst/Pester.RSpec.Configuration.ts.ps1
+++ b/tst/Pester.RSpec.Configuration.ts.ps1
@@ -353,6 +353,8 @@ i -PassThru:$PassThru {
             $tests.Count | Verify-Equal 4
             $tests[0].Name | Verify-Equal "passing"
             $tests[1].Name | Verify-Equal "fails"
+            $tests[2].Name | Verify-Equal "passing with testcases"
+            $tests[3].Name | Verify-Equal "passing with testcases"
         }
 
         t "Filtering test with testcases based on line of It" {
@@ -374,6 +376,9 @@ i -PassThru:$PassThru {
 
             $tests.Count | Verify-Equal 2
             $tests[0].Name | Verify-Equal "passing with testcases"
+            $tests[0].Data.Value | Verify-Equal 1
+            $tests[1].Name | Verify-Equal "passing with testcases"
+            $tests[1].Data.Value | Verify-Equal 2
         }
 
         t "Filtering test based on name will find the test" {

--- a/tst/Pester.RSpec.Configuration.ts.ps1
+++ b/tst/Pester.RSpec.Configuration.ts.ps1
@@ -362,7 +362,7 @@ i -PassThru:$PassThru {
                     PassThru = $true
                 }
                 Filter = @{
-                    Line = "$PSScriptRoot/testProjects/BasicTests/folder1/file1.Tests.ps1:8"
+                    Line = "$PSScriptRoot/testProjects/BasicTests/folder1/file1.Tests.ps1:12"
                 }
                 Output = @{
                     Verbosity = 'None'
@@ -372,8 +372,8 @@ i -PassThru:$PassThru {
             $r = Invoke-Pester -Configuration $c
             $tests = @($r.Containers.Blocks.Tests | where { $_.ShouldRun })
 
-            $tests.Count | Verify-Equal 1
-            $tests[0].Name | Verify-Equal "fails"
+            $tests.Count | Verify-Equal 2
+            $tests[0].Name | Verify-Equal "passing with testcases"
         }
 
         t "Filtering test based on name will find the test" {

--- a/tst/Pester.RSpec.Configuration.ts.ps1
+++ b/tst/Pester.RSpec.Configuration.ts.ps1
@@ -312,7 +312,7 @@ i -PassThru:$PassThru {
             'slow' -notin $runTags | Verify-True
         }
 
-        t "Filtering test based on line" {
+        t "Filtering test based on line of It" {
             $c = [PesterConfiguration]@{
                 Run = @{
                     Path = "$PSScriptRoot/testProjects/BasicTests"
@@ -333,7 +333,7 @@ i -PassThru:$PassThru {
             $tests[0].Name | Verify-Equal "fails"
         }
 
-        t "Filtering test based on line" {
+        t "Filtering tests based on line of Describe" {
             $c = [PesterConfiguration]@{
                 Run = @{
                     Path = "$PSScriptRoot/testProjects/BasicTests"
@@ -350,9 +350,30 @@ i -PassThru:$PassThru {
             $r = Invoke-Pester -Configuration $c
             $tests = @($r.Containers.Blocks.Tests | where { $_.ShouldRun })
 
-            $tests.Count | Verify-Equal 2
+            $tests.Count | Verify-Equal 4
             $tests[0].Name | Verify-Equal "passing"
             $tests[1].Name | Verify-Equal "fails"
+        }
+
+        t "Filtering test with testcases based on line of It" {
+            $c = [PesterConfiguration]@{
+                Run = @{
+                    Path = "$PSScriptRoot/testProjects/BasicTests"
+                    PassThru = $true
+                }
+                Filter = @{
+                    Line = "$PSScriptRoot/testProjects/BasicTests/folder1/file1.Tests.ps1:8"
+                }
+                Output = @{
+                    Verbosity = 'None'
+                }
+            }
+
+            $r = Invoke-Pester -Configuration $c
+            $tests = @($r.Containers.Blocks.Tests | where { $_.ShouldRun })
+
+            $tests.Count | Verify-Equal 1
+            $tests[0].Name | Verify-Equal "fails"
         }
 
         t "Filtering test based on name will find the test" {

--- a/tst/Pester.Runtime.ts.ps1
+++ b/tst/Pester.Runtime.ts.ps1
@@ -63,6 +63,7 @@ i -PassThru:$PassThru {
                 [System.Collections.IDictionary] $Data,
                 [String] $Id,
                 [ScriptBlock] $ScriptBlock,
+                [int] $StartLine,
                 [Switch] $Focus,
                 [Switch] $Skip
             )
@@ -72,6 +73,7 @@ i -PassThru:$PassThru {
             $t.Name = $Name
             $t.Path = $Path
             $t.Tag = $Tag
+            $t.StartLine = $StartLine
             $t.Focus = [Bool]$Focus
             $t.Skip = [Bool]$Skip
             $t.Data = $Data
@@ -467,7 +469,7 @@ i -PassThru:$PassThru {
             }
 
             t "Given a test with file path and line number it includes it when it matches the lines filter" {
-                $t = New-TestObject -Name "test1" -ScriptBlock ($sb = { "test" })
+                $t = New-TestObject -Name "test1" -ScriptBlock ($sb = { "test" }) -StartLine $sb.StartPosition.StartLine
 
                 $f = New-FilterObject -Line "$($sb.File):$($sb.StartPosition.StartLine)"
 
@@ -476,7 +478,7 @@ i -PassThru:$PassThru {
             }
 
             t "Given a test with file path and line number it maybes it when it does not match the lines filter" {
-                $t = New-TestObject -Name "test1" -ScriptBlock { "test" }
+                $t = New-TestObject -Name "test1" -ScriptBlock { "test" } -StartLine 1
 
                 $f = New-FilterObject -Line "C:\file.tests.ps1:10"
 

--- a/tst/Pester.Runtime.ts.ps1
+++ b/tst/Pester.Runtime.ts.ps1
@@ -539,6 +539,7 @@ i -PassThru:$PassThru {
         }
 
         t "re-runs failing tests" {
+            # Tests stored in file to make StartLine predictable as it's needed for New-Block/-Test parameter for filtering to work
             $testFile = "$PSScriptRoot/testProjects/RerunFailed.tests.ps1"
 
             $willPass = $false
@@ -562,8 +563,7 @@ i -PassThru:$PassThru {
             # on them and use them for filtering the run in the next run
             # I should probably re-do the navigation to make it see how deep # I am in the scope, I have som Scopes prototype in the Mock imho
 
-            #TODO: Change to $_.StartLine when I find out why it's 0.....
-            $lines = $pre | Where-Failed | % { "$($_.ScriptBlock.File):$($_.ScriptBlock.StartPosition.StartLine)" }
+            $lines = $pre | Where-Failed | % { "$($_.ScriptBlock.File):$($_.StartLine)" }
             $lines.Length | Verify-Equal 2
 
             Write-Host "`n`n`n"

--- a/tst/testProjects/BasicTests/folder1/file1.Tests.ps1
+++ b/tst/testProjects/BasicTests/folder1/file1.Tests.ps1
@@ -8,4 +8,11 @@ Describe "describe state tests" {
     It "fails" {
         1 | Should -Be 2
     }
+
+    It "passing with testcases" -TestCases @(
+        @{Value = 1}
+        @{Value = 2}
+    ) {
+        1 | Should -Be 1
+    }
 }

--- a/tst/testProjects/RerunFailed.tests.ps1
+++ b/tst/testProjects/RerunFailed.tests.ps1
@@ -1,0 +1,19 @@
+Set-StrictMode -Version Latest
+
+# Tests has to be placed in file to make predictable as New-Block/-Test
+# requires the parameter for line filter to work
+
+New-Block "rerun block1" -StartLine 6 {
+    New-Test "test1" -StartLine 7 { "a" }
+    New-Block "rerun block2" -StartLine 8 {
+        New-Test "test2" -StartLine 9 {
+            throw
+        }
+    }
+}
+
+New-Block "rerun block3" -StartLine 15 {
+    New-Test "test3" -StartLine 16 {
+        if (-not $willPass) { throw }
+    }
+}

--- a/tst/testProjects/RerunFailed.tests.ps1
+++ b/tst/testProjects/RerunFailed.tests.ps1
@@ -1,19 +1,16 @@
 Set-StrictMode -Version Latest
 
-# Tests has to be placed in file to make predictable as New-Block/-Test
-# requires the parameter for line filter to work
-
-New-Block "rerun block1" -StartLine 6 {
-    New-Test "test1" -StartLine 7 { "a" }
-    New-Block "rerun block2" -StartLine 8 {
-        New-Test "test2" -StartLine 9 {
+New-Block "rerun block1" -StartLine 3 {
+    New-Test "test1" -StartLine 4 { "a" }
+    New-Block "rerun block2" -StartLine 5 {
+        New-Test "test2" -StartLine 6 {
             throw
         }
     }
 }
 
-New-Block "rerun block3" -StartLine 15 {
-    New-Test "test3" -StartLine 16 {
+New-Block "rerun block3" -StartLine 12 {
+    New-Test "test3" -StartLine 13 {
         if (-not $willPass) { throw }
     }
 }


### PR DESCRIPTION
## 1. General summary of the pull request

"Run Test" in VS Code doesn't work for running a single test which contains multiple lines to define testcases. The issue is caused by differences in how VS Code would identify the line number for a test compared to Pester's logic. Pester uses the start of scriptblock as the line number, while VS Code uses the line of `It`. VS Code's approach is preferred going forward as it's more consistent with other scenarios like describe, context and tests without testcases as well as being easier for an end user. 

```
It "Test with multiline testcases" -TestCases @(
    @{Value = 1}
    @{Value = 2}
    ) {
        1 | Should -Be 1
    }
}

# Pester's expectation of linefilter for the test above
# Before fix: filepath:4 (start of scriptblock)
# After fix: filepath:1 (line of "It")
```

This PR changes the linefilter-check to use a new "StartLine" property in Pester-objects of type Block (Describe/Context) and Test (It) which stores the location of the function name. This should solve the issue mentioned above.

Fix #1659 
Original issue: https://github.com/PowerShell/vscode-powershell/issues/2880

- [x] Extend Block/Test.cs
- [x] Update line filter
- [x] Add test for multiline testcases
- [x] Fix failing tests
- [x] Update affected output functions: Get-WriteScreenPlugin