### PR TITLE
Fix setting passed on parent block when some blocks are not run

### DIFF
--- a/src/Pester.Runtime.ps1
+++ b/src/Pester.Runtime.ps1
@@ -2192,7 +2192,7 @@ function PostProcess-ExecutedBlock {
                 foreach ($child in $childBlocks) {
                     # check that no child block failed, the Passed is aggregate failed, so it will be false
                     # when any test fails in the child, or if the block itself fails
-                    if (-not $child.Passed) {
+                    if ($child.ShouldRun -and -not $child.Passed) {
                         $anyChildBlockFailed = $true
                     }
 

--- a/tst/Pester.Runtime.ts.ps1
+++ b/tst/Pester.Runtime.ts.ps1
@@ -2214,7 +2214,7 @@ i -PassThru:$PassThru {
         # issue: https://github.com/pester/Pester/issues/1848, the parent block was actually marked as
         # failed because one of the blocks were not executed and we only check for .passed in the code
         # and not consider not run blocks
-        dt "Multiple blocks in one block will mark the block as passed even when one of them is filtered out" {
+        t "Multiple blocks in one block will mark the block as passed even when one of them is filtered out" {
             $actual = Invoke-Test -SessionState $ExecutionContext.SessionState -BlockContainer (
                 New-BlockContainerObject -ScriptBlock {
                     # describe
@@ -2255,7 +2255,7 @@ i -PassThru:$PassThru {
             $actual.Blocks[0].Passed | Verify-True
         }
 
-        dt "Multiple blocks in root block will mark the block as passed when one of them is filtered out" {
+        t "Multiple blocks in root block will mark the block as passed when one of them is filtered out" {
             $actual = Invoke-Test -SessionState $ExecutionContext.SessionState -BlockContainer (
                 New-BlockContainerObject -ScriptBlock {
                     # context


### PR DESCRIPTION
Fix #1848

Ensure that when there are multiple blocks in a block we don't incorrectly mark the block as Passed = $false, when one of them is not run because it is filtered out, or skipped because of the -skip parameter.