### PR TITLE
Throw when legacy syntax is used

### DIFF
--- a/src/functions/assertions/Should.ps1
+++ b/src/functions/assertions/Should.ps1
@@ -38,7 +38,7 @@ function Should {
 
     .LINK
     about_Should
-    
+
     .LINK
     about_Pester
 
@@ -118,24 +118,8 @@ function Should {
         # A bit of Regex lets us know if the line used the old form
         if ($myLine -match '^\s{0,}should\s{1,}(?<Operator>[^\-\@\s]+)')
         {
-            # Now it gets tricky.  This will be called once for each unmapped parameter.
-            # So while we always want to return here, we only want to error once
-            # The message uniqueness can be one part of our error.
             $shouldErrorMsg = "Legacy Should syntax (without dashes) is not supported in Pester 5. Please refer to migration guide at: https://pester.dev/docs/migrations/v3-to-v4"
-
-            # The rest of the uniqueness we can cobble together out of $MyInvocation.
-            $uniqueErrorMsg = $shouldErrorMsg,
-                $MyInvocation.HistoryId, # The history ID is unique per run
-                $MyInvocation.PSCommandPath, # the command path is unique per file
-                $myLine  -join '.' # and the whole line should be.  Join all of these pieces by .
-
-
-            if ($script:lastShouldErrorMsg -ne $uniqueErrorMsg) {
-                $script:lastShouldErrorMsg  = $uniqueErrorMsg
-                Write-Error $shouldErrorMsg
-                return
-            }
-            return
+            throw $shouldErrorMsg
         } else {
             Get-AssertionDynamicParams
         }

--- a/tst/Pester.RSpec.ts.ps1
+++ b/tst/Pester.RSpec.ts.ps1
@@ -1249,7 +1249,7 @@ i -PassThru:$PassThru {
     }
 
     b "Should with legacy syntax will throw" {
-        dt "Should with legacy syntax will throw" {
+        t "Should with legacy syntax will throw" {
             $sb = {
                 Describe "d" {
                     It "i" {

--- a/tst/Pester.RSpec.ts.ps1
+++ b/tst/Pester.RSpec.ts.ps1
@@ -1247,4 +1247,22 @@ i -PassThru:$PassThru {
             $r.Containers[0].Blocks[0].Tests[0].ExpandedName | Verify-Equal "i Jakub is string"
         }
     }
+
+    b "Should with legacy syntax will throw" {
+        dt "Should with legacy syntax will throw" {
+            $sb = {
+                Describe "d" {
+                    It "i" {
+                        1 | Should Be 1
+                    }
+                }
+            }
+
+            $container = New-TestContainer -ScriptBlock $sb
+            $r = Invoke-Pester -Container $container -PassThru
+            $test = $r.Containers[0].Blocks[0].Tests[0]
+            $test.Result | Verify-Equal "Failed"
+            $test.ErrorRecord[0] -like "*Legacy Should syntax (without dashes) is not supported in Pester 5.*"
+        }
+    }
 }


### PR DESCRIPTION
Fixes #1703
