### PR TITLE
(GH-1655) Add support for "-Not" to "Should -Invoke" tests

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -1,0 +1,13 @@
+## Building Pester
+
+Pester has a C# Solution which requires .Net Framework SDKs and Developer Packs in order to compile. The targetted frameworks can be found in `src\csharp\Pester\Pester.csproj`.
+
+### Required Software
+
+#### Install .NET Core 3.1 SDK
+
+[Download Link](https://dotnet.microsoft.com/download/dotnet-core/3.1)
+
+#### .Net Framework 4.5 Developer Pack
+
+[Download Link](https://dotnet.microsoft.com/download/dotnet-framework/net452)

--- a/src/functions/Mock.ps1
+++ b/src/functions/Mock.ps1
@@ -346,6 +346,7 @@ function Should-InvokeInternal {
         [string] $ModuleName,
 
         [switch]$Exactly,
+        [switch]$Negate,
 
         [Parameter(Mandatory)]
         [Management.Automation.SessionState] $SessionState,
@@ -406,22 +407,38 @@ function Should-InvokeInternal {
         }
     }
 
-    if ($matchingCalls.Count -ne $Times -and ($Exactly -or ($Times -eq 0))) {
-        return [PSCustomObject] @{
-            Succeeded      = $false
-            FailureMessage = "Expected ${commandName}${moduleMessage} to be called $Times times exactly but was called $($matchingCalls.Count) times"
+    if ($Negate) {
+        # Negative checks
+        if ($matchingCalls.Count -eq $Times -and ($Exactly -or !$PSBoundParameters.ContainsKey("Times"))) {
+            return [PSCustomObject] @{
+                Succeeded      = $false
+                FailureMessage = "Expected ${commandName}${moduleMessage} not to be called exactly $Times times"
+            }
         }
-    }
-    elseif ($matchingCalls.Count -lt $Times) {
-        return [PSCustomObject] @{
-            Succeeded      = $false
-            FailureMessage = "Expected ${commandName}${moduleMessage} to be called at least $Times times but was called $($matchingCalls.Count) times"
+        elseif ($matchingCalls.Count -ge $Times -and !$Exactly) {
+            return [PSCustomObject] @{
+                Succeeded      = $false
+                FailureMessage = "Expected ${commandName}${moduleMessage} to be called less than $Times times but was called $($matchingCalls.Count) times"
+            }
         }
-    }
-    elseif ($filterIsExclusive -and $nonMatchingCalls.Count -gt 0) {
-        return [PSCustomObject] @{
-            Succeeded      = $false
-            FailureMessage = "Expected ${commandName}${moduleMessage} to only be called with with parameters matching the specified filter, but $($nonMatchingCalls.Count) non-matching calls were made"
+    } else {
+        if ($matchingCalls.Count -ne $Times -and ($Exactly -or ($Times -eq 0))) {
+            return [PSCustomObject] @{
+                Succeeded      = $false
+                FailureMessage = "Expected ${commandName}${moduleMessage} to be called $Times times exactly but was called $($matchingCalls.Count) times"
+            }
+        }
+        elseif ($matchingCalls.Count -lt $Times) {
+            return [PSCustomObject] @{
+                Succeeded      = $false
+                FailureMessage = "Expected ${commandName}${moduleMessage} to be called at least $Times times but was called $($matchingCalls.Count) times"
+            }
+        }
+        elseif ($filterIsExclusive -and $nonMatchingCalls.Count -gt 0) {
+            return [PSCustomObject] @{
+                Succeeded      = $false
+                FailureMessage = "Expected ${commandName}${moduleMessage} to only be called with with parameters matching the specified filter, but $($nonMatchingCalls.Count) non-matching calls were made"
+            }
         }
     }
 

--- a/tst/functions/Mock.Tests.ps1
+++ b/tst/functions/Mock.Tests.ps1
@@ -708,6 +708,70 @@ Describe "When Calling Should -Invoke 0 without exactly" {
     }
 }
 
+Describe "When Calling Should -Not -Invoke without exactly" {
+    BeforeEach {
+        Mock FunctionUnderTest {}
+        FunctionUnderTest "one"
+
+        try {
+            Should -Not -Invoke FunctionUnderTest
+        }
+        Catch {
+            $result = $_
+        }
+    }
+
+    It "Should throw if mock was called once" {
+        $result.Exception.Message | Should -Be "Expected FunctionUnderTest not to be called exactly 1 times"
+    }
+
+    It "Should not throw if mock was not called" {
+        Should -Not -Invoke FunctionUnderTest -ParameterFilter { $param1 -eq "stupid" }
+    }
+}
+
+Describe "When Calling Should -Not -Invoke [Times] without exactly" {
+    BeforeEach {
+        Mock FunctionUnderTest {}
+    }
+
+    It "Should not throw if the mock was called less (<MockCalls>) than the number of times specified (<Times>)" -TestCases @(
+        @{ MockCalls = 3; Times = 15 }
+        @{ MockCalls = 2; Times = 5 }
+        @{ MockCalls = 0; Times = 1 }
+    ) {
+        param($MockCalls, $Times)
+
+        for ($i = 0; $i -lt $MockCalls; $i++) {
+            FunctionUnderTest "one"
+        }
+
+        Should -Not -Invoke FunctionUnderTest $Times
+    }
+
+    It "Should throw if the mock was called (<MockCalls>) at least the number of times specified (<Times>)" -TestCases @(
+        @{ MockCalls = 15; Times = 3 }
+        @{ MockCalls = 3; Times = 3 }
+        @{ MockCalls = 1; Times = 1 }
+        @{ MockCalls = 0; Times = 0 }
+    ) {
+        param($MockCalls, $Times)
+
+        for ($i = 0; $i -lt $MockCalls; $i++) {
+            FunctionUnderTest "one"
+        }
+
+        try {
+            Should -Not -Invoke FunctionUnderTest $Times
+        }
+        Catch {
+            $result = $_
+        }
+
+        $result.Exception.Message | Should -Be "Expected FunctionUnderTest to be called less than $Times times but was called $MockCalls times"
+    }
+}
+
 Describe "When Calling Should -Invoke with exactly" {
     BeforeAll {
         Mock FunctionUnderTest {}
@@ -728,6 +792,71 @@ Describe "When Calling Should -Invoke with exactly" {
 
     It "Should not throw if mock was called the number of times specified" {
         Should -Invoke FunctionUnderTest -Exactly 2 -ParameterFilter { $param1 -eq "one" } -Scope Describe
+    }
+}
+
+Describe "When Calling Should -Not -Invoke with exactly" {
+    BeforeAll {
+        Mock FunctionUnderTest {}
+        FunctionUnderTest "one"
+
+        try {
+            Should -Not -Invoke FunctionUnderTest -Exactly
+        }
+        Catch {
+            $result = $_
+        }
+    }
+
+    It "Should throw if mock was called" {
+        $result.Exception.Message | Should -Be "Expected FunctionUnderTest not to be called exactly 1 times"
+    }
+
+    It "Should not throw if mock was not called" {
+        Should -Not -Invoke FunctionUnderTest -ParameterFilter { $param1 -eq "stupid" }
+    }
+}
+
+Describe "When Calling Should -Not -Invoke [Times] with exactly" {
+    BeforeEach {
+        Mock FunctionUnderTest {}
+    }
+
+    It "Should not throw if the mock is called (<MockCalls>) less or more than the number of times specified (<Times>)" -TestCases @(
+        @{ MockCalls = 3; Times = 15 }
+        @{ MockCalls = 15; Times = 3 }
+        @{ MockCalls = 2; Times = 5 }
+        @{ MockCalls = 0; Times = 1 }
+        @{ MockCalls = 1; Times = 0 }
+    ) {
+        param($MockCalls, $Times)
+
+        for ($i = 0; $i -lt $MockCalls; $i++) {
+            FunctionUnderTest "one"
+        }
+
+        Should -Not -Invoke FunctionUnderTest $Times -Exactly
+    }
+
+    It "Should throw if mock was called at exactly the number of times specified (<Times>)" -TestCases @(
+        @{ MockCalls = 3; Times = 3 }
+        @{ MockCalls = 1; Times = 1 }
+        @{ MockCalls = 0; Times = 0 }
+    ) {
+        param($MockCalls, $Times)
+
+        for ($i = 0; $i -lt $MockCalls; $i++) {
+            FunctionUnderTest "one"
+        }
+
+        try {
+            Should -Not -Invoke FunctionUnderTest $Times -Exactly
+        }
+        Catch {
+            $result = $_
+        }
+
+        $result.Exception.Message | Should -Be "Expected FunctionUnderTest not to be called exactly $Times times"
     }
 }
 
@@ -755,6 +884,18 @@ Describe "When Calling Should -Invoke without exactly" {
     It "Should throw an error if any non-matching calls to the mock are made, and the -ExclusiveFilter parameter is used" {
         $scriptBlock = { Should -Invoke FunctionUnderTest -ExclusiveFilter { $param1 -eq 'one' } -Scope Describe }
         $scriptBlock | Should -Throw '*1 non-matching calls were made*'
+    }
+}
+
+Describe "When Calling Should -Not -Invoke -ExclusiveFilter" {
+    BeforeAll {
+        Mock FunctionUnderTest {}
+        FunctionUnderTest "one"
+    }
+
+    It "Should throw an error" {
+        $scriptBlock = { Should -Not -Invoke FunctionUnderTest -ExclusiveFilter { $param1 -eq 'one' } -Scope Describe }
+        $scriptBlock | Should -Throw 'Cannot use -ExclusiveFilter when -Not is specified. Use -ParameterFilter instead.'
     }
 }
 


### PR DESCRIPTION
Fixes #1655 

Pester has a C# Solution which requires .Net Framework SDKs and Developer Packs
in order to compile. The targetted frameworks can be found in
`src\csharp\Pester\Pester.csproj`.  This commit adds instructions for where to
download these files from.
 
Previously Should -Invoke would ignore a negative expectation i.e. Should -Not
-Invoke.  This commit updates the Should-Invoke and Should-InvokeInternal
functions to pass through the Negation and then change the error raising
behaviour.  In particular, using -Not should have the opposite effect of if
it was not negated. That is, if it raised an error, then the negated expectation
would not raise an error, and vice versa.

This commit also adds tests for using -Not.

Note that using -Not and -ExclusiveFilter is not a valid combination as it
does not behave in an obvious manner.

---

- [x] Add tests for scenarios
- [x] Cleanup Build.md file
- [x] Cleanup commits