### PR TITLE
Suppress scriptanalyzer warns buildscripts, update tests.ps1

### DIFF
--- a/Pester.BuildAnalyzerRules/Pester.BuildAnalyzerRules.psm1
+++ b/Pester.BuildAnalyzerRules/Pester.BuildAnalyzerRules.psm1
@@ -2,16 +2,16 @@
 $SafeCommands = & { . "$PSScriptRoot/../src/functions/Pester.SafeCommands.ps1"; $Script:SafeCommands }
 # Workaround as RuleSuppressionID-based suppression is bugged. returns error.
 # Should be replaced with the following line when PSScriptAnalyzer is fixed. See Invoke-Pester
-# [Diagnostics.CodeAnalysis.SuppressMessageAttribute('Pester.BuildAnalyzerRules\Measure-SafeComands', 'Remove-Variable')]
+# [Diagnostics.CodeAnalysis.SuppressMessageAttribute('Pester.BuildAnalyzerRules\Measure-SafeCommands', 'Remove-Variable')]
 $IgnoreUnsafeCommands = @('Remove-Variable')
-function Measure-SafeComands {
+function Measure-SafeCommands {
     <#
     .SYNOPSIS
     Should use $SafeCommand-variant of external function when available.
     .DESCRIPTION
-    Pester module defines a $SafeCommands dictionary for external commands to avoid hijacking. To fix a violation of this rule, update the call to use SafeCoomands variant, ex. `& $SafeCommands['CommandName'] -Param1 Value1`.
+    Pester module defines a $SafeCommands dictionary for external commands to avoid hijacking. To fix a violation of this rule, update the call to use SafeCommands variant, ex. `& $SafeCommands['CommandName'] -Param1 Value1`.
     .EXAMPLE
-    Measure-SafeComands -CommandAst $CommandAst
+    Measure-SafeCommands -CommandAst $CommandAst
     .INPUTS
     [System.Management.Automation.Language.CommandAst]
     .OUTPUTS
@@ -19,6 +19,9 @@ function Measure-SafeComands {
     .NOTES
     None
     #>
+    # TODO This warning is currently thrown for SafeCommand
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseOutputTypeCorrectly", "")]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("Pester.BuildAnalyzerRules\Measure-SafeCommands", "")]
     [CmdletBinding()]
     [OutputType([Microsoft.Windows.PowerShell.ScriptAnalyzer.Generic.DiagnosticRecord[]])]
     Param

--- a/build.ps1
+++ b/build.ps1
@@ -15,7 +15,7 @@
     .PARAMETER Clean
         Cleans the build folder ./bin and rebuilds the assemblies.
 #>
-
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute("Pester.BuildAnalyzerRules\Measure-SafeCommands", "")]
 param (
     [switch] $Debug,
     [switch] $Load,

--- a/publish/buildNugetPackage.ps1
+++ b/publish/buildNugetPackage.ps1
@@ -1,3 +1,5 @@
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute("Pester.BuildAnalyzerRules\Measure-SafeCommands", "")]
+param()
 $VerbosePreference = 'Continue'
 $ErrorActionPreference = 'Stop'
 

--- a/publish/chocolateyInstall.ps1
+++ b/publish/chocolateyInstall.ps1
@@ -1,3 +1,5 @@
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute("Pester.BuildAnalyzerRules\Measure-SafeCommands", "")]
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSAvoidOverwritingBuiltInCmdlets", "Get-FileHash")]
 [CmdletBinding()]
 param ( )
 

--- a/publish/cleanUpBeforeBuild.ps1
+++ b/publish/cleanUpBeforeBuild.ps1
@@ -6,7 +6,8 @@
 # this clean up is not removing all unneeded files,
 # it only removes the main parts
 # each package then decides what will be part of it
-
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute("Pester.BuildAnalyzerRules\Measure-SafeCommands", "")]
+param()
 $buildDir = "$PSScriptRoot\build"
 $ErrorActionPreference = 'Stop'
 

--- a/publish/getNugetExe.ps1
+++ b/publish/getNugetExe.ps1
@@ -1,3 +1,9 @@
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute("Pester.BuildAnalyzerRules\Measure-SafeCommands", "")]
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSAvoidUsingWriteHost", "")]
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSAvoidUsingCmdletAliases", "")]
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSAvoidUsingPositionalParameters", "")]
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSAvoidOverwritingBuiltInCmdlets", "")]
+param()
 $VerbosePreference = 'Continue'
 $ErrorActionPreference = 'Stop'
 

