### PR TITLE
Add New-PesterConfiguration function

### DIFF
--- a/src/Pester.RSpec.ps1
+++ b/src/Pester.RSpec.ps1
@@ -235,10 +235,74 @@ function Get-RSpecObjectDecoratorPlugin () {
 }
 
 function New-PesterConfiguration {
-    [CmdletBinding()]
-    param()
+<#
+.SYNOPSIS
+Creates a new [PesterConfiguration] object for advanced configuration of Invoke-Pester.
 
-    [PesterConfiguration]@{}
+.DESCRIPTION
+The New-PesterConfiguration function creates a new [PesterConfiguration] object
+to enable advanced configurations for runnings tests using Invoke-Pester.
+
+Without parameters, the function generates a configuration-object with default
+options. The returned [PesterConfiguration] object can be modified to suit your
+requirements. You may also use the -Configuration parameter to provide a pre-defined
+dictionary of custom options to override certain default values.
+
+.PARAMETER Default
+Create a new [PesterConfiguration] object with default values. This switch is
+optional and is an alternative to calling the function without parameters or
+using [PesterConfiguration]::Default directly.
+
+.PARAMETER Configuration
+Override the default values for the options defined in the provided dictionary/hashtable.
+Inspect a default [PesterConfiguration] object to learn about the schema and
+available options.
+
+.EXAMPLE
+$config = New-PesterConfiguration -Default
+$config.Run.PassThru = $true
+
+Invoke-Pester -Configuration $c
+
+Creates a default [PesterConfiguration] object and changes the Run.PassThru option
+to return the result object after the test run. The configuration object is
+provided to Invoke-Pester to alter the default behaviour.
+
+.EXAMPLE
+$MyOptions = @{
+    Run = @{ # <- Run configuration.
+        PassThru = $true # <- Return result object after finishing the test run.
+    }
+    Filter = @{ # <- Filter configuration
+        Tag = "Core","Integration" # <- Run only Describe/Context/It-blocks with 'Core' or 'Integration' tags
+    }
+}
+
+$config = New-PesterConfiguration -Configuration $MyOptions
+
+Invoke-Pester -Configuration $config
+
+A hashtable is created with custom options and passed to the New-PesterConfiguration to merge
+with the default configuration. The options will override the default values.
+The configuration object is then provided to Invoke-Pester to begin the test run using
+the new configuration.
+
+.LINK
+Invoke-Pester
+#>
+    [CmdletBinding(DefaultParameterSetName="Default")]
+    param(
+        [Parameter(ParameterSetName = "Default")]
+        [switch] $Default,
+
+        [Parameter(Mandatory, ParameterSetName = "Custom")]
+        [System.Collections.IDictionary] $Configuration
+    )
+
+    switch ($PSCmdlet.ParameterSetName) {
+        "Custom" { [PesterConfiguration]::new($Configuration) }
+        Default {    [PesterConfiguration]::Default }
+    }
 }
 
 function Remove-RSpecNonPublicProperties ($run){

--- a/src/Pester.Runtime.psm1
+++ b/src/Pester.Runtime.psm1
@@ -34,16 +34,6 @@ $state = [PSCustomObject] @{
     UserCodeStopWatch   = $null
     FrameworkStopWatch  = $null
     Stack               = [Collections.Stack]@()
-
-    ExpandName          = {
-        param([string]$Name, [HashTable]$Data)
-
-        $n = $Name
-        foreach ($pair in $Data.GetEnumerator()) {
-            $n = $n -replace "<$($pair.Key)>", "$($pair.Value)"
-        }
-        $n
-    }
 }
 
 function Reset-TestSuiteState {
@@ -145,6 +135,26 @@ function ConvertTo-ExecutedBlockContainer {
 
 }
 
+function New-ParametrizedBlock {
+    param (
+        [Parameter(Mandatory = $true)]
+        [String] $Name,
+        [Parameter(Mandatory = $true)]
+        [ScriptBlock] $ScriptBlock,
+        [int] $StartLine = $MyInvocation.ScriptLineNumber,
+        [String[]] $Tag = @(),
+        [HashTable] $FrameworkData = @{ },
+        [Switch] $Focus,
+        [String] $Id,
+        [Switch] $Skip,
+        $Data
+    )
+
+    foreach ($d in @($Data)) {
+        New-Block -Name $Name -ScriptBlock $ScriptBlock -StartLine $StartLine -Tag $Tag -FrameworkData $FrameworkData -Focus:$Focus -Skip:$Skip -Data $d
+    }
+}
+
 # endpoint for adding a block that contains tests
 # or other blocks
 function New-Block {
@@ -159,7 +169,7 @@ function New-Block {
         [Switch] $Focus,
         [String] $Id,
         [Switch] $Skip,
-        [Collections.IDictionary] $Data
+        $Data
     )
 
     # Switch-Timer -Scope Framework
@@ -204,7 +214,37 @@ function New-Block {
         if ($PesterPreference.Debug.WriteDebugMessages.Value) {
             Write-PesterDebugMessage -Scope DiscoveryCore "Discovering in body of block $Name"
         }
-        & $ScriptBlock
+
+        if ($null -ne $block.Data) {
+            $context = @{}
+            Add-DataToContext -Destination $context -Data $block.Data
+
+            $setVariablesAndRunBlock = {
+                param ($private:______parameters)
+
+                foreach ($private:______current in $private:______parameters.Context.GetEnumerator()) {
+                    $ExecutionContext.SessionState.PSVariable.Set($private:______current.Key, $private:______current.Value)
+                }
+
+                $private:______current = $null
+
+                . $private:______parameters.ScriptBlock
+            }
+
+            $parameters = @{
+                Context = $context
+                ScriptBlock = $ScriptBlock
+            }
+
+            $SessionStateInternal = $script:ScriptBlockSessionStateInternalProperty.GetValue($ScriptBlock, $null)
+            $script:ScriptBlockSessionStateInternalProperty.SetValue($setVariablesAndRunBlock, $SessionStateInternal, $null)
+
+            & $setVariablesAndRunBlock $parameters
+        }
+        else {
+            & $ScriptBlock
+        }
+
         if ($PesterPreference.Debug.WriteDebugMessages.Value) {
             Write-PesterDebugMessage -Scope DiscoveryCore "Finished discovering in body of block $Name"
         }
@@ -244,6 +284,7 @@ function Invoke-Block ($previousBlock) {
 
                 $block.ExecutedAt = [DateTime]::Now
                 $block.Executed = $true
+
                 if ($PesterPreference.Debug.WriteDebugMessages.Value) {
                     Write-PesterDebugMessage -Scope Runtime "Executing body of block '$($block.Name)'"
                 }
@@ -286,24 +327,51 @@ function Invoke-Block ($previousBlock) {
                         & $______pester_invoke_block_parameters.Invoke_Block -previousBlock $______pester_invoke_block_parameters.Block
                     }
 
+                    $context = @{
+                        ______pester_invoke_block_parameters = @{
+                            Invoke_Block = ${function:Invoke-Block}
+                            Block        = $block
+                        }
+                        ____Pester = $State
+                    }
+
+                    if ($null -ne $block.Data) {
+                        Add-DataToContext -Destination $context -Data $block.Data
+                    }
+
                     $sessionStateInternal = $script:ScriptBlockSessionStateInternalProperty.GetValue($block.ScriptBlock, $null)
                     $script:ScriptBlockSessionStateInternalProperty.SetValue($sb, $SessionStateInternal)
 
                     $result = Invoke-ScriptBlock `
                         -ScriptBlock $sb `
-                        -OuterSetup $( if (-not (Is-Discovery) -and (-not $Block.Skip)) {
-                            @($previousBlock.EachBlockSetup) + @($block.OneTimeTestSetup)
-                        }) `
+                        -OuterSetup @(
+                            $(if (-not (Is-Discovery) -and (-not $Block.Skip)) {
+                                @($previousBlock.EachBlockSetup) + @($block.OneTimeTestSetup)
+                            })
+                            $(if (-not $Block.IsRoot) {
+                                # expand block name by evaluating the <> templates, only match templates that have at least 1 character and are not escaped by `<abc`>
+                                # avoid using variables so we don't run into conflicts
+                                $sb = {
+                                    $____Pester.CurrentBlock.ExpandedName = & ([ScriptBlock]::Create(('"'+ ($____Pester.CurrentBlock.Name -replace '\$', '`$' -replace '"', '`"' -replace '(?<!`)<([^>^`]+)>', '$$($$$1)') + '"')))
+                                    $____Pester.CurrentBlock.ExpandedPath = if ($____Pester.CurrentBlock.Parent.IsRoot) {
+                                        # to avoid including Root name in the path
+                                        $____Pester.CurrentBlock.ExpandedName
+                                    }
+                                    else {
+                                        "$($____Pester.CurrentBlock.Parent.ExpandedPath).$($____Pester.CurrentBlock.ExpandedName)"
+                                    }
+                                }
+
+                                $SessionStateInternal = $script:ScriptBlockSessionStateInternalProperty.GetValue($State.CurrentBlock.ScriptBlock, $null)
+                                $script:ScriptBlockSessionStateInternalProperty.SetValue($sb, $SessionStateInternal)
+
+                                $sb
+                            })
+                        ) `
                         -OuterTeardown $( if (-not (Is-Discovery) -and (-not $Block.Skip)) {
                             @($block.OneTimeTestTeardown) + @($previousBlock.EachBlockTeardown)
                         } ) `
