### PR TITLE
Fix mock behavior for Mock and Should -Invoke

### DIFF
--- a/src/Main.ps1
+++ b/src/Main.ps1
@@ -697,7 +697,7 @@ function Invoke-Pester {
         # TODO: Remove all references to mock table, there should not be many.
         $script:mockTable = @{}
         # todo: move mock cleanup to BeforeAllBlockContainer when there is any
-        Remove-MockFunctionsAndAliases
+        Remove-MockFunctionsAndAliases -SessionState $PSCmdlet.SessionState
     }
 
     end {

--- a/src/functions/Mock.ps1
+++ b/src/functions/Mock.ps1
@@ -36,6 +36,7 @@ function New-MockBehavior {
         ModuleName  = $ContextInfo.TargetModule
         Filter      = $ParameterFilter
         IsDefault   = $null -eq $ParameterFilter
+        IsInModule  = -not [string]::IsNullOrEmpty($ContextInfo.TargetModule)
         Verifiable  = $Verifiable
         ScriptBlock = $MockWith
         Hook        = $Hook
@@ -878,7 +879,7 @@ function FindMatchingBehavior {
     )
 
     if ($PesterPreference.Debug.WriteDebugMessages.Value) {
-        Write-PesterDebugMessage -Scope Mock "Finding a mock behavior."
+        Write-PesterDebugMessage -Scope Mock "Finding behavior to use, one that passes filter or a default:"
     }
 
     $foundDefaultBehavior = $false

--- a/src/functions/Pester.SessionState.Mock.ps1
+++ b/src/functions/Pester.SessionState.Mock.ps1
@@ -1151,7 +1151,9 @@ function Invoke-Mock {
                     }
                 }
                 else {
-                    Write-PesterDebugMessage -Scope Mock -Message "Behavior is a default behavior from script scope, but we already have one that was defined more recently it, skipping it:`n$(& $getBehaviorMessage $b)"
+                    if ($PesterPreference.Debug.WriteDebugMessages.Value) {
+                        Write-PesterDebugMessage -Scope Mock -Message "Behavior is a default behavior from script scope, but we already have one that was defined more recently it, skipping it:`n$(& $getBehaviorMessage $b)"
+                    }
                 }
             }
             else {

--- a/src/functions/Pester.SessionState.Mock.ps1
+++ b/src/functions/Pester.SessionState.Mock.ps1
@@ -239,7 +239,7 @@ https://pester.dev/docs/usage/mocking
     }
 
     if ($PesterPreference.Debug.WriteDebugMessages.Value) {
-        Write-PesterDebugMessage -Scope Mock -Message "Setting up $(if ($ParameterFilter) {"parametrized"} else {"default"}) mock for$(if ($_moduleName) {" $_moduleName -"}) $CommandName."
+        Write-PesterDebugMessage -Scope Mock -Message "Setting up $(if ($ParameterFilter) {"parametrized"} else {"default"}) mock for$(if ($ModuleName) {" $ModuleName -"}) $CommandName."
     }
 
     $SessionState = $PSCmdlet.SessionState
@@ -253,7 +253,7 @@ https://pester.dev/docs/usage/mocking
     $invokeMockCallBack = $ExecutionContext.SessionState.InvokeCommand.GetCommand('Invoke-Mock', 'function')
 
     $mockData = Get-MockDataForCurrentScope
