### PR TITLE
Fix blank code coverage 1621

### DIFF
--- a/src/Pester.ps1
+++ b/src/Pester.ps1
@@ -1011,6 +1011,7 @@ function Invoke-Pester {
                     OutputEncoding = $PesterPreference.CodeCoverage.OutputEncoding.Value
                     ExcludeTests = $PesterPreference.CodeCoverage.ExcludeTests.Value
                     Path = @($paths)
+                    RecursePaths = $PesterPreference.CodeCoverage.RecursePaths.Value
                     TestExtension = $PesterPreference.Run.TestExtension.Value
                 }
 

--- a/src/csharp/Pester/Configuration.cs
+++ b/src/csharp/Pester/Configuration.cs
@@ -572,6 +572,7 @@ namespace Pester
         private StringOption _outputEncoding;
         private StringArrayOption _path;
         private BoolOption _excludeTests;
+        private BoolOption _recursePaths;
 
         public static CodeCoverageConfiguration Default { get { return new CodeCoverageConfiguration(); } }
 
@@ -587,7 +588,7 @@ namespace Pester
             OutputEncoding = new StringOption("Encoding of the output file.", "UTF8");
             Path = new StringArrayOption("Directories or files to be used for codecoverage, by default the Path(s) from general settings are used, unless overridden here.", new string[0]);
             ExcludeTests = new BoolOption("Exclude tests from code coverage. This uses the TestFilter from general configuration.", true);
-
+            RecursePaths = new BoolOption("Will recurse through directories in the Path option.", true);
         }
 
         public CodeCoverageConfiguration(IDictionary configuration) : this()
@@ -600,6 +601,7 @@ namespace Pester
                 OutputEncoding = configuration.GetObjectOrNull<string>("OutputEncoding") ?? OutputEncoding;
                 Path = configuration.GetArrayOrNull<string>("Path") ?? Path;
                 ExcludeTests = configuration.GetValueOrNull<bool>("ExcludeTests") ?? ExcludeTests;
+                RecursePaths = configuration.GetValueOrNull<bool>("RecursePaths") ?? RecursePaths;
             }
         }
 
@@ -695,6 +697,22 @@ namespace Pester
                 else
                 {
                     _excludeTests = new BoolOption(_excludeTests, value.Value);
+                }
+            }
+        }
+
+        public BoolOption RecursePaths
+        {
+            get { return _recursePaths; }
+            set
+            {
+                if (_recursePaths == null)
+                {
+                    _recursePaths = value;
+                }
+                else
+                {
+                    _recursePaths = new BoolOption(_recursePaths, value.Value);
                 }
             }
         }

