### PR TITLE
Add -ForEach parameter to Describe, Context, and as an alias to -Test…

### DIFF
--- a/src/Pester.Runtime.psm1
+++ b/src/Pester.Runtime.psm1
@@ -586,7 +586,9 @@ function Invoke-TestItem {
                         # expand block name by evaluating the <> templates, only match templates that have at least 1 character and are not escaped by `<abc`>
                         # avoid using any variables to avoid running into conflict with user variables
                         $sb = {
-                            $____Pester.CurrentTest.ExpandedName = $ExecutionContext.SessionState.InvokeCommand.ExpandString(($____Pester.CurrentTest.Name -replace '\$', '`$' -replace '(?<!`)<([^>^`]+)>', '$$($$$1)'))
+                            $____s = ($____Pester.CurrentTest.Name -replace '\$', '`$' -replace '(?<!`)<([^>^`]+)>', '$$($$$1)')
+                            Write-Host "name: '$____s'"
+                            $____Pester.CurrentTest.ExpandedName = $ExecutionContext.SessionState.InvokeCommand.ExpandString($____s)
                             $____Pester.CurrentTest.ExpandedPath = "$($____Pester.CurrentTest.Block.Path -join '.').$($____Pester.CurrentTest.ExpandedName)"
                         }
 

--- a/src/Pester.Runtime.psm1
+++ b/src/Pester.Runtime.psm1
@@ -352,7 +352,7 @@ function Invoke-Block ($previousBlock) {
                                 # expand block name by evaluating the <> templates, only match templates that have at least 1 character and are not escaped by `<abc`>
                                 # avoid using variables so we don't run into conflicts
                                 $sb = {
-                                    $____Pester.CurrentBlock.ExpandedName = $ExecutionContext.SessionState.InvokeCommand.ExpandString(($____Pester.CurrentBlock.Name -replace '\$', '`$' -replace '(?<!`)<([^>^`]+)>', '$$($$$1)'))
+                                    $____Pester.CurrentBlock.ExpandedName = & ([ScriptBlock]::Create(('"'+ ($____Pester.CurrentBlock.Name -replace '\$', '`$' -replace '"', '`"' -replace '(?<!`)<([^>^`]+)>', '$$($$$1)') + '"')))
                                     $____Pester.CurrentBlock.ExpandedPath = if ($____Pester.CurrentBlock.Parent.IsRoot) {
                                         # to avoid including Root name in the path
                                         $____Pester.CurrentBlock.ExpandedName
@@ -597,8 +597,10 @@ function Invoke-TestItem {
                     $(
                         # expand block name by evaluating the <> templates, only match templates that have at least 1 character and are not escaped by `<abc`>
                         # avoid using any variables to avoid running into conflict with user variables
+                        # $ExecutionContext.SessionState.InvokeCommand.ExpandString() has some weird bug in PowerShell 4 and 3, that makes hashtable resolve to null
+                        # instead I create a expandable string in a scriptblock and evaluate
                         $sb = {
-                            $____Pester.CurrentTest.ExpandedName = $ExecutionContext.SessionState.InvokeCommand.ExpandString(($____Pester.CurrentTest.Name -replace '\$', '`$' -replace '(?<!`)<([^>^`]+)>', '$$($$$1)'))
+                            $____Pester.CurrentTest.ExpandedName = & ([ScriptBlock]::Create(('"'+ ($____Pester.CurrentTest.Name -replace '\$', '`$' -replace '"', '`"' -replace '(?<!`)<([^>^`]+)>', '$$($$$1)') + '"')))
                             $____Pester.CurrentTest.ExpandedPath = "$($____Pester.CurrentTest.Block.ExpandedPath -join '.').$($____Pester.CurrentTest.ExpandedName)"
                         }
 

--- a/src/Pester.Runtime.psm1
+++ b/src/Pester.Runtime.psm1
@@ -586,8 +586,8 @@ function Invoke-TestItem {
                         # expand block name by evaluating the <> templates, only match templates that have at least 1 character and are not escaped by `<abc`>
                         # avoid using any variables to avoid running into conflict with user variables
                         $sb = {
-                            $____Pester.CurrentTest.ExpandedName = $ExecutionContext.SessionState.InvokeCommand.ExpandString(($____Pester.CurrentTest.Name -replace '\$', '`$' -replace '(?<!`)<([^>^`]+)>', '$$($$$1)'))
-                            $____Pester.CurrentTest.ExpandedPath = "$($____Pester.CurrentTest.Block.Path -join '.').$($____Pester.CurrentTest.ExpandedName)"
+                            $____Pester.CurrentBlock.ExpandedName = $ExecutionContext.SessionState.InvokeCommand.ExpandString(($____Pester.CurrentBlock.Name -replace '\$', '`$' -replace '(?<!`)<([^>^`]+)>', '$$($$$1)'))
+                            $____Pester.CurrentBlock.ExpandedPath = if ($____Pester.CurrentBlock.IsRoot) { $____Pester.CurrentBlock.ExpandedName} else { "$($____Pester.CurrentBlock.Parent.ExpandedPath).$($____Pester.CurrentBlock.ExpandedName)" }
                         }
 
                         $SessionStateInternal = $script:ScriptBlockSessionStateInternalProperty.GetValue($State.CurrentTest.ScriptBlock, $null)

--- a/src/Pester.Runtime.psm1
+++ b/src/Pester.Runtime.psm1
@@ -586,9 +586,7 @@ function Invoke-TestItem {
                         # expand block name by evaluating the <> templates, only match templates that have at least 1 character and are not escaped by `<abc`>
                         # avoid using any variables to avoid running into conflict with user variables
                         $sb = {
-                            $____s = ($____Pester.CurrentTest.Name -replace '\$', '`$' -replace '(?<!`)<([^>^`]+)>', '$$($$$1)')
-                            Write-Host "name: '$____s'"
-                            $____Pester.CurrentTest.ExpandedName = $ExecutionContext.SessionState.InvokeCommand.ExpandString($____s)
+                            $____Pester.CurrentTest.ExpandedName = $ExecutionContext.SessionState.InvokeCommand.ExpandString(($____Pester.CurrentTest.Name -replace '\$', '`$' -replace '(?<!`)<([^>^`]+)>', '$$($$$1)'))
                             $____Pester.CurrentTest.ExpandedPath = "$($____Pester.CurrentTest.Block.Path -join '.').$($____Pester.CurrentTest.ExpandedName)"
                         }
 

--- a/src/Pester.Runtime.psm1
+++ b/src/Pester.Runtime.psm1
@@ -585,14 +585,16 @@ function Invoke-TestItem {
                         [Array]::Reverse($eachTestSetups)
                         @( { $Test.FrameworkData.Runtime.ExecutionStep = 'EachTestSetup' }) + @($eachTestSetups)
                     }
-                    # setting the execution info here so I don't have to invoke change the
-                    # contract of Invoke-ScriptBlock to accept multiple -ScriptBlock, because
-                    # that is not needed, and would complicate figuring out in which session
-                    # state we should run.
-                    # this should run every time.
-                    {
-                        $Test.FrameworkData.Runtime.ExecutionStep = 'Test'
 
+                    {
+                        # setting the execution info here so I don't have to invoke change the
+                        # contract of Invoke-ScriptBlock to accept multiple -ScriptBlock, because
+                        # that is not needed, and would complicate figuring out in which session
+                        # state we should run.
+                        # this should run every time.
+                        $Test.FrameworkData.Runtime.ExecutionStep = 'Test'
+                    }
+                    $(
                         # expand block name by evaluating the <> templates, only match templates that have at least 1 character and are not escaped by `<abc`>
                         # avoid using any variables to avoid running into conflict with user variables
                         $sb = {
@@ -602,8 +604,8 @@ function Invoke-TestItem {
 
                         $SessionStateInternal = $script:ScriptBlockSessionStateInternalProperty.GetValue($State.CurrentTest.ScriptBlock, $null)
                         $script:ScriptBlockSessionStateInternalProperty.SetValue($sb, $SessionStateInternal)
-                        & $sb
-                    }
+                        $sb
+                    )
                 ) `
                     -ScriptBlock $Test.ScriptBlock `
                     -Teardown @(

--- a/src/Pester.Runtime.psm1
+++ b/src/Pester.Runtime.psm1
@@ -36,12 +36,19 @@ $state = [PSCustomObject] @{
     Stack               = [Collections.Stack]@()
 
     ExpandName          = {
-        param([string]$Name, [HashTable]$Data)
+        param([string]$Name, $Data)
+
+        if ($null -eq $Data) { return $Name }
 
         $n = $Name
-        foreach ($pair in $Data.GetEnumerator()) {
-            $n = $n -replace "<$($pair.Key)>", "$($pair.Value)"
+        $n = $n -replace "<_>", "$Data"
+
+        if ($Data -is [Collections.IDictionary]) {
+            foreach ($pair in $Data.GetEnumerator()) {
+                $n = $n -replace "<$($pair.Key)>", "$($pair.Value)"
+            }
         }
+
         $n
     }
 }
@@ -145,6 +152,26 @@ function ConvertTo-ExecutedBlockContainer {
 
 }
 
+function New-ParametrizedBlock {
+    param (
+        [Parameter(Mandatory = $true)]
+        [String] $Name,
+        [Parameter(Mandatory = $true)]
+        [ScriptBlock] $ScriptBlock,
+        [int] $StartLine = $MyInvocation.ScriptLineNumber,
+        [String[]] $Tag = @(),
+        [HashTable] $FrameworkData = @{ },
+        [Switch] $Focus,
+        [String] $Id,
+        [Switch] $Skip,
+        $Data
+    )
+
+    foreach ($d in @($Data)) {
+        New-Block -Name $Name -ScriptBlock $ScriptBlock -StartLine $StartLine -Tag $Tag -FrameworkData $FrameworkData -Focus:$Focus -Skip:$Skip -Data $d
+    }
+}
+
 # endpoint for adding a block that contains tests
 # or other blocks
 function New-Block {
@@ -159,7 +186,7 @@ function New-Block {
         [Switch] $Focus,
         [String] $Id,
         [Switch] $Skip,
-        [Collections.IDictionary] $Data
+        $Data
     )
 
     # Switch-Timer -Scope Framework
@@ -204,7 +231,37 @@ function New-Block {
         if ($PesterPreference.Debug.WriteDebugMessages.Value) {
             Write-PesterDebugMessage -Scope DiscoveryCore "Discovering in body of block $Name"
         }
-        & $ScriptBlock
+
+        if ($null -ne $block.Data) {
+            $context = @{}
+            Add-DataToContext -Destination $context -Data $block.Data
+
+            $setVariablesAndRunBlock = {
+                param ($private:______parameters)
+
+                foreach ($private:______current in $private:______parameters.Context.GetEnumerator()) {
+                    $ExecutionContext.SessionState.PSVariable.Set($private:______current.Key, $private:______current.Value)
+                }
+
+                $private:______current = $null
+
+                . $private:______parameters.ScriptBlock
+            }
+
+            $parameters = @{
+                Context = $context
+                ScriptBlock = $ScriptBlock
+            }
+
+            $SessionStateInternal = $script:ScriptBlockSessionStateInternalProperty.GetValue($ScriptBlock, $null)
+            $script:ScriptBlockSessionStateInternalProperty.SetValue($setVariablesAndRunBlock, $SessionStateInternal, $null)
+
+            & $setVariablesAndRunBlock $parameters
+        }
+        else {
+            & $ScriptBlock
+        }
+
         if ($PesterPreference.Debug.WriteDebugMessages.Value) {
             Write-PesterDebugMessage -Scope DiscoveryCore "Finished discovering in body of block $Name"
         }
@@ -244,6 +301,10 @@ function Invoke-Block ($previousBlock) {
 
                 $block.ExecutedAt = [DateTime]::Now
                 $block.Executed = $true
+
+                $block.ExpandedName = & $state.ExpandName -Name $block.Name -Data $block.Data
+                $block.ExpandedPath = if ($block.IsRoot) { $block.ExpandedName} else { "$($block.Parent.ExpandedPath).$($Block.ExpandedName)" }
+
                 if ($PesterPreference.Debug.WriteDebugMessages.Value) {
                     Write-PesterDebugMessage -Scope Runtime "Executing body of block '$($block.Name)'"
                 }
@@ -286,24 +347,40 @@ function Invoke-Block ($previousBlock) {
                         & $______pester_invoke_block_parameters.Invoke_Block -previousBlock $______pester_invoke_block_parameters.Block
                     }
 
+                    $context = @{
+                        ______pester_invoke_block_parameters = @{
+                            Invoke_Block = ${function:Invoke-Block}
+                            Block        = $block
+                        }
+                        ____Pester = $State
+                    }
+
+                    if ($null -ne $block.Data) {
+                        Add-DataToContext -Destination $context -Data $block.Data
+                    }
+
                     $sessionStateInternal = $script:ScriptBlockSessionStateInternalProperty.GetValue($block.ScriptBlock, $null)
                     $script:ScriptBlockSessionStateInternalProperty.SetValue($sb, $SessionStateInternal)
 
                     $result = Invoke-ScriptBlock `
                         -ScriptBlock $sb `
                         -OuterSetup $( if (-not (Is-Discovery) -and (-not $Block.Skip)) {
-                            @($previousBlock.EachBlockSetup) + @($block.OneTimeTestSetup)
+                            @($previousBlock.EachBlockSetup) + @($block.OneTimeTestSetup) + @({
+                                # expand block name by evaluating the <> templates, only match templates that have at least 1 character and are not escaped by `<abc`>
+                                # avoid using variables so we don't run into conflicts
+                                $sb = {
+                                    $____Pester.CurrentBlock.ExpandedName = $ExecutionContext.SessionState.InvokeCommand.ExpandString(($____Pester.CurrentBlock.Name -replace '\$', '`$' -replace '(?<!`)<([^>^`]+)>', '$$($$$1)'))
+                                }
+
+                                $SessionStateInternal = $script:ScriptBlockSessionStateInternalProperty.GetValue($State.CurrentBlock.ScriptBlock, $null)
+                                $script:ScriptBlockSessionStateInternalProperty.SetValue($sb, $SessionStateInternal)
+                                & $sb
+                            })
                         }) `
                         -OuterTeardown $( if (-not (Is-Discovery) -and (-not $Block.Skip)) {
                             @($block.OneTimeTestTeardown) + @($previousBlock.EachBlockTeardown)
                         } ) `
-                        -Context @{
-                        ______pester_invoke_block_parameters = @{
-                            Invoke_Block = ${function:Invoke-Block}
-                            Block        = $block
-                        }
-                    } `
-                        -ReduceContextToInnerScope `
+                        -Context $context `
                         -MoveBetweenScopes `
                         -Configuration $state.Configuration
 
@@ -371,7 +448,7 @@ function New-Test {
         [ScriptBlock] $ScriptBlock,
         [int] $StartLine = $MyInvocation.ScriptLineNumber,
         [String[]] $Tag = @(),
-        [System.Collections.IDictionary] $Data = @{ },
+        $Data,
         [String] $Id,
         [Switch] $Focus,
         [Switch] $Skip
@@ -492,21 +569,12 @@ function Invoke-TestItem {
         else {
 
             if ($frameworkSetupResult.Success) {
-                # TODO: use PesterContext as the name, or some other better reserved name to avoid conflicts
                 $context = @{
-                    # context visible in test
-                    Context = [PSCustomObject]@{ Name = $t.Name; Path = $t.Path }
+                    ____Pester = $State
                 }
 
-                # user provided data are merged with Pester provided context
-                # Merge-Hashtable -Source $Test.Data -Destination $context
-                foreach ($p in $Test.Data.GetEnumerator()) {
-                    # only add non existing keys so in case of conflict
-                    # the framework name wins, as if we had explicit parameters
-                    # on a scriptblock, then the parameter would also win
-                    if (-not $context.ContainsKey($p.Key)) {
-                        $context.Add($p.Key, $p.Value)
-                    }
+                if ($null -ne $test.Data) {
+                    Add-DataToContext -Destination $context -Data $test.Data
                 }
 
                 # recurse up Recurse-Up $Block { param ($b) $b.EachTestSetup }
@@ -535,7 +603,19 @@ function Invoke-TestItem {
                     # that is not needed, and would complicate figuring out in which session
                     # state we should run.
                     # this should run every time.
-                    { $Test.FrameworkData.Runtime.ExecutionStep = 'Test' }
+                    {
+                        $Test.FrameworkData.Runtime.ExecutionStep = 'Test'
+
+                        # expand block name by evaluating the <> templates, only match templates that have at least 1 character and are not escaped by `<abc`>
+                        # avoid using any variables to avoid running into conflict with user variables
+                        $sb = {
+                            $____Pester.CurrentTest.ExpandedName = $ExecutionContext.SessionState.InvokeCommand.ExpandString(($____Pester.CurrentTest.Name -replace '\$', '`$' -replace '(?<!`)<([^>^`]+)>', '$$($$$1)'))
+                        }
+
+                        $SessionStateInternal = $script:ScriptBlockSessionStateInternalProperty.GetValue($State.CurrentTest.ScriptBlock, $null)
+                        $script:ScriptBlockSessionStateInternalProperty.SetValue($sb, $SessionStateInternal)
+                        & $sb
+                    }
                 ) `
                     -ScriptBlock $Test.ScriptBlock `
                     -Teardown @(
@@ -793,6 +873,10 @@ function Discover-Test {
         $root.First = $true
         $root.Last = $true
 
+        # set the data from the container to get them
+        # set correctly as if we provided -Data to New-Block
+        $root.Data = $root.BlockContainer.Data
+
         Reset-PerContainerState -RootBlock $root
 
         $steps = $state.Plugin.ContainerDiscoveryStart
@@ -948,6 +1032,11 @@ function Run-Test {
             # before all script, but it might be better to make this a plugin, because there we can pass data.
             $setVariables = {
                 param($private:____parameters)
+
+                if ($null -eq $____parameters.Data) {
+                    return
+                }
+
                 foreach($private:____d in $____parameters.Data.GetEnumerator()) {
                     & $____parameters.Set_Variable -Name $private:____d.Name -Value $private:____d.Value
                 }
@@ -1247,6 +1336,11 @@ function Invoke-ScriptBlock {
                     if ($______parameters.EnableWriteDebug) { &$______parameters.WriteDebug "Setting context variable '$($______current.Key)' with value '$($______current.Value)'" }
                     $ExecutionContext.SessionState.PSVariable.Set($______current.Key, $______current.Value)
                 }
+
+                if ($______outerSplat.ContainsKey("_")) {
+                    $______outerSplat.Remove("_")
+                }
+
                 $______current = $null
             }
             else {
@@ -1278,6 +1372,11 @@ function Invoke-ScriptBlock {
                             if ($______parameters.EnableWriteDebug) { &$______parameters.WriteDebug "Setting context variable '$ ($______current.Key)' with value '$($______current.Value)'" }
                             $ExecutionContext.SessionState.PSVariable.Set($______current.Key, $______current.Value)
                         }
+
+                        if ($______outerSplat.ContainsKey("_")) {
+                            $______outerSplat.Remove("_")
+                        }
+
                         $______current = $null
                     }
                     else {
@@ -2230,7 +2329,7 @@ function New-BlockContainerObject {
         [String] $Path,
         [Parameter(Mandatory, ParameterSetName = "File")]
         [System.IO.FileInfo] $File,
-        [Collections.IDictionary] $Data
+        $Data
     )
 
     $type, $item = switch ($PSCmdlet.ParameterSetName) {
@@ -2243,7 +2342,7 @@ function New-BlockContainerObject {
     $c = [Pester.ContainerInfo]::Create()
     $c.Type = $type
     $c.Item = $item
-    $c.Data = if ($null -ne $Data) { $Data } else { @{} }
+    $c.Data = $Data
     $c
 }
 
@@ -2399,20 +2498,15 @@ function New-ParametrizedTest () {
         [int] $StartLine = $MyInvocation.ScriptLineNumber,
         [String[]] $Tag = @(),
         # do not use [hashtable[]] because that throws away the order if user uses [ordered] hashtable
-        [System.Collections.IDictionary[]] $Data = @{ },
+        [object[]] $Data,
         [Switch] $Focus,
         [Switch] $Skip
     )
 
-    # we don't need to switch the timer, all the code that runs during discovery is "overhead"
-    # Switch-Timer -Scope Framework
-    # TODO: there used to be counter, that was added to the id, seems like I am missing TestGroup on the test cases, so I can reconcile them back if they were generated from testcases
-    # $counter = 0
-
-    # using the start line of the scriptblock as the id of the test so we can join multiple testcases together, this should be unique enough because it only needs to be unique for the current block, so the way to break this would be to inline multiple tests, but that is unlikely to happen. When it happens just use StartLine:StartPosition
-    $id = $ScriptBlock.StartPosition.StartLine
+    # using the position of It as Id for the the test so we can join multiple testcases together, this should be unique enough because it only needs to be unique for the current block, so the way to break this would be to inline multiple tests, but that is unlikely to happen. When it happens just use StartLine:StartPosition
+    # TODO: I don't think the Id is needed anymore
+    $id = $StartLine
     foreach ($d in $Data) {
-        #    $innerId = if (-not $hasExternalId) { $null } else { "$Id-$(($counter++))" }
         New-Test -Id $id -Name $Name -Tag $Tag -ScriptBlock $ScriptBlock -StartLine $StartLine -Data $d -Focus:$Focus -Skip:$Skip
     }
 }

--- a/src/Pester.Runtime.psm1
+++ b/src/Pester.Runtime.psm1
@@ -586,8 +586,8 @@ function Invoke-TestItem {
                         # expand block name by evaluating the <> templates, only match templates that have at least 1 character and are not escaped by `<abc`>
                         # avoid using any variables to avoid running into conflict with user variables
                         $sb = {
-                            $____Pester.CurrentBlock.ExpandedName = $ExecutionContext.SessionState.InvokeCommand.ExpandString(($____Pester.CurrentBlock.Name -replace '\$', '`$' -replace '(?<!`)<([^>^`]+)>', '$$($$$1)'))
-                            $____Pester.CurrentBlock.ExpandedPath = if ($____Pester.CurrentBlock.IsRoot) { $____Pester.CurrentBlock.ExpandedName} else { "$($____Pester.CurrentBlock.Parent.ExpandedPath).$($____Pester.CurrentBlock.ExpandedName)" }
+                            $____Pester.CurrentTest.ExpandedName = $ExecutionContext.SessionState.InvokeCommand.ExpandString(($____Pester.CurrentTest.Name -replace '\$', '`$' -replace '(?<!`)<([^>^`]+)>', '$$($$$1)'))
+                            $____Pester.CurrentTest.ExpandedPath = "$($____Pester.CurrentTest.Block.Path -join '.').$($____Pester.CurrentTest.ExpandedName)"
                         }
 
                         $SessionStateInternal = $script:ScriptBlockSessionStateInternalProperty.GetValue($State.CurrentTest.ScriptBlock, $null)

--- a/src/Pester.Utility.ps1
+++ b/src/Pester.Utility.ps1
@@ -189,6 +189,29 @@ function tryRemoveKey ($Hashtable, $Key) {
     }
 }
 
+function Add-DataToContext ($Destination, $Data) {
+    # works as Merge-Hashtable, but additionally adds _
+    # which will become $_, and checks if the Data is
+    # expandable, otherwise it just defines $_
+
+    if ($Data.Count -eq 0) {
+        $a = 10
+    }
+    if (-not $Destination.ContainsKey("_")) {
+        $Destination.Add("_", $Data)
+    }
+
+    if ($Data -is [Collections.IDictionary]) {
+        # only add non existing keys so in case of conflict
+        # the framework name wins, as if we had explicit parameters
+        # on a scriptblock, then the parameter would also win
+        foreach ($p in $Data.GetEnumerator()) {
+            if (-not $Destination.ContainsKey($p.Key)) {
+                $Destination.Add($p.Key, $p.Value)
+            }
+        }
+    }
+}
 
 function Merge-Hashtable ($Source, $Destination) {
     foreach ($p in $Source.GetEnumerator()) {

--- a/src/Pester.ps1
+++ b/src/Pester.ps1
@@ -750,9 +750,9 @@ function Invoke-Pester {
                         $cs = @()
 
                         foreach ($c in $Container) {
-                            $data = if ($null -eq $c.Data) { @(@{}) } else { $c.Data }
+                            $data = $c.Data
                             if ($c -is [Pester.TestScriptBlock]) {
-                                foreach ($d in $data) {
+                                foreach ($d in @($data)) {
                                     $cs += New-BlockContainerObject -ScriptBlock $c.ScriptBlock -Data $d
                                 }
                             }

--- a/src/csharp/Pester/Block.cs
+++ b/src/csharp/Pester/Block.cs
@@ -16,7 +16,6 @@ namespace Pester
         {
             ItemType = "Block";
             FrameworkData = new Hashtable();
-            Data = new Hashtable();
             PluginData = new Hashtable();
             Tests = new List<Test>();
             Order = new List<object>();
@@ -26,7 +25,9 @@ namespace Pester
 
         public string Name { get; set; }
         public List<string> Path { get; set; }
-        public IDictionary Data { get; set; }
+        public object Data { get; set; }
+        public string ExpandedName { get; set; }
+        public string ExpandedPath { get; set; }
         public List<Block> Blocks { get; set; } = new List<Block>();
         public List<Test> Tests { get; set; } = new List<Test>();
 

--- a/src/csharp/Pester/Container.cs
+++ b/src/csharp/Pester/Container.cs
@@ -48,7 +48,7 @@ namespace Pester
 
         public string Type { get; set; }
         public object Item { get; set; }
-        public IDictionary Data { get; set; }
+        public object Data { get; set; }
         public List<Block> Blocks { get; set; } = new List<Block>();
         public string Result { get; set; } = "NotRun";
         public TimeSpan Duration { get => DiscoveryDuration + UserDuration + FrameworkDuration; }

--- a/src/csharp/Pester/ContainerInfo.cs
+++ b/src/csharp/Pester/ContainerInfo.cs
@@ -13,6 +13,6 @@ namespace Pester
 
         public string Type { get; set; } = "File";
         public object Item { get; set; }
-        public IDictionary Data { get; set; }
+        public object Data { get; set; }
     }
 }

--- a/src/csharp/Pester/PesterFile.cs
+++ b/src/csharp/Pester/PesterFile.cs
@@ -7,7 +7,7 @@ namespace Pester
     public abstract class TestContainer
     {
         public object Container { get; set; }
-        public IDictionary[] Data { get; set; }
+        public object[] Data { get; set; }
     }
 
     public class TestPath : TestContainer
@@ -17,7 +17,7 @@ namespace Pester
             return new TestPath(path);
         }
 
-        public static TestPath Create(string path, IDictionary[] data)
+        public static TestPath Create(string path, object[] data)
         {
             return new TestPath(path, data);
         }
@@ -28,7 +28,7 @@ namespace Pester
 
         }
 
-        public TestPath(string path, IDictionary[] data)
+        public TestPath(string path, object[] data)
         {
             Container = Path = path ?? throw new ArgumentNullException(nameof(path));
             Data = data;
@@ -46,7 +46,7 @@ namespace Pester
             return new TestScriptBlock(scriptBlock);
         }
 
-        public static TestScriptBlock Create(ScriptBlock scriptBlock, IDictionary[] data)
+        public static TestScriptBlock Create(ScriptBlock scriptBlock, object[] data)
         {
             return new TestScriptBlock(scriptBlock, data);
         }
@@ -54,7 +54,7 @@ namespace Pester
         {
         }
 
-        public TestScriptBlock(ScriptBlock scriptBlock, IDictionary[] data)
+        public TestScriptBlock(ScriptBlock scriptBlock, object[] data)
         {
             Container = ScriptBlock = scriptBlock;
             Data = data;

--- a/src/csharp/Pester/Test.cs
+++ b/src/csharp/Pester/Test.cs
@@ -15,7 +15,6 @@ namespace Pester
         public Test()
         {
             ItemType = "Test";
-            Data = new Hashtable();
             PluginData = new Hashtable();
             ErrorRecord = new List<object>();
 
@@ -28,7 +27,7 @@ namespace Pester
 
         public string Name { get; set; }
         public List<string> Path { get; set; }
-        public IDictionary Data { get; set; }
+        public object Data { get; set; }
         public string ExpandedName { get; set; }
         public string ExpandedPath { get; set; }
 

--- a/src/functions/Context.ps1
+++ b/src/functions/Context.ps1
@@ -22,6 +22,12 @@ containing the same Tag.
 Script that is executed. This may include setup specific to the context
 and one or more It blocks that validate the expected outcomes.
 
+.PARAMETER ForEach
+Allows data driven tests to be written.
+Takes an array of data and generates one block for each item in the array, and makes the item
+available as $_ in all child blocks. When the array is an array of hashtables, it additionally
+defines each key in the hashatble as variable.
+
 .EXAMPLE
 ```ps
 function Add-Numbers($a, $b) {
@@ -76,7 +82,9 @@ https://pester.dev/docs/usage/testdrive
         [ScriptBlock] $Fixture,
 
         # [Switch] $Focus,
-        [Switch] $Skip
+        [Switch] $Skip,
+
+        $Foreach
     )
 
     $Focus = $false
@@ -89,8 +97,13 @@ https://pester.dev/docs/usage/testdrive
         }
     }
 
-    if ($ExecutionContext.SessionState.PSVariable.Get("invokedViaInvokePester")) {
-        New-Block -Name $Name -ScriptBlock $Fixture -StartLine $MyInvocation.ScriptLineNumber -Tag $Tag -FrameworkData @{ CommandUsed = "Context" } -Focus:$Focus -Skip:$Skip
+    if ($ExecutionContext.SessionState.PSVariable.Get('invokedViaInvokePester')) {
+        if (any $ForEach) {
+            New-ParametrizedBlock -Name $Name -ScriptBlock $Fixture -StartLine $MyInvocation.ScriptLineNumber -Tag $Tag -FrameworkData @{ CommandUsed = 'Context' } -Focus:$Focus -Skip:$Skip -Data $ForEach
+        }
+        else {
+            New-Block -Name $Name -ScriptBlock $Fixture -StartLine $MyInvocation.ScriptLineNumber -Tag $Tag -FrameworkData @{ CommandUsed = 'Context' } -Focus:$Focus -Skip:$Skip
+        }
     }
     else {
         if ($invokedInteractively) {

--- a/src/functions/Context.ps1
+++ b/src/functions/Context.ps1
@@ -98,8 +98,14 @@ https://pester.dev/docs/usage/testdrive
     }
 
     if ($ExecutionContext.SessionState.PSVariable.Get('invokedViaInvokePester')) {
-        if ($null -ne  $ForEach -and 0 -lt @($ForEach).Count) {
-            New-ParametrizedBlock -Name $Name -ScriptBlock $Fixture -StartLine $MyInvocation.ScriptLineNumber -Tag $Tag -FrameworkData @{ CommandUsed = 'Context' } -Focus:$Focus -Skip:$Skip -Data $ForEach
+        if ($PSBoundParameters.ContainsKey('ForEach')) {
+            if ($null -ne  $ForEach -and 0 -lt @($ForEach).Count) {
+                New-ParametrizedBlock -Name $Name -ScriptBlock $Fixture -StartLine $MyInvocation.ScriptLineNumber -Tag $Tag -FrameworkData @{ CommandUsed = 'Context' } -Focus:$Focus -Skip:$Skip -Data $ForEach
+            }
+            else {
+                # @() or $null is provided do nothing
+
+            }
         }
         else {
             New-Block -Name $Name -ScriptBlock $Fixture -StartLine $MyInvocation.ScriptLineNumber -Tag $Tag -FrameworkData @{ CommandUsed = 'Context' } -Focus:$Focus -Skip:$Skip

--- a/src/functions/Context.ps1
+++ b/src/functions/Context.ps1
@@ -98,7 +98,7 @@ https://pester.dev/docs/usage/testdrive
     }
 
     if ($ExecutionContext.SessionState.PSVariable.Get('invokedViaInvokePester')) {
-        if (any $ForEach) {
+        if ($null -ne  $ForEach -and 0 -lt @($ForEach).Count) {
             New-ParametrizedBlock -Name $Name -ScriptBlock $Fixture -StartLine $MyInvocation.ScriptLineNumber -Tag $Tag -FrameworkData @{ CommandUsed = 'Context' } -Focus:$Focus -Skip:$Skip -Data $ForEach
         }
         else {

--- a/src/functions/Describe.ps1
+++ b/src/functions/Describe.ps1
@@ -96,8 +96,13 @@ about_TestDrive
 
 
     if ($ExecutionContext.SessionState.PSVariable.Get('invokedViaInvokePester')) {
-        if ($null -ne  $ForEach -and 0 -lt @($ForEach).Count) {
-            New-ParametrizedBlock -Name $Name -ScriptBlock $Fixture -StartLine $MyInvocation.ScriptLineNumber -Tag $Tag -FrameworkData @{ CommandUsed = 'Describe' } -Focus:$Focus -Skip:$Skip -Data $ForEach
+        if ($PSBoundParameters.ContainsKey('ForEach')) {
+            if ($null -ne  $ForEach -and 0 -lt @($ForEach).Count) {
+                New-ParametrizedBlock -Name $Name -ScriptBlock $Fixture -StartLine $MyInvocation.ScriptLineNumber -Tag $Tag -FrameworkData @{ CommandUsed = 'Describe' } -Focus:$Focus -Skip:$Skip -Data $ForEach
+            }
+            else {
+                # @() or $null is provided do nothing
+            }
         }
         else {
             New-Block -Name $Name -ScriptBlock $Fixture -StartLine $MyInvocation.ScriptLineNumber -Tag $Tag -FrameworkData @{ CommandUsed = 'Describe' } -Focus:$Focus -Skip:$Skip

--- a/src/functions/Describe.ps1
+++ b/src/functions/Describe.ps1
@@ -24,6 +24,12 @@ Optional parameter containing an array of strings.  When calling Invoke-Pester,
 it is possible to specify a -Tag parameter which will only execute Describe blocks
 containing the same Tag.
 
+.PARAMETER ForEach
+Allows data driven tests to be written.
+Takes an array of data and generates one block for each item in the array, and makes the item
+available as $_ in all child blocks. When the array is an array of hashtables, it additionally
+defines each key in the hashatble as variable.
+
 .EXAMPLE
 function Add-Numbers($a, $b) {
     return $a + $b
@@ -73,7 +79,9 @@ about_TestDrive
         [ScriptBlock] $Fixture,
 
         # [Switch] $Focus,
-        [Switch] $Skip
+        [Switch] $Skip,
+
+        $ForEach
     )
 
     $Focus = $false
@@ -88,7 +96,12 @@ about_TestDrive
 
 
     if ($ExecutionContext.SessionState.PSVariable.Get('invokedViaInvokePester')) {
-        New-Block -Name $Name -ScriptBlock $Fixture -StartLine $MyInvocation.ScriptLineNumber -Tag $Tag -FrameworkData @{ CommandUsed = 'Describe' } -Focus:$Focus -Skip:$Skip
+        if (any $ForEach) {
+            New-ParametrizedBlock -Name $Name -ScriptBlock $Fixture -StartLine $MyInvocation.ScriptLineNumber -Tag $Tag -FrameworkData @{ CommandUsed = 'Describe' } -Focus:$Focus -Skip:$Skip -Data $ForEach
+        }
+        else {
+            New-Block -Name $Name -ScriptBlock $Fixture -StartLine $MyInvocation.ScriptLineNumber -Tag $Tag -FrameworkData @{ CommandUsed = 'Describe' } -Focus:$Focus -Skip:$Skip
+        }
     }
     else {
         Invoke-Interactively -CommandUsed 'Describe' -ScriptName $PSCmdlet.MyInvocation.ScriptName -SessionState $PSCmdlet.SessionState -BoundParameters $PSCmdlet.MyInvocation.BoundParameters

--- a/src/functions/Describe.ps1
+++ b/src/functions/Describe.ps1
@@ -96,7 +96,7 @@ about_TestDrive
 
 
     if ($ExecutionContext.SessionState.PSVariable.Get('invokedViaInvokePester')) {
-        if (any $ForEach) {
+        if ($null -ne  $ForEach -and 0 -lt @($ForEach).Count) {
             New-ParametrizedBlock -Name $Name -ScriptBlock $Fixture -StartLine $MyInvocation.ScriptLineNumber -Tag $Tag -FrameworkData @{ CommandUsed = 'Describe' } -Focus:$Focus -Skip:$Skip -Data $ForEach
         }
         else {

--- a/src/functions/It.ps1
+++ b/src/functions/It.ps1
@@ -145,7 +145,7 @@ about_should
         }
     }
 
-    if (any $TestCases) {
+    if ($null -ne  $TestCases -and 0 -lt @($TestCases).Count) {
         New-ParametrizedTest -Name $Name -ScriptBlock $Test -StartLine $MyInvocation.ScriptLineNumber -Data $TestCases -Tag $Tag -Focus:$Focus -Skip:$Skip
     }
     else {

--- a/src/functions/It.ps1
+++ b/src/functions/It.ps1
@@ -109,9 +109,10 @@ about_should
         [string] $Name,
 
         [Parameter(Position = 1)]
-        [ScriptBlock] $Test = {},
+        [ScriptBlock] $Test,
 
-        [System.Collections.IDictionary[]] $TestCases,
+        [Alias("ForEach")]
+        [object[]] $TestCases,
 
         [String[]] $Tag,
 
@@ -133,6 +134,15 @@ about_should
 
         $Skip = $Pending
         # $SkipBecause = "This test is pending."
+    }
+
+    if ($null -eq $Test) {
+        if ($Name.Contains("`n")) {
+            throw "Test name has multiple lines and no test scriptblock is provided. Did you provide the test name?"
+        }
+        else {
+            throw "No test scriptblock is provided. Did you put the opening curly brace on the next line?"
+        }
     }
 
     if (any $TestCases) {

--- a/src/functions/It.ps1
+++ b/src/functions/It.ps1
@@ -145,8 +145,13 @@ about_should
         }
     }
 
-    if ($null -ne  $TestCases -and 0 -lt @($TestCases).Count) {
-        New-ParametrizedTest -Name $Name -ScriptBlock $Test -StartLine $MyInvocation.ScriptLineNumber -Data $TestCases -Tag $Tag -Focus:$Focus -Skip:$Skip
+    if ($PSBoundParameters.ContainsKey('TestCases')) {
+        if ($null -ne $TestCases -and 0 -lt @($TestCases).Count) {
+            New-ParametrizedTest -Name $Name -ScriptBlock $Test -StartLine $MyInvocation.ScriptLineNumber -Data $TestCases -Tag $Tag -Focus:$Focus -Skip:$Skip
+        }
+        else {
+            # @() or $null is provided do nothing
+        }
     }
     else {
         New-Test -Name $Name -ScriptBlock $Test -StartLine $MyInvocation.ScriptLineNumber -Tag $Tag -Focus:$Focus -Skip:$Skip

--- a/src/functions/Output.ps1
+++ b/src/functions/Output.ps1
@@ -543,7 +543,7 @@ function Get-WriteScreenPlugin ($Verbosity) {
             $level = $block.Path.Count - 1
             $margin = $ReportStrings.Margin * $level
 
-            $text = $ReportStrings.$commandUsed -f $block.Name
+            $text = $ReportStrings.$commandUsed -f $block.ExpandedName
 
             if ($PesterPreference.Debug.ShowNavigationMarkers.Value) {
                 $text += ", $($block.ScriptBlock.File):$($block.StartLine)"

--- a/tst/Format.Tests.ps1
+++ b/tst/Format.Tests.ps1
@@ -86,7 +86,7 @@ Describe "Format-Null" {
 }
 
 Describe "Format-String" {
-    It "Formats empty string to '<empty>'" {
+    It "Formats empty string to '``<empty``>'" {
         Format-String -Value "" | Verify-Equal '<empty>'
     }
 

--- a/tst/TypeClass.Tests.ps1
+++ b/tst/TypeClass.Tests.ps1
@@ -129,7 +129,7 @@ Describe "Is-Dictionary" {
 
 # -- collection
 Describe "Is-Collection" {
-    It "Given a collection '<value>' of type '<type>' it returns `$true" -TestCases @(
+    It "Given a collection '<value>' of type '<value.GetType()>' it returns `$true" -TestCases @(
         @{ Value = @() }
         @{ Value = 1, 2, 3 }
         # the extra casts are for powershell v2 compatibility
@@ -146,7 +146,7 @@ Describe "Is-Collection" {
         Is-Collection -Value $null | Verify-False
     }
 
-    It "Given an object '<value>' of type '<type>' that is not a collection it returns `$false" -TestCases @(
+    It "Given an object '<value>' of type '<value.GetType()>' that is not a collection it returns `$false" -TestCases @(
         @{ Value = [char] 'a' }
         @{ Value = "a" }
 

--- a/tst/functions/Pester.TestRegistry.ts.ps1
+++ b/tst/functions/Pester.TestRegistry.ts.ps1
@@ -6,7 +6,7 @@ Get-Module Pester.Runtime, Pester.Utility, P, Pester, Axiom, Stack | Remove-Modu
 Import-Module $PSScriptRoot\..\p.psm1 -DisableNameChecking
 Import-Module $PSScriptRoot\..\axiom\Axiom.psm1 -DisableNameChecking
 
-if ($PSVersionTable.PSVersion.Major -le 5 -or -not $IsWindows) {
+if ($PSVersionTable.PSVersion.Major -gt 5 -and -not $IsWindows) {
     Write-Host "Not on Windows skipping TestRegistry tests." -ForegroundColor Yellow
     return (i -PassThru:$PassThru { })
 }


### PR DESCRIPTION
Add -ForEach parameter to Describe, Context, and as an alias to -TesCases on It.

Allow -ForEach and -TestCases to use any arrays, and not just arrays of hashtables.

Expand the name template in the context of the respective block and expand dot-notation.

Fix #1679 
Fix #1628
Fix #832
Fix #1682