### PR TITLE
Removed test-step in PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,6 @@
 <!--
 
-Thank you for contributing to Pester! 
+Thank you for contributing to Pester!
 
 -->
 
@@ -22,8 +22,6 @@ If your pull request integrates Pester with another system, please tell us how t
 - [ ] Summary describes changes
 - [ ] PR is ready to be merged
   - If not, use the arrow next to `Create Pull Request` to mark it as a draft. PR can be marked `Ready for review` when it's ready.
-- [ ] All tests pass
-    - Run `./build.ps1 -Clean; ./test.ps1 -NoBuild`. Use  a new PowerShell process when C# code is changed.
 - [ ] Tests are added/update *(if required)*
 - [ ] Documentation is updated/added *(if required)*
 


### PR DESCRIPTION
## PR Summary

Removes requirement for running local tests as discussed in https://github.com/pester/Pester/pull/1743#issuecomment-717965537


## PR Checklist

- [x] PR has meaningful title
- [x] Summary describes changes
- [x] PR is ready to be merged
  - If not, use the arrow next to `Create Pull Request` to mark it as a draft. PR can be marked `Ready for review` when it's ready.