### PR TITLE
Fix conflicting name "arguments" in parameter filter

### DIFF
--- a/src/functions/Mock.ps1
+++ b/src/functions/Mock.ps1
@@ -409,13 +409,13 @@ function Should-InvokeInternal {
 
     if ($Negate) {
         # Negative checks
-        if ($Exactly -and $matchingCalls.Count -eq $Times) {
+        if ($matchingCalls.Count -eq $Times -and ($Exactly -or !$PSBoundParameters.ContainsKey("Times"))) {
             return [PSCustomObject] @{
                 Succeeded      = $false
-                FailureMessage = "Expected ${commandName}${moduleMessage} to be called less or more than $Times, but it was called exactly $Times times"
+                FailureMessage = "Expected ${commandName}${moduleMessage} not to be called exactly $Times times"
             }
         }
-        elseif (-Not $Exactly -and $matchingCalls.Count -ge $Times) {
+        elseif ($matchingCalls.Count -ge $Times -and !$Exactly) {
             return [PSCustomObject] @{
                 Succeeded      = $false
                 FailureMessage = "Expected ${commandName}${moduleMessage} to be called less than $Times times but was called $($matchingCalls.Count) times"

--- a/src/functions/Mock.ps1
+++ b/src/functions/Mock.ps1
@@ -409,13 +409,13 @@ function Should-InvokeInternal {
 
     if ($Negate) {
         # Negative checks
-        if ($matchingCalls.Count -eq $Times -and ($Exactly -or !$PSBoundParameters.ContainsKey("Times"))) {
+        if ($Exactly -and $matchingCalls.Count -eq $Times) {
             return [PSCustomObject] @{
                 Succeeded      = $false
-                FailureMessage = "Expected ${commandName}${moduleMessage} not to be called exactly $Times times"
+                FailureMessage = "Expected ${commandName}${moduleMessage} to be called less or more than $Times, but it was called exactly $Times times"
             }
         }
-        elseif ($matchingCalls.Count -ge $Times -and !$Exactly) {
+        elseif (-Not $Exactly -and $matchingCalls.Count -ge $Times) {
             return [PSCustomObject] @{
                 Succeeded      = $false
                 FailureMessage = "Expected ${commandName}${moduleMessage} to be called less than $Times times but was called $($matchingCalls.Count) times"

--- a/src/functions/Mock.ps1
+++ b/src/functions/Mock.ps1
@@ -1082,11 +1082,11 @@ function Test-ParameterFilter {
         # this should not be private, it should leak into Should command when used in ParameterFilter
         $______isInMockParameterFilter = $true
         # $private:BoundParameters = $private:______mock_parameters.BoundParameters
-        $private:Arguments = $private:______mock_parameters.Arguments
+        $private:______arguments = $private:______mock_parameters.Arguments
         # TODO: not binding the bound parameters here because it would make the parameters unbound when the user does
         # not provide a param block, which they would never provide, so that is okay, but if there is a workaround this then
         # it would be nice to have. maybe changing the order in which I bind?
-        & $private:______mock_parameters.ScriptBlock @Arguments
+        & $private:______mock_parameters.ScriptBlock @______arguments
     }
 
     if ($PesterPreference.Debug.WriteDebugMessages.Value) {


### PR DESCRIPTION


Fix #1819