### PR TITLE
Fix warnings in tst/axiom

### DIFF
--- a/tst/axiom/Verify-AssertionFailed.ps1
+++ b/tst/axiom/Verify-AssertionFailed.ps1
@@ -1,28 +1,30 @@
 function Verify-AssertionFailed {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("Pester.BuildAnalyzerRules\Measure-SafeCommands", "")]
     param (
         [Parameter(Mandatory = $true, ValueFromPipeline = $true)]
         [ScriptBlock]$ScriptBlock
     )
+    PROCESS {
+        $assertionExceptionThrown = $false
+        $err = $null
 
-    $assertionExceptionThrown = $false
-    $err = $null
-
-    try {
-        $null = & $ScriptBlock
-    }
-    catch [Exception] {
-        $assertionExceptionThrown = ($_.FullyQualifiedErrorId -eq 'PesterAssertionFailed')
-        $err = $_
-        $err
-    }
-
-    if (-not $assertionExceptionThrown) {
-        $result = if ($null -eq $err) {
-            "no assertion failure error was thrown!"
+        try {
+            $null = & $ScriptBlock
         }
-        else {
-            "other error was thrown! $($err | Format-List -Force * | Out-String)"
+        catch [Exception] {
+            $assertionExceptionThrown = ($_.FullyQualifiedErrorId -eq 'PesterAssertionFailed')
+            $err = $_
+            $err
         }
-        throw [Exception]"Expected the script block { $ScriptBlock } to fail in Pester assertion, but $result"
+
+        if (-not $assertionExceptionThrown) {
+            $result = if ($null -eq $err) {
+                "no assertion failure error was thrown!"
+            }
+            else {
+                "other error was thrown! $($err | Format-List -Force * | Out-String)"
+            }
+            throw [Exception]"Expected the script block { $ScriptBlock } to fail in Pester assertion, but $result"
+        }
     }
 }

--- a/tst/axiom/Verify-AssertionFailed.ps1
+++ b/tst/axiom/Verify-AssertionFailed.ps1
@@ -4,7 +4,7 @@ function Verify-AssertionFailed {
         [Parameter(Mandatory = $true, ValueFromPipeline = $true)]
         [ScriptBlock]$ScriptBlock
     )
-    PROCESS {
+    END {
         $assertionExceptionThrown = $false
         $err = $null
 

--- a/tst/axiom/Verify-Equal.ps1
+++ b/tst/axiom/Verify-Equal.ps1
@@ -6,7 +6,7 @@
         [Parameter(Mandatory = $true, Position = 0)]
         $Expected
     )
-    PROCESS {
+    END {
         if ($Expected -ne $Actual) {
             $message = "Expected and actual values differ!`n" +
             "Expected: '$Expected'`n" +

--- a/tst/axiom/Verify-Equal.ps1
+++ b/tst/axiom/Verify-Equal.ps1
@@ -6,17 +6,18 @@
         [Parameter(Mandatory = $true, Position = 0)]
         $Expected
     )
-
-    if ($Expected -ne $Actual) {
-        $message = "Expected and actual values differ!`n" +
-        "Expected: '$Expected'`n" +
-        "Actual  : '$Actual'"
-        if ($Expected -is [string] -and $Actual -is [string]) {
-            $message += "`nExpected length: $($Expected.Length)`nActual length: $($Actual.Length)"
+    PROCESS {
+        if ($Expected -ne $Actual) {
+            $message = "Expected and actual values differ!`n" +
+            "Expected: '$Expected'`n" +
+            "Actual  : '$Actual'"
+            if ($Expected -is [string] -and $Actual -is [string]) {
+                $message += "`nExpected length: $($Expected.Length)`nActual length: $($Actual.Length)"
+            }
+            $message += "`n$($PSCmdlet.MyInvocation.PositionMessage)"
+            throw [Exception]$message
         }
-        $message += "`n$($PSCmdlet.MyInvocation.PositionMessage)"
-        throw [Exception]$message
-    }
 
-    $Actual
+        $Actual
+    }
 }

--- a/tst/axiom/Verify-False.ps1
+++ b/tst/axiom/Verify-False.ps1
@@ -3,7 +3,7 @@ function Verify-False {
         [Parameter(ValueFromPipeline = $true)]
         $Actual
     )
-    PROCESS {
+    END {
         if ($null -eq $Actual) {
             throw [Exception]"Expected `$false but got '`$null'."
         }

--- a/tst/axiom/Verify-False.ps1
+++ b/tst/axiom/Verify-False.ps1
@@ -3,14 +3,15 @@ function Verify-False {
         [Parameter(ValueFromPipeline = $true)]
         $Actual
     )
+    PROCESS {
+        if ($null -eq $Actual) {
+            throw [Exception]"Expected `$false but got '`$null'."
+        }
 
-    if ($null -eq $Actual) {
-        throw [Exception]"Expected `$false but got '`$null'."
+        if ($Actual) {
+            throw [Exception]"Expected `$false but got '$Actual'."
+        }
+
+        $Actual
     }
-
-    if ($Actual) {
-        throw [Exception]"Expected `$false but got '$Actual'."
-    }
-
-    $Actual
 }

--- a/tst/axiom/Verify-NotNull.ps1
+++ b/tst/axiom/Verify-NotNull.ps1
@@ -3,7 +3,7 @@ function Verify-NotNull {
         [Parameter(ValueFromPipeline = $true)]
         $Actual
     )
-    PROCESS {
+    END {
         if ($null -eq $Actual) {
             throw [Exception]"Expected not `$null but got `$null."
         }

--- a/tst/axiom/Verify-NotNull.ps1
+++ b/tst/axiom/Verify-NotNull.ps1
@@ -3,10 +3,11 @@ function Verify-NotNull {
         [Parameter(ValueFromPipeline = $true)]
         $Actual
     )
+    PROCESS {
+        if ($null -eq $Actual) {
+            throw [Exception]"Expected not `$null but got `$null."
+        }
 
-    if ($null -eq $Actual) {
-        throw [Exception]"Expected not `$null but got `$null."
+        $Actual
     }
-
-    $Actual
 }

--- a/tst/axiom/Verify-NotSame.ps1
+++ b/tst/axiom/Verify-NotSame.ps1
@@ -5,10 +5,11 @@
         [Parameter(Mandatory = $true, Position = 0)]
         $Expected
     )
+    PROCESS {
+        if ([object]::ReferenceEquals($Expected, $Actual)) {
+            throw [Exception]"Expected the objects to be different instance but they were the same instance."
+        }
 
-    if ([object]::ReferenceEquals($Expected, $Actual)) {
-        throw [Exception]"Expected the objects to be different instance but they were the same instance."
+        $Actual
     }
-
-    $Actual
 }

--- a/tst/axiom/Verify-NotSame.ps1
+++ b/tst/axiom/Verify-NotSame.ps1
@@ -5,7 +5,7 @@
         [Parameter(Mandatory = $true, Position = 0)]
         $Expected
     )
-    PROCESS {
+    END {
         if ([object]::ReferenceEquals($Expected, $Actual)) {
             throw [Exception]"Expected the objects to be different instance but they were the same instance."
         }

--- a/tst/axiom/Verify-Null.ps1
+++ b/tst/axiom/Verify-Null.ps1
@@ -3,10 +3,11 @@ function Verify-Null {
         [Parameter(ValueFromPipeline = $true)]
         $Actual
     )
+    PROCESS {
+        if ($null -ne $Actual) {
+            throw [Exception]"Expected `$null but got '$Actual'."
+        }
 
-    if ($null -ne $Actual) {
-        throw [Exception]"Expected `$null but got '$Actual'."
+        $Actual
     }
-
-    $Actual
 }

--- a/tst/axiom/Verify-Null.ps1
+++ b/tst/axiom/Verify-Null.ps1
@@ -3,7 +3,7 @@ function Verify-Null {
         [Parameter(ValueFromPipeline = $true)]
         $Actual
     )
-    PROCESS {
+    END {
         if ($null -ne $Actual) {
             throw [Exception]"Expected `$null but got '$Actual'."
         }

--- a/tst/axiom/Verify-Same.ps1
+++ b/tst/axiom/Verify-Same.ps1
@@ -5,7 +5,7 @@ function Verify-Same {
         [Parameter(Mandatory = $true, Position = 0)]
         $Expected
     )
-    PROCESS {
+    END {
         if (-not [object]::ReferenceEquals($Expected, $Actual)) {
             throw [Exception]"Expected the objects to be the same instance but they were not."
         }

--- a/tst/axiom/Verify-Same.ps1
+++ b/tst/axiom/Verify-Same.ps1
@@ -5,10 +5,11 @@ function Verify-Same {
         [Parameter(Mandatory = $true, Position = 0)]
         $Expected
     )
+    PROCESS {
+        if (-not [object]::ReferenceEquals($Expected, $Actual)) {
+            throw [Exception]"Expected the objects to be the same instance but they were not."
+        }
 
-    if (-not [object]::ReferenceEquals($Expected, $Actual)) {
-        throw [Exception]"Expected the objects to be the same instance but they were not."
+        $Actual
     }
-
-    $Actual
 }

--- a/tst/axiom/Verify-Throw.ps1
+++ b/tst/axiom/Verify-Throw.ps1
@@ -3,7 +3,7 @@ function Verify-Throw {
         [Parameter(Mandatory = $true, ValueFromPipeline = $true)]
         [ScriptBlock]$ScriptBlock
     )
-    PROCESS {
+    END {
         $exceptionThrown = $false
         try {
             $null = & $ScriptBlock

--- a/tst/axiom/Verify-Throw.ps1
+++ b/tst/axiom/Verify-Throw.ps1
@@ -3,17 +3,18 @@ function Verify-Throw {
         [Parameter(Mandatory = $true, ValueFromPipeline = $true)]
         [ScriptBlock]$ScriptBlock
     )
+    PROCESS {
+        $exceptionThrown = $false
+        try {
+            $null = & $ScriptBlock
+        }
+        catch {
+            $exceptionThrown = $true
+            $_
+        }
 
-    $exceptionThrown = $false
-    try {
-        $null = & $ScriptBlock
-    }
-    catch {
-        $exceptionThrown = $true
-        $_
-    }
-
-    if (-not $exceptionThrown) {
-        throw [Exception]"An exception was expected, but no exception was thrown!"
+        if (-not $exceptionThrown) {
+            throw [Exception]"An exception was expected, but no exception was thrown!"
+        }
     }
 }

--- a/tst/axiom/Verify-True.ps1
+++ b/tst/axiom/Verify-True.ps1
@@ -3,14 +3,15 @@ function Verify-True {
         [Parameter(ValueFromPipeline = $true)]
         $Actual
     )
+    PROCESS {
+        if ($null -eq $Actual) {
+            throw [Exception]"Expected `$true but got '`$null'."
+        }
 
-    if ($null -eq $Actual) {
-        throw [Exception]"Expected `$true but got '`$null'."
+        if (-not $Actual) {
+            throw [Exception]"Expected `$true but got '$Actual'."
+        }
+
+        $Actual
     }
-
-    if (-not $Actual) {
-        throw [Exception]"Expected `$true but got '$Actual'."
-    }
-
-    $Actual
 }

--- a/tst/axiom/Verify-True.ps1
+++ b/tst/axiom/Verify-True.ps1
@@ -3,7 +3,7 @@ function Verify-True {
         [Parameter(ValueFromPipeline = $true)]
         $Actual
     )
-    PROCESS {
+    END {
         if ($null -eq $Actual) {
             throw [Exception]"Expected `$true but got '`$null'."
         }

--- a/tst/axiom/Verify-Type.ps1
+++ b/tst/axiom/Verify-Type.ps1
@@ -5,17 +5,18 @@
         [Parameter(Mandatory = $true, Position = 0)]
         [Type]$Expected
     )
+    PROCESS {
+        if ($Actual -isnot $Expected) {
+            $message = "Expected value to be of type $($Expected.FullName)"
+            $Actual = "but got " + $(if ($null -eq $Actual) {
+                    "'<null>'"
+                }
+                else {
+                    "'$($Actual.GetType().FullName)'"
+                })
+            throw [Exception]"$message, $Actual"
+        }
 
-    if ($Actual -isnot $Expected) {
-        $message = "Expected value to be of type $($Expected.FullName)"
-        $Actual = "but got " + $(if ($null -eq $Actual) {
-                "'<null>'"
-            }
-            else {
-                "'$($Actual.GetType().FullName)'"
-            })
-        throw [Exception]"$message, $Actual"
+        $Actual
     }
-
-    $Actual
 }

--- a/tst/axiom/Verify-Type.ps1
+++ b/tst/axiom/Verify-Type.ps1
@@ -5,7 +5,7 @@
         [Parameter(Mandatory = $true, Position = 0)]
         [Type]$Expected
     )
-    PROCESS {
+    END {
         if ($Actual -isnot $Expected) {
             $message = "Expected value to be of type $($Expected.FullName)"
             $Actual = "but got " + $(if ($null -eq $Actual) {


### PR DESCRIPTION
<!-- Thank you for contributing to Pester! -->

## PR Summary
<!-- Please describe what your pull request fixes, or how it improves Pester.

If your pull request resolves a reported issue, please mention it by using `Fix #<issue_number>` on a new line, this will close the linked issue automatically when this PR is merged. For more info see: [Closing issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/).

If your pull request integrates Pester with another system, please tell us how the change can be tested. -->
This fixes the warnings in tst/axiom.  Introduces PROCESS to address the recommendation.  Includes a suppression of safecommand in a test with Out-String.  

WIP #1635 

## PR Checklist

- [X] PR has meaningful title
- [X] Summary describes changes
- [X] PR is ready to be merged
  - If not, use the arrow next to `Create Pull Request` to mark it as a draft. PR can be marked `Ready for review` when it's ready.
- [ ] Tests are added/update *(if required)*
- [ ] Documentation is updated/added *(if required)*

<!-- Before you continue, please review [Contributing to Pester](https://pester.dev/docs/contributing/introduction).

Our continuous integration system doesn't send any notifications about failed tests. Please return to the opened pull request (after ~60 minutes) to check if everything is OK. -->
