### PR TITLE
Added missing codeblock to help examples

### DIFF
--- a/src/Pester.ps1
+++ b/src/Pester.ps1
@@ -30,6 +30,7 @@ function Add-ShouldOperator {
     If -Name is different from the actual function name, record the actual function name here.
     Used by Get-ShouldOperator to pull function help.
 .EXAMPLE
+    ```powershell
     function BeAwesome($ActualValue, [switch] $Negate)
     {
 
@@ -60,6 +61,7 @@ function Add-ShouldOperator {
 
     PS C:\> "bad" | should -BeAwesome
     {bad} is not Awesome
+    ```
 #>
     [CmdletBinding()]
     param (
@@ -548,6 +550,7 @@ function Invoke-Pester {
     with 'Util' and their subdirectories.
 
     .EXAMPLE
+    ```powershell
     $config = [PesterConfiguration]@{
     Should = @{ <- # Should configuration.
         ErrorAction = 'Stop' # <- "Controls if Should throws on error."
@@ -555,10 +558,10 @@ function Invoke-Pester {
     }
 
     Invoke-Pester -Configuration $config
+    ```
 
     .EXAMPLE
     $config = [PesterConfiguration]::Default
-
     Invoke-Pester -Configuration $config
 
     .LINK
@@ -1452,6 +1455,7 @@ function BeforeDiscovery {
         The ScritpBlock to run.
 
         .EXAMPLE
+            ```powershell
             PS > BeforeDiscovery {
                 $files = "file1.txt", "file2.txt"
             }
@@ -1463,6 +1467,7 @@ function BeforeDiscovery {
                     }
                 }
             }
+            ```
 
             The result of commands will be execution of tests and saving results of them in a NUnitMXL file where the root "test-suite"
             will be named "Tests - Set A".

--- a/src/functions/Context.ps1
+++ b/src/functions/Context.ps1
@@ -29,7 +29,7 @@ available as $_ in all child blocks. When the array is an array of hashtables, i
 defines each key in the hashatble as variable.
 
 .EXAMPLE
-```ps
+```powershell
 function Add-Numbers($a, $b) {
     return $a + $b
 }

--- a/src/functions/Describe.ps1
+++ b/src/functions/Describe.ps1
@@ -31,6 +31,7 @@ available as $_ in all child blocks. When the array is an array of hashtables, i
 defines each key in the hashatble as variable.
 
 .EXAMPLE
+```powershell
 function Add-Numbers($a, $b) {
     return $a + $b
 }
@@ -56,6 +57,7 @@ Describe "Add-Numbers" {
         $sum | Should -Be "twothree"
     }
 }
+```
 
 .LINK
 https://pester.dev/docs/commands/Describe

--- a/src/functions/InModuleScope.ps1
+++ b/src/functions/InModuleScope.ps1
@@ -18,7 +18,7 @@ function InModuleScope {
 .PARAMETER ScriptBlock
    The code to be executed within the script module.
 .EXAMPLE
-    ```ps
+    ```powershell
     # The script module:
     function PublicFunction
     {

--- a/src/functions/It.ps1
+++ b/src/functions/It.ps1
@@ -47,6 +47,7 @@ parameter with the syntax 'Adds numbers <A> and <B>' (assuming you have keys nam
 in your TestCases hashtables.)
 
 .EXAMPLE
+```powershell
 function Add-Numbers($a, $b) {
     return $a + $b
 }
@@ -72,8 +73,10 @@ Describe "Add-Numbers" {
         $sum | Should -Be "twothree"
     }
 }
+```
 
 .EXAMPLE
+```powershell
 function Add-Numbers($a, $b) {
     return $a + $b
 }
@@ -93,6 +96,7 @@ Describe "Add-Numbers" {
         $sum | Should -Be $expectedResult
     }
 }
+```
 
 .LINK
 https://github.com/pester/Pester/wiki/It

--- a/src/functions/New-MockObject.ps1
+++ b/src/functions/New-MockObject.ps1
@@ -12,7 +12,7 @@ An .NET assembly for the particular type must be available in the system and loa
 The .NET type to create an object based on.
 
 .EXAMPLE
-```ps
+```powershell
 $obj = New-MockObject -Type 'System.Diagnostics.Process'
 $obj.GetType().FullName
     System.Diagnostics.Process

--- a/src/functions/Pester.SessionState.Mock.ps1
+++ b/src/functions/Pester.SessionState.Mock.ps1
@@ -116,8 +116,7 @@ originally implemented the command.
 .EXAMPLE
 Mock Get-ChildItem { return @{FullName = "A_File.TXT"} }
 
-Using this Mock, all calls to Get-ChildItem will return a hashtable with a
-FullName property returning "A_File.TXT"
+Using this Mock, all calls to Get-ChildItem will return a hashtable with a FullName property returning "A_File.TXT"
 
 .EXAMPLE
 Mock Get-ChildItem { return @{FullName = "A_File.TXT"} } -ParameterFilter { $Path -and $Path.StartsWith($env:temp) }
@@ -137,26 +136,32 @@ Mock Get-ChildItem { return @{FullName = "C_File.TXT"} } -ParameterFilter { $Pat
 Multiple mocks of the same command may be used. The parameter filter determines which is invoked. Here, if Get-ChildItem is called on the "2" directory of the temp folder, then B_File.txt will be returned.
 
 .EXAMPLE
+```powershell
 Mock Get-ChildItem { return @{FullName="B_File.TXT"} } -ParameterFilter { $Path -eq "$env:temp\me" }
 Mock Get-ChildItem { return @{FullName="A_File.TXT"} } -ParameterFilter { $Path -and $Path.StartsWith($env:temp) }
 
 Get-ChildItem $env:temp\me
+```
 
 Here, both mocks could apply since both filters will pass. A_File.TXT will be returned because it was the most recent Mock created.
 
 .EXAMPLE
+```powershell
 Mock Get-ChildItem { return @{FullName = "B_File.TXT"} } -ParameterFilter { $Path -eq "$env:temp\me" }
 Mock Get-ChildItem { return @{FullName = "A_File.TXT"} }
 
 Get-ChildItem c:\windows
+```
 
 Here, A_File.TXT will be returned. Since no filter was specified, it will apply to any call to Get-ChildItem that does not pass another filter.
 
 .EXAMPLE
+```powershell
 Mock Get-ChildItem { return @{FullName = "B_File.TXT"} } -ParameterFilter { $Path -eq "$env:temp\me" }
 Mock Get-ChildItem { return @{FullName = "A_File.TXT"} }
 
 Get-ChildItem $env:temp\me
+```
 
 Here, B_File.TXT will be returned. Even though the filterless mock was created more recently. This illustrates that filterless Mocks are always evaluated last regardless of their creation order.
 
@@ -167,6 +172,7 @@ Using this Mock, all calls to Get-ChildItem from within the MyTestModule module
 will return a hashtable with a FullName property returning "A_File.TXT"
 
 .EXAMPLE
+```powershell
 Get-Module -Name ModuleMockExample | Remove-Module
 New-Module -Name ModuleMockExample  -ScriptBlock {
     function Hidden { "Internal Module Function" }
@@ -190,6 +196,7 @@ Describe "ModuleMockExample" {
         Exported | Should -Be "Mocked"
     }
 }
+```
 
 This example shows how calls to commands made from inside a module can be
 mocked by using the -ModuleName parameter.

--- a/src/functions/Set-ItResult.ps1
+++ b/src/functions/Set-ItResult.ps1
@@ -27,7 +27,7 @@ function Set-ItResult {
     to provide information to the user why the test is neither successful nor failed.
 
     .EXAMPLE
-    ```ps
+    ```powershell
     Describe "Example" {
         It "Skipped test" {
             Set-ItResult -Skipped -Because "we want it to be skipped"

--- a/src/functions/assertions/Should.ps1
+++ b/src/functions/assertions/Should.ps1
@@ -43,7 +43,7 @@ function Should {
     about_Pester
 
     .EXAMPLE
-    ```ps
+    ```powershell
     Describe "d1" {
         BeforeEach { $be = 1 }
         It "i1" {
@@ -54,7 +54,7 @@ function Should {
     ```
 
     .EXAMPLE
-    ```ps
+    ```powershell
     Describe "d1" {
         It "i1" {
             $user = Get-User
@@ -67,7 +67,7 @@ function Should {
     ```
 
     .EXAMPLE
-    ```ps
+    ```powershell
     Describe "d1" {
         It "i1" {
             Mock Get-Command { }
@@ -78,7 +78,7 @@ function Should {
     ```
 
     .EXAMPLE
-    ```ps
+    ```powershell
     Describe "d1" {
         It "i1" {
             Mock Get-Command { }


### PR DESCRIPTION

## PR Summary
Added missing markdown codeblocks to examples where code includes a blank line. This is to help pester.dev show codeblocks correctly.

Also updated some help examples using ` ```ps` to ` ```powershell`.

Fix #1781 

## PR Checklist

- [x] PR has meaningful title
- [x] Summary describes changes
- [x] PR is ready to be merged
  - If not, use the arrow next to `Create Pull Request` to mark it as a draft. PR can be marked `Ready for review` when it's ready.
- [ ] Tests are added/update *(if required)*
- [ ] Documentation is updated/added *(if required)*
