### PR TITLE
Re-implement New-Fixture in Pester v5

### DIFF
--- a/src/Pester.psd1
+++ b/src/Pester.psd1
@@ -59,13 +59,15 @@
         'ConvertTo-Pester4Result'
 
         # config
-        'New-TestContainer',
+        'New-TestContainer'
 
         # legacy
         'Assert-VerifiableMock'
         'Assert-MockCalled'
         'Set-ItResult'
         'New-MockObject'
+
+        'New-Fixture'
     )
 
     # # Cmdlets to export from this module

--- a/src/Pester.psm1
+++ b/src/Pester.psm1
@@ -35,7 +35,7 @@ Set-Alias 'Get-AssertionOperator' 'Get-ShouldOperator'
     'Get-ShouldOperator'
 
     # config
-    'New-TestContainer',
+    'New-TestContainer'
 
     # export
     'Export-NunitReport'
@@ -49,6 +49,8 @@ Set-Alias 'Get-AssertionOperator' 'Get-ShouldOperator'
     'Assert-MockCalled'
     'Set-ItResult'
     'New-MockObject'
+
+    'New-Fixture'
 
 ) -Alias @(
     'Add-AssertionOperator'

--- a/src/Pester.psm1
+++ b/src/Pester.psm1
@@ -51,7 +51,6 @@ Set-Alias 'Get-AssertionOperator' 'Get-ShouldOperator'
     'New-MockObject'
 
     'New-Fixture'
-
 ) -Alias @(
     'Add-AssertionOperator'
     'Get-AssertionOperator'

--- a/src/functions/New-Fixture.ps1
+++ b/src/functions/New-Fixture.ps1
@@ -13,7 +13,7 @@ function New-Fixture {
 
     ```powershell
     function Clean {
-        #Do and maybe return something
+        #Do something
         $true
     }
     ```

--- a/src/functions/New-Fixture.ps1
+++ b/src/functions/New-Fixture.ps1
@@ -13,7 +13,8 @@ function New-Fixture {
 
     ```powershell
     function Clean {
-
+        #Do and maybe return something
+        $true
     }
     ```
 
@@ -26,8 +27,8 @@ function New-Fixture {
 
     Describe "Clean" {
 
-        It "does something useful" {
-            $true | Should -Be $false
+        It "Returns expected output" {
+            Clean | Should -Be $true
         }
     }
     ```
@@ -77,18 +78,25 @@ function New-Fixture {
         [String]$Name
     )
 
-    $Name = $Name -replace '.ps1', ''
+    $Name = $Name -replace '.ps(m?)1', ''
+
+    if($Name -notmatch '^\S+$') {
+        throw "Name is not valid. Whitespace are not allowed in a function name."
+    }
 
     #keep this formatted as is. the format is output to the file as is, including indentation
-    $scriptCode = "function $Name {$([System.Environment]::NewLine)$([System.Environment]::NewLine)}"
+    $scriptCode = "function $Name {
+    #Do something
+    `$true
+}"
 
     $testCode = 'BeforeAll {
     . $PSCommandPath.Replace(''.Tests.ps1'', ''.ps1'')
 }
 
 Describe "#name#" {
-    It "does something useful" {
-        $true | Should -Be $false
+    It "Returns expected output" {
+        #name# | Should -Be $true
     }
 }' -replace "#name#", $Name
 

--- a/src/functions/New-Fixture.ps1
+++ b/src/functions/New-Fixture.ps1
@@ -1,0 +1,117 @@
+function New-Fixture {
+    <#
+    .SYNOPSIS
+    This function generates two scripts, one that defines a function
+    and another one that contains its tests.
+
+    .DESCRIPTION
+    This function generates two scripts, one that defines a function
+    and another one that contains its tests. The files are by default
+    placed in the current directory and are called and populated as such:
+
+    The script defining the function: .\Clean.ps1:
+
+    ```powershell
+    function Clean {
+
+    }
+    ```
+
+    The script containing the example test .\Clean.Tests.ps1:
+
+    ```powershell
+    BeforeAll {
+        . $PSCommandPath.Replace('.Tests.ps1', '.ps1')
+    }
+
+    Describe "Clean" {
+
+        It "does something useful" {
+            $true | Should -Be $false
+        }
+    }
+    ```
+
+    .PARAMETER Name
+    Defines the name of the function and the name of the test to be created.
+
+    .PARAMETER Path
+    Defines path where the test and the function should be created, you can use full or relative path.
+    If the parameter is not specified the scripts are created in the current directory.
+
+    .EXAMPLE
+    New-Fixture -Name Clean
+
+    Creates the scripts in the current directory.
+
+    .EXAMPLE
+    New-Fixture C:\Projects\Cleaner Clean
+
+    Creates the scripts in the C:\Projects\Cleaner directory.
+
+    .EXAMPLE
+    New-Fixture Cleaner Clean
+
+    Creates a new folder named Cleaner in the current directory and creates the scripts in it.
+
+    .LINK
+    https://pester.dev/docs/commands/New-Fixture
+
+    .LINK
+    https://pester.dev/docs/commands/Describe
+
+    .LINK
+    https://pester.dev/docs/commands/Context
+
+    .LINK
+    https://pester.dev/docs/commands/It
+
+    .LINK
+    https://pester.dev/docs/commands/Should
+
+    #>
+
+    param (
+        [String]$Path = $PWD,
+        [Parameter(Mandatory = $true)]
+        [String]$Name
+    )
+
+    $Name = $Name -replace '.ps1', ''
+
+    #keep this formatted as is. the format is output to the file as is, including indentation
+    $scriptCode = "function $Name {$([System.Environment]::NewLine)$([System.Environment]::NewLine)}"
+
+    $testCode = 'BeforeAll {
+    . $PSCommandPath.Replace(''.Tests.ps1'', ''.ps1'')
+}
+
+Describe "#name#" {
+    It "does something useful" {
+        $true | Should -Be $false
+    }
+}' -replace "#name#", $Name
+
+    $Path = $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($Path)
+
+    Create-File -Path $Path -Name "$Name.ps1" -Content $scriptCode
+    Create-File -Path $Path -Name "$Name.Tests.ps1" -Content $testCode
+}
+
+function Create-File ($Path, $Name, $Content) {
+    if (-not (& $SafeCommands['Test-Path'] -Path $Path)) {
+        & $SafeCommands['New-Item'] -ItemType Directory -Path $Path | & $SafeCommands['Out-Null']
+    }
+
+    $FullPath = & $SafeCommands['Join-Path'] -Path $Path -ChildPath $Name
+    if (-not (& $SafeCommands['Test-Path'] -Path $FullPath)) {
+        & $SafeCommands['Set-Content'] -Path  $FullPath -Value $Content -Encoding UTF8
+        & $SafeCommands['Get-Item'] -Path $FullPath
+    }
+    else {
+        # This is deliberately not sent through $SafeCommands, because our own tests rely on
+        # mocking Write-Warning, and it's not really the end of the world if this call happens to
+        # be screwed up in an edge case.
+        Write-Warning "Skipping the file '$FullPath', because it already exists."
+    }
+}

--- a/tst/functions/New-Fixture.Tests.ps1
+++ b/tst/functions/New-Fixture.Tests.ps1
@@ -47,6 +47,7 @@ Describe "New-Fixture" {
             Join-Path -Path "$path\relative" -ChildPath "$name.ps1" | Should -Exist
             Join-Path -Path "$path\relative" -ChildPath "$name.Tests.ps1" | Should -Exist
         }
+
         It "Creates fixture if Path is set to '.'" {
             $name = "Relative2-Fixture"
             $path = "TestDrive:\"
@@ -58,6 +59,7 @@ Describe "New-Fixture" {
             Join-Path -Path "$path" -ChildPath "$name.ps1" | Should -Exist
             Join-Path -Path "$path" -ChildPath "$name.Tests.ps1" | Should -Exist
         }
+
         It "Creates fixture if Path is set to '(pwd)'" {
             $name = "Relative3-Fixture"
             $path = "TestDrive:\"
@@ -69,6 +71,7 @@ Describe "New-Fixture" {
             Join-Path -Path "$path" -ChildPath "$name.ps1" | Should -Exist
             Join-Path -Path "$path" -ChildPath "$name.Tests.ps1" | Should -Exist
         }
+
         It "Creates fixture if Path is set to '(pwd)' and Name contains the 'ps1' extension" {
             $name = "Relative4-Fixture.ps1"
             $nameWithoutExtension = $name.Substring(0, $($name.Length) - 4)
@@ -81,6 +84,20 @@ Describe "New-Fixture" {
             Join-Path -Path "$path" -ChildPath "$nameWithoutExtension.ps1" | Should -Exist
             Join-Path -Path "$path" -ChildPath "$nameWithoutExtension.Tests.ps1" | Should -Exist
         }
+
+        It "Creates fixture if Path is set to '(pwd)' and Name contains the 'psm1' extension" {
+            $name = "Relative4-Fixture.psm1"
+            $nameWithoutExtension = $name.Substring(0, $($name.Length) - 5)
+            $path = "TestDrive:\"
+
+            Push-Location -Path $path
+            New-Fixture -Name $name -Path (Get-Location) | Out-Null
+            Pop-Location
+
+            Join-Path -Path "$path" -ChildPath "$nameWithoutExtension.ps1" | Should -Exist
+            Join-Path -Path "$path" -ChildPath "$nameWithoutExtension.Tests.ps1" | Should -Exist
+        }
+
         It "Writes warning if file exists" {
             $name = "Warning-Fixture"
             $path = "TestDrive:\"
@@ -91,9 +108,7 @@ Describe "New-Fixture" {
             New-Fixture -Name $name -Path $path | Out-Null
             New-Fixture -Name $name -Path $path -WarningVariable warnings -WarningAction SilentlyContinue | Out-Null
 
-            Assert-VerifiableMock
+            Should -InvokeVerifiable
         }
     }
-
-    #TODO add tests that validate the contents of default files
 }

--- a/tst/functions/New-Fixture.Tests.ps1
+++ b/tst/functions/New-Fixture.Tests.ps1
@@ -1,0 +1,99 @@
+Set-StrictMode -Version Latest
+
+Describe "New-Fixture" {
+    It "Name parameter is mandatory:" {
+        (Get-Command New-Fixture ).Parameters.Name.ParameterSets.__AllParameterSets.IsMandatory | Should -Be $true
+    }
+
+    Context "Only Name parameter is specified" {
+        It "Creates fixture in current directory" {
+            $name = "Test-Fixture"
+            $path = "TestDrive:\"
+
+            Push-Location -Path $path
+            New-Fixture -Name $name | Out-Null
+            Pop-Location
+
+            Join-Path -Path $path -ChildPath "$name.ps1" | Should -Exist
+            Join-Path -Path $path -ChildPath "$name.Tests.ps1" | Should -Exist
+        }
+    }
+
+    Context "Name and Path parameter is specified" {
+        #use different fixture names to avoid interference among the test cases
+        #cleaning up would be also possible, but difficult if the assertion fails
+        It "Creates fixture in full Path" {
+            $name = "Test-Fixture"
+            $path = "TestDrive:\full"
+
+            New-Fixture -Name $name -Path $path | Out-Null
+
+            Join-Path -Path $path -ChildPath "$name.ps1" | Should -Exist
+            Join-Path -Path $path -ChildPath "$name.Tests.ps1" | Should -Exist
+
+            #cleanup
+            Join-Path -Path "$path" -ChildPath "$name.ps1" | Remove-Item -Force
+            Join-Path -Path "$path" -ChildPath "$name.Tests.ps1" | Remove-Item -Force
+        }
+
+        It "Creates fixture in relative Path" {
+            $name = "Relative1-Fixture"
+            $path = "TestDrive:\"
+
+            Push-Location -Path $path
+            New-Fixture -Name $name -Path relative | Out-Null
+            Pop-Location
+
+            Join-Path -Path "$path\relative" -ChildPath "$name.ps1" | Should -Exist
+            Join-Path -Path "$path\relative" -ChildPath "$name.Tests.ps1" | Should -Exist
+        }
+        It "Creates fixture if Path is set to '.'" {
+            $name = "Relative2-Fixture"
+            $path = "TestDrive:\"
+
+            Push-Location -Path $path
+            New-Fixture -Name $name -Path . | Out-Null
+            Pop-Location
+
+            Join-Path -Path "$path" -ChildPath "$name.ps1" | Should -Exist
+            Join-Path -Path "$path" -ChildPath "$name.Tests.ps1" | Should -Exist
+        }
+        It "Creates fixture if Path is set to '(pwd)'" {
+            $name = "Relative3-Fixture"
+            $path = "TestDrive:\"
+
+            Push-Location -Path $path
+            New-Fixture -Name $name -Path (Get-Location) | Out-Null
+            Pop-Location
+
+            Join-Path -Path "$path" -ChildPath "$name.ps1" | Should -Exist
+            Join-Path -Path "$path" -ChildPath "$name.Tests.ps1" | Should -Exist
+        }
+        It "Creates fixture if Path is set to '(pwd)' and Name contains the 'ps1' extension" {
+            $name = "Relative4-Fixture.ps1"
+            $nameWithoutExtension = $name.Substring(0, $($name.Length) - 4)
+            $path = "TestDrive:\"
+
+            Push-Location -Path $path
+            New-Fixture -Name $name -Path (Get-Location) | Out-Null
+            Pop-Location
+
+            Join-Path -Path "$path" -ChildPath "$nameWithoutExtension.ps1" | Should -Exist
+            Join-Path -Path "$path" -ChildPath "$nameWithoutExtension.Tests.ps1" | Should -Exist
+        }
+        It "Writes warning if file exists" {
+            $name = "Warning-Fixture"
+            $path = "TestDrive:\"
+
+            Mock -Verifiable -ModuleName Pester Write-Warning { }
+
+            #Create the same files twice
+            New-Fixture -Name $name -Path $path | Out-Null
+            New-Fixture -Name $name -Path $path -WarningVariable warnings -WarningAction SilentlyContinue | Out-Null
+
+            Assert-VerifiableMock
+        }
+    }
+
+    #TODO add tests that validate the contents of default files
+}

--- a/tst/functions/New-Fixture.Tests.ps1
+++ b/tst/functions/New-Fixture.Tests.ps1
@@ -1,7 +1,7 @@
 Set-StrictMode -Version Latest
 
 Describe "New-Fixture" {
-    It "Name parameter is mandatory:" {
+    It "Name parameter is mandatory" {
         (Get-Command New-Fixture ).Parameters.Name.ParameterSets.__AllParameterSets.IsMandatory | Should -Be $true
     }
 
@@ -86,7 +86,7 @@ Describe "New-Fixture" {
         }
 
         It "Creates fixture if Path is set to '(pwd)' and Name contains the 'psm1' extension" {
-            $name = "Relative4-Fixture.psm1"
+            $name = "Relative5-Fixture.psm1"
             $nameWithoutExtension = $name.Substring(0, $($name.Length) - 5)
             $path = "TestDrive:\"
 
@@ -109,6 +109,13 @@ Describe "New-Fixture" {
             New-Fixture -Name $name -Path $path -WarningVariable warnings -WarningAction SilentlyContinue | Out-Null
 
             Should -InvokeVerifiable
+        }
+
+        It "Throws on whitespace in Name" {
+            $name = "Test Fixture"
+            $path = "TestDrive:\"
+
+            { New-Fixture -Path $path -Name $name } | Should -Throw -Because "whitespace is not allowed in fixture name"
         }
     }
 }

--- a/tst/functions/New-Fixture.ts.ps1
+++ b/tst/functions/New-Fixture.ts.ps1
@@ -1,0 +1,42 @@
+param ([switch] $PassThru)
+
+Get-Module Pester.Runtime, Pester.Utility, P, Pester, Axiom, Stack | Remove-Module
+
+Import-Module $PSScriptRoot\..\p.psm1 -DisableNameChecking
+Import-Module $PSScriptRoot\..\axiom\Axiom.psm1 -DisableNameChecking
+
+Import-Module $PSScriptRoot\..\..\bin\Pester.psd1
+
+$global:PesterPreference = @{
+    Debug = @{
+        ShowFullErrors         = $true
+    }
+}
+
+i -PassThru:$PassThru {
+    b "New-Fixture" {
+        t "Generated fixture works" {
+            $tempFolder = [IO.Path]::GetTempPath()
+            $name = "Fixture$([Guid]::NewGuid().Guid)"
+
+            $scriptPath = Join-Path $tempFolder "$name.ps1"
+            $testsPath = Join-Path $tempFolder "$name.Tests.ps1"
+
+            try {
+                New-Fixture -Path $tempFolder -Name $name
+
+                $r = Invoke-Pester -Path $testsPath -PassThru
+                $r.Containers[0].Blocks[0].Tests[0].Result | Verify-Equal "Passed"
+            }
+            finally {
+                if (Test-Path $scriptPath) {
+                    Remove-Item $scriptPath -Force
+                }
+
+                if (Test-Path $testsPath) {
+                    Remove-Item $testsPath -Force
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 1. General summary of the pull request

The `New-Fixture` function available in previous Pester versions was not migrated to Pester v5 in the first releases. This PR re-introduces the feature with the following improvements:
- Pester 5 compliant
- Updated sample/template code to be testable
- Improved parameter validation:
  - Now also strips .psm1 from Name in addition to the .ps1 like previous versions
  - Validates no whitespace in Name as it's not allowed in function names
- A P-test has also been added to validate the generated script and test code (previous todo comment in Pester v4 tests).

Fix #1723 