### PR TITLE
Fixed type in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -540,7 +540,7 @@ $configuration = [PesterConfiguration]@{
         ErrorAction = 'Continue'
     }
     CodeCoverage = @{
-        Enable = $true
+        Enabled = $true
     }
 }
 


### PR DESCRIPTION
## PR Summary

In the configuration example, there's this code snippet:

    CodeCoverage = @{
        Enable = $true
    }

`Enable` should be `Enabled`

## PR Checklist

- [x] PR has meaningful title
- [x] Summary describes changes
- [x] PR is ready to be merged
  - If not, use the arrow next to `Create Pull Request` to mark it as a draft. PR can be marked `Ready for review` when it's ready.
- [ ] Tests are added/update *(if required)*
- [x] Documentation is updated/added *(if required)*
