### PR TITLE
Fix interactive execution of parameterized tests

### DIFF
--- a/src/Pester.Runtime.psm1
+++ b/src/Pester.Runtime.psm1
@@ -1046,7 +1046,7 @@ function Run-Test {
                 }
 
                 foreach($private:____d in $____parameters.Data.GetEnumerator()) {
-                    & $____parameters.Set_Variable -Name $private:____d.Name -Value $private:____d.Value
+                    & $____parameters.Set_Variable -Name $private:____d.Key -Value $private:____d.Value
                 }
             }
 

--- a/src/functions/Describe.ps1
+++ b/src/functions/Describe.ps1
@@ -153,12 +153,16 @@ function Invoke-Interactively ($CommandUsed, $ScriptName, $SessionState, $BoundP
         # but make sure we are invoking it in the caller session state, because
         # paths don't stay attached to session state
         $invokePester =  {
-            param($private:Path, $private:Out_Null)
-            Invoke-Pester -Path $Path | & $Out_Null
+            param($private:Path, $private:ScriptParameters, $private:Out_Null)
+            $private:c = New-PesterContainer -Path $Path -Data $ScriptParameters
+            Invoke-Pester -Container $c Path | & $Out_Null
         }
 
+        # get PSBoundParameters from script to allow interactive execution of parameterized tests.
+        $scriptBoundParameters = $PSCmdlet.SessionState.PSVariable.GetValue("PSBoundParameters")
+
         Set-ScriptBlockScope -SessionState $SessionState -ScriptBlock $invokePester
-        & $invokePester $ScriptName $SafeCommands['Out-Null']
+        & $invokePester $ScriptName $scriptBoundParameters $SafeCommands['Out-Null']
         $script:lastExecutedFile = $ScriptName
         $script:lastExecutedAt = [datetime]::Now
     }

--- a/src/functions/Describe.ps1
+++ b/src/functions/Describe.ps1
@@ -158,8 +158,8 @@ function Invoke-Interactively ($CommandUsed, $ScriptName, $SessionState, $BoundP
             Invoke-Pester -Container $c Path | & $Out_Null
         }
 
-        # get PSBoundParameters from script to allow interactive execution of parameterized tests.
-        $scriptBoundParameters = $PSCmdlet.SessionState.PSVariable.GetValue("PSBoundParameters")
+        # get PSBoundParameters from caller script to allow interactive execution of parameterized tests.
+        $scriptBoundParameters = $SessionState.PSVariable.GetValue("PSBoundParameters")
 
         Set-ScriptBlockScope -SessionState $SessionState -ScriptBlock $invokePester
         & $invokePester $ScriptName $scriptBoundParameters $SafeCommands['Out-Null']


### PR DESCRIPTION
## PR Summary
Pester 5.1 re-introduces parameterized testfiles using ContainerInfo-objects created with `New-PesterContainer`. This PR extends this effort by allowing parameterized testfiles to be called using interactive execution, ex.
`& ./SampleProject/CodingStyle.Tests.ps1 -File "build.ps1"`

Fix #1784

## PR Checklist

- [x] PR has meaningful title
- [x] Summary describes changes
- [x] PR is ready to be merged
  - If not, use the arrow next to `Create Pull Request` to mark it as a draft. PR can be marked `Ready for review` when it's ready.
- [x] Tests are added/update *(if required)*
- [ ] Documentation is updated/added *(if required)*