### PR TITLE
Fix index error when using Get-Command on Should

### DIFF
--- a/src/functions/assertions/Should.ps1
+++ b/src/functions/assertions/Should.ps1
@@ -119,8 +119,10 @@ function Should {
 
     dynamicparam {
         # Figuring out if we are using the old syntax is 'easy'
-        $myLine = # we can use $myInvocation.Line to get the surrounding context
+        # we can use $myInvocation.Line to get the surrounding context
+        $myLine = if ($null -ne $MyInvocation -and 0 -le ($MyInvocation.OffsetInLine - 1)) {
             $MyInvocation.Line.Substring($MyInvocation.OffsetInLine - 1)
+        }
 
         # A bit of Regex lets us know if the line used the old form
         if ($myLine -match '^\s{0,}should\s{1,}(?<Operator>[^\-\@\s]+)')

--- a/tst/functions/assertions/Should.Tests.ps1
+++ b/tst/functions/assertions/Should.Tests.ps1
@@ -118,4 +118,10 @@ InPesterModuleScope {
             { throw "abc" } | Should -ErrorId "abc" # -Throw is not used
         }
     }
+
+    Describe 'Using Should without MyInvocation when generating help' {
+        It 'Get-Command Should -Syntax should show all help' {
+            Get-Command Should -Syntax | Should -Not -BeNullOrEmpty
+        }
+    }
 }


### PR DESCRIPTION
<!-- Thank you for contributing to Pester! -->

## PR Summary
<!-- Please describe what your pull request fixes, or how it improves Pester.

If your pull request resolves a reported issue, please mention it by using `Fix #<issue_number>` on a new line, this will close the linked issue automatically when this PR is merged. For more info see: [Closing issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/).

If your pull request integrates Pester with another system, please tell us how the change can be tested. -->

When generating help automatically $MyInvocation is not defined and we index out of the array in the dynamic operators.

## PR Checklist

- [x] PR has meaningful title
- [x] Summary describes changes
- [x] PR is ready to be merged
  - If not, use the arrow next to `Create Pull Request` to mark it as a draft. PR can be marked `Ready for review` when it's ready.
- [x] Tests are added/update *(if required)*
- [x] Documentation is updated/added *(if required)*

<!-- Before you continue, please review [Contributing to Pester](https://pester.dev/docs/contributing/introduction).

Our continuous integration system doesn't send any notifications about failed tests. Please return to the opened pull request (after ~60 minutes) to check if everything is OK. -->