-    $contextInfo = Resolve-Command $CommandName $_moduleName -SessionState $SessionState
+    $contextInfo = Resolve-Command $CommandName $ModuleName -SessionState $SessionState
 
     if ($contextInfo.IsMockBootstrapFunction) {
         if ($PesterPreference.Debug.WriteDebugMessages.Value) {
@@ -432,7 +432,7 @@ function Get-AssertMockTable {
         $Frame,
         [Parameter(Mandatory)]
         [String] $CommandName,
-        [String] $_moduleName
+        [String] $ModuleName
     )
     # frame looks like this
     # [PSCustomObject]@{
@@ -441,7 +441,7 @@ function Get-AssertMockTable {
     #     IsTest = bool
     # }
 
-    $key = "$_moduleName||$CommandName"
+    $key = "$ModuleName||$CommandName"
     $scope = $Frame.Scope
     $inTest = $Frame.IsTest
     # this is used for assertions, in here we need to collect
@@ -490,7 +490,7 @@ function Get-AssertMockTable {
             #     }
 
             #     if (none $mockInBlock) {
-            #         throw "Could not find any mock definition for $CommandName$(if ($_moduleName) { " from module $_moduleName"})."
+            #         throw "Could not find any mock definition for $CommandName$(if ($ModuleName) { " from module $ModuleName"})."
             #     }
             #     else {
             #         # the mock was defined in some upper scope but it was not called in this it
@@ -703,7 +703,7 @@ https://pester.dev/docs/commands/Assert-MockCalled
         [Parameter(ParameterSetName = 'ExclusiveFilter', Mandatory = $true)]
         [scriptblock] $ExclusiveFilter,
 
-        [string] $_moduleName,
+        [string] $ModuleName,
 
         [string] $Scope = 0,
         [switch] $Exactly
@@ -868,7 +868,7 @@ to the original.
         [Parameter(ParameterSetName = 'ExclusiveFilter', Mandatory = $true)]
         [scriptblock] $ExclusiveFilter,
 
-        [string] $_moduleName,
+        [string] $ModuleName,
         [string] $Scope = 0,
         [switch] $Exactly,
 
@@ -989,7 +989,7 @@ to the original.
     }
 
     $SessionState = $CallerSessionState
-    $contextInfo = Resolve-Command $CommandName $_moduleName -SessionState $SessionState
+    $contextInfo = Resolve-Command $CommandName $ModuleName -SessionState $SessionState
     $resolvedModule = $contextInfo.TargetModule
     $resolvedCommand = $contextInfo.Command.Name
 

--- a/src/functions/Pester.SessionState.Mock.ps1
+++ b/src/functions/Pester.SessionState.Mock.ps1
@@ -990,7 +990,18 @@ to the original.
     }
 
     $SessionState = $CallerSessionState
+    # This resolve happens only because we need to resolve from an alias to the real command
+    # name, and we cannot know what all aliases are there for a command in the module, easily,
+    # we could short circuit this resolve when we find history, and only resolve if we don't
+    # have any history. We could also keep info about the alias from which we originally
+    # resolved the command, which would give us another piece of info. But without scanning
+    # all the aliases in the module we won't be able to get rid of this, but that would be
+    # cost we would have to pay all the time, instead of just doing extra resolve when we find
+    # no history.
     $contextInfo = Resolve-Command $CommandName $ModuleName -SessionState $SessionState
+    if ($null -eq $contextInfo.Hook) {
+        throw "Should -Invoke: Could not find Mock for command $CommandName in module $ModuleName. Was the mock defined? Did you use the same -ModuleName as on the Mock? When using InModuleScope are both Mock and Should -Invoke using the same -ModuleName?"
+    }
     $resolvedModule = $contextInfo.TargetModule
     $resolvedCommand = $contextInfo.Command.Name
 

--- a/src/functions/Pester.SessionState.Mock.ps1
+++ b/src/functions/Pester.SessionState.Mock.ps1
@@ -1000,7 +1000,7 @@ to the original.
     # no history.
     $contextInfo = Resolve-Command $CommandName $ModuleName -SessionState $SessionState
     if ($null -eq $contextInfo.Hook) {
-        throw "Should -Invoke: Could not find Mock for command $CommandName in module $ModuleName. Was the mock defined? Did you use the same -ModuleName as on the Mock? When using InModuleScope are both Mock and Should -Invoke using the same -ModuleName?"
+        throw "Should -Invoke: Could not find Mock for command $CommandName in $(if ([string]::IsNullOrEmpty($ModuleName)){ "script scope" } else { "module $ModuleName" }). Was the mock defined? Did you use the same -ModuleName as on the Mock? When using InModuleScope are InModuleScope, Mock and Should -Invoke using the same -ModuleName?"
     }
     $resolvedModule = $contextInfo.TargetModule
     $resolvedCommand = $contextInfo.Command.Name

--- a/src/functions/Pester.SessionState.Mock.ps1
+++ b/src/functions/Pester.SessionState.Mock.ps1
@@ -228,7 +228,7 @@ https://pester.dev/docs/usage/mocking
         [ScriptBlock]$MockWith = {},
         [switch]$Verifiable,
         [ScriptBlock]$ParameterFilter,
-        [string]$_moduleName,
+        [string]$ModuleName,
         [string[]]$RemoveParameterType,
         [string[]]$RemoveParameterValidation
     )

--- a/tst/Pester.Mock.RSpec.ts.ps1
+++ b/tst/Pester.Mock.RSpec.ts.ps1
@@ -816,4 +816,179 @@ i -PassThru:$PassThru {
             $result.Containers[0].Blocks[0].Tests[0].Passed | Verify-True
         }
     }
