### PR TITLE
Add analyzerrule for highlighting slow *-object commands

### DIFF
--- a/Pester.BuildAnalyzerRules/Pester.BuildAnalyzerRules.psm1
+++ b/Pester.BuildAnalyzerRules/Pester.BuildAnalyzerRules.psm1
@@ -73,4 +73,67 @@ function Measure-SafeComands {
     }
 }
 
+Function Measure-ObjectCmdlets {
+    <#
+    .SYNOPSIS
+    Should avoid usage of New/Where/Foreach/Select-Object.
+    .DESCRIPTION
+    The built-in *-Object-cmdlets are slow compared to alternatives in .NET. To fix a violation of this rule, consider using an alterantive like `foreach`-keyword etc.`.
+    .EXAMPLE
+    Measure-ObjectCmdlets -CommandAst $CommandAst
+    .INPUTS
+    [System.Management.Automation.Language.CommandAst]
+    .OUTPUTS
+    [Microsoft.Windows.PowerShell.ScriptAnalyzer.Generic.DiagnosticRecord[]]
+    .NOTES
+    None
+    #>
+    [CmdletBinding()]
+    [OutputType([Microsoft.Windows.PowerShell.ScriptAnalyzer.Generic.DiagnosticRecord[]])]
+    Param
+    (
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [System.Management.Automation.Language.CommandAst]
+        $CommandAst
+    )
+
+    Process {
+        $results = @()
+
+        #StringConstantExpressionAst match (direct cmdlet usage)
+        $objectCommands = "(?:New|Where|Foreach|Select)-Object"
+
+        $result = [Microsoft.Windows.PowerShell.ScriptAnalyzer.Generic.DiagnosticRecord]@{
+            'Message'              = "$((Get-Help $MyInvocation.MyCommand.Name).Description.Text)"
+            'Extent'               = $CommandAst.Extent
+            'RuleName'             = $PSCmdlet.MyInvocation.InvocationName
+            'Severity'             = 'Information'
+        }
+
+        try {
+            $commandName = $CommandAst.GetCommandName()
+
+            if ($null -ne $commandName -and $commandName -match $objectCommands) {
+                # Cmdlet used
+                $results += $result
+
+            } elseif ($CommandAst.InvocationOperator -eq [System.Management.Automation.Language.TokenKind]::Ampersand) {
+                $invocatedCmd = $CommandAst.CommandElements[0]
+
+                if ($invocatedCmd -is [System.Management.Automation.Language.IndexExpressionAst] -and
+                    $invocatedCmd.Target -match 'SafeCommands'-and $invocatedCmd.Index -match $objectCommands) {
+                    # SafeCommands
+                    $results += $result
+                }
+            }
+
+            return $results
+        }
+        catch {
+            $PSCmdlet.ThrowTerminatingError($PSItem)
+        }
+    }
+}
+
 Export-ModuleMember -Function 'Measure-*'


### PR DESCRIPTION
## PR Summary

New PSSA analyzer-rule to highlight usage of most `*-Object` built-in cmdlets as they can be slower than other alternatives.
Currently Information-level.

Based on https://github.com/pester/Pester/pull/1745#issuecomment-719455100


## PR Checklist

- [x] PR has meaningful title
- [x] Summary describes changes
- [x] PR is ready to be merged
  - If not, use the arrow next to `Create Pull Request` to mark it as a draft. PR can be marked `Ready for review` when it's ready.
- [ ] Tests are added/update *(if required)*
- [ ] Documentation is updated/added *(if required)*