### PR TITLE
Remove Bug label from issue

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,7 @@
 name: 🐛 Bug Report
 about: Report errors or unexpected behavior
 title: 'My descriptive bug title'
-labels: 'Bug'
+labels: ''
 assignees: ''
 
 ---


### PR DESCRIPTION
I know it was my idea to add the label but I find it unnecessarily noisy. Just having Feature and Documentation labels for the other types of issues is enough.