### PR TITLE
Removes about_ links (as currently breaking website MDX rendering)

### DIFF
--- a/src/Pester.ps1
+++ b/src/Pester.ps1
@@ -588,9 +588,6 @@ function Invoke-Pester {
 
     .LINK
     https://pester.dev/docs/commands/Describe
-
-    .LINK
-    about_Pester
     #>
     # Currently doesn't work. $IgnoreUnsafeCommands filter used in rule as workaround
     # [Diagnostics.CodeAnalysis.SuppressMessageAttribute('Pester.BuildAnalyzerRules\Measure-SafeCommands', 'Remove-Variable', Justification = 'Remove-Variable can't remove "optimized variables" when using "alias" for Remove-Variable.')]

--- a/src/functions/Describe.ps1
+++ b/src/functions/Describe.ps1
@@ -70,15 +70,6 @@ https://pester.dev/docs/commands/Context
 
 .LINK
 https://pester.dev/docs/commands/Invoke-Pester
-
-.LINK
-about_Should
-
-.LINK
-about_Mocking
-
-.LINK
-about_TestDrive
 #>
 
     param(

--- a/src/functions/SetupTeardown.ps1
+++ b/src/functions/SetupTeardown.ps1
@@ -46,9 +46,6 @@ function BeforeEach {
 
     .LINK
         https://pester.dev/docs/usage/setup-and-teardown
-
-    .LINK
-        about_BeforeEach_AfterEach
     #>
     [CmdletBinding()]
     param
@@ -115,9 +112,6 @@ function AfterEach {
 
     .LINK
         https://pester.dev/docs/usage/setup-and-teardown
-
-    .LINK
-        about_BeforeEach_AfterEach
     #>
     [CmdletBinding()]
     param
@@ -194,9 +188,6 @@ function BeforeAll {
 
     .LINK
         https://pester.dev/docs/usage/setup-and-teardown
-
-    .LINK
-        about_BeforeEach_AfterEach
     #>
     [CmdletBinding()]
     param
@@ -259,13 +250,7 @@ function AfterAll {
         the tests in the Describe-block.
 
     .LINK
-        https://pester.dev/docs/commands/AfterAll
-
-    .LINK
         https://pester.dev/docs/usage/setup-and-teardown
-
-    .LINK
-        about_BeforeEach_AfterEach
 #>
     [CmdletBinding()]
     param

--- a/src/functions/SetupTeardown.ps1
+++ b/src/functions/SetupTeardown.ps1
@@ -250,6 +250,9 @@ function AfterAll {
         the tests in the Describe-block.
 
     .LINK
+        https://pester.dev/docs/commands/AfterAll
+
+    .LINK
         https://pester.dev/docs/usage/setup-and-teardown
 #>
     [CmdletBinding()]

--- a/src/functions/assertions/Should.ps1
+++ b/src/functions/assertions/Should.ps1
@@ -43,12 +43,6 @@ function Should {
     .LINK
     https://pester.dev/docs/usage/assertions
 
-    .LINK
-    about_Should
-
-    .LINK
-    about_Pester
-
     .EXAMPLE
     ```powershell
     Describe "d1" {


### PR DESCRIPTION
This removes the about_links from the `.ps1` Get-Help for two reasons:

1. they break the automated rendering of the website MDX help pages
2. they are pointing to heavily outdated (text-based) content

> Also removes an AfterAll link because it was pointing at itself.

IMO the existing text files should be removed as well, replacing the `about_Pester` help file with a generic message, pointing to the website. Then replace at some point in the future with actual data, if desired. **Add to this PR?**