### PR TITLE
Cleanup command reference help and add online help link

### DIFF
--- a/Pester.BuildAnalyzerRules/Pester.BuildAnalyzerRules.psm1
+++ b/Pester.BuildAnalyzerRules/Pester.BuildAnalyzerRules.psm1
@@ -2,16 +2,16 @@
 $SafeCommands = & { . "$PSScriptRoot/../src/functions/Pester.SafeCommands.ps1"; $Script:SafeCommands }
 # Workaround as RuleSuppressionID-based suppression is bugged. returns error.
 # Should be replaced with the following line when PSScriptAnalyzer is fixed. See Invoke-Pester
-# [Diagnostics.CodeAnalysis.SuppressMessageAttribute('Pester.BuildAnalyzerRules\Measure-SafeComands', 'Remove-Variable')]
+# [Diagnostics.CodeAnalysis.SuppressMessageAttribute('Pester.BuildAnalyzerRules\Measure-SafeCommands', 'Remove-Variable')]
 $IgnoreUnsafeCommands = @('Remove-Variable')
-function Measure-SafeComands {
+function Measure-SafeCommands {
     <#
     .SYNOPSIS
     Should use $SafeCommand-variant of external function when available.
     .DESCRIPTION
-    Pester module defines a $SafeCommands dictionary for external commands to avoid hijacking. To fix a violation of this rule, update the call to use SafeCoomands variant, ex. `& $SafeCommands['CommandName'] -Param1 Value1`.
+    Pester module defines a $SafeCommands dictionary for external commands to avoid hijacking. To fix a violation of this rule, update the call to use SafeCommands variant, ex. `& $SafeCommands['CommandName'] -Param1 Value1`.
     .EXAMPLE
-    Measure-SafeComands -CommandAst $CommandAst
+    Measure-SafeCommands -CommandAst $CommandAst
     .INPUTS
     [System.Management.Automation.Language.CommandAst]
     .OUTPUTS
@@ -19,6 +19,9 @@ function Measure-SafeComands {
     .NOTES
     None
     #>
+    # TODO This warning is currently thrown for SafeCommand
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseOutputTypeCorrectly", "")]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("Pester.BuildAnalyzerRules\Measure-SafeCommands", "")]
     [CmdletBinding()]
     [OutputType([Microsoft.Windows.PowerShell.ScriptAnalyzer.Generic.DiagnosticRecord[]])]
     Param

--- a/src/Pester.RSpec.ps1
+++ b/src/Pester.RSpec.ps1
@@ -397,13 +397,16 @@ function New-PesterContainer {
     execution of the test containers defined in Path or ScriptBlock.
 
     .EXAMPLE
+    ```powershell
     $container = New-PesterContainer -Path 'CodingStyle.Tests.ps1' -Data @{ File = "Get-Emoji.ps1" }
     Invoke-Pester -Container $container
+    ```
 
     This example runs Pester using a generated ContainerInfo-object referencing a file and
     required parameters that's provided to the test-file during execution.
 
     .EXAMPLE
+    ```powershell
     $sb = {
         Describe 'Testing New-PesterContainer' {
             It 'Useless test' {
@@ -413,6 +416,7 @@ function New-PesterContainer {
     }
     $container = New-PesterContainer -ScriptBlock $sb
     Invoke-Pester -Container $container
+    ```
 
     This example runs Pester agianst a scriptblock. New-PesterContainer is used to genreated
     the requried ContainerInfo-object that enables us to do this directly.

--- a/src/Pester.ps1
+++ b/src/Pester.ps1
@@ -1385,8 +1385,10 @@ function ConvertTo-Pester4Result {
     -Passthru or by using the Run.PassThru configuration-option.
 
     .EXAMPLE
+    ```powershell
     $pester5Result = Invoke-Pester -Passthru
     $pester4Result = $pester5Result | ConvertTo-Pester4Result
+    ```
 
     This example runs Pester using the Passthru option to retrieve a result-object
     in the Pester 5 format and converts it to a new Pester 4-compatible result-object.

--- a/src/Pester.ps1
+++ b/src/Pester.ps1
@@ -62,6 +62,8 @@ function Add-ShouldOperator {
     PS C:\> "bad" | should -BeAwesome
     {bad} is not Awesome
     ```
+.LINK
+    https://pester.dev/docs/commands/Add-ShouldOperator
 #>
     [CmdletBinding()]
     param (
@@ -578,10 +580,10 @@ function Invoke-Pester {
     Invoke-Pester -Configuration $config
 
     .LINK
-    https://pester.dev/docs/quick-start
+    https://pester.dev/docs/commands/Invoke-Pester
 
     .LINK
-    https://pester.dev/docs/commands/Invoke-Pester
+    https://pester.dev/docs/quick-start
 
     .LINK
     https://pswiki.net/invoke-pester-pester/

--- a/src/Pester.ps1
+++ b/src/Pester.ps1
@@ -1502,26 +1502,26 @@ function BeforeDiscovery {
     The ScritpBlock to run.
 
     .EXAMPLE
-        ```powershell
-        BeforeDiscovery {
-            $files = Get-ChildItem -Path $PSScriptRoot -Filter '*.ps1' -Recurse
-        }
+    ```powershell
+    BeforeDiscovery {
+        $files = Get-ChildItem -Path $PSScriptRoot -Filter '*.ps1' -Recurse
+    }
 
-        Describe "File - <_>" -ForEach $files {
-            Context "Whitespace" {
-                It "There is no extra whitespace following a line" {
-                    # ...
-                }
+    Describe "File - <_>" -ForEach $files {
+        Context "Whitespace" {
+            It "There is no extra whitespace following a line" {
+                # ...
+            }
 
-                It "File ends with an empty line" {
-                    # ...
-                }
+            It "File ends with an empty line" {
+                # ...
             }
         }
-        ```
+    }
+    ```
 
-        BeforeDiscovery is used to gather a list of files which is used during Discovery-phase to
-        dynamically create a Describe-block and tests for each file found.
+    BeforeDiscovery is used to gather a list of script-files during Discovery-phase to
+    dynamically create a Describe-block and tests for each file found.
 
     .LINK
     https://pester.dev/docs/commands/BeforeDiscovery

--- a/src/Pester.ps1
+++ b/src/Pester.ps1
@@ -593,7 +593,7 @@ function Invoke-Pester {
     about_Pester
     #>
     # Currently doesn't work. $IgnoreUnsafeCommands filter used in rule as workaround
-    # [Diagnostics.CodeAnalysis.SuppressMessageAttribute('Pester.BuildAnalyzerRules\Measure-SafeComands', 'Remove-Variable', Justification = 'Remove-Variable can't remove "optimized variables" when using "alias" for Remove-Variable.')]
+    # [Diagnostics.CodeAnalysis.SuppressMessageAttribute('Pester.BuildAnalyzerRules\Measure-SafeCommands', 'Remove-Variable', Justification = 'Remove-Variable can't remove "optimized variables" when using "alias" for Remove-Variable.')]
     [CmdletBinding(DefaultParameterSetName = 'Simple')]
     param(
         [Parameter(Position = 0, Mandatory = 0, ParameterSetName = "Simple")]

--- a/src/Pester.ps1
+++ b/src/Pester.ps1
@@ -586,12 +586,6 @@ function Invoke-Pester {
     https://pester.dev/docs/quick-start
 
     .LINK
-    https://pswiki.net/invoke-pester-pester/
-
-    .LINK
-    https://pester.dev/docs/commands/Describe
-
-    .LINK
     about_Pester
     #>
     # Currently doesn't work. $IgnoreUnsafeCommands filter used in rule as workaround

--- a/src/Pester.ps1
+++ b/src/Pester.ps1
@@ -1488,32 +1488,44 @@ function ConvertTo-Pester4Result {
 
 function BeforeDiscovery {
     <#
-        .SYNOPSIS
-        Runs setup code that is used during Discovery phase.
-        .DESCRIPTION
-        Runs your code as is, in the place where this function is defined. This is a semantic block to allow you
-        to be explicit about code that you need to run during Discovery, instead of just
-        putting code directly inside of Describe / Context.
-        .PARAMETER ScriptBlock
-        The ScritpBlock to run.
+    .SYNOPSIS
+    Runs setup code that is used during Discovery phase.
 
-        .EXAMPLE
-            ```powershell
-            PS > BeforeDiscovery {
-                $files = "file1.txt", "file2.txt"
-            }
+    .DESCRIPTION
+    Runs your code as is, in the place where this function is defined. This is a semantic block to allow you
+    to be explicit about code that you need to run during Discovery, instead of just
+    putting code directly inside of Describe / Context.
 
-            Describe "File tests" {
-                foreach ($file in $files) {
-                    It "test" {
-                        # ... test code
-                    }
+    .PARAMETER ScriptBlock
+    The ScritpBlock to run.
+
+    .EXAMPLE
+        ```powershell
+        BeforeDiscovery {
+            $files = Get-ChildItem -Path $PSScriptRoot -Filter '*.ps1' -Recurse
+        }
+
+        Describe "File - <_>" -ForEach $files {
+            Context "Whitespace" {
+                It "There is no extra whitespace following a line" {
+                    # ...
+                }
+
+                It "File ends with an empty line" {
+                    # ...
                 }
             }
-            ```
+        }
+        ```
 
-            The result of commands will be execution of tests and saving results of them in a NUnitMXL file where the root "test-suite"
-            will be named "Tests - Set A".
+        BeforeDiscovery is used to gather a list of files which is used during Discovery-phase to
+        dynamically create a Describe-block and tests for each file found.
+
+    .LINK
+    https://pester.dev/docs/commands/BeforeDiscovery
+
+    .LINK
+    https://pester.dev/docs/usage/data-driven-tests
     #>
     [CmdletBinding()]
     param (

--- a/src/Pester.psd1
+++ b/src/Pester.psd1
@@ -4,7 +4,7 @@
     RootModule        = 'Pester.psm1'
 
     # Version number of this module.
-    ModuleVersion     = '5.1.0'
+    ModuleVersion     = '5.2.0'
 
     # ID used to uniquely identify this module
     GUID              = 'a699dea5-2c73-4616-a270-1f7abb777e71'
@@ -111,10 +111,10 @@
             LicenseUri   = "https://www.apache.org/licenses/LICENSE-2.0.html"
 
             # Release notes for this particular version of the module
-            ReleaseNotes = 'https://github.com/pester/Pester/releases/tag/5.1.0'
+            ReleaseNotes = 'https://github.com/pester/Pester/releases/tag/5.2.0-beta1'
 
             # Prerelease string of this module
-            Prerelease   = ''
+            Prerelease   = 'beta1'
         }
     }
 

--- a/src/functions/Context.ps1
+++ b/src/functions/Context.ps1
@@ -49,6 +49,9 @@ Describe "Add-Numbers" {
 ```
 
 .LINK
+https://pester.dev/docs/commands/Context
+
+.LINK
 https://pester.dev/docs/commands/Describe
 
 .LINK

--- a/src/functions/Context.ps1
+++ b/src/functions/Context.ps1
@@ -35,15 +35,19 @@ function Add-Numbers($a, $b) {
 }
 
 Describe "Add-Numbers" {
-
     Context "when root does not exist" {
-         It "..." { ... }
+        It "..." {
+            # ...
+        }
     }
 
     Context "when root does exist" {
-        It "..." { ... }
-        It "..." { ... }
-        It "..." { ... }
+        It "..." {
+            # ...
+        }
+        It "..." {
+            # ...
+        }
     }
 }
 ```

--- a/src/functions/Context.ps1
+++ b/src/functions/Context.ps1
@@ -56,19 +56,7 @@ Describe "Add-Numbers" {
 https://pester.dev/docs/commands/Context
 
 .LINK
-https://pester.dev/docs/commands/Describe
-
-.LINK
-https://pester.dev/docs/commands/It
-
-.LINK
-https://pester.dev/docs/commands/BeforeEach
-
-.LINK
-https://pester.dev/docs/commands/AfterEach
-
-.LINK
-https://pester.dev/docs/commands/Should
+https://pester.dev/docs/usage/test-file-structure
 
 .LINK
 https://pester.dev/docs/usage/mocking

--- a/src/functions/Describe.ps1
+++ b/src/functions/Describe.ps1
@@ -69,6 +69,15 @@ https://pester.dev/docs/usage/test-file-structure
 https://pester.dev/docs/usage/mocking
 
 .LINK
+about_Should
+
+.LINK
+about_Mocking
+
+.LINK
+about_TestDrive
+
+.LINK
 https://pester.dev/docs/usage/testdrive
 #>
 

--- a/src/functions/Describe.ps1
+++ b/src/functions/Describe.ps1
@@ -63,22 +63,13 @@ Describe "Add-Numbers" {
 https://pester.dev/docs/commands/Describe
 
 .LINK
-https://pester.dev/docs/commands/It
+https://pester.dev/docs/usage/test-file-structure
 
 .LINK
-https://pester.dev/docs/commands/Context
+https://pester.dev/docs/usage/mocking
 
 .LINK
-https://pester.dev/docs/commands/Invoke-Pester
-
-.LINK
-about_Should
-
-.LINK
-about_Mocking
-
-.LINK
-about_TestDrive
+https://pester.dev/docs/usage/testdrive
 #>
 
     param(

--- a/src/functions/Get-ShouldOperator.ps1
+++ b/src/functions/Get-ShouldOperator.ps1
@@ -28,6 +28,9 @@ function Get-ShouldOperator {
     -Name is a dynamic parameter that tab completes all available options.
 
     .LINK
+    https://pester.dev/docs/commands/Get-ShouldOperator
+
+    .LINK
     https://pester.dev/docs/commands/Should
 
     #>

--- a/src/functions/InModuleScope.ps1
+++ b/src/functions/InModuleScope.ps1
@@ -53,6 +53,9 @@ function InModuleScope {
     the PowerShell session, because the module only exported
     "PublicFunction".  Using InModuleScope allowed this call to
     "PrivateFunction" to work successfully.
+
+.LINK
+    https://pester.dev/docs/commands/InModuleScope
 #>
 
     [CmdletBinding()]

--- a/src/functions/New-Fixture.ps1
+++ b/src/functions/New-Fixture.ps1
@@ -104,7 +104,7 @@ Describe "#name#" {
 }
 
 function Create-File {
-    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('Pester.BuildAnalyzerRules\Measure-SafeComands', 'Write-Warning', Justification = 'Mocked in unit test for New-Fixture.')]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('Pester.BuildAnalyzerRules\Measure-SafeCommands', 'Write-Warning', Justification = 'Mocked in unit test for New-Fixture.')]
     param($Path, $Name, $Content)
     if (-not (& $SafeCommands['Test-Path'] -Path $Path)) {
         & $SafeCommands['New-Item'] -ItemType Directory -Path $Path | & $SafeCommands['Out-Null']

--- a/src/functions/Pester.SafeCommands.ps1
+++ b/src/functions/Pester.SafeCommands.ps1
@@ -12,7 +12,7 @@ $safeCommandLookupParameters = @{
 }
 
 # Suppress from ScriptAnalyzer rule when possible in root of script (future PSSA release?)
-# [Diagnostics.CodeAnalysis.SuppressMessageAttribute('Pester.BuildAnalyzerRules\Measure-SafeComands', 'Get-Command', Justification = 'Used to generate SafeCommands list used for AnalyzerRule.')]
+# [Diagnostics.CodeAnalysis.SuppressMessageAttribute('Pester.BuildAnalyzerRules\Measure-SafeCommands', 'Get-Command', Justification = 'Used to generate SafeCommands list used for AnalyzerRule.')]
 $Get_Command = Get-Command Get-Command -CommandType Cmdlet -ErrorAction 'Stop'
 $script:SafeCommands = @{
     'Get-Command'          = $Get_Command

--- a/src/functions/Pester.SessionState.Mock.ps1
+++ b/src/functions/Pester.SessionState.Mock.ps1
@@ -120,7 +120,7 @@ more easily.
 
 .PARAMETER RemoveParameterValidation
 Optional list of parameter names in the original command
-that should not have any validation rules applied. This relaxes the 
+that should not have any validation rules applied. This relaxes the
 validation requirements, and allows functions that are strict about their
 parameter validation to be mocked more easily.
 
@@ -140,9 +140,11 @@ Mock Set-Content {} -Verifiable -ParameterFilter { $Path -eq "some_path" -and $V
 When this mock is used, if the Mock is never invoked and Should -InvokeVerifiable is called, an exception will be thrown. The command behavior will do nothing since the ScriptBlock is empty.
 
 .EXAMPLE
+```powershell
 Mock Get-ChildItem { return @{FullName = "A_File.TXT"} } -ParameterFilter { $Path -and $Path.StartsWith($env:temp\1) }
 Mock Get-ChildItem { return @{FullName = "B_File.TXT"} } -ParameterFilter { $Path -and $Path.StartsWith($env:temp\2) }
 Mock Get-ChildItem { return @{FullName = "C_File.TXT"} } -ParameterFilter { $Path -and $Path.StartsWith($env:temp\3) }
+```
 
 Multiple mocks of the same command may be used. The parameter filter determines which is invoked. Here, if Get-ChildItem is called on the "2" directory of the temp folder, then B_File.txt will be returned.
 

--- a/src/functions/Pester.SessionState.Mock.ps1
+++ b/src/functions/Pester.SessionState.Mock.ps1
@@ -619,6 +619,9 @@ Checks if all verifiable Mocks has been called at least once.
 
 THIS COMMAND IS OBSOLETE AND WILL BE REMOVED SOMEWHERE DURING v5 LIFETIME,
 USE Should -InvokeVerifiable INSTEAD.
+
+.LINK
+https://pester.dev/docs/commands/Assert-VerifiableMock
 #>
 
     # Should does not accept a session state, so invoking it directly would
@@ -681,6 +684,9 @@ and throws an exception if it has not.
 
 THIS COMMAND IS OBSOLETE AND WILL BE REMOVED SOMEWHERE DURING v5 LIFETIME,
 USE Should -Invoke INSTEAD.
+
+.LINK
+https://pester.dev/docs/commands/Assert-MockCalled
 #>
     [CmdletBinding(DefaultParameterSetName = 'ParameterFilter')]
     param(

--- a/src/functions/Set-ItResult.ps1
+++ b/src/functions/Set-ItResult.ps1
@@ -42,6 +42,9 @@ function Set-ItResult {
     Tests completed in 0ms
     Tests Passed: 0, Failed: 0, Skipped: 0, Pending: 0, Inconclusive 1
     ```
+
+    .LINK
+    https://pester.dev/docs/commands/Set-ItResult
 #>
     [CmdletBinding()]
     param(

--- a/src/functions/TestResults.ps1
+++ b/src/functions/TestResults.ps1
@@ -68,8 +68,10 @@ function Export-NUnitReport {
     The path where the XML-report should  to the ou the XML report as string.
 
     .EXAMPLE
+    ```powershell
     $p = Invoke-Pester -Passthru
     $p | Export-NUnitReport -Path TestResults.xml
+    ```
 
     This example runs Pester using the Passthru option to retrieve the result-object and
     exports it as an NUnit 2.5-compatible XML-report.
@@ -113,8 +115,10 @@ function Export-JUnitReport {
     The path where the XML-report should  to the ou the XML report as string.
 
     .EXAMPLE
+    ```powershell
     $p = Invoke-Pester -Passthru
     $p | Export-JUnitReport -Path TestResults.xml
+    ```
 
     This example runs Pester using the Passthru option to retrieve the result-object and
     exports it as an JUnit 4-compatible XML-report.
@@ -220,15 +224,19 @@ function ConvertTo-NUnitReport {
     Returns the XML-report as a string.
 
     .EXAMPLE
+    ```powershell
     $p = Invoke-Pester -Passthru
     $p | ConvertTo-NUnitReport
+    ```
 
     This example runs Pester using the Passthru option to retrieve the result-object and
     converts it to an NUnit 2.5-compatible XML-report. The report is returned as an XML-object.
 
     .EXAMPLE
+    ```powershell
     $p = Invoke-Pester -Passthru
     $p | ConvertTo-NUnitReport -AsString
+    ```
 
     This example runs Pester using the Passthru option to retrieve the result-object and
     converts it to an NUnit 2.5-compatible XML-report. The returned object is a string.
@@ -461,15 +469,19 @@ function ConvertTo-JUnitReport {
     Returns the XML-report as a string.
 
     .EXAMPLE
+    ```powershell
     $p = Invoke-Pester -Passthru
     $p | ConvertTo-JUnitReport
+    ```
 
     This example runs Pester using the Passthru option to retrieve the result-object and
     converts it to an JUnit 4-compatible XML-report. The report is returned as an XML-object.
 
     .EXAMPLE
+    ```powershell
     $p = Invoke-Pester -Passthru
     $p | ConvertTo-JUnitReport -AsString
+    ```
 
     This example runs Pester using the Passthru option to retrieve the result-object and
     converts it to an JUnit 4-compatible XML-report. The returned object is a string.

--- a/tst/Help.Tests.ps1
+++ b/tst/Help.Tests.ps1
@@ -23,6 +23,13 @@ Describe "Testing module help" -ForEach @{ exportedFunctions = $exportedFunction
             $help.Synopsis | Should -Not -Match "^\s*$($_.Name)((\s+\[?-\w+)|$)"
         }
 
+        It "Has link sections" {
+            $help.psobject.properties.name -match 'relatedLinks' | Should -Not -BeNullOrEmpty -Because "all exported functions should at least have link to online version as first Uri"
+
+            $firstUri = $help.relatedLinks.navigationLink | Where-Object uri | Select-Object -First 1 -ExpandProperty uri
+            $firstUri | Should -Be "https://pester.dev/docs/commands/$($help.Name)" -Because "first uri-link should be to online version of this help topic"
+        }
+
         # Skipped until Assert-MockCalled and Assert-VerifiableMock are removed
         It "Has at least one example" -Skip {
              $help.Examples | Should -Not -BeNullOrEmpty


### PR DESCRIPTION
## PR Summary
Multiple edits to the command ref help. See https://github.com/pester/docs/pull/78#issuecomment-739539632

- [x] Add missing command ref link to all public functions
- [x] Add test for required link in help to enbale `Get-Help <function> -Online`
- [x] Update BeforeDiscovery example
- [x] Update Context help to (hopefully) fix codeblock indentation in online version
- [x] Add missing codeblocks to all multi-line examples
- [x] Cleanup related links


## PR Checklist

- [x] PR has meaningful title
- [x] Summary describes changes
- [x] PR is ready to be merged
  - If not, use the arrow next to `Create Pull Request` to mark it as a draft. PR can be marked `Ready for review` when it's ready.
- [x] Tests are added/update *(if required)*
- [ ] Documentation is updated/added *(if required)*

<!-- Before you continue, please review [Contributing to Pester](https://pester.dev/docs/contributing/introduction).

Our continuous integration system doesn't send any notifications about failed tests. Please return to the opened pull request (after ~60 minutes) to check if everything is OK. -->
