### PR TITLE
Fix wildcards in dirs

### DIFF
--- a/tst/Pester.RSpec.ts.ps1
+++ b/tst/Pester.RSpec.ts.ps1
@@ -868,7 +868,7 @@ i -PassThru:$PassThru {
             }
         }
 
-        dt "Providing path with wildcard that is in directory names should expand to all directories and all their test files" {
+        t "Providing path with wildcard that is in directory names should expand to all directories and all their test files" {
             try {
                 $sb = {
                     param (


### PR DESCRIPTION
Fix how paths are resolved when wildcard is used. Ensure that we inspect all items when more than 1 resolves from a wildcarded path. But filter those expanded paths down to *.Tests.ps1 to avoid including everyting. On the other hand when just a single file is added, or the wildcard resolves to just a single item, use that no matter what the file or filetype is, to allow any file to be invoked via Pester no matter what the extension is.

Fix #1857 