### PR TITLE
Add Coverage to result object

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -146,7 +146,7 @@ _TeamCity*
 !.axoCover/settings.json
 
 # Coverlet is a free, cross platform Code Coverage Tool
-coverage*[.json, .xml, .info]
+coverage[.json, .xml, .info]
 
 # Visual Studio code coverage results
 *.coverage

--- a/src/Pester.ps1
+++ b/src/Pester.ps1
@@ -1122,6 +1122,7 @@ function Invoke-Pester {
                 $totalMilliseconds = $run.Duration.TotalMilliseconds
                 $jaCoCoReport = Get-JaCoCoReportXml -CommandCoverage $breakpoints -TotalMilliseconds $totalMilliseconds -CoverageReport $coverageReport
                 $jaCoCoReport | & $SafeCommands['Out-File'] $PesterPreference.CodeCoverage.OutputPath.Value -Encoding $PesterPreference.CodeCoverage.OutputEncoding.Value
+                Write-CoverageReport $coverageReport
             }
 
             if (-not $PesterPreference.Debug.ReturnRawResultObject.Value) {

--- a/src/Pester.ps1
+++ b/src/Pester.ps1
@@ -1122,7 +1122,21 @@ function Invoke-Pester {
                 $totalMilliseconds = $run.Duration.TotalMilliseconds
                 $jaCoCoReport = Get-JaCoCoReportXml -CommandCoverage $breakpoints -TotalMilliseconds $totalMilliseconds -CoverageReport $coverageReport
                 $jaCoCoReport | & $SafeCommands['Out-File'] $PesterPreference.CodeCoverage.OutputPath.Value -Encoding $PesterPreference.CodeCoverage.OutputEncoding.Value
-                Write-CoverageReport $coverageReport
+                $reportText = Write-CoverageReport $coverageReport
+
+                $coverage = [Pester.Coverage]::Create()
+                $coverage.CoverageReport = $reportText
+                $coverage.CoveragePercent = $coverageReport.CoveragePercent
+                $coverage.CommandsAnalyzedCount = $coverageReport.NumberOfCommandsAnalyzed
+                $coverage.CommandsExecutedCount = $coverageReport.NumberOfCommandsExecuted
+                $coverage.CommandsMissedCount = $coverageReport.NumberOfCommandsMissed
+                $coverage.FilesAnalyzedCount = $coverageReport.NumberOfFilesAnalyzed
+                $coverage.CommandsMissed = $coverageReport.MissedCommands
+                $coverage.CommandsExecuted = $coverageReport.HitCommands
+                $coverage.FilesAnalyzed = $coverageReport.AnalyzedFiles
+
+                $run.Coverage = $coverage
+
             }
 
             if (-not $PesterPreference.Debug.ReturnRawResultObject.Value) {

--- a/src/csharp/Pester/Coverage.cs
+++ b/src/csharp/Pester/Coverage.cs
@@ -1,0 +1,30 @@
+﻿using System.Collections.Generic;
+
+namespace Pester
+{
+    public class Coverage
+    {
+        public static Coverage Create()
+        {
+            return new Coverage();
+        }
+
+        public decimal CoveragePercent { get; set; }
+
+        public string CoverageReport { get; set; }
+
+        public long CommandsAnalyzedCount { get; set; }
+        public long CommandsExecutedCount { get; set; }
+        public long CommandsMissedCount { get; set; }
+        public long FilesAnalyzedCount { get; set; }
+
+        public List<object> CommandsMissed = new List<object>();
+        public List<object> CommandsExecuted = new List<object>();
+        public List<object> FilesAnalyzed = new List<object>();
+
+        public override string ToString()
+        {
+            return CoveragePercent.ToString("N2 %");
+        }
+    }
+}

--- a/src/csharp/Pester/Factory.cs
+++ b/src/csharp/Pester/Factory.cs
@@ -1,6 +1,7 @@
 using System.Management.Automation;
 using System.Collections.Generic;
 using System;
+using System.Text;
 
 namespace Pester
 {
@@ -31,6 +32,7 @@ namespace Pester
         {
             return CreateErrorRecord("PesterAssertionFailed", message, file, line, lineText, terminating);
         }
+
         public static ErrorRecord CreateErrorRecord(string errorId, string message, string file, string line, string lineText, bool terminating)
         {
             var exception = new Exception(message);
@@ -44,6 +46,11 @@ namespace Pester
             targetObject.Add("Terminating", terminating);
             var errorRecord = new ErrorRecord(exception, errorId, errorCategory, targetObject);
             return errorRecord;
+        }
+
+        public static StringBuilder CreateStringBuilder()
+        {
+            return new StringBuilder();
         }
     }
 }

--- a/src/csharp/Pester/Run.cs
+++ b/src/csharp/Pester/Run.cs
@@ -51,6 +51,8 @@ namespace Pester
         public List<Test> NotRun { get; set; } = new List<Test>();
         public List<Test> Tests { get; set; } = new List<Test>();
 
+        public Coverage Coverage { get; set; }
+
         public override string ToString()
         {
             return ToStringConverter.RunToString(this);

--- a/src/csharp/Pester/Run.cs
+++ b/src/csharp/Pester/Run.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Text;
 
 namespace Pester
 {

--- a/src/functions/Coverage.ps1
+++ b/src/functions/Coverage.ps1
@@ -614,6 +614,7 @@ function Get-CoverageReport {
         MissedCommands           = $missedCommands
         HitCommands              = $hitCommands
         AnalyzedFiles            = $analyzedFiles
+        CoveragePercent          = if ($null -eq $CommandCoverage -or $CommandCoverage.Count -eq 0) { 0 } else { ($hitCommands.Count / $CommandCoverage.Count) * 100 }
     }
 }
 

--- a/src/functions/Output.ps1
+++ b/src/functions/Output.ps1
@@ -294,7 +294,7 @@ function Write-PesterReport {
 function Write-CoverageReport {
     param ([object] $CoverageReport)
 
-    if ($null -eq $CoverageReport -or ($pester.Show -eq [Pester.OutputTypes]::None) -or $CoverageReport.NumberOfCommandsAnalyzed -eq 0) {
+    if ($null -eq $CoverageReport -or ($PesterPreference.Output.Verbosity.Value -notin 'Normal', 'Detailed', 'Diagnostic') -or $CoverageReport.NumberOfCommandsAnalyzed -eq 0) {
         return
     }
 


### PR DESCRIPTION
Added Coverage to the Result object, and printing of the report to screen. The same report is reported to the CoverageObject. 

Fix #1625
