### PR TITLE
Report failures in discovery into result object

### DIFF
--- a/src/Pester.RSpec.ps1
+++ b/src/Pester.RSpec.ps1
@@ -208,10 +208,10 @@ function PostProcess-RspecTestRun ($TestRun) {
         elseif ($b.Passed) {
             "Passed"
         }
-        elseif (-not $discoveryOnly -and $b.ShouldRun -and (-not $b.Executed -or -not $b.Passed)) {
+        elseif (0 -lt $b.ErrorRecord.Count) {
             "Failed"
         }
-        elseif ($discoveryOnly -and 0 -lt $b.ErrorRecord.Count) {
+        elseif (-not $discoveryOnly -and $b.ShouldRun -and (-not $b.Executed -or -not $b.Passed)) {
             "Failed"
         }
         else {

--- a/src/Pester.Runtime.ps1
+++ b/src/Pester.Runtime.ps1
@@ -2192,7 +2192,7 @@ function PostProcess-ExecutedBlock {
                 foreach ($child in $childBlocks) {
                     # check that no child block failed, the Passed is aggregate failed, so it will be false
                     # when any test fails in the child, or if the block itself fails
-                    if (-not $child.Passed) {
+                    if ($child.ShouldRun -and -not $child.Passed) {
                         $anyChildBlockFailed = $true
                     }
 

--- a/src/Pester.Runtime.ps1
+++ b/src/Pester.Runtime.ps1
@@ -919,7 +919,14 @@ function Discover-Test {
             } -ThrowOnFailure
         }
 
-        $null = Invoke-BlockContainer -BlockContainer $container -SessionState $SessionState
+        try {
+            $null = Invoke-BlockContainer -BlockContainer $container -SessionState $SessionState
+        }
+        catch {
+            $root.Passed = $false
+            $root.Result = "Failed"
+            $root.ErrorRecord.Add($_)
+        }
 
         [PSCustomObject] @{
             Container = $container

--- a/src/functions/Output.ps1
+++ b/src/functions/Output.ps1
@@ -506,9 +506,24 @@ function Get-WriteScreenPlugin ($Verbosity) {
         }
     }
 
-    if ($PesterPreference.Output.Verbosity.Value -in 'Detailed', 'Diagnostic') {
-        $p.ContainerDiscoveryEnd = {
-            param ($Context)
+    $p.ContainerDiscoveryEnd = {
+        param ($Context)
+
+        if ("Failed" -eq $Context.Block.Result) {
+            $path = if ("File" -eq $container.Type) {
+                $container.Item.FullName
+            }
+            elseif ("ScriptBlock" -eq $container.Type) {
+                "<ScriptBlock>$($container.Item.File):$($container.Item.StartPosition.StartLine)"
+            }
+            else {
+                throw "Container type '$($container.Type)' is not supported."
+            }
+
+            & $SafeCommands["Write-Host"] -ForegroundColor Red "[-] Discovery in $($path) failed with:"
+            Write-ErrorToScreen $Context.Block.ErrorRecord
+        }
+        elseif ($PesterPreference.Output.Verbosity.Value -in 'Detailed', 'Diagnostic') {
             # todo: this is very very slow because of View-flat
             & $SafeCommands["Write-Host"] -ForegroundColor Magenta "Found $(@(View-Flat -Block $Context.Block).Count) tests. $(ConvertTo-HumanTime $Context.Duration)"
         }

--- a/tst/Pester.Runtime.ts.ps1
+++ b/tst/Pester.Runtime.ts.ps1
@@ -2214,7 +2214,7 @@ i -PassThru:$PassThru {
         # issue: https://github.com/pester/Pester/issues/1848, the parent block was actually marked as
         # failed because one of the blocks were not executed and we only check for .passed in the code
         # and not consider not run blocks
-        dt "Multiple blocks in one block will mark the block as passed even when one of them is filtered out" {
+        t "Multiple blocks in one block will mark the block as passed even when one of them is filtered out" {
             $actual = Invoke-Test -SessionState $ExecutionContext.SessionState -BlockContainer (
                 New-BlockContainerObject -ScriptBlock {
                     # describe
@@ -2255,7 +2255,7 @@ i -PassThru:$PassThru {
             $actual.Blocks[0].Passed | Verify-True
         }
 
-        dt "Multiple blocks in root block will mark the block as passed when one of them is filtered out" {
+        t "Multiple blocks in root block will mark the block as passed when one of them is filtered out" {
             $actual = Invoke-Test -SessionState $ExecutionContext.SessionState -BlockContainer (
                 New-BlockContainerObject -ScriptBlock {
                     # context


### PR DESCRIPTION
Write failures in discovery to the result object as container failures. 

Fix #1843
