### PR TITLE
Fix default Data-value in Invoke-File

### DIFF
--- a/src/Pester.Runtime.psm1
+++ b/src/Pester.Runtime.psm1
@@ -2383,7 +2383,7 @@ function Invoke-File {
         $Path,
         [Parameter(Mandatory = $true)]
         [Management.Automation.SessionState] $SessionState,
-        [Collections.IDictionary] $Data
+        [Collections.IDictionary] $Data = @{}
     )
 
     $sb = {


### PR DESCRIPTION
## PR Summary

Using ParameterAttribute or CmdLetBinding in a parameterized testfile causes ParameterBindingException for a `$null`-value when invoked without providing any parameter-values. $Data-parameter is default null in `Invoke-File`, but is always passed to the scriptblock. This throws the error since advanced functions (testfile) don't implicitly allow arguments.

PR changes $Data to be empty hashtable by default as splatting the empty hashtable will avoid the error while not affecting the script/testfile. Similar to #1730 for Mocks and #1812 for InModuleScope.

Fix #1851

## PR Checklist

- [x] PR has meaningful title
- [x] Summary describes changes
- [x] PR is ready to be merged
  - If not, use the arrow next to `Create Pull Request` to mark it as a draft. PR can be marked `Ready for review` when it's ready.
- [ ] Tests are added/update *(if required)*
- [ ] Documentation is updated/added *(if required)*

<!-- Before you continue, please review [Contributing to Pester](https://pester.dev/docs/contributing/introduction).

Our continuous integration system doesn't send any notifications about failed tests. Please return to the opened pull request (after ~60 minutes) to check if everything is OK. -->
