### PR TITLE
fixed typo in the examples of Invoke-Pester

### DIFF
--- a/src/Pester.ps1
+++ b/src/Pester.ps1
@@ -582,11 +582,11 @@ function Invoke-Pester {
 
     .EXAMPLE
     $config = [PesterConfiguration]::Default
-    $config.TestResults.Enabled = $true
+    $config.TestResult.Enabled = $true
     Invoke-Pester -Configuration $config
 
     This example runs all *.Tests.ps1 files in the current directory and its subdirectories.
-    It uses advanced configuration to enable testresult-output to file. Access $config.TestResults
+    It uses advanced configuration to enable testresult-output to file. Access $config.TestResult
     to see other testresult options like  output path and format and their default values.
 
     .LINK


### PR DESCRIPTION
## PR Summary

Fixed a type in the examples of 'Invoke-Pester' as '$config.TestResults' does not exist.

## PR Checklist

- [x] PR has meaningful title
- [x] Summary describes changes
- [x] PR is ready to be merged
  - If not, use the arrow next to `Create Pull Request` to mark it as a draft. PR can be marked `Ready for review` when it's ready.
- [ ] Tests are added/update *(if required)*
- [ ] Documentation is updated/added *(if required)*
