### PR TITLE
Add basic elipsis to indicate the array was shortened

### DIFF
--- a/src/Format.psm1
+++ b/src/Format.psm1
@@ -8,9 +8,9 @@ function Format-Collection ($Value, [switch]$Pretty) {
     if ($Pretty) {
         $separator = ",`n"
     }
-    #$count = $Value.Count
-    #$trimmed = $count  -gt $Limit
-    '@(' + (($Value | Select -First $Limit | % { Format-Nicely -Value $_ -Pretty:$Pretty }) -join $separator ) + <# $(if ($trimmed) {' +' + [string]($count-$limit)}) + #> ')'
+    $count = $Value.Count
+    $trimmed = $count  -gt $Limit
+    '@(' + (($Value | Select -First $Limit | % { Format-Nicely -Value $_ -Pretty:$Pretty }) -join $separator) + $(if ($trimmed) {', ...'}) + ')'
 }
 
 function Format-Object ($Value, $Property, [switch]$Pretty) {

--- a/tst/Format.Tests.ps1
+++ b/tst/Format.Tests.ps1
@@ -23,6 +23,13 @@ Describe "Format-Collection" {
         param ($Value, $Expected)
         Format-Collection -Value $Value | Verify-Equal $Expected
     }
+
+    It "Formats collection that is longer than 10 with elipsis" -TestCases @(
+        @{ Value = (1..20); Expected = "@(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, ...)" }
+    ) {
+        param ($Value, $Expected)
+        Format-Collection -Value $Value | Verify-Equal $Expected
+    }
 }
 
 Describe "Format-Number" {


### PR DESCRIPTION
Add `...` at the end of arrays that are longer than 10 items when formatting with Format-Nicely. 

Related #1668