--- a/src/functions/Coverage.ps1
+++ b/src/functions/Coverage.ps1
@@ -150,7 +150,7 @@ function Get-CodeCoverageFilePaths {
             $item.FullName
         }
         elseif ($item -is [System.IO.DirectoryInfo] -and $PesterPreference.CodeCoverage.RecursePaths.Value) {
-            $children = & $SafeCommands['Get-ChildItem'] -LiteralPath $item
+            $children = & $SafeCommands['Get-ChildItem'] -LiteralPath $item | Select-Object -ExpandProperty FullName
             Get-CodeCoverageFilePaths -Paths $children -IncludeTests $IncludeTests
         }
         elseif (-not $item.PsIsContainer) {

--- a/src/functions/Coverage.ps1
+++ b/src/functions/Coverage.ps1
@@ -815,7 +815,7 @@ function Get-JaCoCoReportXml {
             $classElementName = $classElementName.Substring(0, $($classElementName.LastIndexOf(".")))
             $classElement = Add-XmlElement $packageElement 'class' -Attributes ([ordered] @{
                     name           = $classElementName
-                    sourcefilename = (& $SafeCommands["Split-Path"] -Path $classElementRelativePath -Leaf)
+                    sourcefilename = $classElementRelativePath
                 })
 
             foreach ($function in $class.Methods.Keys) {
@@ -838,8 +838,9 @@ function Get-JaCoCoReportXml {
 
         foreach ($file in $package.Classes.Keys) {
             $class = $package.Classes.$file
+            $classElementRelativePath = (Get-RelativePath -Path $file -RelativeTo $commonParent).Replace("\", "/")
             $sourceFileElement = Add-XmlElement $packageElement 'sourcefile' -Attributes ([ordered] @{
-                    name = (& $SafeCommands["Split-Path"] -Path $file -Leaf)
+                    name = $classElementRelativePath
                 })
 
             foreach ($line in $class.Lines.Keys) {

--- a/src/functions/Coverage.ps1
+++ b/src/functions/Coverage.ps1
@@ -159,10 +159,10 @@ function Get-CodeCoverageFilePaths {
                 # if we recurse paths return both directories and files so they can be resolved in the
                 # recursive call to Get-CodeCoverageFilePaths, otherwise return just files
                 if ($RecursePaths) {
-                    $i
+                    $i.PSPath
                 }
                 elseif (-not $i.PSIsContainer) {
-                    $i.FullName
+                    $i.PSPath
                 }}
             Get-CodeCoverageFilePaths -Paths $children -IncludeTests $IncludeTests -RecursePaths $RecursePaths
         }

--- a/tst/functions/Coverage.Tests.ps1
+++ b/tst/functions/Coverage.Tests.ps1
@@ -284,7 +284,7 @@ InPesterModuleScope {
                         <counter type="CLASS" missed="0" covered="2" />
                     </package>
                     <package name="CommonRoot/TestSubFolder">
-                        <class name="CommonRoot/TestSubFolder/TestScript3" sourcefilename="TestScript3.ps1">
+                        <class name="CommonRoot/TestSubFolder/TestScript3" sourcefilename="TestSubFolder/TestScript3.ps1">
                             <method name="&lt;script&gt;" desc="()" line="1">
                                 <counter type="INSTRUCTION" missed="0" covered="1" />
                                 <counter type="LINE" missed="0" covered="1" />
@@ -295,7 +295,7 @@ InPesterModuleScope {
                             <counter type="METHOD" missed="0" covered="1" />
                             <counter type="CLASS" missed="0" covered="1" />
                         </class>
-                        <sourcefile name="TestScript3.ps1">
+                        <sourcefile name="TestSubFolder/TestScript3.ps1">
                             <line nr="1" mi="0" ci="1" mb="0" cb="0" />
                             <counter type="INSTRUCTION" missed="0" covered="1" />
                             <counter type="LINE" missed="0" covered="1" />

--- a/tst/functions/Coverage.Tests.ps1
+++ b/tst/functions/Coverage.Tests.ps1
@@ -614,80 +614,80 @@ InPesterModuleScope {
         }
     }
 
-#     Describe 'Path resolution for test files' {
-#         BeforeAll {
-#             $root = (Get-PSDrive TestDrive).Root
-
-#             $null = New-Item -Path $(Join-Path -Path $root -ChildPath TestScript.ps1) -ItemType File -ErrorAction SilentlyContinue
-
-#             $null = New-Item -Path $(Join-Path -Path $root -ChildPath TestScript.tests.ps1) -ItemType File -ErrorAction SilentlyContinue
-
-#             $null = New-Item -Path $(Join-Path -Path $root -ChildPath TestScript2.tests.ps1) -ItemType File -ErrorAction SilentlyContinue
-#         }
-
-#         Context 'Using Path-input (auto-detect)' {
-#             It 'Excludes test files by default when using wildcard path' {
-#                 $coverageInfo = Get-CoverageInfoFromUserInput "$(Join-Path -Path $root -ChildPath *)"
-
-#                 $PesterTests = @($coverageInfo |
-#                         Select-Object -ExpandProperty Path |
-#                         Where-Object { $_ -match '\.tests.ps1$' })
-
-#                 $PesterTests | Should -BeNullOrEmpty
-#             }
-
-#             It 'Includes test files when specified in wildcard path' {
-#                 $coverageInfo = Get-CoverageInfoFromUserInput "$(Join-Path -Path $root -ChildPath *.tests.ps1)"
-
-#                 $PesterTests = @($coverageInfo |
-#                         Select-Object -ExpandProperty Path |
-#                         Where-Object { $_ -match '\.tests.ps1$' })
-
-#                 $PesterTests.Count | Should -Be 2
-#                 $PesterTests | Should -Contain $(Join-Path -Path $root -ChildPath TestScript.tests.ps1)
-#                 $PesterTests | Should -Contain $(Join-Path -Path $root -ChildPath TestScript2.tests.ps1)
-#             }
-
-#             It 'Includes test file when targeted directly using filepath' {
-#                 $path = Join-Path -Path $root -ChildPath TestScript.tests.ps1
-
-#                 $coverageInfo = Get-CoverageInfoFromUserInput $path
-
-#                 $PesterTests = $coverageInfo | Select-Object -ExpandProperty Path
-
-#                 $PesterTests | Should -Be $path
-#             }
-
-#         }
-
-#         Context 'Using object-input' {
-#             It 'Excludes test files when IncludeTests is not specified' {
-#                 $coverageInfo = Get-CoverageInfoFromUserInput @{ Path = "$(Join-Path -Path $root -ChildPath TestScript.tests.ps1)" }
-
-#                 $PesterTests = $coverageInfo | Select-Object -ExpandProperty Path
-
-#                 $PesterTests | Should -BeNullOrEmpty
-#             }
-
-#             It 'Excludes test files when IncludeTests is false' {
-#                 $coverageInfo = Get-CoverageInfoFromUserInput @{ Path = "$(Join-Path -Path $root -ChildPath TestScript.tests.ps1)"; IncludeTests = $false }
-
-#                 $PesterTests = $coverageInfo | Select-Object -ExpandProperty Path
-
-#                 $PesterTests | Should -BeNullOrEmpty
-#             }
-
-#             It 'Includes test files when IncludeTests is true' {
-#                 $path = Join-Path -Path $root -ChildPath TestScript.tests.ps1
-
-#                 $coverageInfo = Get-CoverageInfoFromUserInput @{ Path = $path; IncludeTests = $true }
-
-#                 $PesterTests = $coverageInfo | Select-Object -ExpandProperty Path
-
-#                 $PesterTests | Should -Be $path
-#             }
-#         }
-#     }
+Describe 'Path resolution for test files' {
+    BeforeAll {
+        $root = (Get-PSDrive TestDrive).Root
+        $null = New-Item -Path $(Join-Path -Path $root -ChildPath TestScript.psm1) -ItemType File -ErrorAction SilentlyContinue
+        $null = New-Item -Path $(Join-Path -Path $root -ChildPath TestScript.ps1) -ItemType File -ErrorAction SilentlyContinue
+        $null = New-Item -Path $(Join-Path -Path $root -ChildPath TestScript.tests.ps1) -ItemType File -ErrorAction SilentlyContinue
+        $null = New-Item -Path $(Join-Path -Path $root -ChildPath TestScript2.tests.ps1) -ItemType File -ErrorAction SilentlyContinue
+        $null = New-Item -Path $(Join-Path -Path $root -ChildPath SubFolder\TestScript3.ps1) -ItemType File -Force -ErrorAction SilentlyContinue
+        $null = New-Item -Path $(Join-Path -Path $root -ChildPath SubFolder\TestScript3.tests.ps1) -ItemType File -Force -ErrorAction SilentlyContinue
+    }
+    Context 'Using Path-input (auto-detect)' {
+        It 'Includes script files by default when using wildcard path' {
+            $coverageInfo = Get-CoverageInfoFromUserInput "$(Join-Path -Path $root -ChildPath *)"
+            $PesterTests = @($coverageInfo |
+                    Select-Object -ExpandProperty Path |
+                    Where-Object { $_ -notmatch '\.tests.ps1$' })
+            $PesterTests.Count | Should -Be 3
+            $PesterTests | Should -Contain $(Join-Path -Path $root -ChildPath TestScript.psm1)
+            $PesterTests | Should -Contain $(Join-Path -Path $root -ChildPath TestScript.ps1)
+            $PesterTests | Should -Contain $(Join-Path -Path $root -ChildPath SubFolder\TestScript3.ps1)
+        }
+        It 'Excludes test files by default when using wildcard path' {
+            $coverageInfo = Get-CoverageInfoFromUserInput "$(Join-Path -Path $root -ChildPath *)"
+            $PesterTests = @($coverageInfo |
+                    Select-Object -ExpandProperty Path |
+                    Where-Object { $_ -match '\.tests.ps1$' })
+            $PesterTests | Should -BeNullOrEmpty
+        }
+        It 'Includes test files when specified in wildcard path' {
+            $coverageInfo = Get-CoverageInfoFromUserInput "$(Join-Path -Path $root -ChildPath *.tests.ps1)"
+            $PesterTests = @($coverageInfo |
+                    Select-Object -ExpandProperty Path |
+                    Where-Object { $_ -match '\.tests.ps1$' })
+            $PesterTests.Count | Should -Be 2
+            $PesterTests | Should -Contain $(Join-Path -Path $root -ChildPath TestScript.tests.ps1)
+            $PesterTests | Should -Contain $(Join-Path -Path $root -ChildPath TestScript2.tests.ps1)
+        }
+        It 'Includes test file when targeted directly using filepath' {
+            $path = Join-Path -Path $root -ChildPath TestScript.tests.ps1
+            $coverageInfo = Get-CoverageInfoFromUserInput $path
+            $PesterTests = $coverageInfo | Select-Object -ExpandProperty Path
+            $PesterTests | Should -Be $path
+        }
+    }
+    Context 'Using object-input' {
+        It 'Excludes test files when IncludeTests is not specified' {
+            $coverageInfo = Get-CoverageInfoFromUserInput @{ Path = "$(Join-Path -Path $root -ChildPath TestScript.tests.ps1)" }
+            $PesterTests = $coverageInfo | Select-Object -ExpandProperty Path
+            $PesterTests | Should -BeNullOrEmpty
+        }
+        It 'Excludes test files when IncludeTests is false' {
+            $coverageInfo = Get-CoverageInfoFromUserInput @{ Path = "$(Join-Path -Path $root -ChildPath TestScript.tests.ps1)"; IncludeTests = $false }
+            $PesterTests = $coverageInfo | Select-Object -ExpandProperty Path
+            $PesterTests | Should -BeNullOrEmpty
+        }
+        It 'Includes test files when IncludeTests is true' {
+            $path = Join-Path -Path $root -ChildPath TestScript.tests.ps1
+            $coverageInfo = Get-CoverageInfoFromUserInput @{ Path = $path; IncludeTests = $true }
+            $PesterTests = $coverageInfo | Select-Object -ExpandProperty Path
+            $PesterTests | Should -Be $path
+        }
+        It 'Includes test files when IncludeTests is true and using wildcard path' {
+            $coverageInfo = Get-CoverageInfoFromUserInput @{ Path = "$(Join-Path -Path $root -ChildPath *)"; IncludeTests = $true }
+            $PesterTests = $coverageInfo | Select-Object -ExpandProperty Path
+            $PesterTests.Count | Should -Be 6
+            $PesterTests | Should -Contain $(Join-Path -Path $root -ChildPath TestScript.psm1)
+            $PesterTests | Should -Contain $(Join-Path -Path $root -ChildPath TestScript.ps1)
+            $PesterTests | Should -Contain $(Join-Path -Path $root -ChildPath TestScript.tests.ps1)
+            $PesterTests | Should -Contain $(Join-Path -Path $root -ChildPath TestScript2.tests.ps1)
+            $PesterTests | Should -Contain $(Join-Path -Path $root -ChildPath SubFolder\TestScript3.ps1)
+            $PesterTests | Should -Contain $(Join-Path -Path $root -ChildPath SubFolder\TestScript3.tests.ps1)
+        }
+    }
+}
 
 #     Describe 'Stripping common parent paths' {
 

--- a/tst/functions/Coverage.Tests.ps1
+++ b/tst/functions/Coverage.Tests.ps1
@@ -617,12 +617,15 @@ InPesterModuleScope {
 Describe 'Path resolution for test files' {
     BeforeAll {
         $root = (Get-PSDrive TestDrive).Root
+        $rootSubFolder = Join-Path -Path $root -ChildPath TestSubFolder
+
+        $null = New-Item -Path $rootSubFolder -ItemType Directory -ErrorAction SilentlyContinue
         $null = New-Item -Path $(Join-Path -Path $root -ChildPath TestScript.psm1) -ItemType File -ErrorAction SilentlyContinue
         $null = New-Item -Path $(Join-Path -Path $root -ChildPath TestScript.ps1) -ItemType File -ErrorAction SilentlyContinue
         $null = New-Item -Path $(Join-Path -Path $root -ChildPath TestScript.tests.ps1) -ItemType File -ErrorAction SilentlyContinue
         $null = New-Item -Path $(Join-Path -Path $root -ChildPath TestScript2.tests.ps1) -ItemType File -ErrorAction SilentlyContinue
-        $null = New-Item -Path $(Join-Path -Path $root -ChildPath SubFolder\TestScript3.ps1) -ItemType File -Force -ErrorAction SilentlyContinue
-        $null = New-Item -Path $(Join-Path -Path $root -ChildPath SubFolder\TestScript3.tests.ps1) -ItemType File -Force -ErrorAction SilentlyContinue
+        $null = New-Item -Path $(Join-Path -Path $rootSubFolder -ChildPath TestScript3.ps1) -Force -ItemType File -ErrorAction SilentlyContinue
+        $null = New-Item -Path $(Join-Path -Path $rootSubFolder -ChildPath TestScript3.tests.ps1) -Force -ItemType File -ErrorAction SilentlyContinue
     }
     Context 'Using Path-input (auto-detect)' {
         It 'Includes script files by default when using wildcard path' {
@@ -633,7 +636,7 @@ Describe 'Path resolution for test files' {
             $PesterTests.Count | Should -Be 3
             $PesterTests | Should -Contain $(Join-Path -Path $root -ChildPath TestScript.psm1)
             $PesterTests | Should -Contain $(Join-Path -Path $root -ChildPath TestScript.ps1)
-            $PesterTests | Should -Contain $(Join-Path -Path $root -ChildPath SubFolder\TestScript3.ps1)
+            $PesterTests | Should -Contain $(Join-Path -Path $rootSubFolder -ChildPath TestScript3.ps1)
         }
         It 'Excludes test files by default when using wildcard path' {
             $coverageInfo = Get-CoverageInfoFromUserInput "$(Join-Path -Path $root -ChildPath *)"
@@ -683,8 +686,8 @@ Describe 'Path resolution for test files' {
             $PesterTests | Should -Contain $(Join-Path -Path $root -ChildPath TestScript.ps1)
             $PesterTests | Should -Contain $(Join-Path -Path $root -ChildPath TestScript.tests.ps1)
             $PesterTests | Should -Contain $(Join-Path -Path $root -ChildPath TestScript2.tests.ps1)
-            $PesterTests | Should -Contain $(Join-Path -Path $root -ChildPath SubFolder\TestScript3.ps1)
-            $PesterTests | Should -Contain $(Join-Path -Path $root -ChildPath SubFolder\TestScript3.tests.ps1)
+            $PesterTests | Should -Contain $(Join-Path -Path $rootSubFolder -ChildPath TestScript3.ps1)
+            $PesterTests | Should -Contain $(Join-Path -Path $rootSubFolder -ChildPath TestScript3.tests.ps1)
         }
     }
 }


### PR DESCRIPTION
## PR Summary
Adding ability to recursively traverse sub folders to find all files to be included in code coverage. This can be turned off by setting a new configuration option (CodeCoverageConfiguration.RecursePaths) to false. I have set it to true by default as I feel that this is the default expected behavior.

I also noticed that the coverage.xml file was not fully compatible with ReportGenerator and so I updated the sourcefile names to include the relative path so the code could be populated correctly in the finished report.

This new option should be documented at the https://pester.dev/docs/usage/code-coverage

`Fix #1621` 

## PR Checklist

- [x] PR has meaningful title
- [x] Summary describes changes
- [x] PR is ready to be merged
  - If not, use the arrow next to `Create Pull Request` to mark it as a draft. PR can be marked `Ready for review` when it's ready.
- [x] Tests are added/update *(if required)*
- [ ] Documentation is updated/added *(if required)*
