### PR TITLE
Initialize state in Invoke-Pester and inherit it to children

### DIFF
--- a/src/Pester.ps1
+++ b/src/Pester.ps1
@@ -683,6 +683,11 @@ function Invoke-Pester {
         # this will inherit to child scopes and allow Describe / Context to run directly from a file or command line
         $invokedViaInvokePester = $true
 
+        # this will inherit to child scopes and allow Pester to run in Pester, not checking if this is
+        # already defined because we want a clean state for this Invoke-Pester even if it runs inside another
+        # testrun (which calls Invoke-Pester itself)
+        $state = New-PesterState
+
         # TODO: Remove all references to mock table, there should not be many.
         $script:mockTable = @{}
         # todo: move mock cleanup to BeforeAllBlockContainer when there is any

--- a/tst/Pester.RSpec.ts.ps1
+++ b/tst/Pester.RSpec.ts.ps1
@@ -1426,4 +1426,28 @@ i -PassThru:$PassThru {
             $test.ErrorRecord[0] -like "*Legacy Should syntax (without dashes) is not supported in Pester 5.*"
         }
     }
+
+    b "Running Pester in Pester" {
+        t "Invoke-Pester can run in Invoke-Pester" {
+            $container = New-PesterContainer -ScriptBlock {
+                Describe "Run Pester in Pester" {
+                    It "Runs the test" {
+                        $c = New-PesterContainer -ScriptBlock {
+                            Describe "d" {
+                                It "i" {
+                                    1 | Should -Be 1
+                                }
+                            }
+                        }
+
+                        $r = Invoke-Pester -Container $c -PassThru
+                        $r.TotalCount | Should -Be 1
+                    }
+                }
+            }
+
+            $result = Invoke-Pester -Container $container -PassThru
+            $result.TotalCount | Should -Be 1
+        }
+    }
 }

