### PR TITLE
CI switch does not enable CodeCoverage by default

### DIFF
--- a/src/Main.ps1
+++ b/src/Main.ps1
@@ -755,7 +755,6 @@ function Invoke-Pester {
                 if ($PSBoundParameters.ContainsKey('CI')) {
                     if ($CI) {
                         $Configuration.Run.Exit = $true
-                        $Configuration.CodeCoverage.Enabled = $true
                         $Configuration.TestResult.Enabled = $true
                     }
 

--- a/src/Main.ps1
+++ b/src/Main.ps1
@@ -299,12 +299,15 @@ function Invoke-Pester {
 
     .PARAMETER CI
     (Introduced v5)
-    Enable Code Coverage, Test Results and Exit after Run
+    Enable Test Results and Exit after Run.
 
     Replace with ConfigurationProperty
-        CodeCoverage.Enabled = $true
         TestResult.Enabled = $true
         Run.Exit = $true
+
+    Since 5.2.0, this option no longer enables CodeCoverage.
+    To also enable CodeCoverage use this configuration option:
+        CodeCoverage.Enabled = $true
 
     .PARAMETER CodeCoverage
     (Deprecated v4)


### PR DESCRIPTION
Disabling code coverage for -CI switch because it is rarely used, and it is slow in every version of PowerShell and won't ever be fast on v5, and v6, and older v7 unless we use some ugly hacks.
Fix #1547 