-                        -Context @{
-                        ______pester_invoke_block_parameters = @{
-                            Invoke_Block = ${function:Invoke-Block}
-                            Block        = $block
-                        }
-                    } `
-                        -ReduceContextToInnerScope `
+                        -Context $context `
                         -MoveBetweenScopes `
                         -Configuration $state.Configuration
 
@@ -371,7 +439,7 @@ function New-Test {
         [ScriptBlock] $ScriptBlock,
         [int] $StartLine = $MyInvocation.ScriptLineNumber,
         [String[]] $Tag = @(),
-        [System.Collections.IDictionary] $Data = @{ },
+        $Data,
         [String] $Id,
         [Switch] $Focus,
         [Switch] $Skip
@@ -448,10 +516,6 @@ function Invoke-TestItem {
         $Test.ExecutedAt = [DateTime]::Now
         $Test.Executed = $true
 
-        $Test.ExpandedName = & $state.ExpandName -Name $Test.Name -Data $Test.Data
-
-        $test.ExpandedPath = "$($Test.Block.Path -join '.').$($Test.ExpandedName)"
-
         $block = $Test.Block
         if ($PesterPreference.Debug.WriteDebugMessages.Value) {
             Write-PesterDebugMessage -Scope Runtime "Running test '$($Test.Name)'."
@@ -492,21 +556,12 @@ function Invoke-TestItem {
         else {
 
             if ($frameworkSetupResult.Success) {
-                # TODO: use PesterContext as the name, or some other better reserved name to avoid conflicts
                 $context = @{
-                    # context visible in test
-                    Context = [PSCustomObject]@{ Name = $t.Name; Path = $t.Path }
+                    ____Pester = $State
                 }
 
-                # user provided data are merged with Pester provided context
-                # Merge-Hashtable -Source $Test.Data -Destination $context
-                foreach ($p in $Test.Data.GetEnumerator()) {
-                    # only add non existing keys so in case of conflict
-                    # the framework name wins, as if we had explicit parameters
-                    # on a scriptblock, then the parameter would also win
-                    if (-not $context.ContainsKey($p.Key)) {
-                        $context.Add($p.Key, $p.Value)
-                    }
+                if ($null -ne $test.Data) {
+                    Add-DataToContext -Destination $context -Data $test.Data
                 }
 
                 # recurse up Recurse-Up $Block { param ($b) $b.EachTestSetup }
@@ -530,12 +585,29 @@ function Invoke-TestItem {
                         [Array]::Reverse($eachTestSetups)
                         @( { $Test.FrameworkData.Runtime.ExecutionStep = 'EachTestSetup' }) + @($eachTestSetups)
                     }
-                    # setting the execution info here so I don't have to invoke change the
-                    # contract of Invoke-ScriptBlock to accept multiple -ScriptBlock, because
-                    # that is not needed, and would complicate figuring out in which session
-                    # state we should run.
-                    # this should run every time.
-                    { $Test.FrameworkData.Runtime.ExecutionStep = 'Test' }
+
+                    {
+                        # setting the execution info here so I don't have to invoke change the
+                        # contract of Invoke-ScriptBlock to accept multiple -ScriptBlock, because
+                        # that is not needed, and would complicate figuring out in which session
+                        # state we should run.
+                        # this should run every time.
+                        $Test.FrameworkData.Runtime.ExecutionStep = 'Test'
+                    }
+                    $(
+                        # expand block name by evaluating the <> templates, only match templates that have at least 1 character and are not escaped by `<abc`>
+                        # avoid using any variables to avoid running into conflict with user variables
+                        # $ExecutionContext.SessionState.InvokeCommand.ExpandString() has some weird bug in PowerShell 4 and 3, that makes hashtable resolve to null
+                        # instead I create a expandable string in a scriptblock and evaluate
+                        $sb = {
+                            $____Pester.CurrentTest.ExpandedName = & ([ScriptBlock]::Create(('"'+ ($____Pester.CurrentTest.Name -replace '\$', '`$' -replace '"', '`"' -replace '(?<!`)<([^>^`]+)>', '$$($$$1)') + '"')))
+                            $____Pester.CurrentTest.ExpandedPath = "$($____Pester.CurrentTest.Block.ExpandedPath -join '.').$($____Pester.CurrentTest.ExpandedName)"
+                        }
+
+                        $SessionStateInternal = $script:ScriptBlockSessionStateInternalProperty.GetValue($State.CurrentTest.ScriptBlock, $null)
+                        $script:ScriptBlockSessionStateInternalProperty.SetValue($sb, $SessionStateInternal)
+                        $sb
+                    )
                 ) `
                     -ScriptBlock $Test.ScriptBlock `
                     -Teardown @(
@@ -793,6 +865,10 @@ function Discover-Test {
         $root.First = $true
         $root.Last = $true
 
+        # set the data from the container to get them
+        # set correctly as if we provided -Data to New-Block
+        $root.Data = $root.BlockContainer.Data
+
         Reset-PerContainerState -RootBlock $root
 
         $steps = $state.Plugin.ContainerDiscoveryStart
@@ -948,6 +1024,11 @@ function Run-Test {
             # before all script, but it might be better to make this a plugin, because there we can pass data.
             $setVariables = {
                 param($private:____parameters)
+
+                if ($null -eq $____parameters.Data) {
+                    return
+                }
+
                 foreach($private:____d in $____parameters.Data.GetEnumerator()) {
                     & $____parameters.Set_Variable -Name $private:____d.Name -Value $private:____d.Value
                 }
@@ -1247,6 +1328,11 @@ function Invoke-ScriptBlock {
                     if ($______parameters.EnableWriteDebug) { &$______parameters.WriteDebug "Setting context variable '$($______current.Key)' with value '$($______current.Value)'" }
                     $ExecutionContext.SessionState.PSVariable.Set($______current.Key, $______current.Value)
                 }
+
+                if ($______outerSplat.ContainsKey("_")) {
+                    $______outerSplat.Remove("_")
+                }
+
                 $______current = $null
             }
             else {
@@ -1278,6 +1364,11 @@ function Invoke-ScriptBlock {
                             if ($______parameters.EnableWriteDebug) { &$______parameters.WriteDebug "Setting context variable '$ ($______current.Key)' with value '$($______current.Value)'" }
                             $ExecutionContext.SessionState.PSVariable.Set($______current.Key, $______current.Value)
                         }
+
+                        if ($______outerSplat.ContainsKey("_")) {
+                            $______outerSplat.Remove("_")
+                        }
+
                         $______current = $null
                     }
                     else {
@@ -2230,7 +2321,7 @@ function New-BlockContainerObject {
         [String] $Path,
         [Parameter(Mandatory, ParameterSetName = "File")]
         [System.IO.FileInfo] $File,
-        [Collections.IDictionary] $Data
+        $Data
     )
 
     $type, $item = switch ($PSCmdlet.ParameterSetName) {
@@ -2243,7 +2334,7 @@ function New-BlockContainerObject {
     $c = [Pester.ContainerInfo]::Create()
     $c.Type = $type
     $c.Item = $item
-    $c.Data = if ($null -ne $Data) { $Data } else { @{} }
+    $c.Data = $Data
     $c
 }
 
@@ -2399,20 +2490,15 @@ function New-ParametrizedTest () {
         [int] $StartLine = $MyInvocation.ScriptLineNumber,
         [String[]] $Tag = @(),
         # do not use [hashtable[]] because that throws away the order if user uses [ordered] hashtable
-        [System.Collections.IDictionary[]] $Data = @{ },
+        [object[]] $Data,
         [Switch] $Focus,
         [Switch] $Skip
     )
 
-    # we don't need to switch the timer, all the code that runs during discovery is "overhead"
-    # Switch-Timer -Scope Framework
-    # TODO: there used to be counter, that was added to the id, seems like I am missing TestGroup on the test cases, so I can reconcile them back if they were generated from testcases
-    # $counter = 0
-
-    # using the start line of the scriptblock as the id of the test so we can join multiple testcases together, this should be unique enough because it only needs to be unique for the current block, so the way to break this would be to inline multiple tests, but that is unlikely to happen. When it happens just use StartLine:StartPosition
-    $id = $ScriptBlock.StartPosition.StartLine
+    # using the position of It as Id for the the test so we can join multiple testcases together, this should be unique enough because it only needs to be unique for the current block, so the way to break this would be to inline multiple tests, but that is unlikely to happen. When it happens just use StartLine:StartPosition
+    # TODO: I don't think the Id is needed anymore
+    $id = $StartLine
     foreach ($d in $Data) {
-        #    $innerId = if (-not $hasExternalId) { $null } else { "$Id-$(($counter++))" }
         New-Test -Id $id -Name $Name -Tag $Tag -ScriptBlock $ScriptBlock -StartLine $StartLine -Data $d -Focus:$Focus -Skip:$Skip
     }
 }

--- a/src/Pester.Utility.ps1
+++ b/src/Pester.Utility.ps1
@@ -189,6 +189,29 @@ function tryRemoveKey ($Hashtable, $Key) {
     }
 }
 
+function Add-DataToContext ($Destination, $Data) {
+    # works as Merge-Hashtable, but additionally adds _
+    # which will become $_, and checks if the Data is
+    # expandable, otherwise it just defines $_
+
+    if ($Data.Count -eq 0) {
+        $a = 10
+    }
+    if (-not $Destination.ContainsKey("_")) {
+        $Destination.Add("_", $Data)
+    }
+
+    if ($Data -is [Collections.IDictionary]) {
+        # only add non existing keys so in case of conflict
+        # the framework name wins, as if we had explicit parameters
+        # on a scriptblock, then the parameter would also win
+        foreach ($p in $Data.GetEnumerator()) {
+            if (-not $Destination.ContainsKey($p.Key)) {
+                $Destination.Add($p.Key, $p.Value)
+            }
+        }
+    }
+}
 
 function Merge-Hashtable ($Source, $Destination) {
     foreach ($p in $Source.GetEnumerator()) {

--- a/src/Pester.ps1
+++ b/src/Pester.ps1
@@ -750,9 +750,9 @@ function Invoke-Pester {
                         $cs = @()
 
                         foreach ($c in $Container) {
-                            $data = if ($null -eq $c.Data) { @(@{}) } else { $c.Data }
+                            $data = $c.Data
                             if ($c -is [Pester.TestScriptBlock]) {
-                                foreach ($d in $data) {
+                                foreach ($d in @($data)) {
                                     $cs += New-BlockContainerObject -ScriptBlock $c.ScriptBlock -Data $d
                                 }
                             }

--- a/src/Pester.psd1
+++ b/src/Pester.psd1
@@ -59,7 +59,8 @@
         'ConvertTo-Pester4Result'
 
         # config
-        'New-TestContainer',
+        'New-TestContainer'
+        'New-PesterConfiguration'
 
         # legacy
         'Assert-VerifiableMock'

--- a/src/Pester.psd1
+++ b/src/Pester.psd1
@@ -4,7 +4,7 @@
     RootModule        = 'Pester.psm1'
 
     # Version number of this module.
-    ModuleVersion     = '5.0.5'
+    ModuleVersion     = '5.1.0'
 
     # ID used to uniquely identify this module
     GUID              = 'a699dea5-2c73-4616-a270-1f7abb777e71'
@@ -109,7 +109,7 @@
             LicenseUri   = "https://www.apache.org/licenses/LICENSE-2.0.html"
 
             # Release notes for this particular version of the module
-            ReleaseNotes = 'https://github.com/pester/Pester/releases/tag/5.0.5'
+            ReleaseNotes = 'https://github.com/pester/Pester/releases/tag/5.1.0'
 
             # Prerelease string of this module
             Prerelease   = 'beta1'

--- a/src/Pester.psm1
+++ b/src/Pester.psm1
@@ -35,7 +35,8 @@ Set-Alias 'Get-AssertionOperator' 'Get-ShouldOperator'
     'Get-ShouldOperator'
 
     # config
-    'New-TestContainer',
+    'New-TestContainer'
+    'New-PesterConfiguration'
 
     # export
     'Export-NunitReport'

--- a/src/csharp/Pester/Block.cs
+++ b/src/csharp/Pester/Block.cs
@@ -16,7 +16,6 @@ namespace Pester
         {
             ItemType = "Block";
             FrameworkData = new Hashtable();
-            Data = new Hashtable();
             PluginData = new Hashtable();
             Tests = new List<Test>();
             Order = new List<object>();
@@ -26,7 +25,9 @@ namespace Pester
 
         public string Name { get; set; }
         public List<string> Path { get; set; }
-        public IDictionary Data { get; set; }
+        public object Data { get; set; }
+        public string ExpandedName { get; set; }
+        public string ExpandedPath { get; set; }
         public List<Block> Blocks { get; set; } = new List<Block>();
         public List<Test> Tests { get; set; } = new List<Test>();
 

--- a/src/csharp/Pester/Container.cs
+++ b/src/csharp/Pester/Container.cs
@@ -48,7 +48,7 @@ namespace Pester
 
         public string Type { get; set; }
         public object Item { get; set; }
-        public IDictionary Data { get; set; }
+        public object Data { get; set; }
         public List<Block> Blocks { get; set; } = new List<Block>();
         public string Result { get; set; } = "NotRun";
         public TimeSpan Duration { get => DiscoveryDuration + UserDuration + FrameworkDuration; }

--- a/src/csharp/Pester/ContainerInfo.cs
+++ b/src/csharp/Pester/ContainerInfo.cs
@@ -13,6 +13,6 @@ namespace Pester
 
         public string Type { get; set; } = "File";
         public object Item { get; set; }
-        public IDictionary Data { get; set; }
+        public object Data { get; set; }
     }
 }

--- a/src/csharp/Pester/PesterFile.cs
+++ b/src/csharp/Pester/PesterFile.cs
@@ -7,7 +7,7 @@ namespace Pester
     public abstract class TestContainer
     {
         public object Container { get; set; }
-        public IDictionary[] Data { get; set; }
+        public object[] Data { get; set; }
     }
 
     public class TestPath : TestContainer
@@ -17,7 +17,7 @@ namespace Pester
             return new TestPath(path);
         }
 
-        public static TestPath Create(string path, IDictionary[] data)
+        public static TestPath Create(string path, object[] data)
         {
             return new TestPath(path, data);
         }
@@ -28,7 +28,7 @@ namespace Pester
 
         }
 
-        public TestPath(string path, IDictionary[] data)
+        public TestPath(string path, object[] data)
         {
             Container = Path = path ?? throw new ArgumentNullException(nameof(path));
             Data = data;
@@ -46,7 +46,7 @@ namespace Pester
             return new TestScriptBlock(scriptBlock);
         }
 
-        public static TestScriptBlock Create(ScriptBlock scriptBlock, IDictionary[] data)
+        public static TestScriptBlock Create(ScriptBlock scriptBlock, object[] data)
         {
             return new TestScriptBlock(scriptBlock, data);
         }
@@ -54,7 +54,7 @@ namespace Pester
         {
         }
 
-        public TestScriptBlock(ScriptBlock scriptBlock, IDictionary[] data)
+        public TestScriptBlock(ScriptBlock scriptBlock, object[] data)
         {
             Container = ScriptBlock = scriptBlock;
             Data = data;

--- a/src/csharp/Pester/Test.cs
+++ b/src/csharp/Pester/Test.cs
@@ -15,7 +15,6 @@ namespace Pester
         public Test()
         {
             ItemType = "Test";
-            Data = new Hashtable();
             PluginData = new Hashtable();
             ErrorRecord = new List<object>();
 
@@ -28,7 +27,7 @@ namespace Pester
 
         public string Name { get; set; }
         public List<string> Path { get; set; }
-        public IDictionary Data { get; set; }
+        public object Data { get; set; }
         public string ExpandedName { get; set; }
         public string ExpandedPath { get; set; }
 

--- a/src/functions/Describe.ps1
+++ b/src/functions/Describe.ps1
@@ -24,6 +24,12 @@ Optional parameter containing an array of strings.  When calling Invoke-Pester,
 it is possible to specify a -Tag parameter which will only execute Describe blocks
 containing the same Tag.
 
+.PARAMETER ForEach
+Allows data driven tests to be written.
+Takes an array of data and generates one block for each item in the array, and makes the item
+available as $_ in all child blocks. When the array is an array of hashtables, it additionally
+defines each key in the hashatble as variable.
+
 .EXAMPLE
 function Add-Numbers($a, $b) {
     return $a + $b
@@ -73,7 +79,9 @@ about_TestDrive
         [ScriptBlock] $Fixture,
 
         # [Switch] $Focus,
-        [Switch] $Skip
+        [Switch] $Skip,
+
+        $ForEach
     )
 
     $Focus = $false
@@ -88,7 +96,17 @@ about_TestDrive
 
 
     if ($ExecutionContext.SessionState.PSVariable.Get('invokedViaInvokePester')) {
-        New-Block -Name $Name -ScriptBlock $Fixture -StartLine $MyInvocation.ScriptLineNumber -Tag $Tag -FrameworkData @{ CommandUsed = 'Describe' } -Focus:$Focus -Skip:$Skip
+        if ($PSBoundParameters.ContainsKey('ForEach')) {
+            if ($null -ne  $ForEach -and 0 -lt @($ForEach).Count) {
+                New-ParametrizedBlock -Name $Name -ScriptBlock $Fixture -StartLine $MyInvocation.ScriptLineNumber -Tag $Tag -FrameworkData @{ CommandUsed = 'Describe' } -Focus:$Focus -Skip:$Skip -Data $ForEach
+            }
+            else {
+                # @() or $null is provided do nothing
+            }
+        }
+        else {
+            New-Block -Name $Name -ScriptBlock $Fixture -StartLine $MyInvocation.ScriptLineNumber -Tag $Tag -FrameworkData @{ CommandUsed = 'Describe' } -Focus:$Focus -Skip:$Skip
+        }
     }
     else {
         Invoke-Interactively -CommandUsed 'Describe' -ScriptName $PSCmdlet.MyInvocation.ScriptName -SessionState $PSCmdlet.SessionState -BoundParameters $PSCmdlet.MyInvocation.BoundParameters

--- a/src/functions/It.ps1
+++ b/src/functions/It.ps1
@@ -109,9 +109,10 @@ about_should
         [string] $Name,
 
         [Parameter(Position = 1)]
-        [ScriptBlock] $Test = {},
+        [ScriptBlock] $Test,
 
-        [System.Collections.IDictionary[]] $TestCases,
+        [Alias("ForEach")]
+        [object[]] $TestCases,
 
         [String[]] $Tag,
 
@@ -135,8 +136,22 @@ about_should
         # $SkipBecause = "This test is pending."
     }
 
-    if (any $TestCases) {
-        New-ParametrizedTest -Name $Name -ScriptBlock $Test -StartLine $MyInvocation.ScriptLineNumber -Data $TestCases -Tag $Tag -Focus:$Focus -Skip:$Skip
+    if ($null -eq $Test) {
+        if ($Name.Contains("`n")) {
+            throw "Test name has multiple lines and no test scriptblock is provided. Did you provide the test name?"
+        }
+        else {
+            throw "No test scriptblock is provided. Did you put the opening curly brace on the next line?"
+        }
+    }
+
+    if ($PSBoundParameters.ContainsKey('TestCases')) {
+        if ($null -ne $TestCases -and 0 -lt @($TestCases).Count) {
+            New-ParametrizedTest -Name $Name -ScriptBlock $Test -StartLine $MyInvocation.ScriptLineNumber -Data $TestCases -Tag $Tag -Focus:$Focus -Skip:$Skip
+        }
+        else {
+            # @() or $null is provided do nothing
+        }
     }
     else {
         New-Test -Name $Name -ScriptBlock $Test -StartLine $MyInvocation.ScriptLineNumber -Tag $Tag -Focus:$Focus -Skip:$Skip

--- a/src/functions/Output.ps1
+++ b/src/functions/Output.ps1
@@ -528,33 +528,18 @@ function Get-WriteScreenPlugin ($Verbosity) {
 
     if ($PesterPreference.Output.Verbosity.Value -in 'Detailed', 'Diagnostic') {
         $p.EachBlockSetupStart = {
+            $Context.Configuration.BlockWritePostponed = $true
+        }
+    }
+
+    if ($PesterPreference.Output.Verbosity.Value -in 'Detailed', 'Diagnostic') {
+        $p.EachTestSetupStart = {
             param ($Context)
-            # the $context does not mean Context block, it's just a generic name
-            # for the invocation context of this callback
-
-            if ($Context.Block.IsRoot) {
-                return
+            # we posponed writing the Describe / Context to grab the Expanded name, because that is done
+            # during execution to get all the variables in scope, if we are the first test then write it
+            if ($Context.Test.First) {
+                Write-BlockToScreen $Context.Test.Block
             }
-
-            $commandUsed = $Context.Block.FrameworkData.CommandUsed
-
-            $block = $Context.Block
-            # -1 moves the block closer to the start of theline
-            $level = $block.Path.Count - 1
-            $margin = $ReportStrings.Margin * $level
-
-            $text = $ReportStrings.$commandUsed -f $block.Name
-
-            if ($PesterPreference.Debug.ShowNavigationMarkers.Value) {
-                $text += ", $($block.ScriptBlock.File):$($block.StartLine)"
-            }
-
-            if (0 -eq $level -and -not $block.First) {
-                # write extra line before top-level describe / context if it is not first
-                # in that case there are already two spaces before the name of the file
-                & $SafeCommands['Write-Host']
-            }
-            & $SafeCommands['Write-Host'] "${margin}${Text}" -ForegroundColor $ReportTheme.$CommandUsed
         }
     }
 
@@ -664,21 +649,39 @@ function Get-WriteScreenPlugin ($Verbosity) {
             return
         }
 
-        if (-not $Context.Block.OwnPassed) {
-            if ($PesterPreference.Output.Verbosity.Value -in 'Detailed', 'Diagnostic') {
-                $level = $Context.Block.Path.Count
-                $margin = $ReportStrings.Margin * ($level)
-                $error_margin = $margin + $ReportStrings.Margin
-            }
-
-            $level = 0
-            $margin = 0
-            $error_margin = $ReportStrings.Margin
-
-            foreach ($e in $Context.Block.ErrorRecord) { ConvertTo-FailureLines $e }
-            & $SafeCommands['Write-Host'] -ForegroundColor Red "[-] $($Context.Block.FrameworkData.CommandUsed) $($Context.Block.Path -join ".") failed"
-            Write-ErrorToScreen $Context.Block.ErrorRecord $error_margin
+        if ($Context.Block.OwnPassed) {
+            return
         }
+
+        if ($PesterPreference.Output.Verbosity.Value -in 'Detailed', 'Diagnostic') {
+            # In Diagnostic output we postpone writing the Describing / Context until before the
+            # setup of the first test to get the correct ExpandedName of the Block with all the
+            # variables in context.
+            # if there is a failure before that (e.g. BeforeAll throws) we need to write Describing here.
+            # But not if the first test already executed.
+            if ($null -ne $Context.Block.Tests -and 0 -lt $Context.Block.Tests.Count) {
+               foreach ($t in $Context.Block.Tests) {
+                    if ($t.First -and -not $t.Executed) {
+                        Write-BlockToScreen $Context.Block
+                        break
+                    }
+                }
+            }
+        }
+
+        $level = 0
+        $margin = 0
+        $error_margin = $ReportStrings.Margin
+
+        if ($PesterPreference.Output.Verbosity.Value -in 'Detailed', 'Diagnostic') {
+            $level = $Context.Block.Path.Count
+            $margin = $ReportStrings.Margin * ($level)
+            $error_margin = $margin + $ReportStrings.Margin
+        }
+
+        foreach ($e in $Context.Block.ErrorRecord) { ConvertTo-FailureLines $e }
+        & $SafeCommands['Write-Host'] -ForegroundColor Red "[-] $($Context.Block.FrameworkData.CommandUsed) $($Context.Block.Path -join ".") failed"
+        Write-ErrorToScreen $Context.Block.ErrorRecord $error_margin
     }
 
     $p.End = {
@@ -715,4 +718,39 @@ function Write-ErrorToScreen {
 
     $withMargin = ($out -split [Environment]::NewLine) -replace '(?m)^', $ErrorMargin -join [Environment]::NewLine
     & $SafeCommands['Write-Host'] -ForegroundColor $ReportTheme.Fail "$withMargin"
+}
+
+function Write-BlockToScreen {
+    # the $context does not mean Context block, it's just a generic name
+    # for the invocation context of this callback
+    param ($Block)
+
+    # this function will write Describe / Context expanded name right before a test setup
+    # or right before describe failure, we need to postpone this write to have the ExpandedName
+    # correctly populated when there are data given to the block
+
+    if ($Block.IsRoot) {
+        return
+    }
+
+    $commandUsed = $Block.FrameworkData.CommandUsed
+
+    # -1 moves the block closer to the start of theline
+    $level = $Block.Path.Count - 1
+    $margin = $ReportStrings.Margin * $level
+
+    $name = if (-not [string]::IsNullOrWhiteSpace($Block.ExpandedName)) { $Block.ExpandedName } else { $Block.Name }
+    $text = $ReportStrings.$commandUsed -f $name
+
+    if ($PesterPreference.Debug.ShowNavigationMarkers.Value) {
+        $text += ", $($block.ScriptBlock.File):$($block.StartLine)"
+    }
+
+    if (0 -eq $level -and -not $block.First) {
+        # write extra line before top-level describe / context if it is not first
+        # in that case there are already two spaces before the name of the file
+        & $SafeCommands['Write-Host']
+    }
+
+    & $SafeCommands['Write-Host'] "${margin}${Text}" -ForegroundColor $ReportTheme.$CommandUsed
 }

--- a/tst/Format.Tests.ps1
+++ b/tst/Format.Tests.ps1
@@ -86,7 +86,7 @@ Describe "Format-Null" {
 }
 
 Describe "Format-String" {
-    It "Formats empty string to '<empty>'" {
+    It "Formats empty string to '``<empty``>'" {
         Format-String -Value "" | Verify-Equal '<empty>'
     }
 

--- a/tst/Pester.RSpec.Nunit.TestResults.ts.ps1
+++ b/tst/Pester.RSpec.Nunit.TestResults.ts.ps1
@@ -365,7 +365,7 @@ i -PassThru:$PassThru {
                 })
             $r = Invoke-Pester -Configuration ([PesterConfiguration]@{ Run = @{ ScriptBlock = $sb; PassThru = $true }; Output = @{ Verbosity = 'None' } })
 
-            $xmlResult = ConvertTo-NUnitReport $r
+            $xmlResult = $r | ConvertTo-NUnitReport
             $xmlTestSuite1 = $xmlResult.'test-results'.'test-suite'.'results'.'test-suite'.'results'.'test-suite'[0]
 
             $xmlTestSuite1.name | Verify-Equal "Describe #1"
@@ -380,6 +380,55 @@ i -PassThru:$PassThru {
             $xmlTestSuite2.result | Verify-Equal "Failure"
             $xmlTestSuite2.success | Verify-Equal "False"
             $xmlTestSuite2.time | Verify-XmlTime $r.Containers[1].Blocks[0].Duration
+        }
+    }
+
+    b "Filtered items should not appear in report" {
+
+        $sb = @(
+            # container 0
+            {
+                # this whole container should be excluded, it has no tests that will run
+                Describe "Excluded describe" {
+                    It "Excluded test" -Tag 'Exclude' {
+                        $true | Should -Be $true
+                    }
+                }
+            }
+
+            # container 1
+            {
+                # this describe should be excluded, it has no test to run
+                Describe "Excluded describe" {
+                    It "Excluded test" -Tag 'Exclude' {
+                        $true | Should -Be $true
+                    }
+                }
+
+                # but the container should still be included because it has
+                # this describe that will run
+                Describe "Included describe" {
+                    It "Included test" {
+                        $true | Should -Be $true
+                    }
+                }
+
+            }
+        )
+
+        t "Report ignores containers, blocks and tests filtered by ExcludeTag" {
+            $r = Invoke-Pester -Configuration ([PesterConfiguration]@{ Run = @{ ScriptBlock = $sb; PassThru = $true }; Output = @{ Verbosity = 'None' }; Filter = @{ ExcludeTag = 'Exclude' }; })
+
+            $r.Containers[0].ShouldRun | Verify-False
+            $r.Containers[1].Blocks[0].Tests[0].ShouldRun | Verify-False
+            $r.Containers[1].Blocks[1].Tests[0].ShouldRun | Verify-True
+
+            $xmlResult = $r | ConvertTo-NUnitReport
+
+            $xmlSuites = @($xmlResult.'test-results'.'test-suite'.'results'.'test-suite'.'results'.'test-suite')
+            $xmlSuites.Count | Verify-Equal 1 # there should be only 1 suite, the others are excluded
+            $xmlSuites[0].'description' | Verify-Equal "Included describe"
+            $xmlSuites[0].'results'.'test-case'.'description' | Verify-Equal "Included test"
         }
     }
 }

--- a/tst/Pester.RSpec.ts.ps1
+++ b/tst/Pester.RSpec.ts.ps1
@@ -911,7 +911,7 @@ i -PassThru:$PassThru {
     }
 
     b "BeforeDiscovery" {
-         t "Variables from BeforeDiscovery are defined in scope" {
+        t "Variables from BeforeDiscovery are defined in scope" {
             $sb = {
                 BeforeDiscovery {
                     $tests = 1,2
@@ -927,9 +927,324 @@ i -PassThru:$PassThru {
             }
 
             $container = New-TestContainer -ScriptBlock $sb
-            $r = Invoke-Pester -Container $container -PassThru -Output Detailed
+            $r = Invoke-Pester -Container $container -PassThru
             $r.Containers[0].Blocks[0].Tests[0].Result | Verify-Equal "Passed"
             $r.Containers[0].Blocks[1].Tests[0].Result | Verify-Equal "Passed"
+        }
+    }
+
+    b "Parametric tests" {
+        t "Providing data will generate as many Its as there are data sets" {
+            $sb = {
+                Describe "d" {
+                    It "i" {
+                    } -TestCases @(@{ Value = 1}, @{ Value  = 2 })
+                }
+            }
+
+            $container = New-TestContainer -ScriptBlock $sb
+            $r = Invoke-Pester -Container $container -PassThru
+            $r.Containers[0].Blocks[0].Tests.Count | Verify-Equal 2
+        }
+
+        t "-ForEach is alias to -TestCases" {
+            $sb = {
+                Describe "d" {
+                    It "i" {
+                    } -ForEach @(@{ Value = 1}, @{ Value  = 2 })
+                }
+            }
+
+            $container = New-TestContainer -ScriptBlock $sb
+            $r = Invoke-Pester -Container $container -PassThru
+            $r.Containers[0].Blocks[0].Tests.Count | Verify-Equal 2
+        }
+
+        t "Providing empty or `$null -TestCases will generate nothing" {
+            $sb = {
+                Describe "d" {
+                    It "i" { } -ForEach @()
+                }
+
+                Describe "d" {
+                    It "i" { } -ForEach $null
+                }
+            }
+
+            $container = New-TestContainer -ScriptBlock $sb
+            $r = Invoke-Pester -Container $container -PassThru
+            $r.Containers[0].Blocks[0].Tests.Count | Verify-Equal 0
+            $r.Containers[0].Blocks[1].Tests.Count | Verify-Equal 0
+        }
+    }
+
+    b "Parametric blocks" {
+        t "Providing data will generate as many blocks as there are data sets" {
+            $sb = {
+                Describe "d" {
+                    It "i" {
+                    }
+                } -ForEach @(@{ Value = 1}, @{ Value  = 2 })
+            }
+
+            $container = New-TestContainer -ScriptBlock $sb
+            $r = Invoke-Pester -Container $container -PassThru #
+            $r.Containers[0].Blocks.Count | Verify-Equal 2
+        }
+
+        t "Providing empty or `$null -ForEach will generate nothing" {
+            $sb = {
+                Describe "d" {
+                    It "i" { }
+                } -ForEach @()
+
+                Describe "d" {
+                    It "i" { }
+                } -ForEach $null
+            }
+
+            $container = New-TestContainer -ScriptBlock $sb
+            $r = Invoke-Pester -Container $container -PassThru
+            $r.Containers[0].Blocks.Count | Verify-Equal 0
+        }
+
+        t "Data will be available in the respective block during Run" {
+            $sb = {
+                Describe "d" {
+                    BeforeAll {
+                        if ($Value -notin 1,2) { throw "`$Value should be 1 or 2 but is '$Value'." }
+                    }
+
+                    BeforeEach {
+                        if ($Value -notin 1,2) { throw "`$Value should be 1 or 2 but is '$Value'." }
+                    }
+
+                    It "i" {
+                        if ($Value -notin 1,2) { throw "`$Value should be 1 or 2 but is '$Value'." }
+                    }
+
+                    AfterEach {
+                        if ($Value -notin 1,2) { throw "`$Value should be 1 or 2 but is '$Value'." }
+                    }
+
+                    AfterAll {
+                        if ($Value -notin 1,2) { throw "`$Value should be 1 or 2 but is '$Value'." }
+                    }
+                } -ForEach @(@{ Value = 1}, @{ Value  = 2 })
+            }
+
+            $container = New-TestContainer -ScriptBlock $sb
+            $r = Invoke-Pester -Container $container -PassThru
+            $r.Containers[0].Blocks[0].Tests[0].Result | Verify-Equal "Passed"
+            $r.Containers[0].Blocks[1].Tests[0].Result | Verify-Equal "Passed"
+        }
+
+        t "`$_ holds the whole hashtable when hastable is used, and it is not overwritten in It" {
+            $sb = {
+                Describe "d" {
+                    BeforeAll {
+                        if ($_.Value -notin 1,2) { throw "`$Value should be 1 or 2 but is '$($_.Value)'." }
+                    }
+
+                    It "i" {
+                        if ($_.Value -notin 1,2) { throw "`$Value should be 1 or 2 but is '$($_.Value)'." }
+                    }
+                } -ForEach @(@{ Value = 1 }, @{ Value  = 2 })
+            }
+
+            $container = New-TestContainer -ScriptBlock $sb
+            $r = Invoke-Pester -Container $container -PassThru
+            $r.Containers[0].Blocks[0].Tests[0].Result | Verify-Equal "Passed"
+            $r.Containers[0].Blocks[1].Tests[0].Result | Verify-Equal "Passed"
+        }
+
+        t "`$_ holds the whole hashtable when hastable is used, and it is overwritten in It if it specifies its own data" {
+            $sb = {
+                Describe "d" {
+                    BeforeAll {
+                        if ($_.Value -notin 1,2) { throw "`$Value should be 1 or 2 but is '$($_.Value)'." }
+                    }
+
+                    It "i" {
+                        if ($_.Value -ne 10) { throw "`$Value should be 10 '$($_.Value)'." }
+                    } -ForEach @{ Value = 10 }
+                } -ForEach @(@{ Value = 1 }, @{ Value  = 2 })
+            }
+
+            $container = New-TestContainer -ScriptBlock $sb
+            $r = Invoke-Pester -Container $container -PassThru
+            $r.Containers[0].Blocks[0].Tests[0].Result | Verify-Equal "Passed"
+            $r.Containers[0].Blocks[1].Tests[0].Result | Verify-Equal "Passed"
+        }
+
+        t "`$_ holds the current item array of any object is used, and it is overwritten in It if it specifies its own data" {
+            $sb = {
+                Describe "d" {
+                    BeforeAll {
+                        if ($_ -notin 1,2) { throw "`$Value should be 1 or 2 but is '$_'." }
+                    }
+
+                    # maybe a bit unexpected to get the values of TestCases here, but BeforeEach
+                    # runs in the same scope as It, so the variables are available there as well
+                    BeforeEach {
+                        if ($_ -notin 3,4) { throw "`$Value should be 3 or 4 but is '$_'." }
+                    }
+
+                    It "i" {
+                        if ($_ -notin 3,4) { throw "`$Value should be 3 or 4 but is '$_'." }
+                    } -ForEach 3, 4
+                } -ForEach 1, 2
+            }
+
+            $container = New-TestContainer -ScriptBlock $sb
+            $r = Invoke-Pester -Container $container -PassThru
+            $r.Containers[0].Blocks[0].Tests[0].Result | Verify-Equal "Passed"
+            $r.Containers[0].Blocks[1].Tests[0].Result | Verify-Equal "Passed"
+        }
+
+        t "Data provided to container are accessible in ForEach on each level" {
+            $scenarios = @(
+                @{
+                    Scenario = @{
+                        Name = "A"
+                        Contexts = @(
+                            @{
+                                Name = "AA"
+                                Examples = @(
+                                    @{ User = @{ Name = "Jakub"; Age = 31 } }
+                                    @{ User = @{ Name = "Tomas"; Age = 27 } }
+                                )
+                            }
+                            @{
+                                Name = "AB"
+                                Examples = @(
+                                    @{ User = @{ Name = "Peter"; Age = 30 } }
+                                    @{ User = @{ Name = "Jaap"; Age = 22 } }
+                                )
+                            }
+                        )
+                    }
+                }
+                @{
+                    Scenario = @{
+                        Name = "B"
+                        Contexts = @{
+                            Name = "BB"
+                            Examples = @(
+                                @{ User = @{ Name = "Jane"; Age = 25 } }
+                            )
+                        }
+                    }
+                }
+            )
+
+            $sb = {
+                param ($Scenario)
+
+                Describe "Scenario - <name>" -ForEach $Scenario {
+
+                    Context "Context - <name>" -ForEach $Contexts {
+                        It "Example - <user.name> with age <user.age> is less than 35" -ForEach $Examples {
+                            $User.Age | Should -BeLessOrEqual 35
+                        }
+                    }
+                }
+            }
+
+            $container = New-TestContainer -ScriptBlock $sb -Data $scenarios
+
+            $r = Invoke-Pester -Container $container -PassThru -Output Detailed
+            $r.Containers[0].Blocks[0].ExpandedName | Verify-Equal "Scenario - A"
+            $r.Containers[0].Blocks[0].Blocks[0].ExpandedName | Verify-Equal "Context - AA"
+            $r.Containers[0].Blocks[0].Blocks[0].Tests[0].ExpandedName | Verify-Equal "Example - Jakub with age 31 is less than 35"
+
+            $r.Containers[0].Blocks[0].Blocks[1].ExpandedName | Verify-Equal "Context - AB"
+            $r.Containers[0].Blocks[0].Blocks[1].Tests[0].ExpandedName | Verify-Equal "Example - Peter with age 30 is less than 35"
+        }
+
+        t "<_> expands to `$_ in Describe and It" {
+            $sb = {
+                Describe "d <_>" {
+                    It "i <_>" { } -ForEach 2
+                } -ForEach 1
+            }
+
+            $container = New-TestContainer -ScriptBlock $sb
+            $r = Invoke-Pester -Container $container -PassThru
+            $r.Containers[0].Blocks[0].Tests[0].Result | Verify-Equal "Passed"
+            $r.Containers[0].Blocks[0].Tests[0].ExpandedName | Verify-Equal "i 2"
+            $r.Containers[0].Blocks[0].ExpandedName | Verify-Equal "d 1"
+        }
+
+        t "<_> expands to `$_ in It even if It does not define any data" {
+            $sb = {
+                Describe "d <_>" {
+                    It "i <_>" {
+                        $_ | Should -Be 1
+                    }
+                } -ForEach 1
+            }
+
+            $container = New-TestContainer -ScriptBlock $sb
+            $r = Invoke-Pester -Container $container -PassThru
+            $r.Containers[0].Blocks[0].Tests[0].Result | Verify-Equal "Passed"
+            $r.Containers[0].Blocks[0].Tests[0].ExpandedName | Verify-Equal "i 1"
+            $r.Containers[0].Blocks[0].ExpandedName | Verify-Equal "d 1"
+        }
+
+        t "<user.name> expands to `$user.name" {
+            $sb = {
+                Describe "d <user.name>" {
+                    It "i <user.name>" { }
+                } -ForEach @(@{User = @{ Name = "Jakub" }})
+            }
+
+            $container = New-TestContainer -ScriptBlock $sb
+            $r = Invoke-Pester -Container $container -PassThru
+            $r.Containers[0].Blocks[0].Tests[0].Result | Verify-Equal "Passed"
+            $r.Containers[0].Blocks[0].Tests[0].ExpandedName | Verify-Equal "i Jakub"
+            $r.Containers[0].Blocks[0].ExpandedName | Verify-Equal "d Jakub"
+        }
+
+        t "`$variable remains as literal text after expanding" {
+            $sb = {
+                Describe "d `$abc" {
+                    It "i `$abc" { }
+                } -ForEach @(@{User = @{ Name = "Jakub" }})
+            }
+
+            $container = New-TestContainer -ScriptBlock $sb
+            $r = Invoke-Pester -Container $container -PassThru
+            $r.Containers[0].Blocks[0].Tests[0].Result | Verify-Equal "Passed"
+            $r.Containers[0].Blocks[0].Tests[0].ExpandedName | Verify-Equal "i `$abc"
+            $r.Containers[0].Blocks[0].ExpandedName | Verify-Equal "d `$abc"
+        }
+
+        t 'template can be escaped by grave accent' {
+            $sb = {
+                Describe "d ``<fff``>" {
+                    It 'i `<fff`>' { }
+                } -ForEach @(@{User = @{ Name = "Jakub" }})
+            }
+
+            $container = New-TestContainer -ScriptBlock $sb
+            $r = Invoke-Pester -Container $container -PassThru
+            $r.Containers[0].Blocks[0].Tests[0].Result | Verify-Equal "Passed"
+            $r.Containers[0].Blocks[0].Tests[0].ExpandedName | Verify-Equal "i `<fff`>"
+            $r.Containers[0].Blocks[0].ExpandedName | Verify-Equal "d `<fff`>"
+        }
+
+        t 'template evaluates simple code' {
+            $sb = {
+                Describe "d" {
+                    It 'i <user.name> is <user.Name.GetType()>' { }
+                } -ForEach @(@{User = @{ Name = "Jakub" }})
+            }
+
+            $container = New-TestContainer -ScriptBlock $sb
+            $r = Invoke-Pester -Container $container -PassThru -Output Detailed
+            $r.Containers[0].Blocks[0].Tests[0].Result | Verify-Equal "Passed"
+            $r.Containers[0].Blocks[0].Tests[0].ExpandedName | Verify-Equal "i Jakub is string"
         }
     }
 }

--- a/tst/TypeClass.Tests.ps1
+++ b/tst/TypeClass.Tests.ps1
@@ -129,7 +129,7 @@ Describe "Is-Dictionary" {
 
 # -- collection
 Describe "Is-Collection" {
-    It "Given a collection '<value>' of type '<type>' it returns `$true" -TestCases @(
+    It "Given a collection '<value>' of type '<value.GetType()>' it returns `$true" -TestCases @(
         @{ Value = @() }
         @{ Value = 1, 2, 3 }
         # the extra casts are for powershell v2 compatibility
@@ -146,7 +146,7 @@ Describe "Is-Collection" {
         Is-Collection -Value $null | Verify-False
     }
 
-    It "Given an object '<value>' of type '<type>' that is not a collection it returns `$false" -TestCases @(
+    It "Given an object '<value>' of type '<value.GetType()>' that is not a collection it returns `$false" -TestCases @(
         @{ Value = [char] 'a' }
         @{ Value = "a" }
 

--- a/tst/functions/Pester.TestRegistry.ts.ps1
+++ b/tst/functions/Pester.TestRegistry.ts.ps1
@@ -6,7 +6,7 @@ Get-Module Pester.Runtime, Pester.Utility, P, Pester, Axiom, Stack | Remove-Modu
 Import-Module $PSScriptRoot\..\p.psm1 -DisableNameChecking
 Import-Module $PSScriptRoot\..\axiom\Axiom.psm1 -DisableNameChecking
 
-if ($PSVersionTable.PSVersion.Major -le 5 -or -not $IsWindows) {
+if ($PSVersionTable.PSVersion.Major -gt 5 -and -not $IsWindows) {
     Write-Host "Not on Windows skipping TestRegistry tests." -ForegroundColor Yellow
     return (i -PassThru:$PassThru { })
 }


### PR DESCRIPTION
## 1. General summary of the pull request

Extends and exports a wrapper-function for creating `[PesterConfiguration]` objects used to run `Invoke-Pester` with advanced configurations. Binary classes like this aren't available until a module is imported, which may cause errors for users who depend on auto-loading as creating the configuration object is normally the first step before any call to `Invoke-Pester` or any other public functions. 

Using this wrapper, a user will always be able to create a configuration-object. The function is kept simple and has few parameters to avoid confusion for the user as the `[PesterConfiguration]` is intuitive, self-explanatory and might change over time.

Fix #1674 

- [x] Extend and export existing New-PesterConfiguration
- [x] Add documentation to function
- [ ] Add tests?
- [ ] Update other documentation?