+
+    b "Mocking across modules" {
+        t "Mock defined in module is not called when calling from script" {
+            $sb = {
+                BeforeAll {
+                    Get-Module m | Remove-Module
+                    New-Module m -ScriptBlock {
+                        function f ($a) { "real in module m" }
+                    } | Import-Module
+                }
+
+                Describe "d" {
+                    It "i" {
+                        Mock f -ModuleName m { "mock in m" }
+
+                        # called in script, invokes real function
+                        f | Should -Be "real in module m"
+
+                        Should -Invoke f -ModuleName m -Exactly 0
+                    }
+                }
+            }
+
+            $r = Invoke-Pester -Configuration ([PesterConfiguration]@{
+                Run = @{ ScriptBlock = $sb; PassThru = $true }
+            })
+
+            $t = $r.Containers[0].Blocks[0].Tests[0]
+            $t.Result | Verify-Equal "Passed"
+        }
+
+        t "Mock defined in module is called when calling from that module" {
+            $sb = {
+                BeforeAll {
+                    Get-Module m | Remove-Module
+                    New-Module m -ScriptBlock {
+                        function f ($a) { "real in module m" }
+                    } | Import-Module
+                }
+
+                Describe "d" {
+                    It "i" {
+                        Mock f -ModuleName m { "mock in module m" }
+
+                        # called in script, invokes real function
+                        & (Get-Module m ) { f } | Should -Be "mock in module m"
+
+                        Should -Invoke f -ModuleName m -Exactly 1
+                    }
+                }
+            }
+
+            $r = Invoke-Pester -Configuration ([PesterConfiguration]@{
+                Run = @{ ScriptBlock = $sb; PassThru = $true }
+            })
+
+            $t = $r.Containers[0].Blocks[0].Tests[0]
+            $t.Result | Verify-Equal "Passed"
+        }
+
+        t "Mock defined in module is called when public function invokes the mocked function in that module" {
+            $sb = {
+                BeforeAll {
+                    Get-Module m, n | Remove-Module
+                    New-Module m -ScriptBlock {
+                        function f ($a) { "real in module m" }
+                    } | Import-Module
+
+                    New-Module n -ScriptBlock {
+                        # n can call f that is exported from m, but it calls it from within
+                        # module n, so the mock needs to be effective in n
+                        function g () { f }
+                    } | Import-Module
+                }
+
+                Describe "d" {
+                    It "i" {
+                        Mock f -ModuleName n { "mock in module n" }
+
+                        # this mock in m is ignored
+                        Mock f -ModuleName m { "mock in module m" }
+
+                        # this mock in script is ignored
+                        Mock f { "mock in script" }
+
+
+                        # called in script, but invokes function in module n
+                        g | Should -Be "mock in module n"
+
+                        Should -Invoke f -ModuleName n -Exactly 1
+                        Should -Invoke f -ModuleName m -Exactly 0
+                        Should -Invoke f -Exactly 0
+                    }
+                }
+            }
+
+            $r = Invoke-Pester -Configuration ([PesterConfiguration]@{
+                Run = @{ ScriptBlock = $sb; PassThru = $true }
+            })
+
+            $t = $r.Containers[0].Blocks[0].Tests[0]
+            $t.Result | Verify-Equal "Passed"
+        }
+
+        t "Mock defined in module falls back to script default behavior when no default behavior is defined in the module" {
+            $sb = {
+                BeforeAll {
+                    Get-Module m | Remove-Module
+                    New-Module m -ScriptBlock {
+                        function f ($a) { "real in module m" }
+
+                        function g () { f }
+                    } | Import-Module
+                }
+
+                Describe "d" {
+                    It "i" {
+                        # we fallback to this from the module when no filtered mock is matched there
+                        # but we don't fallback to it when we don't have any mock in the module, because
+                        # there is no hook
+                        Mock f { "mock in script" }
+                        Mock f -ModuleName m { "mock in module" } -ParameterFilter { $false }
+
+                        g | Should -Be "mock in script"
+
+                        # Should -Invoke f -ModuleName m -Exactly 0
+                        Should -Invoke f -Exactly 1
+                    }
+                }
+            }
+
+            $r = Invoke-Pester -Configuration ([PesterConfiguration]@{
+                Run = @{ ScriptBlock = $sb; PassThru = $true }
+            })
+
+            $t = $r.Containers[0].Blocks[0].Tests[0]
+            $t.Result | Verify-Equal "Passed"
+        }
+    }
+
+    b "Mock cleanup" {
+        t "Invoke-Pester cleans up orphaned mock hooks and aliases in modules" {
+
+            # define mock like functions in third party module
+            Get-Module m | Remove-Module
+            New-Module m -ScriptBlock {
+                function PesterMock_aaa () { }
+                Set-Alias -Name aaa -Value PesterMock_aaa
+
+                Export-ModuleMember -Function ""
+            } | Import-Module
+
+            # in caller scope
+            function PesterMock_bbb () { }
+            Set-Alias -Name bbb -Value PesterMock_bbb
+
+            # and in Pester module
+            . (Get-Module Pester) {
+                function PesterMock_ccc () { }
+                Set-Alias -Name aaa -Value PesterMock_aaa
+            }
+
+            # just trigger empty run to get cleanup
+            Invoke-Pester -Configuration ([PesterConfiguration]@{
+                Run = @{ ScriptBlock = {}; PassThru = $true }
+            })
+
+            $moduleCommands = & (Get-Module m) { Get-Command | Where-Object { $_.Name -like "*aaa" } }
+            $moduleCommands | Verify-Null
+            $commands = Get-Command | Where-Object { $_.Name -like "*bbb" }
+            $commands | Verify-Null
+            $pesterCommands = & (Get-Module Pester) { Get-Command | Where-Object { $_.Name -like "*ccc" } }
+            $pesterCommands | Verify-Null
+        }
+    }
 }

--- a/tst/Pester.Mock.RSpec.ts.ps1
+++ b/tst/Pester.Mock.RSpec.ts.ps1
@@ -992,7 +992,7 @@ i -PassThru:$PassThru {
     }
 
     b "Mock not found throws" {
-        dt "Resolving to function that is not a mock in Should -Invoke throws helpful message" {
+        t "Resolving to function that is not a mock in Should -Invoke throws helpful message" {
             # https://github.com/pester/Pester/issues/1878
             $sb = {
                 BeforeAll {


### PR DESCRIPTION
Set mocks into the module specified by -ModuleName, or when not present into the current module. This means that in script it will be set into the script, but when running InModuleScope then the module will be used.

Fix how mock resolve is done to respect the -ModuleName, and only fallback to the default script behavior when a parametrized mock in module fails and there is no default behavior. 

Remove mocks in all modules and user scope on startup to clean up after cancelled runs. 

Throw when we resolve command in Should but it is not a Hook.


Fix #1827
Fix #1878
Fix #1868