### PR TITLE
Remove pipeline support from Should -Invoke

### DIFF
--- a/src/functions/Pester.SessionState.Mock.ps1
+++ b/src/functions/Pester.SessionState.Mock.ps1
@@ -856,12 +856,7 @@ to the original.
     )
 
     if ($null -ne $ActualValue) {
-        if ($ActualValue -is [string]) {
-            $CommandName = $ActualValue
-        }
-        else {
-            throw "Should -Invoke does not take pipeline input or ActualValue."
-        }
+        throw "Should -Invoke does not take pipeline input or ActualValue."
     }
 
     # Assert-DescribeInProgress -CommandName Should -Invoke

--- a/tst/functions/Mock.Tests.ps1
+++ b/tst/functions/Mock.Tests.ps1
@@ -901,12 +901,12 @@ Describe "When Calling Should -Not -Invoke -ExclusiveFilter" {
 
 Describe "When Calling Should -Invoke with pipeline-input or -ActualValue" {
     It "Should throw an error on pipeline-input" {
-        $scriptBlock = { "FunctionUnderTest" | Should -Invoke -CommandName "ABC" -Scope Describe }
+        $scriptBlock = { "value" | Should -Invoke -CommandName "ABC" -Scope Describe }
         $scriptBlock | Should -Throw 'Should -Invoke does not take pipeline input or ActualValue.'
     }
 
     It "Should throw an error on ActualInput-value" {
-        $scriptBlock = { Should -Invoke -CommandName "ABC" -ActualValue "FunctionUnderTest" -Scope Describe }
+        $scriptBlock = { Should -Invoke -CommandName "ABC" -ActualValue "value" -Scope Describe }
         $scriptBlock | Should -Throw 'Should -Invoke does not take pipeline input or ActualValue.'
     }
 }

--- a/tst/functions/Mock.Tests.ps1
+++ b/tst/functions/Mock.Tests.ps1
@@ -899,6 +899,18 @@ Describe "When Calling Should -Not -Invoke -ExclusiveFilter" {
     }
 }
 
+Describe "When Calling Should -Invoke with pipeline-input or -ActualValue" {
+    It "Should throw an error on pipeline-input" {
+        $scriptBlock = { "FunctionUnderTest" | Should -Invoke -CommandName "ABC" -Scope Describe }
+        $scriptBlock | Should -Throw 'Should -Invoke does not take pipeline input or ActualValue.'
+    }
+
+    It "Should throw an error on ActualInput-value" {
+        $scriptBlock = { Should -Invoke -CommandName "ABC" -ActualValue "FunctionUnderTest" -Scope Describe }
+        $scriptBlock | Should -Throw 'Should -Invoke does not take pipeline input or ActualValue.'
+    }
+}
+
 Describe "Using Pester Scopes (Describe,Context,It)" {
     BeforeAll {
         Mock FunctionUnderTest {return "I am the first mock test"} -parameterFilter {$param1 -eq "one"}


### PR DESCRIPTION
Updates `Should -Invoke` to always throw on pipeline-input or when `-ActualValue` is provided. Previously accepted a string through which would override `-CommandName`. Since `-CommandName` is mandatory the pipeline only worked in this confusing scenario:

```
"functionB" | Should -Invoke -CommandName "functionA"
# Checks if 'functionB' was called
```

After this PR, valid usage is:

```
Should -Invoke functionA                # + additional parameters for -Invoke
Should -Invoke -CommandName functionA   # + additional parameters for -Invoke
```

Fix #1696 

- [x] Update invoke to always throw
- [x] Add tests
