### PR TITLE
Updated New-Fixture template

### DIFF
--- a/src/functions/New-Fixture.ps1
+++ b/src/functions/New-Fixture.ps1
@@ -73,9 +73,9 @@ function New-Fixture {
     #>
 
     param (
-        [String]$Path = $PWD,
         [Parameter(Mandatory = $true)]
-        [String]$Name
+        [String]$Name,
+        [String]$Path = $PWD
     )
 
     $Name = $Name -replace '.ps(m?)1', ''
@@ -86,8 +86,7 @@ function New-Fixture {
 
     #keep this formatted as is. the format is output to the file as is, including indentation
     $scriptCode = "function $Name {
-    #Do something
-    `$true
+    throw [NotImplementedException]'$Name is not implemented.'
 }"
 
     $testCode = 'BeforeAll {
@@ -96,7 +95,7 @@ function New-Fixture {
 
 Describe "#name#" {
     It "Returns expected output" {
-        #name# | Should -Be $true
+        #name# | Should -Be "YOUR_EXPECTED_VALUE"
     }
 }' -replace "#name#", $Name
 

--- a/tst/functions/New-Fixture.Tests.ps1
+++ b/tst/functions/New-Fixture.Tests.ps1
@@ -2,7 +2,7 @@ Set-StrictMode -Version Latest
 
 Describe "New-Fixture" {
     It "Name parameter is mandatory" {
-        (Get-Command New-Fixture ).Parameters.Name.ParameterSets.__AllParameterSets.IsMandatory | Should -Be $true
+        (Get-Command New-Fixture).Parameters.Name.ParameterSets.__AllParameterSets.IsMandatory | Should -Be $true
     }
 
     Context "Only Name parameter is specified" {
@@ -115,7 +115,7 @@ Describe "New-Fixture" {
             $name = "Test Fixture"
             $path = "TestDrive:\"
 
-            { New-Fixture -Path $path -Name $name } | Should -Throw -Because "whitespace is not allowed in fixture name"
+            { New-Fixture -Name $name -Path $path } | Should -Throw -Because "whitespace is not allowed in fixture name"
         }
     }
 }

--- a/tst/functions/New-Fixture.ts.ps1
+++ b/tst/functions/New-Fixture.ts.ps1
@@ -9,7 +9,7 @@ Import-Module $PSScriptRoot\..\..\bin\Pester.psd1
 
 $global:PesterPreference = @{
     Debug = @{
-        ShowFullErrors         = $true
+        ShowFullErrors         = $false
     }
 }
 
@@ -26,7 +26,8 @@ i -PassThru:$PassThru {
                 New-Fixture -Path $tempFolder -Name $name
 
                 $r = Invoke-Pester -Path $testsPath -PassThru
-                $r.Containers[0].Blocks[0].Tests[0].Result | Verify-Equal "Passed"
+                $r.Containers[0].Blocks[0].Tests[0].Result | Verify-Equal "Failed"
+                $r.Containers[0].Blocks[0].Tests[0].ErrorRecord.Exception | Verify-Type ([System.NotImplementedException])
             }
             finally {
                 if (Test-Path $scriptPath) {

--- a/tst/functions/New-Fixture.ts.ps1
+++ b/tst/functions/New-Fixture.ts.ps1
@@ -15,7 +15,7 @@ $global:PesterPreference = @{
 
 i -PassThru:$PassThru {
     b "New-Fixture" {
-        t "Generated fixture works" {
+        t "Generated fixture fails as expected" {
             $tempFolder = [IO.Path]::GetTempPath()
             $name = "Fixture$([Guid]::NewGuid().Guid)"
 


### PR DESCRIPTION
<!--

Thank you for contributing to Pester!

-->

## PR Summary

Updated New-Fixture with:
- New template that fails by default as discussed in #1766 .
- Moved `-Name` to be first positional parameter to enable usage like `New-Fixture "Get-MyNewFunction"`. `-Path` already defaults to current directory, so no need to be first.

Fix #1766

## PR Checklist

- [x] PR has meaningful title
- [x] Summary describes changes
- [x] PR is ready to be merged
  - If not, use the arrow next to `Create Pull Request` to mark it as a draft. PR can be marked `Ready for review` when it's ready.
- [x] Tests are added/update *(if required)*
- [ ] Documentation is updated/added *(if required)*

<!--

Before you continue, please review [Contributing to Pester](https://pester.dev/docs/contributing/introduction).

Our continuous integration system doesn't send any notifications about failed tests. Please return to the opened pull request (after ~60 minutes) to check if everything is OK.

-->
