### PR TITLE
Fix output for currently set fullname-filter

### DIFF
--- a/src/Pester.Runtime.ps1
+++ b/src/Pester.Runtime.ps1
@@ -2266,7 +2266,7 @@ function flattenBlock ($Block, $Accumulator) {
 function New-FilterObject {
     [CmdletBinding()]
     param (
-        [String[][]] $FullName,
+        [String[]] $FullName,
         [String[]] $Tag,
         [String[]] $ExcludeTag,
         [String[]] $Line


### PR DESCRIPTION
## PR Summary
Fixes broken output for currently set FullName-filter. Caused by a cast to `string[][]` which seems to be a typo.

Fix #1892 

## PR Checklist

- [x] PR has meaningful title
- [x] Summary describes changes
- [x] PR is ready to be merged
  - If not, use the arrow next to `Create Pull Request` to mark it as a draft. PR can be marked `Ready for review` when it's ready.
- [ ] Tests are added/update *(if required)*
- [ ] Documentation is updated/added *(if required)*