### PR TITLE
Add missing and update help for exported functions

### DIFF
--- a/src/Pester.RSpec.ps1
+++ b/src/Pester.RSpec.ps1
@@ -370,6 +370,59 @@ function Remove-RSpecNonPublicProperties ($run){
 }
 
 function New-PesterContainer {
+    <#
+    .SYNOPSIS
+    Generates ContainerInfo-objects used as for Invoke-Pester -Container
+
+    .DESCRIPTION
+    Pester 5 supports running tests files and scriptblocks using parameter-input.
+    To use this feature, Invoke-Pester expects one or more ContainerInfo-objects
+    created using this funciton, that specify test containers in the form of paths
+    to the test files or scriptblocks containing the tests directly.
+
+    An optional Data-dictionary can be provided to supply the containers with any
+    required parameter-values. This is useful in when tests are generated dynamically
+    based on parameter-input. This method enables complex test-solutions while being
+    able to re-use a lot of test-code.
+
+    .PARAMETER Path
+    Specifies one or more paths to files containing tests. The value is a path\file
+    name or name pattern. Wildcards are permitted.
+
+    .PARAMETER ScriptBlock
+    Specifies one or more scriptblocks containing tests.
+
+    .PARAMETER Data
+    Allows a dictionary to be provided with parameter-values that should be used during
+    execution of the test containers defined in Path or ScriptBlock.
+
+    .EXAMPLE
+    $container = New-PesterContainer -Path 'CodingStyle.Tests.ps1' -Data @{ File = "Get-Emoji.ps1" }
+    Invoke-Pester -Container $container
+
+    This example runs Pester using a generated ContainerInfo-object referencing a file and
+    required parameters that's provided to the test-file during execution.
+
+    .EXAMPLE
+    $sb = {
+        Describe 'Testing New-PesterContainer' {
+            It 'Useless test' {
+                "foo" | Should -Not -Be "bar"
+            }
+        }
+    }
+    $container = New-PesterContainer -ScriptBlock $sb
+    Invoke-Pester -Container $container
+
+    This example runs Pester agianst a scriptblock. New-PesterContainer is used to genreated
+    the requried ContainerInfo-object that enables us to do this directly.
+
+    .LINK
+    https://pester.dev/docs/commands/New-PesterContainer
+
+    .LINK
+    https://pester.dev/docs/commands/Invoke-Pester
+    #>
     [CmdletBinding(DefaultParameterSetName="Path")]
     param(
         [Parameter(Mandatory, ParameterSetName = "Path")]

--- a/src/Pester.RSpec.ps1
+++ b/src/Pester.RSpec.ps1
@@ -422,6 +422,9 @@ function New-PesterContainer {
 
     .LINK
     https://pester.dev/docs/commands/Invoke-Pester
+
+    .LINK
+    https://pester.dev/docs/usage/data-driven-tests
     #>
     [CmdletBinding(DefaultParameterSetName="Path")]
     param(

--- a/src/Pester.RSpec.ps1
+++ b/src/Pester.RSpec.ps1
@@ -380,7 +380,7 @@ function New-PesterContainer {
     created using this funciton, that specify test containers in the form of paths
     to the test files or scriptblocks containing the tests directly.
 
-    An optional Data-dictionary can be provided to supply the containers with any
+    A optional Data-dictionary can be provided to supply the containers with any
     required parameter-values. This is useful in when tests are generated dynamically
     based on parameter-input. This method enables complex test-solutions while being
     able to re-use a lot of test-code.

--- a/src/Pester.ps1
+++ b/src/Pester.ps1
@@ -480,9 +480,8 @@ function Invoke-Pester {
 
     .PARAMETER Path
     Aliases Script
-    Specifies a test to run. The value is a path\file
-    name or name pattern. Wildcards are permitted. All hash tables in a Script
-    parameter values must have a Path key.
+    Specifies one or more paths to files containing tests. The value is a path\file
+    name or name pattern. Wildcards are permitted.
 
     .PARAMETER PesterOption
     (Deprecated v4)

--- a/src/Pester.ps1
+++ b/src/Pester.ps1
@@ -587,7 +587,9 @@ function Invoke-Pester {
     https://pswiki.net/invoke-pester-pester/
 
     .LINK
-    Describe
+    https://pester.dev/docs/commands/Describe
+
+    .LINK
     about_Pester
     #>
     # Currently doesn't work. $IgnoreUnsafeCommands filter used in rule as workaround

--- a/src/Pester.ps1
+++ b/src/Pester.ps1
@@ -1351,6 +1351,34 @@ function Contain-AnyStringLike ($Filter, $Collection) {
 }
 
 function ConvertTo-Pester4Result {
+    <#
+    .SYNOPSIS
+    Converts a Pester 5 result-object to an Pester 4-compatible object
+
+    .DESCRIPTION
+    Pester 5 uses a new format for it's result-object compared to previous
+    versions of Pester. This function is provided as a way to convert the
+    result-object into an object using the previous format. This can be
+    useful as a temporary measure to easier migrate to Pester 5 without
+    having to redesign compelx CI/CD-pipelines.
+
+    .PARAMETER PesterResult
+    Result object from a Pester 5-run. This can be retrieved using Invoke-Pester
+    -Passthru or by using the Run.PassThru configuration-option.
+
+    .EXAMPLE
+    $pester5Result = Invoke-Pester -Passthru
+    $pester4Result = $pester5Result | ConvertTo-Pester4Result
+
+    This example runs Pester using the Passthru option to retrieve a result-object
+    in the Pester 5 format and converts it to a new Pester 4-compatible result-object.
+
+    .LINK
+    https://pester.dev/docs/commands/ConvertTo-Pester4Result
+
+    .LINK
+    https://pester.dev/docs/commands/Invoke-Pester
+    #>
     [CmdletBinding()]
     param(
         [Parameter(Mandatory, ValueFromPipeline)]

--- a/src/Pester.ps1
+++ b/src/Pester.ps1
@@ -388,8 +388,12 @@ function Invoke-Pester {
     Run.Path - Directories to be searched for tests, paths directly to test files, or combination of both.
         Default is: .
     Run.ScriptBlock - ScriptBlocks containing tests to be executed.
+    Run.Container - ContainerInfo objects containing tests to be executed.
     Run.TestExtension - Filter used to identify test files.
         Default is: *.Tests.ps1*
+
+    [PesterConfiguration]::Default.Output
+    ------------
     Output.Verbosity - The verbosity of output, options are None, Normal, Detailed and Diagnostic.
         Default is: Normal
 
@@ -424,6 +428,11 @@ function Invoke-Pester {
     Filter.Tag - Tags of Describe, Context or It to be run.
     Should.ErrorAction - Controls if Should throws on error. Use 'Stop' to throw on error, or 'Continue' to fail at the end of the test.
 
+    [PesterConfiguration]::Default.Should
+    ------------
+    Should.ErrorAction - Controls if Should throws on error. Use 'Stop' to throw on error, or 'Continue' to fail at the end of the test.
+        Default is: Stop
+
     [PesterConfiguration]::Default.Debug
     -----
     Debug.ShowFullErrors - Show full errors including Pester internal stack.
@@ -431,6 +440,11 @@ function Invoke-Pester {
     Debug.WriteDebugMessages - Write Debug messages to screen.
     Debug.WriteDebugMessagesFrom - Write Debug messages from a given source, WriteDebugMessages must be set to true for this to work. You can use like wildcards to get messages from multiple sources, as well as * to get everything.
         Available options: "Discovery", "Skip", "Filter", "Mock", "CodeCoverage"
+
+    .PARAMETER Container
+    Specifies one or more ContainerInfo-objects that define containers with tests.
+    ContainerInfo-objects are generated using New-PesterContainer. Useful for
+    scenarios where data-driven test are generated, e.g. parametrized test files.
 
     .PARAMETER EnableExit
     (Deprecated v4)

--- a/src/en-US/about_Pester.help.txt
+++ b/src/en-US/about_Pester.help.txt
@@ -286,7 +286,7 @@ LONG DESCRIPTION
 
 
 SEE ALSO
-    Pester wiki: https://github.com/pester/pester/wiki
+    Pester website: https://pester.dev
     Describe
     Context
     It

--- a/src/functions/Context.ps1
+++ b/src/functions/Context.ps1
@@ -14,7 +14,7 @@ apply to tests within that Context .
 The name of the Context. This is a phrase describing a set of tests within a describe.
 
 .PARAMETER Tag
-Optional parameter containing an array of strings.  When calling Invoke-Pester,
+Optional parameter containing an array of strings. When calling Invoke-Pester,
 it is possible to specify a -Tag parameter which will only execute Context blocks
 containing the same Tag.
 

--- a/src/functions/Describe.ps1
+++ b/src/functions/Describe.ps1
@@ -63,16 +63,13 @@ Describe "Add-Numbers" {
 https://pester.dev/docs/commands/Describe
 
 .LINK
-https://github.com/pester/Pester/wiki/Describe
+https://pester.dev/docs/commands/It
 
 .LINK
-It
+https://pester.dev/docs/commands/Context
 
 .LINK
-Context
-
-.LINK
-Invoke-Pester
+https://pester.dev/docs/commands/Invoke-Pester
 
 .LINK
 about_Should
@@ -82,7 +79,6 @@ about_Mocking
 
 .LINK
 about_TestDrive
-
 #>
 
     param(

--- a/src/functions/Describe.ps1
+++ b/src/functions/Describe.ps1
@@ -20,7 +20,7 @@ in this block but are typically nested each in its own It block. Assertions are
 typically performed by the Should command within the It blocks.
 
 .PARAMETER Tag
-Optional parameter containing an array of strings.  When calling Invoke-Pester,
+Optional parameter containing an array of strings. When calling Invoke-Pester,
 it is possible to specify a -Tag parameter which will only execute Describe blocks
 containing the same Tag.
 

--- a/src/functions/Get-ShouldOperator.ps1
+++ b/src/functions/Get-ShouldOperator.ps1
@@ -18,10 +18,12 @@ function Get-ShouldOperator {
 
     .EXAMPLE
     Get-ShouldOperator
+
     Return all available Should assertion operators and their aliases.
 
     .EXAMPLE
     Get-ShouldOperator -Name Be
+
     Return help examples for the Be assertion operator.
     -Name is a dynamic parameter that tab completes all available options.
 

--- a/src/functions/InModuleScope.ps1
+++ b/src/functions/InModuleScope.ps1
@@ -17,6 +17,10 @@ function InModuleScope {
    PowerShell session.
 .PARAMETER ScriptBlock
    The code to be executed within the script module.
+.PARAMETER Parameters
+   A optional hashtable of parameters to be passed to the scriptblock.
+.PARAMETER ArgumentList
+   A optional list of arguments to be passed to the scriptblock.
 .EXAMPLE
     ```powershell
     # The script module:

--- a/src/functions/It.ps1
+++ b/src/functions/It.ps1
@@ -46,6 +46,10 @@ the test to appear differently for each test case, you can embed tokens into the
 parameter with the syntax 'Adds numbers <A> and <B>' (assuming you have keys named A and B
 in your TestCases hashtables.)
 
+.PARAMETER Tag
+Optional parameter containing an array of strings. When calling Invoke-Pester,
+it is possible to include or exclude tests containing the same Tag.
+
 .EXAMPLE
 ```powershell
 function Add-Numbers($a, $b) {

--- a/src/functions/It.ps1
+++ b/src/functions/It.ps1
@@ -103,13 +103,16 @@ Describe "Add-Numbers" {
 ```
 
 .LINK
-https://github.com/pester/Pester/wiki/It
+https://pester.dev/docs/commands/It
 
 .LINK
-Describe
-Context
-Set-TestInconclusive
-about_should
+https://pester.dev/docs/commands/Describe
+
+.LINK
+https://pester.dev/docs/commands/Context
+
+.LINK
+https://pester.dev/docs/commands/Set-ItResult
 #>
     [CmdletBinding(DefaultParameterSetName = 'Normal')]
     param(

--- a/src/functions/New-Fixture.ps1
+++ b/src/functions/New-Fixture.ps1
@@ -69,9 +69,7 @@ function New-Fixture {
 
     .LINK
     https://pester.dev/docs/commands/Should
-
     #>
-
     param (
         [Parameter(Mandatory = $true)]
         [String]$Name,

--- a/src/functions/Pester.SessionState.Mock.ps1
+++ b/src/functions/Pester.SessionState.Mock.ps1
@@ -49,7 +49,6 @@ function Get-MockPlugin () {
 }
 
 function Mock {
-
     <#
 .SYNOPSIS
 Mocks the behavior of an existing command with an alternate
@@ -112,6 +111,14 @@ Optional string specifying the name of the module where this command
 is to be mocked.  This should be a module that _calls_ the mocked
 command; it doesn't necessarily have to be the same module which
 originally implemented the command.
+
+.PARAMETER RemoveParameterType
+Optional list of parameter names in the original command
+that should not keep the same type-requirement in the mock.
+
+.PARAMETER RemoveParameterValidation
+Optional list of parameter names in the original command
+that should not have the same valdiation rules in the mock.
 
 .EXAMPLE
 Mock Get-ChildItem { return @{FullName = "A_File.TXT"} }

--- a/src/functions/Pester.SessionState.Mock.ps1
+++ b/src/functions/Pester.SessionState.Mock.ps1
@@ -208,14 +208,12 @@ Describe "ModuleMockExample" {
 This example shows how calls to commands made from inside a module can be
 mocked by using the -ModuleName parameter.
 
+.LINK
+https://pester.dev/docs/commands/Mock
 
 .LINK
-Should
-Describe
-Context
-It
-about_Should
-about_Mocking
+https://pester.dev/docs/usage/mocking
+
 #>
     # Mock
     [CmdletBinding()]

--- a/src/functions/Pester.SessionState.Mock.ps1
+++ b/src/functions/Pester.SessionState.Mock.ps1
@@ -113,12 +113,16 @@ command; it doesn't necessarily have to be the same module which
 originally implemented the command.
 
 .PARAMETER RemoveParameterType
-Optional list of parameter names in the original command
-that should not keep the same type-requirement in the mock.
+Optional list of parameter names that should use Object as the parameter
+type instead of the parameter type defined by the function. This relaxes the
+type requirements and allows some strongly typed functions to be mocked
+more easily.
 
 .PARAMETER RemoveParameterValidation
 Optional list of parameter names in the original command
-that should not have the same valdiation rules in the mock.
+that should not have any validation rules applied. This relaxes the 
+validation requirements, and allows functions that are strict about their
+parameter validation to be mocked more easily.
 
 .EXAMPLE
 Mock Get-ChildItem { return @{FullName = "A_File.TXT"} }
@@ -1111,7 +1115,6 @@ function Assert-RunInProgress {
         throw "$CommandName can run only during Run, but not during Discovery."
     }
 }
-
 
 
 

--- a/src/functions/SetupTeardown.ps1
+++ b/src/functions/SetupTeardown.ps1
@@ -5,14 +5,47 @@ function BeforeEach {
         the current Context or Describe block.
 
     .DESCRIPTION
-        BeforeEach, AfterEach, BeforeAll, and AfterAll are unique in that they apply
-        to the entire Context or Describe block, regardless of the order of the
-        statements in the Context or Describe.  For a full description of this
-        behavior, as well as how multiple BeforeEach or AfterEach blocks interact
-        with each other, please refer to the about_BeforeEach_AfterEach help file.
+        BeforeEach runs once before every test in the current or any child blocks.
+        Typically this is used to create all the prerequisites for the current test,
+        such as writing content to a file.
+
+        BeforeEach and AfterEach are unique in that they apply to the entire Context
+        or Describe block, regardless of the order of the statements in the
+        Context or Describe.
+
+    .PARAMETER ScriptBlock
+        A scriptblock with steps to be executed during setup.
+
+    .EXAMPLE
+        ```powershell
+        Describe "File parsing" {
+            BeforeEach {
+                # randomized path, to get fresh file for each test
+                $file = "$([IO.Path]::GetTempPath())/$([Guid]::NewGuid())_form.xml"
+                Copy-Item -Source $template -Destination $file -Force | Out-Null
+            }
+
+            It "Writes username" {
+                Write-XmlForm -Path $file -Field "username" -Value "nohwnd"
+                $content = Get-Content $file
+                # ...
+            }
+
+            It "Writes name" {
+                Write-XmlForm -Path $file -Field "name" -Value "Jakub"
+                $content = Get-Content $file
+                # ...
+            }
+        }
+        ```
+
+        The example uses BeforeEach to ensure a clean sample-file is used for each test.
 
     .LINK
-        https://github.com/pester/Pester/wiki/BeforeEach-and-AfterEach
+        https://pester.dev/docs/commands/BeforeEach
+
+    .LINK
+        https://pester.dev/docs/usage/setup-and-teardown
 
     .LINK
         about_BeforeEach_AfterEach
@@ -38,14 +71,50 @@ function AfterEach {
         the current Context or Describe block.
 
     .DESCRIPTION
-        BeforeEach, AfterEach, BeforeAll, and AfterAll are unique in that they apply
-        to the entire Context or Describe block, regardless of the order of the
-        statements in the Context or Describe.  For a full description of this
-        behavior, as well as how multiple BeforeEach or AfterEach blocks interact
-        with each other, please refer to the about_BeforeEach_AfterEach help file.
+        AfterEach runs once after every test in the current or any child blocks.
+        Typically this is used to clean up resources created by the test or its setups.
+        AfterEach runs in a finally block, and is guaranteed to run even if the test
+        (or setup) fails.
+
+        BeforeEach and AfterEach are unique in that they apply to the entire Context
+        or Describe block, regardless of the order of the statements in the
+        Context or Describe.
+
+    .PARAMETER ScriptBlock
+        A scriptblock with steps to be executed during teardown.
+
+    .EXAMPLE
+        ```powershell
+        Describe "Testing export formats" {
+            BeforeAll {
+                $filePath = "$([IO.Path]::GetTempPath())/$([Guid]::NewGuid())"
+            }
+            It "Test Export-CSV" {
+                Get-ChildItem | Export-CSV -Path $filePath -NoTypeInformation
+                $dir = Import-CSV -Path $filePath
+                # ...
+            }
+            It "Test Export-Clixml" {
+                Get-ChildItem | Export-Clixml -Path $filePath
+                $dir = Import-Clixml -Path $filePath
+                # ...
+            }
+
+            AfterEach {
+                if (Test-Path $file) {
+                    Remove-Item $file -Force
+                }
+            }
+        }
+        ```
+
+        The example uses AfterEach to remove a temporary file after each test.
 
     .LINK
-        https://github.com/pester/Pester/wiki/BeforeEach-and-AfterEach
+        https://pester.dev/docs/commands/AfterEach
+
+    .LINK
+        https://pester.dev/docs/usage/setup-and-teardown
 
     .LINK
         about_BeforeEach_AfterEach
@@ -67,16 +136,64 @@ function AfterEach {
 function BeforeAll {
     <#
     .SYNOPSIS
-        Defines a series of steps to perform at the beginning of the current Context
-        or Describe block.
+        Defines a series of steps to perform at the beginning of the current container,
+        Context or Describe block.
 
     .DESCRIPTION
-        BeforeEach, AfterEach, BeforeAll, and AfterAll are unique in that they apply
-        to the entire Context or Describe block, regardless of the order of the
-        statements in the Context or Describe.
+        BeforeAll is used to share setup among all the tests in a container, Describe
+        or Context including all child blocks and tests. BeforeAll runs during Run phase
+        and runs only once in the current level.
+
+        The typical usage is to setup the whole test script, most commonly to
+        import the tested function, by dot-sourcing the script file that contains it.
+
+        BeforeAll and AfterAll are unique in that they apply to the entire container,
+        Context or Describe block regardless of the order of the statements compared to
+        other Context or Describe blcoks at the same level.
+
+    .PARAMETER ScriptBlock
+        A scriptblock with steps to be executed during setup.
+
+    .EXAMPLE
+        ```powershell
+        BeforeAll {
+            . $PSCommandPath.Replace('.Tests.ps1','.ps1')
+        }
+
+        Describe "API validation" {
+            # ...
+        }
+        ```
+
+        This example uses dot-sourcing in BeforeAll to make functions in the script-file
+        available for the tests.
+
+    .EXAMPLE
+        ```powershell
+        Describe "API validation" {
+            BeforeAll {
+                # this calls REST API and takes roughly 1 second
+                $response = Get-Pokemon -Name Pikachu
+            }
+
+            It "response has Name = 'Pikachu'" {
+                $response.Name | Should -Be 'Pikachu'
+            }
+
+            It "response has Type = 'electric'" {
+                $response.Type | Should -Be 'electric'
+            }
+        }
+        ```
+
+        This example uses BeforeAll to perform an expensive operation only once, before validating
+        the results in separate tests.
 
     .LINK
-        https://github.com/pester/Pester/wiki/BeforeEach-and-AfterEach
+        https://pester.dev/docs/commands/BeforeAll
+
+    .LINK
+        https://pester.dev/docs/usage/setup-and-teardown
 
     .LINK
         about_BeforeEach_AfterEach
@@ -96,20 +213,59 @@ function BeforeAll {
 
 function AfterAll {
     <#
-.SYNOPSIS
-    Defines a series of steps to perform at the end of the current Context
-    or Describe block.
+    .SYNOPSIS
+        Defines a series of steps to perform at the end of the current container,
+        Context or Describe block.
 
-.DESCRIPTION
-    BeforeEach, AfterEach, BeforeAll, and AfterAll are unique in that they apply
-    to the entire Context or Describe block, regardless of the order of the
-    statements in the Context or Describe.
+    .DESCRIPTION
+        AfterAll is used to share teardown after all the tests in a container, Describe
+        or Context including all child blocks and tests. AfterAll runs during Run phase
+        and runs only once in the current block. It's guaranteed to run even if tests
+        fail.
+
+        The typical usage is to clean up state or temporary used in tests.
+
+        BeforeAll and AfterAll are unique in that they apply to the entire container,
+        Context or Describe block regardless of the order of the statements compared to
+        other Context or Describe blcoks at the same level.
+
+    .PARAMETER ScriptBlock
+        A scriptblock with steps to be executed during teardown.
+
+    .EXAMPLE
+        ```powershell
+        Describe "Validate important file" {
+            BeforeAll {
+                $samplePath = "$([IO.Path]::GetTempPath())/$([Guid]::NewGuid()).txt"
+                Write-Host $samplePath
+                1..100 | Set-Content -Path $samplePath
+            }
+
+            It "File Contains 100 lines" {
+                @(Get-Content $samplePath).Count | Should -Be 100
+            }
+
+            It "First ten lines should be 1 -> 10" {
+                @(Get-Content $samplePath -TotalCount 10) | Should -Be @(1..10)
+            }
+
+            AfterAll {
+                Remove-Item -Path $samplePath
+            }
+        }
+        ```
+
+        This example uses AfterAll to clean up a sample-file generated only for
+        the tests in the Describe-block.
 
     .LINK
-        https://github.com/pester/Pester/wiki/BeforeEach-and-AfterEach
+        https://pester.dev/docs/commands/AfterAll
 
     .LINK
-    about_BeforeEach_AfterEach
+        https://pester.dev/docs/usage/setup-and-teardown
+
+    .LINK
+        about_BeforeEach_AfterEach
 #>
     [CmdletBinding()]
     param

--- a/src/functions/TestResults.ps1
+++ b/src/functions/TestResults.ps1
@@ -47,6 +47,39 @@ function Export-PesterResults {
 }
 
 function Export-NUnitReport {
+    <#
+    .SYNOPSIS
+    Exports a Pester result-object to an NUnit-compatible XML-report
+
+    .DESCRIPTION
+    Pester can generate a result-object containing information about all
+    tests that are processed in a run. This object can then be exported to an
+    NUnit-compatible XML-report using this function. The report is generated
+    using the NUnit 2.5-schema.
+
+    This can be useful for further processing or publishing of test results,
+    e.g. as part of a CI/CD pipeline.
+
+    .PARAMETER Result
+    Result object from a Pester-run. This can be retrieved using Invoke-Pester
+    -Passthru or by using the Run.PassThru configuration-option.
+
+    .PARAMETER Path
+    The path where the XML-report should  to the ou the XML report as string.
+
+    .EXAMPLE
+    $p = Invoke-Pester -Passthru
+    $p | Export-NUnitReport -Path TestResults.xml
+
+    This example runs Pester using the Passthru option to retrieve the result-object and
+    exports it as an NUnit 2.5-compatible XML-report.
+
+    .LINK
+    https://pester.dev/docs/commands/Export-NUnitReport
+
+    .LINK
+    https://pester.dev/docs/commands/Invoke-Pester
+    #>
     param (
         [parameter(Mandatory = $true, ValueFromPipeline = $true)]
         $Result,
@@ -59,6 +92,39 @@ function Export-NUnitReport {
 }
 
 function Export-JUnitReport {
+    <#
+    .SYNOPSIS
+    Exports a Pester result-object to an JUnit-compatible XML-report
+
+    .DESCRIPTION
+    Pester can generate a result-object containing information about all
+    tests that are processed in a run. This object can then be exported to an
+    JUnit-compatible XML-report using this function. The report is generated
+    using the JUnit 4-schema.
+
+    This can be useful for further processing or publishing of test results,
+    e.g. as part of a CI/CD pipeline.
+
+    .PARAMETER Result
+    Result object from a Pester-run. This can be retrieved using Invoke-Pester
+    -Passthru or by using the Run.PassThru configuration-option.
+
+    .PARAMETER Path
+    The path where the XML-report should  to the ou the XML report as string.
+
+    .EXAMPLE
+    $p = Invoke-Pester -Passthru
+    $p | Export-JUnitReport -Path TestResults.xml
+
+    This example runs Pester using the Passthru option to retrieve the result-object and
+    exports it as an JUnit 4-compatible XML-report.
+
+    .LINK
+    https://pester.dev/docs/commands/Export-JUnitReport
+
+    .LINK
+    https://pester.dev/docs/commands/Invoke-Pester
+    #>
     param (
         [parameter(Mandatory = $true, ValueFromPipeline = $true)]
         $Result,
@@ -132,6 +198,47 @@ function Export-XmlReport {
 }
 
 function ConvertTo-NUnitReport {
+    <#
+    .SYNOPSIS
+    Converts a Pester result-object to an NUnit 2.5-compatible XML-report
+
+    .DESCRIPTION
+    Pester can generate a result-object containing information about all
+    tests that are processed in a run. This objects can then be converted to an
+    NUnit-compatible XML-report using this function. The report is generated
+    using the NUnit 2.5-schema.
+
+    The function can convert to both XML-object or a string containing the XML.
+    This can be useful for further processing or publishing of test results,
+    e.g. as part of a CI/CD pipeline.
+
+    .PARAMETER Result
+    Result object from a Pester-run. This can be retrieved using Invoke-Pester
+    -Passthru or by using the Run.PassThru configuration-option.
+
+    .PARAMETER AsString
+    Returns the XML-report as a string.
+
+    .EXAMPLE
+    $p = Invoke-Pester -Passthru
+    $p | ConvertTo-NUnitReport
+
+    This example runs Pester using the Passthru option to retrieve the result-object and
+    converts it to an NUnit 2.5-compatible XML-report. The report is returned as an XML-object.
+
+    .EXAMPLE
+    $p = Invoke-Pester -Passthru
+    $p | ConvertTo-NUnitReport -AsString
+
+    This example runs Pester using the Passthru option to retrieve the result-object and
+    converts it to an NUnit 2.5-compatible XML-report. The returned object is a string.
+
+    .LINK
+    https://pester.dev/docs/commands/ConvertTo-NUnitReport
+
+    .LINK
+    https://pester.dev/docs/commands/Invoke-Pester
+    #>
     param (
         [parameter(Mandatory = $true, ValueFromPipeline = $true)]
         $Result,
@@ -332,6 +439,47 @@ function Write-JUnitReport($Result, [System.Xml.XmlWriter] $XmlWriter) {
 }
 
 function ConvertTo-JUnitReport {
+    <#
+    .SYNOPSIS
+    Converts a Pester result-object to an JUnit-compatible XML report
+
+    .DESCRIPTION
+    Pester can generate a result-object containing information about all
+    tests that are processed in a run. This objects can then be converted to an
+    NUnit-compatible XML-report using this function. The report is generated
+    using the JUnit 4-schema.
+
+    The function can convert to both XML-object or a string containing the XML.
+    This can be useful for further processing or publishing of test results,
+    e.g. as part of a CI/CD pipeline.
+
+    .PARAMETER Result
+    Result object from a Pester-run. This can be retrieved using Invoke-Pester
+    -Passthru or by using the Run.PassThru configuration-option.
+
+    .PARAMETER AsString
+    Returns the XML-report as a string.
+
+    .EXAMPLE
+    $p = Invoke-Pester -Passthru
+    $p | ConvertTo-JUnitReport
+
+    This example runs Pester using the Passthru option to retrieve the result-object and
+    converts it to an JUnit 4-compatible XML-report. The report is returned as an XML-object.
+
+    .EXAMPLE
+    $p = Invoke-Pester -Passthru
+    $p | ConvertTo-JUnitReport -AsString
+
+    This example runs Pester using the Passthru option to retrieve the result-object and
+    converts it to an JUnit 4-compatible XML-report. The returned object is a string.
+
+    .LINK
+    https://pester.dev/docs/commands/ConvertTo-JUnitReport
+
+    .LINK
+    https://pester.dev/docs/commands/Invoke-Pester
+    #>
     param (
         [parameter(Mandatory = $true, ValueFromPipeline = $true)]
         $Result,

--- a/src/functions/assertions/Should.ps1
+++ b/src/functions/assertions/Should.ps1
@@ -1,4 +1,4 @@
-function Get-FailureMessage($assertionEntry, $negate, $value, $expected) {
+﻿function Get-FailureMessage($assertionEntry, $negate, $value, $expected) {
     if ($negate) {
         $failureMessageFunction = $assertionEntry.GetNegativeFailureMessage
     }
@@ -36,6 +36,9 @@ function Should {
     .PARAMETER ActualValue
     The actual value that was obtained in the test which should be verified against
     a expected value.
+
+    .LINK
+    https://pester.dev/docs/commands/Should
 
     .LINK
     https://pester.dev/docs/usage/assertions

--- a/src/functions/assertions/Should.ps1
+++ b/src/functions/assertions/Should.ps1
@@ -1,4 +1,4 @@
-﻿function Get-FailureMessage($assertionEntry, $negate, $value, $expected) {
+function Get-FailureMessage($assertionEntry, $negate, $value, $expected) {
     if ($negate) {
         $failureMessageFunction = $assertionEntry.GetNegativeFailureMessage
     }
@@ -32,6 +32,10 @@ function Should {
     Should can be used more than once in the It block if more than one assertion
     need to be verified. Each Should keyword needs to be on a separate line.
     Test will be passed only when all assertion will be met (logical conjuction).
+
+    .PARAMETER ActualValue
+    The actual value that was obtained in the test which should be verified against
+    a expected value.
 
     .LINK
     https://pester.dev/docs/usage/assertions

--- a/tst/Help.Tests.ps1
+++ b/tst/Help.Tests.ps1
@@ -1,0 +1,29 @@
+Set-StrictMode -Version Latest
+
+BeforeDiscovery {
+    $moduleName = "Pester"
+    $exportedFunctions = Get-Command -CommandType Cmdlet, Function -Module $moduleName
+}
+
+Describe "Testing module help for exported commands" -ForEach @{ exportedFunctions = $exportedFunctions; moduleName = $moduleName } {
+
+    Context "<_.CommandType> <_.Name>" -Foreach $exportedFunctions {
+
+        BeforeAll {
+            $help = Get-Help -Name $_.Name
+        }
+
+        It "Help exists" {
+            $help.Name | Should -Be $_.Name
+            $help.Category | Should -Be $_.CommandType
+            $help.ModuleName | Should -Be $moduleName
+        }
+
+        It "Synopsis is defined" {
+            $help.Synopsis | Should -Not -BeNullOrEmpty
+            # Missing synopsis causes syntax to be shown, so exclude syntax-pattern
+            $help.Synopsis | Should -Not -Match "^\s*$($_.Name)((\s+\[?-\w+)|$)"
+        }
+
+    }
+}

--- a/tst/Help.Tests.ps1
+++ b/tst/Help.Tests.ps1
@@ -6,14 +6,12 @@ BeforeDiscovery {
 }
 
 Describe "Testing module help for exported commands" -ForEach @{ exportedFunctions = $exportedFunctions; moduleName = $moduleName } {
-
     Context "<_.CommandType> <_.Name>" -Foreach $exportedFunctions {
-
         BeforeAll {
             $help = Get-Help -Name $_.Name
         }
 
-        It "Help exists" {
+        It "Help is found" -Skip {
             $help.Name | Should -Be $_.Name
             $help.Category | Should -Be $_.CommandType
             $help.ModuleName | Should -Be $moduleName
@@ -21,9 +19,13 @@ Describe "Testing module help for exported commands" -ForEach @{ exportedFunctio
 
         It "Synopsis is defined" {
             $help.Synopsis | Should -Not -BeNullOrEmpty
-            # Missing synopsis causes syntax to be shown, so exclude syntax-pattern
+            # Missing synopsis causes syntax to be shown. Verify it doesn't happen
             $help.Synopsis | Should -Not -Match "^\s*$($_.Name)((\s+\[?-\w+)|$)"
         }
 
+        # Skipped until Assert-MockCalled and Assert-VerifiableMock are removed
+        It "Has at least one example" -Skip {
+             $help.Examples | Should -Not -BeNullOrEmpty
+        }
     }
 }

--- a/tst/Help.Tests.ps1
+++ b/tst/Help.Tests.ps1
@@ -5,13 +5,13 @@ BeforeDiscovery {
     $exportedFunctions = Get-Command -CommandType Cmdlet, Function -Module $moduleName
 }
 
-Describe "Testing module help for exported commands" -ForEach @{ exportedFunctions = $exportedFunctions; moduleName = $moduleName } {
+Describe "Testing module help" -ForEach @{ exportedFunctions = $exportedFunctions; moduleName = $moduleName } {
     Context "<_.CommandType> <_.Name>" -Foreach $exportedFunctions {
         BeforeAll {
             $help = Get-Help -Name $_.Name
         }
 
-        It "Help is found" -Skip {
+        It "Help is found" {
             $help.Name | Should -Be $_.Name
             $help.Category | Should -Be $_.CommandType
             $help.ModuleName | Should -Be $moduleName
@@ -26,6 +26,19 @@ Describe "Testing module help for exported commands" -ForEach @{ exportedFunctio
         # Skipped until Assert-MockCalled and Assert-VerifiableMock are removed
         It "Has at least one example" -Skip {
              $help.Examples | Should -Not -BeNullOrEmpty
+        }
+
+        # Skipped until Assert-MockCalled are removed
+        It "All static parameters have description" -Skip {
+            if ($help.parameters) {
+                $parametersMissingHelp = @($help.parameters | ForEach-Object Parameter |
+                Where-Object { $_.psobject.properties.name -notcontains 'description' } |
+                ForEach-Object name)
+
+                $parametersMissingHelp | Should -Be @()
+            } else {
+                Set-ItResult -Skipped -Because "no static parameters to test"
+            }
         }
     }
 }


### PR DESCRIPTION
## PR Summary
This PR adds and updates help for exported functions.

- Add missing help:
  - [x] ConvertTo-JUnitReport
  - [x] ConvertTo-NUnitReport
  - [x] ConvertTo-Pester4Result
  - [x] Export-JUnitReport
  - [x] Export-NUnitReport
  - [x] New-PesterContainer
- Update help for:
  - [x] BeforeEach
  - [x] AfterEach
  - [x] BeforeAll
  - [x] AfterAll
- Add missing parameter help for:
  - [x] InModuleScope: Parameters and ArgumentList
  - [x] Invoke-Pester: Container (and Run.Container)
  - [x] It: Tag
  - [x] Mock: RemoveParameterType and RemoveParameterValidation
  - [x] Should: ActualValue
- [x] Updated wiki-links and command-ref to pester.dev in exported functions
- [x] Replaced .LINK sections with multiple values with multiple .LINK values. Should be one section per reference
- Add tests for detecting missing help elements
  - [x] Synopsis
  - [x] Example (currently skipped)
  - [x] Parameters (currently skipped)

Fix #1783 
Related #1634

## PR Checklist

- [x] PR has meaningful title
- [x] Summary describes changes
- [x] PR is ready to be merged
  - If not, use the arrow next to `Create Pull Request` to mark it as a draft. PR can be marked `Ready for review` when it's ready.
- [x] Tests are added/update *(if required)*
- [x] Documentation is updated/added *(if required)*
