### PR TITLE
Coverage gutters

### DIFF
--- a/src/Pester.ps1
+++ b/src/Pester.ps1
@@ -1127,7 +1127,15 @@ function Invoke-Pester {
                 $breakpoints = @($run.PluginData.Coverage.CommandCoverage)
                 $coverageReport = Get-CoverageReport -CommandCoverage $breakpoints
                 $totalMilliseconds = $run.Duration.TotalMilliseconds
-                [xml] $jaCoCoReport = [xml] (Get-JaCoCoReportXml -CommandCoverage $breakpoints -TotalMilliseconds $totalMilliseconds -CoverageReport $coverageReport)
+
+                $configuration = $run.PluginConfiguration.Coverage
+
+                if ("JaCoCo" -eq $configuration.OutputFormat -or "CoverageGutters" -eq $configuration.OutputFormat) {
+                [xml] $jaCoCoReport = [xml] (Get-JaCoCoReportXml -CommandCoverage $breakpoints -TotalMilliseconds $totalMilliseconds -CoverageReport $coverageReport -Format $configuration.OutputFormat)
+                }
+                else {
+                    throw "CodeCoverage.CoverageFormat must be 'JaCoCo' or 'CoverageGutters', but it was $($configuration.OutputFormat), please review your configuration."
+                }
 
                 $settings = [Xml.XmlWriterSettings] @{
                     Indent              = $true

--- a/src/csharp/Pester/CodeCoverageConfiguration.cs
+++ b/src/csharp/Pester/CodeCoverageConfiguration.cs
@@ -42,7 +42,7 @@ namespace Pester
         public CodeCoverageConfiguration() : base("CodeCoverage configuration.")
         {
             Enabled = new BoolOption("Enable CodeCoverage.", false);
-            OutputFormat = new StringOption("Format to use for code coverage report. Possible values: JaCoCo", "JaCoCo");
+            OutputFormat = new StringOption("Format to use for code coverage report. Possible values: JaCoCo, CoverageGutters", "JaCoCo");
             OutputPath = new StringOption("Path relative to the current directory where code coverage report is saved.", "coverage.xml");
             OutputEncoding = new StringOption("Encoding of the output file.", "UTF8");
             Path = new StringArrayOption("Directories or files to be used for codecoverage, by default the Path(s) from general settings are used, unless overridden here.", new string[0]);

--- a/src/csharp/Pester/Factory.cs
+++ b/src/csharp/Pester/Factory.cs
@@ -2,6 +2,7 @@ using System.Management.Automation;
 using System.Collections.Generic;
 using System;
 using System.Text;
+using System.IO;
 
 namespace Pester
 {
@@ -51,6 +52,11 @@ namespace Pester
         public static StringBuilder CreateStringBuilder()
         {
             return new StringBuilder();
+        }
+
+        public static StringWriter CreateStringWriter()
+        {
+            return new StringWriter();
         }
     }
 }

--- a/src/functions/Coverage.ps1
+++ b/src/functions/Coverage.ps1
@@ -750,7 +750,6 @@ function Get-JaCoCoReportXml {
     )
 
     $isGutters = "CoverageGutters" -eq $Format
-    $isGutters = $true
 
     if ($null -eq $CoverageReport -or ($pester.Show -eq [Pester.OutputTypes]::None) -or $CoverageReport.NumberOfCommandsAnalyzed -eq 0) {
         return

--- a/src/functions/Coverage.ps1
+++ b/src/functions/Coverage.ps1
@@ -676,6 +676,11 @@ function Get-CoverageReport {
 function Get-CommonParentPath {
     param ([string[]] $Path)
 
+    if ("CoverageGutters" -eq $PesterPreference.CodeCoverage.OutputFormat.Value) {
+        # for coverage gutters the root path is relative to the coverage.xml
+        return (& $SafeCommands['Split-Path'] -Path $PesterPreference.CodeCoverage.OutputPath.Value | Normalize-Path )
+    }
+
     $pathsToTest = @(
         $Path |
             Normalize-Path |
@@ -740,8 +745,12 @@ function Get-JaCoCoReportXml {
         [parameter(Mandatory = $true)]
         [object] $CoverageReport,
         [parameter(Mandatory = $true)]
-        [long] $TotalMilliseconds
+        [long] $TotalMilliseconds,
+        [string] $Format
     )
+
+    $isGutters = "CoverageGutters" -eq $Format
+    $isGutters = $true
 
     if ($null -eq $CoverageReport -or ($pester.Show -eq [Pester.OutputTypes]::None) -or $CoverageReport.NumberOfCommandsAnalyzed -eq 0) {
         return
@@ -863,11 +872,24 @@ function Get-JaCoCoReportXml {
     foreach ($package in $packageList) {
         $packageRelativePath = Get-RelativePath -Path $package.Name -RelativeTo $commonParent
 
-        if ($null -eq $packageRelativePath) {
-            $packageName = $commonParentLeaf
+        # e.g. "." for gutters, and "package" for non gutters in root
+        # and "sub-dir" for gutters, and "package/sub-dir" for non-gutters
+        $packageName = if ($null -eq $packageRelativePath -or "" -eq $packageRelativePath) {
+            if ($isGutters) {
+                "."
+            }
+            else {
+                $commonParentLeaf
+            }
         }
         else {
-            $packageName = "{0}/{1}" -f $commonParentLeaf, $($packageRelativePath.Replace("\", "/"))
+            $packageRelativePathFormatted = $packageRelativePath.Replace("\", "/")
+            if ($isGutters) {
+                $packageRelativePathFormatted
+            }
+            else {
+                "$commonParentLeaf/$packageRelativePathFormatted"
+            }
         }
 
         $packageElement = Add-XmlElement $reportElement "package" @{
@@ -877,11 +899,21 @@ function Get-JaCoCoReportXml {
         foreach ($file in $package.Classes.Keys) {
             $class = $package.Classes.$file
             $classElementRelativePath = (Get-RelativePath -Path $file -RelativeTo $commonParent).Replace("\", "/")
-            $classElementName = "{0}/{1}" -f $commonParentLeaf, $classElementRelativePath
+            $classElementName = if ($isGutters) {
+                    $classElementRelativePath
+                }
+                else {
+                    "$commonParentLeaf/$classElementRelativePath"
+                }
             $classElementName = $classElementName.Substring(0, $($classElementName.LastIndexOf(".")))
             $classElement = Add-XmlElement $packageElement 'class' -Attributes ([ordered] @{
                     name           = $classElementName
-                    sourcefilename = $classElementRelativePath
+                    sourcefilename = if ($isGutters) {
+                        & $SafeCommands["Split-Path"] $classElementRelativePath -Leaf
+                    }
+                    else {
+                        $classElementRelativePath
+                    }
                 })
 
             foreach ($function in $class.Methods.Keys) {
@@ -906,7 +938,12 @@ function Get-JaCoCoReportXml {
             $class = $package.Classes.$file
             $classElementRelativePath = (Get-RelativePath -Path $file -RelativeTo $commonParent).Replace("\", "/")
             $sourceFileElement = Add-XmlElement $packageElement 'sourcefile' -Attributes ([ordered] @{
-                    name = $classElementRelativePath
+                    name = if ($isGutters) {
+                        & $SafeCommands["Split-Path"] $classElementRelativePath -Leaf
+                    }
+                    else {
+                        $classElementRelativePath
+                    }
                 })
 
             foreach ($line in $class.Lines.Keys) {

--- a/src/functions/assertions/Be.ps1
+++ b/src/functions/assertions/Be.ps1
@@ -163,7 +163,7 @@ function Get-CompareStringMessage {
 
     if ($null -eq $ContextLength) {
         # this is how much text we want to see after difference in the excerpt
-        $ContextLength = 10
+        $ContextLength = $MaximumLineLength / 7
     }
     $ExpectedValueLength = $ExpectedValue.Length
     $actualLength = $actual.Length

--- a/test.ps1
+++ b/test.ps1
@@ -95,7 +95,7 @@ if (-not $SkipPTests) {
 Get-Module Pester | Remove-Module
 
 Import-Module $PSScriptRoot/bin/Pester.psd1 -ErrorAction Stop
-Import-Module $PSScriptRoot/tst/axiom/Axiom.psm1
+Import-Module $PSScriptRoot/tst/axiom/Axiom.psm1 -DisableNameChecking
 
 # reset pester and all preferences
 $PesterPreference = [PesterConfiguration]::Default

--- a/tst/functions/Coverage.Tests.ps1
+++ b/tst/functions/Coverage.Tests.ps1
@@ -315,6 +315,138 @@ InPesterModuleScope {
                 ')
             }
 
+            It 'JaCoCo for CoverageGutters report must be correct' {
+                # when using output for coverage gutters the output needs to be slightly different
+                # adding a new formatter, instead of changing the old one
+                [String]$jaCoCoReportXml = Get-JaCoCoReportXml -CommandCoverage $breakpoints -TotalMilliseconds 10000 -CoverageReport $coverageReport -Format "CoverageGutters"
+                $jaCoCoReportXml = $jaCoCoReportXml -replace 'Pester \([^\)]*', 'Pester (date'
+                $jaCoCoReportXml = $jaCoCoReportXml -replace 'start="[0-9]*"', 'start=""'
+                $jaCoCoReportXml = $jaCoCoReportXml -replace 'dump="[0-9]*"', 'dump=""'
+                $jaCoCoReportXml = $jaCoCoReportXml -replace "$([System.Environment]::NewLine)", ''
+                $jaCoCoReportXml = $jaCoCoReportXml -replace "$(Split-Path -Path $root -Leaf)", 'CommonRoot'
+                $jaCoCoReportXml = $jaCoCoReportXml.Replace($root.Replace('\', '/'), '')
+                (Clear-WhiteSpace $jaCoCoReportXml) | Should -Be (Clear-WhiteSpace '
+                <?xml version="1.0" encoding="UTF-8" standalone="no"?>
+                <!DOCTYPE report PUBLIC "-//JACOCO//DTD Report 1.1//EN" "report.dtd">
+                <report name="Pester (date)">
+                    <sessioninfo id="this" start="" dump="" />
+                    <package name="CommonRoot">
+                        <class name="CommonRoot/TestScript" sourcefilename="TestScript.ps1">
+                            <method name="NestedFunction" desc="()" line="5">
+                                <counter type="INSTRUCTION" missed="0" covered="2" />
+                                <counter type="LINE" missed="0" covered="2" />
+                                <counter type="METHOD" missed="0" covered="1" />
+                            </method>
+                            <method name="FunctionOne" desc="()" line="9">
+                                <counter type="INSTRUCTION" missed="1" covered="6" />
+                                <counter type="LINE" missed="0" covered="5" />
+                                <counter type="METHOD" missed="0" covered="1" />
+                            </method>
+                            <method name="FunctionTwo" desc="()" line="22">
+                                <counter type="INSTRUCTION" missed="1" covered="0" />
+                                <counter type="LINE" missed="1" covered="0" />
+                                <counter type="METHOD" missed="1" covered="0" />
+                            </method>
+                            <method name="&lt;script&gt;" desc="()" line="25">
+                                <counter type="INSTRUCTION" missed="0" covered="3" />
+                                <counter type="LINE" missed="0" covered="3" />
+                                <counter type="METHOD" missed="0" covered="1" />
+                            </method>
+                            <method name="MyClass" desc="()" line="32">
+                                <counter type="INSTRUCTION" missed="0" covered="1" />
+                                <counter type="LINE" missed="0" covered="1" />
+                                <counter type="METHOD" missed="0" covered="1" />
+                            </method>
+                            <method name="MethodOne" desc="()" line="37">
+                                <counter type="INSTRUCTION" missed="0" covered="1" />
+                                <counter type="LINE" missed="0" covered="1" />
+                                <counter type="METHOD" missed="0" covered="1" />
+                            </method>
+                            <method name="MethodTwo" desc="()" line="42">
+                                <counter type="INSTRUCTION" missed="1" covered="0" />
+                                <counter type="LINE" missed="1" covered="0" />
+                                <counter type="METHOD" missed="1" covered="0" />
+                            </method>
+                            <counter type="INSTRUCTION" missed="3" covered="13" />
+                            <counter type="LINE" missed="2" covered="12" />
+                            <counter type="METHOD" missed="2" covered="5" />
+                            <counter type="CLASS" missed="0" covered="1" />
+                        </class>
+                        <class name="CommonRoot/TestScript2" sourcefilename="TestScript2.ps1">
+                            <method name="&lt;script&gt;" desc="()" line="1">
+                                <counter type="INSTRUCTION" missed="0" covered="1" />
+                                <counter type="LINE" missed="0" covered="1" />
+                                <counter type="METHOD" missed="0" covered="1" />
+                            </method>
+                            <counter type="INSTRUCTION" missed="0" covered="1" />
+                            <counter type="LINE" missed="0" covered="1" />
+                            <counter type="METHOD" missed="0" covered="1" />
+                            <counter type="CLASS" missed="0" covered="1" />
+                        </class>
+                        <sourcefile name="TestScript.ps1">
+                            <line nr="5" mi="0" ci="1" mb="0" cb="0" />
+                            <line nr="6" mi="0" ci="1" mb="0" cb="0" />
+                            <line nr="9" mi="0" ci="1" mb="0" cb="0" />
+                            <line nr="11" mi="0" ci="1" mb="0" cb="0" />
+                            <line nr="12" mi="0" ci="1" mb="0" cb="0" />
+                            <line nr="15" mi="1" ci="1" mb="0" cb="0" />
+                            <line nr="17" mi="0" ci="2" mb="0" cb="0" />
+                            <line nr="22" mi="1" ci="0" mb="0" cb="0" />
+                            <line nr="25" mi="0" ci="1" mb="0" cb="0" />
+                            <line nr="32" mi="0" ci="1" mb="0" cb="0" />
+                            <line nr="37" mi="0" ci="1" mb="0" cb="0" />
+                            <line nr="42" mi="1" ci="0" mb="0" cb="0" />
+                            <line nr="46" mi="0" ci="1" mb="0" cb="0" />
+                            <line nr="47" mi="0" ci="1" mb="0" cb="0" />
+                            <counter type="INSTRUCTION" missed="3" covered="13" />
+                            <counter type="LINE" missed="2" covered="12" />
+                            <counter type="METHOD" missed="2" covered="5" />
+                            <counter type="CLASS" missed="0" covered="1" />
+                        </sourcefile>
+                        <sourcefile name="TestScript2.ps1">
+                            <line nr="1" mi="0" ci="1" mb="0" cb="0" />
+                            <counter type="INSTRUCTION" missed="0" covered="1" />
+                            <counter type="LINE" missed="0" covered="1" />
+                            <counter type="METHOD" missed="0" covered="1" />
+                            <counter type="CLASS" missed="0" covered="1" />
+                        </sourcefile>
+                        <counter type="INSTRUCTION" missed="3" covered="14" />
+                        <counter type="LINE" missed="2" covered="13" />
+                        <counter type="METHOD" missed="2" covered="6" />
+                        <counter type="CLASS" missed="0" covered="2" />
+                    </package>
+                    <package name="CommonRoot/TestSubFolder">
+                        <class name="CommonRoot/TestSubFolder/TestScript3" sourcefilename="TestSubFolder/TestScript3.ps1">
+                            <method name="&lt;script&gt;" desc="()" line="1">
+                                <counter type="INSTRUCTION" missed="0" covered="1" />
+                                <counter type="LINE" missed="0" covered="1" />
+                                <counter type="METHOD" missed="0" covered="1" />
+                            </method>
+                            <counter type="INSTRUCTION" missed="0" covered="1" />
+                            <counter type="LINE" missed="0" covered="1" />
+                            <counter type="METHOD" missed="0" covered="1" />
+                            <counter type="CLASS" missed="0" covered="1" />
+                        </class>
+                        <sourcefile name="TestSubFolder/TestScript3.ps1">
+                            <line nr="1" mi="0" ci="1" mb="0" cb="0" />
+                            <counter type="INSTRUCTION" missed="0" covered="1" />
+                            <counter type="LINE" missed="0" covered="1" />
+                            <counter type="METHOD" missed="0" covered="1" />
+                            <counter type="CLASS" missed="0" covered="1" />
+                        </sourcefile>
+                        <counter type="INSTRUCTION" missed="0" covered="1" />
+                        <counter type="LINE" missed="0" covered="1" />
+                        <counter type="METHOD" missed="0" covered="1" />
+                        <counter type="CLASS" missed="0" covered="1" />
+                    </package>
+                    <counter type="INSTRUCTION" missed="3" covered="15" />
+                    <counter type="LINE" missed="2" covered="14" />
+                    <counter type="METHOD" missed="2" covered="7" />
+                    <counter type="CLASS" missed="0" covered="3" />
+                </report>
+                ')
+            }
+
             It 'Reports the right line numbers' {
                 $coverageReport.HitCommands[$coverageReport.NumberOfCommandsExecuted - 1].Line | Should -Be 1
                 $coverageReport.HitCommands[$coverageReport.NumberOfCommandsExecuted - 1].StartLine | Should -Be 1

--- a/tst/functions/Coverage.Tests.ps1
+++ b/tst/functions/Coverage.Tests.ps1
@@ -186,7 +186,7 @@ InPesterModuleScope {
             }
 
             It 'JaCoCo report must be correct' {
-                [String]$jaCoCoReportXml = Get-JaCoCoReportXml -CommandCoverage $breakpoints -TotalMilliseconds 10000 -CoverageReport $coverageReport
+                [String]$jaCoCoReportXml = Get-JaCoCoReportXml -CommandCoverage $breakpoints -TotalMilliseconds 10000 -CoverageReport $coverageReport -Format "JaCoCo"
                 $jaCoCoReportXml = $jaCoCoReportXml -replace 'Pester \([^\)]*', 'Pester (date'
                 $jaCoCoReportXml = $jaCoCoReportXml -replace 'start="[0-9]*"', 'start=""'
                 $jaCoCoReportXml = $jaCoCoReportXml -replace 'dump="[0-9]*"', 'dump=""'
@@ -316,8 +316,9 @@ InPesterModuleScope {
             }
 
             It 'JaCoCo for CoverageGutters report must be correct' {
-                # when using output for coverage gutters the output needs to be slightly different
-                # adding a new formatter, instead of changing the old one
+                # when using output for CoverageGutters in VSCodethe output needs to be slightly different,
+                # paths need to be reported relative to the output file and sourcefile name must be just the
+                # file name, adding a new formatter, instead of changing the default one
                 [String]$jaCoCoReportXml = Get-JaCoCoReportXml -CommandCoverage $breakpoints -TotalMilliseconds 10000 -CoverageReport $coverageReport -Format "CoverageGutters"
                 $jaCoCoReportXml = $jaCoCoReportXml -replace 'Pester \([^\)]*', 'Pester (date'
                 $jaCoCoReportXml = $jaCoCoReportXml -replace 'start="[0-9]*"', 'start=""'
@@ -330,8 +331,8 @@ InPesterModuleScope {
                 <!DOCTYPE report PUBLIC "-//JACOCO//DTD Report 1.1//EN" "report.dtd">
                 <report name="Pester (date)">
                     <sessioninfo id="this" start="" dump="" />
-                    <package name="CommonRoot">
-                        <class name="CommonRoot/TestScript" sourcefilename="TestScript.ps1">
+                    <package name=".">
+                        <class name="TestScript" sourcefilename="TestScript.ps1">
                             <method name="NestedFunction" desc="()" line="5">
                                 <counter type="INSTRUCTION" missed="0" covered="2" />
                                 <counter type="LINE" missed="0" covered="2" />
@@ -372,7 +373,7 @@ InPesterModuleScope {
                             <counter type="METHOD" missed="2" covered="5" />
                             <counter type="CLASS" missed="0" covered="1" />
                         </class>
-                        <class name="CommonRoot/TestScript2" sourcefilename="TestScript2.ps1">
+                        <class name="TestScript2" sourcefilename="TestScript2.ps1">
                             <method name="&lt;script&gt;" desc="()" line="1">
                                 <counter type="INSTRUCTION" missed="0" covered="1" />
                                 <counter type="LINE" missed="0" covered="1" />
@@ -415,8 +416,8 @@ InPesterModuleScope {
                         <counter type="METHOD" missed="2" covered="6" />
                         <counter type="CLASS" missed="0" covered="2" />
                     </package>
-                    <package name="CommonRoot/TestSubFolder">
-                        <class name="CommonRoot/TestSubFolder/TestScript3" sourcefilename="TestSubFolder/TestScript3.ps1">
+                    <package name="TestSubFolder">
+                        <class name="TestSubFolder/TestScript3" sourcefilename="TestScript3.ps1">
                             <method name="&lt;script&gt;" desc="()" line="1">
                                 <counter type="INSTRUCTION" missed="0" covered="1" />
                                 <counter type="LINE" missed="0" covered="1" />
@@ -427,7 +428,7 @@ InPesterModuleScope {
                             <counter type="METHOD" missed="0" covered="1" />
                             <counter type="CLASS" missed="0" covered="1" />
                         </class>
-                        <sourcefile name="TestSubFolder/TestScript3.ps1">
+                        <sourcefile name="TestScript3.ps1">
                             <line nr="1" mi="0" ci="1" mb="0" cb="0" />
                             <counter type="INSTRUCTION" missed="0" covered="1" />
                             <counter type="LINE" missed="0" covered="1" />


### PR DESCRIPTION
Add a coverage format specific to Coverage Gutters, to make it easy to use with Pester in VSCode and also fix some of the problems with it. Now you can specify whatever path your want covered, including the path to which coverage.xml is output, and not just a subfolder. The root is determined based on the location of coverage.xml not the common root of files, so it is static and not dynamic. 

Building on this article: https://web.archive.org/web/20201107233838/https://www.pwsh.site/powershell/2019/01/10/how-to-enable-coverage-markings-in-vscode-for-your-powershell-projects.html

Integration with the PowerShell extension Code Lens in VSCode is not done yet, because the pester integration does not have the ability to provide a custom setup script, but can be either done by a custom launch json task, which points to a script. 

```json
# .vscode/launch.json
{
    "version": "0.2.0",
    "configurations": [
        {
            "name": "Run tests in current file with CC",
            "type": "PowerShell",
            "request": "launch",
            "script": "${workspaceFolder}/test.ps1",
            "args": [
                "-Path", "'${file}'",
                "-Output", "${config:powershell.pester.debugOutputVerbosity}",
                "-CodeCoverage",
            ],
            "cwd": "${file}",
        }
    ]
}
```
```powershell 
# test.ps1
param (
    [String] $Path = ".",
    [String] $Output = "Normal",
    [Switch] $CodeCoverage
)

$Configuration = [PesterConfiguration]::Default

$Configuration.Run.Path = $Path

$Configuration.Output.Verbosity = $Output

$Configuration.CodeCoverage.Enabled = [bool] $CodeCoverage
# CoverageGutters is new option in Pester 5.2 pre-release
$Configuration.CodeCoverage.OutputFormat = "CoverageGutters"
$Configuration.CodeCoverage.Path = "$PSScriptRoot/src"
$Configuration.CodeCoverage.OutputPath = "$PSScriptRoot/coverage.xml"
$Configuration.CodeCoverage.CoveragePercentTarget = 90

$Configuration.Debug.WriteDebugMessages = $true
$Configuration.Debug.WriteDebugMessagesFrom = "CodeCoverage"


# for convenience just run the passed file when we invoke this via launchConfig.json when
# the file is a non-test file
$isDirectory = (Get-Item $Path).PSIsContainer
$isTestFile = $Path.EndsWith($Configuration.Run.TestExtension.Value)
if (-not $isDirectory -and -not $isTestFile) {
    & $Path
    return
}

Invoke-Pester -Configuration $Configuration
```

```json
# .vscode/settings.json
{
    // disable gutters to make breakpoints usable
    "coverage-gutters.showGutterCoverage": false,
    "coverage-gutters.showLineCoverage": true
}
```
Ensure that you have [CoverageGutters](https://marketplace.visualstudio.com/items?itemName=ryanluker.vscode-coverage-gutters) extension installed VSCode, and run "Coverage Gutters: Watch". 


( You can also integrate with the code lens, but it's fragile. You can set `$script:PesterPreference = $Configuration` from test.ps1, which would be then used while it is in scope. But because not all files are run when you use the code lens it will produce confusing code coverage results. )
