### PR TITLE
Filter excluded tests from NUnit results

### DIFF
--- a/src/functions/TestResults.ps1
+++ b/src/functions/TestResults.ps1
@@ -276,6 +276,11 @@ function Write-NUnitTestSuiteElements($Node, [System.Xml.XmlWriter] $XmlWriter, 
         }
 
         foreach ($testCase in $suite.Group) {
+            if (-not $testCase.ShouldRun) {
+                # skip tests that were discovered but did not run
+                continue
+            }
+
             $suiteName = if ($testGroupId) { $parameterizedSuiteInfo.Name } else { "" }
             Write-NUnitTestCaseElement -TestResult $testCase -XmlWriter $XmlWriter -Path ($testCase.Path -join '.') -ParameterizedSuiteName $suiteName
         }
@@ -593,11 +598,6 @@ function Write-NUnitTestSuiteAttributes($TestSuiteInfo, [string] $TestSuiteType 
 }
 
 function Write-NUnitTestCaseElement($TestResult, [System.Xml.XmlWriter] $XmlWriter, [string] $ParameterizedSuiteName, [string] $Path) {
-
-    if (-not $TestResult.ShouldRun) {
-        return
-    }
-
     $XmlWriter.WriteStartElement('test-case')
 
     Write-NUnitTestCaseAttributes -TestResult $TestResult -XmlWriter $XmlWriter -ParameterizedSuiteName $ParameterizedSuiteName -Path $Path

--- a/src/functions/TestResults.ps1
+++ b/src/functions/TestResults.ps1
@@ -584,14 +584,18 @@ function Write-NUnitTestSuiteAttributes($TestSuiteInfo, [string] $TestSuiteType 
 }
 
 function Write-NUnitTestCaseElement($TestResult, [System.Xml.XmlWriter] $XmlWriter, [string] $ParameterizedSuiteName, [string] $Path) {
-    $XmlWriter.WriteStartElement('test-case')
+    
+    if ($TestResult.ShouldRun) {
+        $XmlWriter.WriteStartElement('test-case')
 
-    Write-NUnitTestCaseAttributes -TestResult $TestResult -XmlWriter $XmlWriter -ParameterizedSuiteName $ParameterizedSuiteName -Path $Path
+        Write-NUnitTestCaseAttributes -TestResult $TestResult -XmlWriter $XmlWriter -ParameterizedSuiteName $ParameterizedSuiteName -Path $Path
 
-    $XmlWriter.WriteEndElement()
+        $XmlWriter.WriteEndElement()
+	}
 }
 
 function Write-NUnitTestCaseAttributes($TestResult, [System.Xml.XmlWriter] $XmlWriter, [string] $ParameterizedSuiteName, [string] $Path) {
+
     $testName = $TestResult.ExpandedPath
 
     # todo: this comparison would fail if the test name would contain $(Get-Date) or something similar that changes all the time


### PR DESCRIPTION
## 1. Filter excluded test from the NUnit Results

 Fix #1662 

Tests the ShouldRun property of a test result to determine if it was included or excluded from the run using tag or exclude tag.
Added two new tests to demonstrate the fix. Looking for feedback on situation where describe block is filtered out so the NUnit report has a test suite reported as succeeded but contains no results or test cases.