### PR TITLE
Add support for VSCode problem-tracking for failed assertions

### DIFF
--- a/README.md
+++ b/README.md
@@ -511,7 +511,6 @@ ShowFullErrors         : Show full errors including Pester internal stack. (Fals
 WriteDebugMessages     : Write Debug messages to screen. (False, default: False)
 WriteDebugMessagesFrom : Write Debug messages from a given source, WriteDebugMessages must be set to true for this to work. You can use like wildcards to get messages from multiple sources, as well as * to get everything. (*, default: *)
 ShowNavigationMarkers  : Write paths after every block and test, for easy navigation in VSCode. (False, default: False)
-WriteVSCodeMarker      : Write VSCode marker for better integration with VSCode. (False, default: False)
 ```
 
 The configuration object can be constructed either via the Default static property or by casting a hashtable to it. You can also cast a hashtable to any of its sections. Here are three different ways to the same goal:

--- a/src/Pester.ps1
+++ b/src/Pester.ps1
@@ -428,7 +428,6 @@ function Invoke-Pester {
     Debug.WriteDebugMessages - Write Debug messages to screen.
     Debug.WriteDebugMessagesFrom - Write Debug messages from a given source, WriteDebugMessages must be set to true for this to work. You can use like wildcards to get messages from multiple sources, as well as * to get everything.
         Available options: "Discovery", "Skip", "Filter", "Mock", "CodeCoverage"
-    Debug.WriteVSCodeMarker - Write VSCode marker for better integration with VSCode.
 
     .PARAMETER EnableExit
     (Deprecated v4)

--- a/src/csharp/Pester/Configuration.cs
+++ b/src/csharp/Pester/Configuration.cs
@@ -462,7 +462,6 @@ namespace Pester
             WriteDebugMessages = new BoolOption("Write Debug messages to screen.", false);
             WriteDebugMessagesFrom = new StringArrayOption("Write Debug messages from a given source, WriteDebugMessages must be set to true for this to work. You can use like wildcards to get messages from multiple sources, as well as * to get everything.", new string[] { "Discovery", "Skip", "Filter", "Mock", "CodeCoverage" });
             ShowNavigationMarkers = new BoolOption("Write paths after every block and test, for easy navigation in VSCode.", false);
-            WriteVSCodeMarker = new BoolOption("Write VSCode marker for better integration with VSCode.", false);
             ReturnRawResultObject = new BoolOption("Returns unfiltered result object, this is for development only. Do not rely on this object for additional properties, non-public properties will be renamed without previous notice.", false);
         }
 
@@ -474,7 +473,6 @@ namespace Pester
                 WriteDebugMessages = configuration.GetValueOrNull<bool>("WriteDebugMessages") ?? WriteDebugMessages;
                 WriteDebugMessagesFrom = configuration.GetArrayOrNull<string>("WriteDebugMessagesFrom") ?? WriteDebugMessagesFrom;
                 ShowNavigationMarkers = configuration.GetValueOrNull<bool>("ShowNavigationMarkers") ?? ShowNavigationMarkers;
-                WriteVSCodeMarker = configuration.GetValueOrNull<bool>("WriteVSCodeMarker") ?? WriteVSCodeMarker;
                 ReturnRawResultObject = configuration.GetValueOrNull<bool>("ReturnRawResultObject") ?? ReturnRawResultObject;
             }
         }
@@ -483,7 +481,6 @@ namespace Pester
         private BoolOption _writeDebugMessages;
         private StringArrayOption _writeDebugMessagesFrom;
         private BoolOption _showNavigationMarkers;
-        private BoolOption _writeVsCodeMarker;
         private BoolOption _returnRawResultObject;
 
         public BoolOption ShowFullErrors
@@ -546,22 +543,6 @@ namespace Pester
                 else
                 {
                     _showNavigationMarkers = new BoolOption(_showNavigationMarkers, value.Value);
-                }
-            }
-        }
-
-        public BoolOption WriteVSCodeMarker
-        {
-            get { return _writeVsCodeMarker; }
-            set
-            {
-                if (_writeVsCodeMarker == null)
-                {
-                    _writeVsCodeMarker = value;
-                }
-                else
-                {
-                    _writeVsCodeMarker = new BoolOption(_writeVsCodeMarker, value.Value);
                 }
             }
         }

--- a/tst/Pester.RSpec.Configuration.ts.ps1
+++ b/tst/Pester.RSpec.Configuration.ts.ps1
@@ -156,10 +156,6 @@ i -PassThru:$PassThru {
         t "Debug.ShowNavigationMarkers is `$false" {
             [PesterConfiguration]::Default.Debug.ShowNavigationMarkers.Value | Verify-False
         }
