### PR TITLE
Remove delay bps option because it is never faster

### DIFF
--- a/src/csharp/Pester/CodeCoverageConfiguration.cs
+++ b/src/csharp/Pester/CodeCoverageConfiguration.cs
@@ -28,8 +28,7 @@ namespace Pester
         private StringArrayOption _path;
         private BoolOption _excludeTests;
         private BoolOption _recursePaths;
-        private BoolOption _delayBps;
-        private BoolOption _shBp;
+        private BoolOption _singleHitBreakpoints;
         private DecimalOption _coveragePercentTarget;
 
 
@@ -48,11 +47,8 @@ namespace Pester
             Path = new StringArrayOption("Directories or files to be used for codecoverage, by default the Path(s) from general settings are used, unless overridden here.", new string[0]);
             ExcludeTests = new BoolOption("Exclude tests from code coverage. This uses the TestFilter from general configuration.", true);
             RecursePaths = new BoolOption("Will recurse through directories in the Path option.", true);
-            CoveragePercentTarget = new DecimalOption("Target percent of code coverage that you want to achieve, default 75%", 75m);
-
-            SingleHitBreakpoints = new BoolOption("EXPERIMENTAL: Remove breakpoint when it is hit.", true);
-            DelayWritingBreakpoints = new BoolOption("EXPERIMENTAL: Try writing breakpoints all at once.", true);
-
+            CoveragePercentTarget = new DecimalOption("Target percent of code coverage that you want to achieve, default 75%.", 75m);
+            SingleHitBreakpoints = new BoolOption("Remove breakpoint when it is hit.", true);
         }
 
         public CodeCoverageConfiguration(IDictionary configuration) : this()
@@ -69,7 +65,6 @@ namespace Pester
                 CoveragePercentTarget = configuration.GetValueOrNull<decimal>("CoveragePercentTarget") ?? CoveragePercentTarget;
 
                 SingleHitBreakpoints = configuration.GetValueOrNull<bool>("SingleHitBreakpoints") ?? SingleHitBreakpoints;
-                DelayWritingBreakpoints = configuration.GetValueOrNull<bool>("DelayWritingBreakpoints") ?? DelayWritingBreakpoints;
             }
         }
 
@@ -202,35 +197,18 @@ namespace Pester
             }
         }
 
-
-        public BoolOption DelayWritingBreakpoints
-        {
-            get { return _delayBps; }
-            set
-            {
-                if (_delayBps == null)
-                {
-                    _delayBps = value;
-                }
-                else
-                {
-                    _delayBps = new BoolOption(_delayBps, value.Value);
-                }
-            }
-        }
-
         public BoolOption SingleHitBreakpoints
         {
-            get { return _shBp; }
+            get { return _singleHitBreakpoints; }
             set
             {
-                if (_shBp == null)
+                if (_singleHitBreakpoints == null)
                 {
-                    _shBp = value;
+                    _singleHitBreakpoints = value;
                 }
                 else
                 {
-                    _shBp = new BoolOption(_shBp, value.Value);
+                    _singleHitBreakpoints = new BoolOption(_singleHitBreakpoints, value.Value);
                 }
             }
         }

--- a/src/functions/Coverage.ps1
+++ b/src/functions/Coverage.ps1
@@ -32,6 +32,7 @@ function Enter-CoverageAnalysis {
             & $logger "Using single hit breakpoints."
         }
 
