### PR TITLE
Little improvements to coverage output

### DIFF
--- a/src/Pester.Runtime.psm1
+++ b/src/Pester.Runtime.psm1
@@ -28,6 +28,7 @@ $state = [PSCustomObject] @{
 
     Plugin              = $null
     PluginConfiguration = $null
+    PluginData          = $null
     Configuration       = $null
 
     TotalStopWatch      = $null
@@ -45,6 +46,7 @@ function Reset-TestSuiteState {
 
     $state.Plugin = $null
     $state.PluginConfiguration = $null
+    $state.PluginData = $null
     $state.Configuration = $null
 
     $state.CurrentBlock = $null
@@ -991,6 +993,16 @@ function Run-Test {
     )
 
     $state.Discovery = $false
+    $steps = $state.Plugin.RunStart
+    if ($null -ne $steps -and 0 -lt @($steps).Count) {
+        Invoke-PluginStep -Plugins $state.Plugin -Step RunStart -Context @{
+            Blocks        = $Block
+            Configuration = $state.PluginConfiguration
+            Data          = $state.PluginData
+            WriteDebugMessages = $PesterPreference.Debug.WriteDebugMessages.Value
+            Write_PesterDebugMessage = if ($PesterPreference.Debug.WriteDebugMessages) { $script:SafeCommands['Write-PesterDebugMessage'] }
+        } -ThrowOnFailure
+    }
     foreach ($rootBlock in $Block) {
         $blockStartTime = $state.UserCodeStopWatch.Elapsed
         $overheadStartTime = $state.FrameworkStopWatch.Elapsed
@@ -1823,6 +1835,7 @@ function Invoke-Test {
         $Filter,
         $Plugin,
         $PluginConfiguration,
+        $PluginData,
         $Configuration
     )
 
@@ -1832,6 +1845,7 @@ function Invoke-Test {
 
     $state.Plugin = $Plugin
     $state.PluginConfiguration = $PluginConfiguration
+    $state.PluginData = $PluginData
     $state.Configuration = $Configuration
 
     # # TODO: this it potentially unreliable, because supressed errors are written to Error as well. And the errors are captured only from the caller state. So let's use it only as a useful indicator during migration and see how it works in production code.

--- a/src/csharp/Pester/Configuration.cs
+++ b/src/csharp/Pester/Configuration.cs
@@ -193,6 +193,16 @@ namespace Pester
         {
             return new DecimalOption(string.Empty, value, value);
         }
+
+        public static implicit operator DecimalOption(int value)
+        {
+            return new DecimalOption(string.Empty, value, value);
+        }
+
+        public static implicit operator DecimalOption(double value)
+        {
+            return new DecimalOption(string.Empty, (decimal) value, (decimal) value);
+        }
     }
 
     public class StringArrayOption : Option<string[]>
@@ -573,6 +583,10 @@ namespace Pester
         private StringArrayOption _path;
         private BoolOption _excludeTests;
         private BoolOption _recursePaths;
+        private BoolOption _delayBps;
+        private BoolOption _shBp;
+        private DecimalOption _coveragePercentTarget;
+
 
         public static CodeCoverageConfiguration Default { get { return new CodeCoverageConfiguration(); } }
 
@@ -589,6 +603,7 @@ namespace Pester
             Path = new StringArrayOption("Directories or files to be used for codecoverage, by default the Path(s) from general settings are used, unless overridden here.", new string[0]);
             ExcludeTests = new BoolOption("Exclude tests from code coverage. This uses the TestFilter from general configuration.", true);
             RecursePaths = new BoolOption("Will recurse through directories in the Path option.", true);
+            CoveragePercentTarget = new DecimalOption("Target percent of code coverage that you want to achieve, default 75%", 75m);
 
             SingleHitBreakpoints = new BoolOption("EXPERIMENTAL: Remove breakpoint when it is hit.", true);
             DelayWritingBreakpoints = new BoolOption("EXPERIMENTAL: Try writing breakpoints all at once.", true);
@@ -606,6 +621,7 @@ namespace Pester
                 Path = configuration.GetArrayOrNull<string>("Path") ?? Path;
                 ExcludeTests = configuration.GetValueOrNull<bool>("ExcludeTests") ?? ExcludeTests;
                 RecursePaths = configuration.GetValueOrNull<bool>("RecursePaths") ?? RecursePaths;
+                CoveragePercentTarget = configuration.GetValueOrNull<decimal>("CoveragePercentTarget") ?? CoveragePercentTarget;
 
                 SingleHitBreakpoints = configuration.GetValueOrNull<bool>("SingleHitBreakpoints") ?? SingleHitBreakpoints;
                 DelayWritingBreakpoints = configuration.GetValueOrNull<bool>("DelayWritingBreakpoints") ?? DelayWritingBreakpoints;
@@ -725,7 +741,23 @@ namespace Pester
         }
 
 
-        private BoolOption _delayBps;
+        public DecimalOption CoveragePercentTarget
+        {
+            get { return _coveragePercentTarget; }
+            set
+            {
+                if (_coveragePercentTarget == null)
+                {
+                    _coveragePercentTarget = value;
+                }
+                else
+                {
+                    _coveragePercentTarget = new DecimalOption(_coveragePercentTarget, value.Value);
+                }
+            }
+        }
+
+
         public BoolOption DelayWritingBreakpoints
         {
             get { return _delayBps; }
@@ -742,7 +774,6 @@ namespace Pester
             }
         }
 
-        private BoolOption _shBp;
         public BoolOption SingleHitBreakpoints
         {
             get { return _shBp; }

--- a/src/csharp/Pester/Coverage.cs
+++ b/src/csharp/Pester/Coverage.cs
@@ -11,6 +11,7 @@ namespace Pester
         }
 
         public decimal CoveragePercent { get; set; }
+        public decimal CoveragePercentTarget { get; set; }
 
         public string CoverageReport { get; set; }
 
@@ -25,7 +26,7 @@ namespace Pester
 
         public override string ToString()
         {
-            return string.Format("{0:N2} %", CoveragePercent);
+            return string.Format("{0:0.##}% / {1:0.##}%", CoveragePercent, CoveragePercentTarget);
         }
     }
 }

--- a/src/functions/Output.ps1
+++ b/src/functions/Output.ps1
@@ -351,7 +351,7 @@ function Write-CoverageReport {
         }
     }
     else {
-        $coverageMessage = $ReportStrings.CoverageMessage -f $command, $file, $executedPercent, $totalCommandCount, $fileCount
+        $coverageMessage = $ReportStrings.CoverageMessage -f $command, $file, $executedPercent, $totalCommandCount, $fileCount, $PesterPreference.CodeCoverage.CoveragePercentTarget.Value
         $coverageMessage + "`n"
         if ($writeToScreen) {
             & $SafeCommands['Write-Host'] $coverageMessage -Foreground $ReportTheme.Pass


### PR DESCRIPTION
Improve output, add percentage target so we can print green or red coverage message. Disable outputting missed commands in non-detailed output, but keep it in the result object.