--- a/tst/Pester.Runtime.ts.ps1
+++ b/tst/Pester.Runtime.ts.ps1
@@ -146,7 +146,6 @@ i -PassThru:$PassThru {
 
         b "Basic" {
             t "Given a scriptblock with 1 test in it, it finds 1 test" {
-                Reset-TestSuiteState
                 $actual = (Find-Test -SessionState $ExecutionContext.SessionState -BlockContainer (New-BlockContainerObject -ScriptBlock {
                     New-Block "block1" {
                         New-Test "test1" { }
@@ -158,7 +157,6 @@ i -PassThru:$PassThru {
             }
 
             t "Given scriptblock with 2 tests in it it finds 2 tests" {
-                Reset-TestSuiteState
                 $actual = (Find-Test -SessionState $ExecutionContext.SessionState -BlockContainer (New-BlockContainerObject -ScriptBlock {
                     New-Block "block1" {
                         New-Test "test1" { }
@@ -174,14 +172,12 @@ i -PassThru:$PassThru {
 
         b "block" {
             t "Given 0 tests it returns block containing no tests" {
-                Reset-TestSuiteState
                 $actual = Find-Test -SessionState $ExecutionContext.SessionState -BlockContainer (New-BlockContainerObject -ScriptBlock { })
 
                 $actual.Blocks[0].Tests.Count | Verify-Equal 0
             }
 
             t "Given 0 tests it returns block containing 0 tests" {
-                Reset-TestSuiteState
                 $actual = Find-Test -SessionState $ExecutionContext.SessionState -BlockContainer (New-BlockContainerObject -ScriptBlock {
                     New-Block "block1" {
                         New-Test "test1" { }
@@ -194,7 +190,6 @@ i -PassThru:$PassThru {
 
         b "Find common setup for each test" {
             t "Given block that has test setup for each test it finds it" {
-                Reset-TestSuiteState
                 $actual = Find-Test -SessionState $ExecutionContext.SessionState -BlockContainer (New-BlockContainerObject -ScriptBlock {
                         New-Block "block1" {
                         New-EachTestSetup { setup }
@@ -208,7 +203,6 @@ i -PassThru:$PassThru {
 
         b "Finding setup for all tests" {
             t "Find setup to run before all tests in the block" {
-                Reset-TestSuiteState
                 $actual = Find-Test -SessionState $ExecutionContext.SessionState -BlockContainer (New-BlockContainerObject -ScriptBlock {
                         New-Block "block1" {
                             New-OneTimeTestSetup { oneTimeSetup }
@@ -222,7 +216,6 @@ i -PassThru:$PassThru {
 
         b "Finding blocks" {
             t "Find tests in block that is explicitly specified" {
-                Reset-TestSuiteState
                 $actual = Find-Test -SessionState $ExecutionContext.SessionState -BlockContainer (New-BlockContainerObject -ScriptBlock {
                         New-Block "block1" {
                             New-Test "test1" { }
@@ -234,7 +227,6 @@ i -PassThru:$PassThru {
             }
 
             t "Find tests in blocks that are next to each other" {
-                Reset-TestSuiteState
                 $actual = Find-Test -SessionState $ExecutionContext.SessionState -BlockContainer (New-BlockContainerObject -ScriptBlock {
                         New-Block "block1" {
                             New-Test "test1" { }
@@ -253,7 +245,6 @@ i -PassThru:$PassThru {
             }
 
             t "Find tests in blocks that are inside of each other" {
-                Reset-TestSuiteState
                 $actual = Find-Test -SessionState $ExecutionContext.SessionState -BlockContainer (New-BlockContainerObject -ScriptBlock {
                         New-Block "block1" {
                             New-Test "test1" { }
@@ -275,7 +266,6 @@ i -PassThru:$PassThru {
 
         b "Executing tests" {
             t "Executes 1 test" {
-                Reset-TestSuiteState
                 $actual = Invoke-Test -SessionState $ExecutionContext.SessionState -BlockContainer (New-BlockContainerObject -ScriptBlock {
                         New-Block "block1" {
                             New-Test "test1" { "a" }
@@ -289,7 +279,6 @@ i -PassThru:$PassThru {
             }
 
             t "Executes 2 tests next to each other" {
-                Reset-TestSuiteState
                 $actual = Invoke-Test -SessionState $ExecutionContext.SessionState -BlockContainer (New-BlockContainerObject -ScriptBlock {
                         New-Block "block1" {
                             New-Test "test1" { "a" }
@@ -309,7 +298,6 @@ i -PassThru:$PassThru {
             }
 
             t "Executes 2 tests in blocks next to each other" {
-                Reset-TestSuiteState
                 $actual = Invoke-Test -SessionState $ExecutionContext.SessionState -BlockContainer (New-BlockContainerObject -ScriptBlock {
                         New-Block "block1" {
                             New-Test "test1" { "a" }
@@ -333,7 +321,6 @@ i -PassThru:$PassThru {
             }
 
             t "Executes 2 tests deeper in blocks" {
-                Reset-TestSuiteState
                 $actual = Invoke-Test -SessionState $ExecutionContext.SessionState -BlockContainer (New-BlockContainerObject -ScriptBlock {
                         New-Block "block1" {
                             New-Test "test1" { "a" }
@@ -360,7 +347,6 @@ i -PassThru:$PassThru {
                 $c = @{
                     Call = 0
                 }
-                Reset-TestSuiteState
                 $actual = Invoke-Test -SessionState $ExecutionContext.SessionState -BlockContainer @(
                     (New-BlockContainerObject -ScriptBlock {
                             $c.Call++
@@ -875,7 +861,6 @@ i -PassThru:$PassThru {
         }
 
         t "continues to second block even if the first block is excluded" {
-            Reset-TestSuiteState
             $actual = Invoke-Test -SessionState $ExecutionContext.SessionState -BlockContainer (New-BlockContainerObject -ScriptBlock {
                     New-Block "block1" -Tag "DoNotRun" {
                         New-Test "test1" { "a" }
@@ -894,7 +879,6 @@ i -PassThru:$PassThru {
         }
 
         t "continues to second test even if the first test is excluded" {
-            Reset-TestSuiteState
             $actual = Invoke-Test -SessionState $ExecutionContext.SessionState -BlockContainer (New-BlockContainerObject -ScriptBlock {
                     New-Block "block1" {
                         New-Test "test1" { "a" } -Tag "DoNotRun"

--- a/tst/functions/It.Tests.ps1
+++ b/tst/functions/It.Tests.ps1
@@ -1,6 +1,6 @@
 Set-StrictMode -Version Latest
 
-# TODO: These tests depend on Pester state that no longer exists, keeping this for future reference, most of it is already tested by P
+# TODO: These tests depend on the OLD Pester state that no longer exists, keeping this for future reference, most of it is already tested by P
 return
 
 

--- a/tst/functions/PesterState.Tests.ps1
+++ b/tst/functions/PesterState.Tests.ps1
@@ -1,4 +1,4 @@
-# TODO: Pester state no longer exists, keeping this for reference, to see if there are some egde cases worth testing
+# TODO: the OLD Pester state no longer exists, keeping this for reference, to see if there are some egde cases worth testing
 return
 Set-StrictMode -Version Latest
 


### PR DESCRIPTION
Initialize state in Invoke-Pester rather than using global one to allow running Pester in Pester.

Fix #1867