+        # remove itself on hit
         { & $SafeCommands['Remove-PSBreakpoint'] -Id $_.Id }
     }
     else {
@@ -39,7 +40,8 @@ function Enter-CoverageAnalysis {
             & $logger "Using normal breakpoints."
         }
 
-        {} # empty ScriptBlock
+        # empty ScriptBlock
+        {}
     }
 
     foreach ($breakpoint in $breakpoints) {
@@ -355,15 +357,9 @@ function New-CoverageBreakpoint {
         Script = $Command.Extent.File
         Line   = $Command.Extent.StartLineNumber
         Column = $Command.Extent.StartColumnNumber
-        Action = if (!$PesterPreference.CodeCoverage.DelayWritingBreakpoints.Value) { {} } else { $null }
-    }
-
-
-    if (!$PesterPreference.CodeCoverage.DelayWritingBreakpoints.Value) {
-        $breakpoint = & $SafeCommands['Set-PSBreakPoint'] @params
-    }
-    else {
-        $breakpoint = $null
+        # we write the breakpoint later, the action will become empty scriptblock
+        # or scriptblock that removes the breakpoint on hit depending on configuration
+        Action = $null
     }
 
     [pscustomobject] @{
@@ -375,7 +371,8 @@ function New-CoverageBreakpoint {
         StartColumn         = $Command.Extent.StartColumnNumber
         EndColumn           = $Command.Extent.EndColumnNumber
         Command             = Get-CoverageCommandText -Ast $Command
-        Breakpoint          = $breakpoint
+        # keep property for breakpoint but we will set it later
+        Breakpoint          = $null
         BreakpointLocation  = $params
     }
 }

--- a/src/functions/Mock.ps1
+++ b/src/functions/Mock.ps1
@@ -199,7 +199,7 @@ function Create-MockHook ($contextInfo, $InvokeMockCallback) {
 
     $mockScript = [scriptblock]::Create($code)
 
-    $mockName = "PesterMock_$(if ([string]::IsNullOrEmpty($ModuleName)) { "<none>" } else { $ModuleName })_$CommandName_$([Guid]::NewGuid().Guid)"
+    $mockName = "PesterMock_$(if ([string]::IsNullOrEmpty($ModuleName)) { "script" } else { $ModuleName })_${CommandName}_$([Guid]::NewGuid().Guid)"
 
     $mock = @{
         OriginalCommand         = $contextInfo.Command

--- a/src/functions/Pester.SessionState.Mock.ps1
+++ b/src/functions/Pester.SessionState.Mock.ps1
@@ -1116,7 +1116,7 @@ function Invoke-Mock {
     }
 
     if ($PesterPreference.Debug.WriteDebugMessages.Value) {
-        Write-PesterDebugMessage -Scope Mock -Message "Filtering behaviors for command $CommandName, for target module $(if ($targettingAModule) { $TargetModule } else { '$null' }) (shows all behaviors, actual filtered list is further in the log, look for 'Filtered parametrized behaviors:' and 'Filtered default behaviors:'):"
+        Write-PesterDebugMessage -Scope Mock -Message "Filtering behaviors for command $CommandName, for target module $(if ($targettingAModule) { $TargetModule } else { '$null' }) (Showing all behaviors for this command, actual filtered list is further in the log, look for 'Filtered parametrized behaviors:' and 'Filtered default behaviors:'):"
     }
 
     $moduleBehaviors = [System.Collections.Generic.List[Object]]@()
@@ -1156,7 +1156,7 @@ function Invoke-Mock {
             else {
                 # not the targetted module, skip it
                 if ($PesterPreference.Debug.WriteDebugMessages.Value) {
-                    Write-PesterDebugMessage -Scope Mock -Message "Behavior is not from the target module $TargetModule, skipping it:`n$(& $getBehaviorMessage $b)"
+                    Write-PesterDebugMessage -Scope Mock -Message "Behavior is not from the target module $(if ($targettingAModule) { $TargetModule } else { '$null' }), skipping it:`n$(& $getBehaviorMessage $b)"
                 }
             }
         }
@@ -1231,7 +1231,7 @@ function Invoke-Mock {
             }
         }
         if (-not $any) {
-            $message = "<none>"
+            $message = '$null'
         }
         Write-PesterDebugMessage -Scope Mock -Message "Filtered parametrized behaviors:`n$message"
 
@@ -1241,7 +1241,7 @@ function Invoke-Mock {
                 break
             }
         }
-        $message = if ($null -ne $default) { & $getBehaviorMessage $b } else { "<none>" }
+        $message = if ($null -ne $default) { & $getBehaviorMessage $b } else { '$null' }
         $fallBack = if ($null -ne $default -and $targettingAModule -and [string]::IsNullOrEmpty($b.ModuleName) ) { " (fallback to script scope default behavior)" } else { $null }
         Write-PesterDebugMessage -Scope Mock -Message "Filtered default behavior$($fallBack):`n$message"
     }

--- a/test.ps1
+++ b/test.ps1
@@ -146,14 +146,6 @@ if ($CI) {
     # not using code coverage, it is still very slow
     $configuration.CodeCoverage.Enabled = $false
     $configuration.CodeCoverage.Path = "$PSScriptRoot/src/*"
-
-    # experimental, will try to write breakpoints close together
-    # not one by one while it is figuring out AST.
-    # this appears to be significantly faster.
-    $configuration.CodeCoverage.DelayWritingBreakpoints = $true
-    # experimental, will delete BP as soon as it is hit
-    # only effective when DelayWritingBreakpoints is $true.
-    # this is me trying out an approach. Not sure about the impact.
     $configuration.CodeCoverage.SingleHitBreakpoints = $true
 
 


### PR DESCRIPTION
Remove the option because the new approach is always faster so there is no point in having an option to do it the old much slower way.

Also fix some minor Mock output that I did notice when writing release notes. 