--- a/publish/publishPSGalleryPackage.ps1
+++ b/publish/publishPSGalleryPackage.ps1
@@ -1,3 +1,7 @@
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute("Pester.BuildAnalyzerRules\Measure-SafeCommands", "")]
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSAvoidOverwritingBuiltInCmdlets", "Get-FileHash")]
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSAvoidUsingWriteHost", "")]
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSReviewUnusedParameter", "")]
 param (
     [Parameter(Mandatory)]
     [string] $ApiKey,

--- a/publish/release.ps1
+++ b/publish/release.ps1
@@ -1,4 +1,7 @@
 # build should provide '%system.teamcity.build.checkoutDir%'
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute("Pester.BuildAnalyzerRules\Measure-SafeCommands", "")]
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSAvoidOverwritingBuiltInCmdlets", "Get-FileHash")]
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSAvoidUsingWriteHost", "")]
 param (
     [Parameter(Mandatory)]
     [String] $PsGalleryApiKey,

--- a/publish/signModule.ps1
+++ b/publish/signModule.ps1
@@ -1,3 +1,6 @@
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute("Pester.BuildAnalyzerRules\Measure-SafeCommands", "")]
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSAvoidOverwritingBuiltInCmdlets", "Get-FileHash")]
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSAvoidUsingWriteHost", "")]
 param($Thumbprint, $Path)
 $ErrorActionPreference = 'Stop'
 

--- a/publish/testRelease.ps1
+++ b/publish/testRelease.ps1
@@ -1,3 +1,5 @@
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute("Pester.BuildAnalyzerRules\Measure-SafeCommands", "")]
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSAvoidOverwritingBuiltInCmdlets", "Get-FileHash")]
 param(
     [switch] $LocalBuild
 )

