### PR TITLE
Fix default InModuleScope args-value

### DIFF
--- a/src/functions/InModuleScope.ps1
+++ b/src/functions/InModuleScope.ps1
@@ -71,7 +71,7 @@ function InModuleScope {
         [HashTable]
         $Parameters,
 
-        $ArgumentList
+        $ArgumentList = @()
     )
 
     $module = Get-ScriptModule -ModuleName $ModuleName -ErrorAction Stop


### PR DESCRIPTION
## PR Summary
Using ParameterAttribute or CmdLetBinding in InModuleScope scriptblock causes ParameterBindingException for the default when no arguments are provided. $ArgumentList-parameter is default null and is always passed to the scriptblock, which throws the error since advanced functions don't implicitly allow arguments.

PR changes $ArgumentList to be empty array by default as it won't cause the exception when not defined. Similar to #1730 for Mocks.

Fix #1809 

## PR Checklist

- [x] PR has meaningful title
- [x] Summary describes changes
- [x] PR is ready to be merged
  - If not, use the arrow next to `Create Pull Request` to mark it as a draft. PR can be marked `Ready for review` when it's ready.
- [x] Tests are added/update *(if required)*
- [ ] Documentation is updated/added *(if required)*
