### PR TITLE
Fix help for Invoke-Pester

### DIFF
--- a/src/Pester.ps1
+++ b/src/Pester.ps1
@@ -592,8 +592,9 @@ function Invoke-Pester {
     .LINK
     about_Pester
     #>
+
     # Currently doesn't work. $IgnoreUnsafeCommands filter used in rule as workaround
-    # [Diagnostics.CodeAnalysis.SuppressMessageAttribute('Pester.BuildAnalyzerRules\Measure-SafeComands', 'Remove-Variable', Justification = 'Remove-Variable can't remove "optimized variables" when using "alias" for Remove-Variable.')]
+    # [Diagnostics.CodeAnalysis.SuppressMessageAttribute('Pester.BuildAnalyzerRules\Measure-SafeCommands', 'Remove-Variable', Justification = 'Remove-Variable can't remove "optimized variables" when using "alias" for Remove-Variable.')]
     [CmdletBinding(DefaultParameterSetName = 'Simple')]
     param(
         [Parameter(Position = 0, Mandatory = 0, ParameterSetName = "Simple")]

--- a/src/Pester.ps1
+++ b/src/Pester.ps1
@@ -565,17 +565,27 @@ function Invoke-Pester {
     .EXAMPLE
     ```powershell
     $config = [PesterConfiguration]@{
-    Should = @{ <- # Should configuration.
-        ErrorAction = 'Stop' # <- "Controls if Should throws on error."
+        Should = @{ # <- Should configuration.
+            ErrorAction = 'Continue' # <- Always run all Should-assertions in a test
         }
     }
 
     Invoke-Pester -Configuration $config
     ```
 
+    This example runs all *.Tests.ps1 files in the current directory and its subdirectories.
+    It shows how advanced configuration can be used by casting a hashtable to override
+    default settings, in this case to make Pester run all Should-assertions in a test
+    even if the first fails.
+
     .EXAMPLE
     $config = [PesterConfiguration]::Default
+    $config.TestResults.Enabled = $true
     Invoke-Pester -Configuration $config
+
+    This example runs all *.Tests.ps1 files in the current directory and its subdirectories.
+    It uses advanced configuration to enable testresult-output to file. Access $config.TestResults
+    to see other testresult options like  output path and format and their default values.
 
     .LINK
     https://pester.dev/docs/quick-start

--- a/src/Pester.psd1
+++ b/src/Pester.psd1
@@ -4,7 +4,7 @@
     RootModule        = 'Pester.psm1'
 
     # Version number of this module.
-    ModuleVersion     = '5.1.0'
+    ModuleVersion     = '5.2.0'
 
     # ID used to uniquely identify this module
     GUID              = 'a699dea5-2c73-4616-a270-1f7abb777e71'
@@ -111,10 +111,10 @@
             LicenseUri   = "https://www.apache.org/licenses/LICENSE-2.0.html"
 
             # Release notes for this particular version of the module
-            ReleaseNotes = 'https://github.com/pester/Pester/releases/tag/5.1.0'
+            ReleaseNotes = 'https://github.com/pester/Pester/releases/tag/5.2.0-beta1'
 
             # Prerelease string of this module
-            Prerelease   = ''
+            Prerelease   = 'beta1'
         }
     }
 


### PR DESCRIPTION
## PR Summary
Fixes RELATED LINKS in `Invoke-Pester` help. 
Commented placeholder for ScriptAnalyzer suppression-rule got too close to the comment-based help which resulted in this issue:

```
RELATED LINKS
    https://pester.dev/docs/quick-start
    https://pester.dev/docs/commands/Invoke-Pester
    https://pswiki.net/invoke-pester-pester/
    https://pester.dev/docs/commands/Describe
    about_Pester
    
    Currently doesn't work. $IgnoreUnsafeCommands filter used in rule as workaround
    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('Pester.BuildAnalyzerRules\Measure-SafeComands', 'Remove-Variable', Justification = 'Remove-Variable can't remove "optimized variables" when using "alias" for Remove-Variable.')] 
```

Also updates examples with missing description.

## PR Checklist

- [x] PR has meaningful title
- [x] Summary describes changes
- [x] PR is ready to be merged
  - If not, use the arrow next to `Create Pull Request` to mark it as a draft. PR can be marked `Ready for review` when it's ready.
- [ ] Tests are added/update *(if required)*
- [ ] Documentation is updated/added *(if required)*

