### PR TITLE
Fix broken Version-property in Pester4Result object

### DIFF
--- a/src/Pester.ps1
+++ b/src/Pester.ps1
@@ -1359,7 +1359,7 @@ function ConvertTo-Pester4Result {
     )
     process {
         $legacyResult = [PSCustomObject] @{
-            Version = 4.99.0
+            Version = "4.99.0"
             TagFilter = $null
             ExcludeTagFilter = $null
             TestNameFilter = $null

--- a/tst/Pester.RSpec.ts.ps1
+++ b/tst/Pester.RSpec.ts.ps1
@@ -1447,7 +1447,24 @@ i -PassThru:$PassThru {
             }
 
             $result = Invoke-Pester -Container $container -PassThru
-            $result.TotalCount | Should -Be 1
+            $result.TotalCount | Verify-Equal 1
+        }
+    }
+
+    b "Converting Pester 5 to Pester4 result" {
+        t "It uses version 4.99.0" {
+            # https://github.com/pester/Pester/issues/1786
+            # .0 because I want some spare numbers if needed in the future
+            $container = New-PesterContainer -ScriptBlock {
+                Describe "d" {
+                    It "t" {
+                        1 | Should -Be 1
+                    }
+                }
+            }
+
+            $result = Invoke-Pester -Container $container -PassThru | ConvertTo-Pester4Result
+            $result.Version | Verify-Equal "4.99.0"
         }
     }
 }


### PR DESCRIPTION
## PR Summary
The Pester 4-compliant result-object returned from `ConvertTo-Pester4Result` includes a blank version-property and not `4.99.0` as expected. PR sets the value as string-type, just like the version-property in Pester5 result-object

Fix #1786

## PR Checklist

- [x] PR has meaningful title
- [x] Summary describes changes
- [x] PR is ready to be merged
  - If not, use the arrow next to `Create Pull Request` to mark it as a draft. PR can be marked `Ready for review` when it's ready.
- [ ] Tests are added/update *(if required)*
- [ ] Documentation is updated/added *(if required)*

