### PR TITLE
Update github templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -2,15 +2,13 @@
 
 Please provide a descriptive title in the field 'Title' too.
 
-Please be aware that Pester version 3.4.0 - which is shipped with Windows 10 and Windows Server 2016 - is not supported anymore. Please update Pester to the latest version. See [Installation and update guide](https://pester.dev/docs/introduction/installation).
+Only Pester 4.10.x and 5.x.x are supported, try updating to the latest version to see if that solves your problem. See [Installation and update guide](https://pester.dev/docs/introduction/installation).
 
 -->
 
 ## Question
 
-<!-- 
-
-Please be clear and concise as it will help us answer you faster.
+<!-- Please be clear and concise as it will help us answer you faster.
 
 Provide sample code and output if it helps - use code blocks like below.
 
@@ -23,16 +21,11 @@ Provide sample code and output if it helps - use code blocks like below.
 
 **Environment data**
 
-<!--Please provide the output of a code provided below.
+<!-- Please provide the output of this script:
 
-Operating System, Pester version, and PowerShell version:
+(Invoke-WebRequest -Uri "https://git.io/JTinj" -UseBasicParsing).Content | Invoke-Expression
 
-$bugReport = &{
-    $p = Get-Command Invoke-Pester | Select-Object -ExpandProperty Module
-    "Pester version     : " + $p.Version + " " + $p.Path
-    "PowerShell version : " + $PSVersionTable.PSVersion
-    "OS version         : " + [System.Environment]::OSVersion.VersionString
-}
-$bugReport
-$bugReport | clip
+The script collects Operating System, Pester version and PowerShell version.
+You can open the URL in a browser to view the code before running it.
+
 -->

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,80 +1,38 @@
-## 1. General summary of the issue
-
 <!--
 
-Please provide a descriptive title of the issue in the field 'Title' too.
+Please provide a descriptive title in the field 'Title' too.
 
-Please be aware that Pester version 3.4.0 - which is shipped with Windows 10 and Windows Server 2016 - is not supported anymore.
-
-Please update Pester - before submitting a bug report - and retest your code under the newest version of Pester.
-
-[Full installation and update guide](https://github.com/pester/Pester/wiki/Installation-and-Update).
+Please be aware that Pester version 3.4.0 - which is shipped with Windows 10 and Windows Server 2016 - is not supported anymore. Please update Pester to the latest version. See [Installation and update guide](https://pester.dev/docs/introduction/installation).
 
 -->
 
-## 2. Describe Your Environment
+## Question
 
-<!--
+<!-- 
 
-If you would like to submit a bug report, please provide the output of a code provided below.
+Please be clear and concise as it will help us answer you faster.
 
-If you would like to write about anything else - like a feature request - feel free to remove a provided template text.
+Provide sample code and output if it helps - use code blocks like below.
+
+```powershell
+    #My code or output
+```
+
+-->
+
+
+**Environment data**
+
+<!--Please provide the output of a code provided below.
 
 Operating System, Pester version, and PowerShell version:
 
-```powershell
 $bugReport = &{
-    $p = Get-Module -Name Pester -ListAvailable | Select-Object -First 1
+    $p = Get-Command Invoke-Pester | Select-Object -ExpandProperty Module
     "Pester version     : " + $p.Version + " " + $p.Path
     "PowerShell version : " + $PSVersionTable.PSVersion
     "OS version         : " + [System.Environment]::OSVersion.VersionString
 }
 $bugReport
 $bugReport | clip
-```
-
-If you use Pester from a folder not included in the Env:PSModulePath please change a provided code accordingly.
-
--->
-
-## 3. Expected Behavior
-
-<!--
-
-If you're describing a bug, tell us what should happen.
-
-If you're suggesting a change/improvement, tell us how it should work. Mainly what the proposed feature is, why it is useful, and what dependencies (if any) it has. It would also be great if you added one or two examples of real-world usage if you have any.
-
--->
-
-## 4.Current Behavior
-
-<!--
-
-If describing a bug, tell us what happens instead of the expected behavior.
-
-If suggesting a change/improvement, explain the difference between the current behavior and the suggested behavior.
-
-Please remember that you can limit Pester output behavior using the `-Show` parameter.
-
--->
-
-## 5. Possible Solution
-
-<!--
-
-Have a solution in mind? Bug fix pull requests are always welcome.
-
-https://github.com/pester/Pester/wiki/Contributing-to-Pester has detailed instructions on how to contribute.
-
-If you are proposing a feature, let's discuss it here first.
-
--->
-
-## 6. Context
-
-<!--
-
-How has this issue affected you? What are you trying to accomplish?
-
 -->

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -24,18 +24,13 @@ Please be aware that Pester version 3.4.0 - which is shipped with Windows 10 and
 
 ## Describe your environment
 
-<!-- Please provide the output of a code provided below.
+<!-- Please provide the output of this script:
 
-Operating System, Pester version, and PowerShell version:
+(Invoke-WebRequest -Uri "https://git.io/JTinj" -UseBasicParsing).Content | Invoke-Expression
 
-$bugReport = &{
-    $p = Get-Command Invoke-Pester | Select-Object -ExpandProperty Module
-    "Pester version     : " + $p.Version + " " + $p.Path
-    "PowerShell version : " + $PSVersionTable.PSVersion
-    "OS version         : " + [System.Environment]::OSVersion.VersionString
-}
-$bugReport
-$bugReport | clip
+The script collects Operating System, Pester version and PowerShell version.
+You can open the URL in a browser to view the code before running it.
+
 -->
 
 ## Steps to reproduce
@@ -57,7 +52,7 @@ Tip: Placing Powershell code in a codeblock like below makes it more readable.
 
 ## Current Behavior
 
-<!-- What happens instead of the expected behavior.. -->
+<!-- What happens instead of the expected behavior. -->
 
 ## Possible Solution?
 

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -11,7 +11,7 @@ assignees: ''
 
 Thank you for using Pester and taking the time to report this issue!
 
-Please be aware that Pester version 3.4.0 - which is shipped with Windows 10 and Windows Server 2016 - is not supported anymore.
+Only Pester 4.10.x and 5.x.x are supported, try updating to the latest version to see if that solves your problem. See [Installation and update guide](https://pester.dev/docs/introduction/installation).
 
 - Please update Pester and retest your code before submitting a bug report. See [Installation and update guide](https://pester.dev/docs/introduction/installation).
 - Search for existing issues.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,68 @@
+---
+name: 🐛 Bug Report
+about: Report erros and unexpected behavior
+title: 'My descriptive bug title'
+labels: ''
+assignees: ''
+
+---
+
+<!--
+
+Thank you for using Pester and taking the time to report this issue!
+
+Please be aware that Pester version 3.4.0 - which is shipped with Windows 10 and Windows Server 2016 - is not supported anymore.
+
+- Please update Pester and retest your code before submitting a bug report. See [Installation and update guide](https://pester.dev/docs/introduction/installation).
+- Search for existing issues.
+- Pester 5 introduced breaking changes and some features were removed or are not yet migrated. See [Breaking changes](https://github.com/pester/Pester#breaking-changes)
+
+-->
+
+## General summary of the issue
+
+
+## Describe your environment
+
+<!-- Please provide the output of a code provided below.
+
+Operating System, Pester version, and PowerShell version:
+
+$bugReport = &{
+    $p = Get-Command Invoke-Pester | Select-Object -ExpandProperty Module
+    "Pester version     : " + $p.Version + " " + $p.Path
+    "PowerShell version : " + $PSVersionTable.PSVersion
+    "OS version         : " + [System.Environment]::OSVersion.VersionString
+}
+$bugReport
+$bugReport | clip
+-->
+
+## Steps to reproduce
+
+<!-- Provide steps and/or sample code to reproduce the issue.
+
+Try to make it as concise as possible, removing irrelevant steps/code and providing sample data where possible. This will enable us to help you faster.
+
+Tip: Placing Powershell code in a codeblock like below makes it more readable.
+
+```powershell
+    #My code
+```
+-->
+
+## Expected Behavior
+
+<!-- A clear and concise description of what you expected to happen. -->
+
+## Current Behavior
+
+<!-- What happens instead of the expected behavior.. -->
+
+## Possible Solution?
+
+<!-- Have a solution in mind?
+
+Bug fix pull requests are always welcome. See https://pester.dev/docs/contributing/introduction has detailed instructions on how to contribute.
+
+-->

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,8 +1,8 @@
 ---
 name: 🐛 Bug Report
-about: Report erros and unexpected behavior
+about: Report errors or unexpected behavior
 title: 'My descriptive bug title'
-labels: ''
+labels: 'bug'
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/commandhelp_issue.md
+++ b/.github/ISSUE_TEMPLATE/commandhelp_issue.md
@@ -15,15 +15,15 @@ Known issue: Documentation of Pester 5 is mostly out of date for all commands. S
 
 Command Reference documentation on the website are generated from comment-based help in the functions and should be reported here.
 
-All other documentation issues on https://pester.dev should be reported in the docs-repo.
+All other documentation issues on https://pester.dev should be reported in the [docs-repo](https://github.com/pester/docs).
 
 -->
 
 ## Location
 
-<!-- Help us find the relevant help location -->
+<!-- Help us identify which documentation to update -->
 
 - Pester version:
-- Function: 
+- Function:
 
 ## General summary of the issue

--- a/.github/ISSUE_TEMPLATE/commandhelp_issue.md
+++ b/.github/ISSUE_TEMPLATE/commandhelp_issue.md
@@ -11,7 +11,7 @@ assignees: ''
 
 Thank you for using Pester and taking the time to report this issue!
 
-Known issue: Documentation is mostly out of date for all commands. See [Breaking changes](https://github.com/pester/Pester#breaking-changes)
+Known issue: Documentation of Pester 5 is mostly out of date for all commands. See [Breaking changes](https://github.com/pester/Pester#breaking-changes)
 
 Command Reference documentation on the website are generated from comment-based help in the functions and should be reported here.
 
@@ -27,4 +27,3 @@ All other documentation issues on https://pester.dev should be reported in the d
 - Function: 
 
 ## General summary of the issue
-

--- a/.github/ISSUE_TEMPLATE/commandhelp_issue.md
+++ b/.github/ISSUE_TEMPLATE/commandhelp_issue.md
@@ -1,0 +1,30 @@
+---
+name: 📖 Problem with Command Reference documentation?
+about: Outdated docs in function help or Command Reference on https://pester.dev? Report them here
+title: 'My documentation issue'
+labels: 'Documentation'
+assignees: ''
+
+---
+
+<!--
+
+Thank you for using Pester and taking the time to report this issue!
+
+Known issue: Documentation is mostly out of date for all commands. See [Breaking changes](https://github.com/pester/Pester#breaking-changes)
+
+Command Reference documentation on the website are generated from comment-based help in the functions and should be reported here.
+
+All other documentation issues on https://pester.dev should be reported in the docs-repo.
+
+-->
+
+## Location
+
+<!-- Help us find the relevant help location -->
+
+- Pester version:
+- Function: 
+
+## General summary of the issue
+

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,7 +1,7 @@
 contact_links:
     - name: Need help?
       url: https://pester.dev/docs/contributing/introduction#where-to-get-support
-      about: Check out the recommended communities available for usage questions before creating a general issue
+      about: Join our online communities to get help with "How to do _____ with Pester?" questions.
     - name: Documentation issue beyond Command Reference?
       url: https://github.com/pester/docs/issues/new
       about: Please report non-command documentation issue for https://pester.dev in the docs repo

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,7 @@
+contact_links:
+    - name: Need help?
+      url: https://pester.dev/docs/contributing/introduction#where-to-get-support
+      about: Check out the recommended communities available for usage questions before creating a general issue
+    - name: Documentation issue beyond Command Reference?
+      url: https://github.com/pester/docs/issues/new
+      about: Please report non-command documentation issue for https://pester.dev in the docs repo

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,36 @@
+---
+name: 💡 Feature Request/Idea
+about: Got a great idea to make Pester better? Submit a suggestion 
+title: 'My amazing idea title'
+labels: ''
+assignees: ''
+
+---
+
+<!--
+
+Thank you for using Pester!
+
+Good ideas are always welcome and there's no commitment to implement it yourself, but feel free to contribute after an initial discussion. 
+
+- Try out the latest version of Pester - maybe your request is already available. See [Installation and update guide](https://pester.dev/docs/introduction/installation).
+- See [README](https://github.com/pester/Pester) for the latest updates and newest features.
+- Search for existing issues to matches your idea. A popular issue/request is more likely to be prioritized.
+
+-->
+
+## Summary of the feature request
+
+<!-- A clear and concise description of your idea.
+
+What problem do you want to solve?
+
+As a user I'd like to be able to get X by doing Y. This would be very useful in situations like Z.
+
+-->
+
+## How should it work? (optional)
+
+<!-- Do you already have an idea of how this experience should be. Feel free to provide a short demo of usage and expected results.
+
+-->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -18,9 +18,9 @@ If your pull request integrates Pester with another system, please tell us how t
 
 ## PR Checklist
 
-- [ ] PR has meaning title
+- [ ] PR has meaningful title
 - [ ] Summary describes changes
-- [ ] PR is ready to be merge
+- [ ] PR is ready to be merged
   - If not, use the arrow next to `Create Pull Request` to mark it as a draft. PR can be marked `Ready for review` when it's ready.
 - [ ] All tests pass
     - Run `./build.ps1 -Clean; ./test.ps1 -NoBuild`. Use  a new PowerShell process when C# code is changed.
@@ -31,6 +31,6 @@ If your pull request integrates Pester with another system, please tell us how t
 
 Before you continue, please review [Contributing to Pester](https://pester.dev/docs/contributing/introduction).
 
-Our continuous integration system doesn't send any notifications about failed tests. Please return to the opened pull request (after ~60 minutes) to check if is everything OK.
+Our continuous integration system doesn't send any notifications about failed tests. Please return to the opened pull request (after ~60 minutes) to check if everything is OK.
 
 -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,22 +1,35 @@
 <!--
 
-Thank you for contributing to Pester! Please provide a descriptive title of the pull request in the field 'Title'.
+Thank you for contributing to Pester! 
 
 -->
 
-## 1. General summary of the pull request
+## PR Summary
 
 <!--
 
 Please describe what your pull request fixes, or how it improves Pester.
 
-If your pull request resolves a reported issue, please mention it by using  `Fix #<issue_number>` on a new line, this will close the linked issue automatically when this PR is merged. For more info see: [Closing issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/).
+If your pull request resolves a reported issue, please mention it by using `Fix #<issue_number>` on a new line, this will close the linked issue automatically when this PR is merged. For more info see: [Closing issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/).
 
 If your pull request integrates Pester with another system, please tell us how the change can be tested.
 
-Please remember to update [the Pester wiki](https://github.com/pester/Pester/wiki) if needed.
+-->
 
-Before you continue, please review [Contributing to Pester](https://github.com/pester/Pester/wiki/Contributing-to-Pester) and [Development rules - technical](https://github.com/pester/Pester/wiki/Developement-rules---technical).
+## PR Checklist
+
+- [ ] PR has meaning title
+- [ ] Summary describes changes
+- [ ] PR is ready to be merge
+  - If not, use the arrow next to `Create Pull Request` to mark it as a draft. PR can be marked `Ready for review` when it's ready.
+- [ ] All tests pass
+    - Run `./build.ps1 -Clean; ./test.ps1 -NoBuild`. Use  a new PowerShell process when C# code is changed.
+- [ ] Tests are added/update *(if required)*
+- [ ] Documentation is updated/added *(if required)*
+
+<!--
+
+Before you continue, please review [Contributing to Pester](https://pester.dev/docs/contributing/introduction).
 
 Our continuous integration system doesn't send any notifications about failed tests. Please return to the opened pull request (after ~60 minutes) to check if is everything OK.
 


### PR DESCRIPTION
## 1. General summary of the pull request
PR suggest changes to the github templates used for the Pester repo. In replace of on large issue template, a use will get the choice between one per issue type:
- Bug report
- Feature request/idea
- Documentation issue
- General/blank issue for anything else

A link to the website for community support is also added

The text is also updated with new documentation-links, tips and updated script for collecting environment data (autodetects using currently loaded `Invoke-Pester`cmdlet).

The pull request template is also updated with new links and a checklist for common steps.

Fix #1732 