### PR TITLE
Exclude noisy Measure-SafeCommands rule by default

### DIFF
--- a/PSScriptAnalyzerSettings.psd1
+++ b/PSScriptAnalyzerSettings.psd1
@@ -5,5 +5,6 @@
     ExcludeRules=@(
         'PSUseShouldProcessForStateChangingFunctions'
         'PSUseApprovedVerbs'
+        'Measure-SafeCommands'
     )
 }


### PR DESCRIPTION
## PR Summary
The custom "Measure-SafeCommands" PSScriptAnalyzer rule is noisy when editing files in VSCode outside of "src\\*" where it shouldn't apply.

There currently isn't a way to limit the paths where VSCode use PSSA automatically, so the rule is excluded in "PSScriptAnalyzerSettings.psd1" for now. That way, we can still benefit from automatic checks against other useful default rules.

The SafeCommands-rule can still be invoked manually using `Invoke-ScriptAnalyzer -Path ./src -CustomRulePath ./Pester.BuildAnalyzerRules/ -Recurse`

Fix #1761 

## PR Checklist

- [X] PR has meaningful title
- [X] Summary describes changes
- [X] PR is ready to be merged
  - If not, use the arrow next to `Create Pull Request` to mark it as a draft. PR can be marked `Ready for review` when it's ready.
- [ ] Tests are added/update *(if required)*
- [ ] Documentation is updated/added *(if required)*
