### PR TITLE
Fix missing LICENSE file in Nuget package (#1839)

### DIFF
--- a/publish/release.ps1
+++ b/publish/release.ps1
@@ -99,6 +99,7 @@ if (Test-Path $nugetDir) {
 }
 $null = New-Item -ItemType Directory -Path $nugetDir
 Copy-Item "$PSScriptRoot/../bin/*" $nugetDir -Recurse
+Copy-Item "$PSScriptRoot/../LICENSE" $nugetDir -Recurse
 
 Out-File $nugetDir\VERIFICATION.txt -InputObject @"
 VERIFICATION


### PR DESCRIPTION
## PR Summary

Fix #1839 

This fixes the issue with Chocolatey validation of the Nuget package. Amended the release to include the LICENSE file.

## PR Checklist

- [X] PR has meaningful title
- [X] Summary describes changes
- [X] PR is ready to be merged
  - If not, use the arrow next to `Create Pull Request` to mark it as a draft. PR can be marked `Ready for review` when it's ready.
- [ ] Tests are added/update *(if required)*
- [ ] Documentation is updated/added *(if required)*