### PR TITLE
Print active filters in Detailed/Diagnostic output

### DIFF
--- a/src/Pester.Runtime.psm1
+++ b/src/Pester.Runtime.psm1
@@ -856,6 +856,7 @@ function Discover-Test {
         Invoke-PluginStep -Plugins $state.Plugin -Step DiscoveryStart -Context @{
             BlockContainers = $BlockContainer
             Configuration   = $state.PluginConfiguration
+            Filter          = $Filter
         } -ThrowOnFailure
     }
 

--- a/src/functions/Output.ps1
+++ b/src/functions/Output.ps1
@@ -462,6 +462,16 @@ function Get-WriteScreenPlugin ($Verbosity) {
         param ($Context)
 
         & $SafeCommands["Write-Host"] -ForegroundColor Magenta "`nStarting discovery in $(@($Context.BlockContainers).Length) files."
+
+        if ($PesterPreference.Output.Verbosity.Value -in 'Detailed', 'Diagnostic') {
+            $activeFilters = $Context.Filter.psobject.Properties | Where-Object { $_.Value }
+            if($null -ne $activeFilters) {
+                foreach ($aFilter in $activeFilters) {
+                    # Assuming only StringArrayOption filter-types. Might break in the future.
+                    & $SafeCommands["Write-Host"] -ForegroundColor Magenta "Filter '$($aFilter.Name)' set to ('$($aFilter.Value -join "', '")')."
+                }
+            }
+        }
     }
 
     if ($PesterPreference.Output.Verbosity.Value -in 'Detailed', 'Diagnostic') {

--- a/src/functions/Output.ps1
+++ b/src/functions/Output.ps1
@@ -464,7 +464,7 @@ function Get-WriteScreenPlugin ($Verbosity) {
         & $SafeCommands["Write-Host"] -ForegroundColor Magenta "`nStarting discovery in $(@($Context.BlockContainers).Length) files."
 
         if ($PesterPreference.Output.Verbosity.Value -in 'Detailed', 'Diagnostic') {
-            $activeFilters = $Context.Filter.psobject.Properties | Where-Object { $_.Value }
+            $activeFilters = $Context.Filter.psobject.Properties | & $SafeCommands['Where-Object'] { $_.Value }
             if($null -ne $activeFilters) {
                 foreach ($aFilter in $activeFilters) {
                     # Assuming only StringArrayOption filter-types. Might break in the future.


### PR DESCRIPTION
## 1. General summary of the pull request
This PR enables Pester to print enabled filters during a run when using Detailed or Diagnostic output level.
The filters are shown at the start of discovery. Example:

> Discovery: Starting test discovery in 2 test containers. 
> 
> Starting discovery in 2 files.
> **Filter 'Tag' set to ('Function').
> Filter 'ExcludeTag' set to ('Ignore', 'Stuff').
> Filter 'Line' set to ('C:\tests\file1.Tests.ps1:37', 'C:\tests\file12.Tests.ps1:371').**
> Discovery: Discovering tests in /workspaces/Pester/demo.ps1 
> Discovering in /workspaces/Pester/demo.ps1.
> Found 3 tests. 13ms
> Discovery: Found 3 tests in 17 ms 
> Discovery: Processing discovery result objects, to set root, parents, filters etc. 
> Filter: ('Set-BuildRunToCI' Unit Tests) There is 'Ignore, Stuff' exclude tag filter. 
> ...

Known issue: It might be confusing to the user that filters are shown before "Found 3 tests" as that number is **before** processing/filtering. Moving the output after that message would require invoking a new plugin-step in `Discover-Test`

Fix #1721 