-
-        t "Debug.WriteVSCodeMarker is `$false" {
-            [PesterConfiguration]::Default.Debug.WriteVSCodeMarker.Value | Verify-False
-        }
     }
 
     b "Assignment" {

--- a/tst/Pester.RSpec.Output.ts.ps1
+++ b/tst/Pester.RSpec.Output.ts.ps1
@@ -43,7 +43,7 @@ function Invoke-PesterInProcess ([ScriptBlock] $ScriptBlock, [ScriptBlock] $Setu
 
 # VSCode-powershell Problem Matcher pattern
 # Storing the original pattern below for easier comparison and maintenance
-$titlePattern = ('^\\s*(?:\\[-\\]\\s+)(.*?)(?:\\s+\\d+\\.?\\d*\\s*m?s)\\s*?(?:\\([\\w\\|]+\\))?\\s*?$' -replace '\\\\', '\')
+$titlePattern = ('^\\s*(?:\\[-\\]\\s+)(.*?)(?:\\s+\\d+\\.?\\d*\\s*m?s)(?:\\s+\\(\\d+\\.?\\d*m?s\\|\\d+\\.?\\d*m?s\\))?\\s*$' -replace '\\\\', '\')
 $atPattern = ('^\\s+[Aa]t\\s+([^,]+,)?(.+?):(\\s+line\\s+)?(\\d+)(\\s+char:\\d+)?$' -replace '\\\\', '\')
 
 

--- a/tst/Pester.RSpec.Output.ts.ps1
+++ b/tst/Pester.RSpec.Output.ts.ps1
@@ -68,8 +68,6 @@ i -PassThru:$PassThru {
             $hostSingleError = $output | Select-String -Pattern 'Single error' -Context 0, 1
             $hostSingleError.Line -match $titlePattern | Verify-True
             $hostSingleError.Context.PostContext[0] -match $atPattern | Verify-True
-
-
         }
 
         t "Matches problem pattern with multiple errors" {

--- a/tst/Pester.RSpec.Output.ts.ps1
+++ b/tst/Pester.RSpec.Output.ts.ps1
@@ -1,0 +1,103 @@
+param ([switch] $PassThru)
+
+Get-Module Pester.Runtime, Pester.Utility, P, Pester, Axiom, Stack | Remove-Module
+
+Import-Module $PSScriptRoot\p.psm1 -DisableNameChecking
+Import-Module $PSScriptRoot\axiom\Axiom.psm1 -DisableNameChecking
+
+& "$PSScriptRoot\..\build.ps1"
+Import-Module $PSScriptRoot\..\bin\Pester.psd1
+
+$global:PesterPreference = @{
+    Debug = @{
+        ShowFullErrors         = $true
+        WriteDebugMessages     = $false
+        WriteDebugMessagesFrom = "Mock"
+        ReturnRawResultObject  = $true
+    }
+    Output = @{
+        Verbosity = "None"
+    }
+}
+$PSDefaultParameterValues = @{}
+
+function Invoke-PesterInProcess ([ScriptBlock] $ScriptBlock, [ScriptBlock] $Setup) {
+    # get the path of the currently loaded Pester to re-import it in the child process
+    $pesterPath = Get-Module Pester | Select-Object -ExpandProperty Path
+    $powershell = Get-Process -Id $pid | Select-Object -ExpandProperty Path
+    # run the test in a separate process to be able to grab all the output
+    $command = {
+        param ($PesterPath, [ScriptBlock] $ScriptBlock, [ScriptBlock] $Setup)
+        Import-Module $PesterPath
+
+        # Modify environment
+        . $Setup
+
+        $container = New-TestContainer -ScriptBlock $ScriptBlock
+        Invoke-Pester -Container $container
+    }.ToString()
+
+    $cmd = "& { $command } -PesterPath ""$PesterPath"" -ScriptBlock { $ScriptBlock } -Setup { $Setup }"
+    & $powershell -NoProfile -ExecutionPolicy Bypass -Command $cmd
+}
+
+# VSCode-powershell Problem Matcher pattern
+# Storing the original pattern below for easier comparison and maintenance
+$titlePattern = ('^\\s*(?:\\[-\\]\\s+)(.*?)(?:\\s+\\d+\\.?\\d*\\s*m?s)\\s*?(?:\\([\\w\\|]+\\))?\\s*?$' -replace '\\\\', '\')
+$atPattern = ('^\\s+[Aa]t\\s+([^,]+,)?(.+?):(\\s+line\\s+)?(\\d+)(\\s+char:\\d+)?$' -replace '\\\\', '\')
+
+
+i -PassThru:$PassThru {
+    b "Output in VSCode mode" {
+        t "Matches problem pattern with single error" {
+            $setup = {
+                $env:TERM_PROGRAM = 'vscode'
+                $psEditor = $null
+            }
+
+            $sb = {
+                Describe 'VSCode Output Test' {
+                    It 'Single error' {
+                        1 | Should -Be 2
+                    }
+                }
+            }
+
+            $output = Invoke-PesterInProcess -ScriptBlock $sb -Setup $setup
+
+            $hostSingleError = $output | Select-String -Pattern 'Single error' -Context 0, 1
+            $hostSingleError.Line -match $titlePattern | Verify-True
+            $hostSingleError.Context.PostContext[0] -match $atPattern | Verify-True
+
+
+        }
+
+        t "Matches problem pattern with multiple errors" {
+            $setup = {
+                $env:TERM_PROGRAM = 'vscode'
+                $psEditor = $null
+
+                $PesterPreference = [PesterConfiguration]::Default
+                $PesterPreference.Should.ErrorAction = 'Continue'
+            }
+
+            $sb = {
+                Describe 'VSCode Output Test' {
+                    It 'Multiple errors' {
+                        1 | Should -Be 2
+                        1 | Should -Be 3
+                    }
+                }
+            }
+
+            $output = Invoke-PesterInProcess $sb -Setup $setup
+
+            $hostMultipleErrors = $output | Select-String -Pattern 'Multiple errors' -Context 0, 1
+            $hostMultipleErrors.Count | Verify-Equal 2
+            $hostMultipleErrors[0].Line -match $titlePattern | Verify-True
+            $hostMultipleErrors[0].Context.PostContext[0] -match $atPattern | Verify-True
+            $hostMultipleErrors[1].Line -match $titlePattern | Verify-True
+            $hostMultipleErrors[1].Context.PostContext[0] -match $atPattern | Verify-True
+        }
+    }
+}


### PR DESCRIPTION
## 1. General summary of the pull request

VSCode's [problem matcher](https://code.visualstudio.com/Docs/editor/tasks#_defining-a-problem-matcher) used to report failed Pester-tests in previous versions using a regex-pattern and task.json setup included in the vscode-powershell extension. New format for test output introduced in Pester v5 broke this feature for this version. See powershell/vscode-powershell#2931

This PR and a related PR in vscode-powershell will restore the feature by providing a similar output format to previous versions when using tasks in VSCode.

When test-tasks are configured to continue beyond the first failed assertion (configuration option `[PesterConfiguration]@{Should=@{ErrorAction="Continue"}}`), all failed assertions will be get it's own failed-test output. This way VSCode can detect and show a problem-error per failed assertion which will also highlight every failed Should-line in a test for easier troubleshooting.

Fix #1577 
Fix #1452

## Todos

- [x] Enable problem-compliant output when using VSCode task
- [x] Add tests for output to avoid future problems with vscode-powershell problem matcher
- [x] Create related PR in vscode-powershell (powershell/vscode-powershell#2998)
       - Update problemMatcher-pattern to support new `(UserDuration|FrameworkDuration)` timings in v5
- [x] Remove WriteVSCodeMarker option in PesterConfiguration. Not used in this PR and navigation links are set using ShowNavigationMarkers-option.