--- a/src/Pester.ps1
+++ b/src/Pester.ps1
@@ -575,7 +575,7 @@ function Invoke-Pester {
     about_Pester
     #>
     # Currently doesn't work. $IgnoreUnsafeCommands filter used in rule as workaround
-    # [Diagnostics.CodeAnalysis.SuppressMessageAttribute('Pester.BuildAnalyzerRules\Measure-SafeComands', 'Remove-Variable', Justification = 'Remove-Variable can't remove "optimized variables" when using "alias" for Remove-Variable.')]
+    # [Diagnostics.CodeAnalysis.SuppressMessageAttribute('Pester.BuildAnalyzerRules\Measure-SafeCommands', 'Remove-Variable', Justification = 'Remove-Variable can't remove "optimized variables" when using "alias" for Remove-Variable.')]
     [CmdletBinding(DefaultParameterSetName = 'Simple')]
     param(
         [Parameter(Position = 0, Mandatory = 0, ParameterSetName = "Simple")]

--- a/src/functions/New-Fixture.ps1
+++ b/src/functions/New-Fixture.ps1
@@ -107,7 +107,7 @@ Describe "#name#" {
 }
 
 function Create-File {
-    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('Pester.BuildAnalyzerRules\Measure-SafeComands', 'Write-Warning', Justification = 'Mocked in unit test for New-Fixture.')]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('Pester.BuildAnalyzerRules\Measure-SafeCommands', 'Write-Warning', Justification = 'Mocked in unit test for New-Fixture.')]
     param($Path, $Name, $Content)
     if (-not (& $SafeCommands['Test-Path'] -Path $Path)) {
         & $SafeCommands['New-Item'] -ItemType Directory -Path $Path | & $SafeCommands['Out-Null']

--- a/src/functions/Pester.SafeCommands.ps1
+++ b/src/functions/Pester.SafeCommands.ps1
@@ -12,7 +12,7 @@ $safeCommandLookupParameters = @{
 }
 
 # Suppress from ScriptAnalyzer rule when possible in root of script (future PSSA release?)
-# [Diagnostics.CodeAnalysis.SuppressMessageAttribute('Pester.BuildAnalyzerRules\Measure-SafeComands', 'Get-Command', Justification = 'Used to generate SafeCommands list used for AnalyzerRule.')]
+# [Diagnostics.CodeAnalysis.SuppressMessageAttribute('Pester.BuildAnalyzerRules\Measure-SafeCommands', 'Get-Command', Justification = 'Used to generate SafeCommands list used for AnalyzerRule.')]
 $Get_Command = Get-Command Get-Command -CommandType Cmdlet -ErrorAction 'Stop'
 $script:SafeCommands = @{
     'Get-Command'          = $Get_Command

--- a/test.ps1
+++ b/test.ps1
@@ -32,13 +32,9 @@
 [Diagnostics.CodeAnalysis.SuppressMessageAttribute("Pester.BuildAnalyzerRules\Measure-SafeCommands", "")]
 param (
     # force P to fail when I leave `dt` in the tests
-    [Parameter(Mandatory=$false)]
     [switch] $CI,
-    [Parameter(Mandatory=$false)]
     [switch] $SkipPTests,
-    [Parameter(Mandatory=$false)]
     [switch] $NoBuild,
-    [Parameter(Mandatory=$false)]
     [string[]] $File
 )
 

--- a/test.ps1
+++ b/test.ps1
@@ -26,21 +26,30 @@
     .NOTES
         Tests are excluded with Tags VersionChecks, StyleRules, Help.
 #>
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseDeclaredVarsMoreThanAssignments", "ErrorView")]
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseDeclaredVarsMoreThanAssignments", "PesterPreference")]
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSAvoidUsingWriteHost", "")]
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute("Pester.BuildAnalyzerRules\Measure-SafeCommands", "")]
 param (
     # force P to fail when I leave `dt` in the tests
+    [Parameter(Mandatory=$false)]
     [switch] $CI,
+    [Parameter(Mandatory=$false)]
     [switch] $SkipPTests,
+    [Parameter(Mandatory=$false)]
     [switch] $NoBuild,
+    [Parameter(Mandatory=$false)]
     [string[]] $File
 )
 
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
-# assigning error view explicitly to change it from the default on PowerShell 7
-$ErrorView = "NormalView"
-"Using PS: $($PsVersionTable.PSVersion)"
-"In path: $($pwd.Path)"
 
+# Assign error view explicitly to change it from the default on PowerShell 7
+$ErrorView = "NormalView"
+
+Write-Output "Using PS: $($PsVersionTable.PSVersion)"
+Write-Output "In path: $($pwd.Path)"
 
 if (-not $NoBuild) {
     & "$PSScriptRoot/build.ps1"
@@ -51,7 +60,7 @@ Get-Module Pester | Remove-Module
 
 if (-not $SkipPTests) {
     $result = @(Get-ChildItem $PSScriptRoot/tst/*.ts.ps1 -Recurse |
-        foreach {
+        ForEach-Object {
             $r = & $_.FullName -PassThru
             if ($r.Failed -gt 0) {
                 [PSCustomObject]@{


### PR DESCRIPTION
<!-- Thank you for contributing to Pester! -->

## PR Summary
<!-- Please describe what your pull request fixes, or how it improves Pester.

If your pull request resolves a reported issue, please mention it by using `Fix #<issue_number>` on a new line, this will close the linked issue automatically when this PR is merged. For more info see: [Closing issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/).

If your pull request integrates Pester with another system, please tell us how the change can be tested. -->
This suppresses scriptanalyzer warnings in the scripts used for build, test, and publish of Pester framework.
It also updates some syntax based on recommendations for test.ps1 script.

WIP for #1635

It includes #1800 fix for spelling of SafeCommand.  Since this PR affects build pipeline and publishing framework scripts it should be reviewed by Pester team before merge.

## PR Checklist

- [X] PR has meaningful title
- [X] Summary describes changes
- [X] PR is ready to be merged
  - If not, use the arrow next to `Create Pull Request` to mark it as a draft. PR can be marked `Ready for review` when it's ready.
- [ ] Tests are added/update *(if required)*
- [ ] Documentation is updated/added *(if required)*

<!-- Before you continue, please review [Contributing to Pester](https://pester.dev/docs/contributing/introduction).

Our continuous integration system doesn't send any notifications about failed tests. Please return to the opened pull request (after ~60 minutes) to check if everything is OK. -->
