### PR TITLE
Fix default Mock Args-value

### DIFF
--- a/src/functions/Mock.ps1
+++ b/src/functions/Mock.ps1
@@ -140,7 +140,7 @@ function Create-MockHook ($contextInfo, $InvokeMockCallback) {
 
     $mockPrototype = @"
     if (`$null -ne `$MyInvocation.MyCommand.Mock.Write_PesterDebugMessage) { & `$MyInvocation.MyCommand.Mock.Write_PesterDebugMessage -Message "Mock bootstrap function #FUNCTIONNAME# called from block #BLOCK#." }
-    `$MyInvocation.MyCommand.Mock.Args = `$null
+    `$MyInvocation.MyCommand.Mock.Args = @()
     if (#CANCAPTUREARGS#) {
         if (`$null -ne `$MyInvocation.MyCommand.Mock.Write_PesterDebugMessage) { & `$MyInvocation.MyCommand.Mock.Write_PesterDebugMessage -Message "Capturing arguments of the mocked command." }
         `$MyInvocation.MyCommand.Mock.Args = `$MyInvocation.MyCommand.Mock.ExecutionContext.SessionState.PSVariable.GetValue('local:args')

--- a/tst/functions/Mock.Tests.ps1
+++ b/tst/functions/Mock.Tests.ps1
@@ -1986,6 +1986,31 @@ Describe '$args handling' {
     }
 }
 
+Describe 'Mocking advanced function' {
+    It 'Avanced functions can be mocked with advanced function' {
+        # https://github.com/pester/Pester/issues/1554
+        function Get-Something {
+            [CmdletBinding()]
+            param
+            (
+                $MyParam1
+            )
+         }
+
+        Mock Get-Something -MockWith {
+            param(
+                [Parameter()]
+                [System.String]
+                $MyParam1
+            )
+
+            return $MyParam1
+        }
+
+        Get-Something -MyParam1 'SomeValue' | Should -Be 'SomeValue'
+    }
+}
+
 Describe 'Single quote in command/module name' {
     BeforeAll {
         $module = New-Module "Module '‘’‚‛" {


### PR DESCRIPTION
## 1. General summary of the pull request

The default Args-value for Mocks of type advanced functions or cmdlets, `$null`, can cause a `ParameterBindingException` when a advanced function/cmdlet is mocked by another advanced function.

The args-value is converted to an object array (`@($null)` ) before being splatted to the mock during execution. That means a `$null` value is actually sent to the mock as an argument. Advanced functions/cmdlet doesn't support arguments by default, so unless a unused parameter is available (for positional binding), the following exception can be thrown:

`ParameterBindingException: A positional parameter cannot be found that accepts argument '$null'`

Changing the default Args-value to an empty array solves the problem. During mock execution, the value is always being casted to `[object[]]`, so using an empty array from the beginning is smart. 

Fix #1554