### PR TITLE
Added missing format tests

### DIFF
--- a/tst/Format.Tests.ps1
+++ b/tst/Format.Tests.ps1
@@ -199,3 +199,23 @@ Describe "Get-ShortType" {
         Get-ShortType -Value $Value | Verify-Equal $Expected
     }
 }
+
+Describe "Join-And" {
+    It "Given '<items>' and default threshold of 2 it returns the correct joined string '<expected>'" -TestCases @(
+        @{ Items = $null; Expected = [string]::Empty},
+        @{ Items = 'one'; Expected = 'one'},
+        @{ Items = 'one', 'two'; Expected = 'one and two'},
+        @{ Items = 'one', 'two', 'three'; Expected = 'one, two and three'}
+    ) {
+        param($Items, $Expected)
+        Join-And -Items $Items | Verify-Equal $Expected
+    }
+
+    It "Given '<items>' and custom threshold <threshold> it returns the correct joined string '<expected>'" -TestCases @(
+        @{ Items = 'one', 'two', 'three'; Threshold = 3; Expected = 'one, two and three'},
+        @{ Items = 'one', 'two', 'three'; Threshold = 4; Expected = 'one, two, three'}
+    ) {
+        param($Items, $Threshold, $Expected)
+        Join-And -Items $Items -Threshold $Threshold | Verify-Equal $Expected
+    }
+}

--- a/tst/Format.Tests.ps1
+++ b/tst/Format.Tests.ps1
@@ -203,17 +203,17 @@ Describe "Get-ShortType" {
 Describe "Join-And" {
     It "Given '<items>' and default threshold of 2 it returns the correct joined string '<expected>'" -TestCases @(
         @{ Items = $null; Expected = [string]::Empty},
-        @{ Items = 'one'; Expected = 'one'},
-        @{ Items = 'one', 'two'; Expected = 'one and two'},
-        @{ Items = 'one', 'two', 'three'; Expected = 'one, two and three'}
+        @{ Items = @('one'); Expected = 'one'},
+        @{ Items = @('one', 'two'); Expected = 'one and two'},
+        @{ Items = @('one', 'two', 'three'); Expected = 'one, two and three'}
     ) {
         param($Items, $Expected)
         Join-And -Items $Items | Verify-Equal $Expected
     }
 
     It "Given '<items>' and custom threshold <threshold> it returns the correct joined string '<expected>'" -TestCases @(
-        @{ Items = 'one', 'two', 'three'; Threshold = 3; Expected = 'one, two and three'},
-        @{ Items = 'one', 'two', 'three'; Threshold = 4; Expected = 'one, two, three'}
+        @{ Items = @('one', 'two', 'three'); Threshold = 3; Expected = 'one, two and three'},
+        @{ Items = @('one', 'two', 'three'); Threshold = 4; Expected = 'one, two, three'}
     ) {
         param($Items, $Threshold, $Expected)
         Join-And -Items $Items -Threshold $Threshold | Verify-Equal $Expected

--- a/tst/Format.Tests.ps1
+++ b/tst/Format.Tests.ps1
@@ -219,3 +219,9 @@ Describe "Join-And" {
         Join-And -Items $Items -Threshold $Threshold | Verify-Equal $Expected
     }
 }
+
+Describe "Add-SpaceToNonEmptyString" {
+    It "Formats non-empty string with leading whitespace" {
+        Add-SpaceToNonEmptyString -Value 'message' | Verify-Equal ' message'
+    }
+}


### PR DESCRIPTION
<!-- Thank you for contributing to Pester! -->

## PR Summary
From browsing the `Format.ps1` functions, I noticed that some functions like `Join-And` and `Add-SpaceToNonEmptyString` are missing tests in `Format.Tests.ps1`. I've added some basic tests to cover these functions.

Let me know if these tests are too simple and/or don't feel the need to include them. I didn't see why not to include them :smile:. 

## PR Checklist

- [x] PR has meaningful title
- [x] Summary describes changes
- [x] PR is ready to be merged
  - If not, use the arrow next to `Create Pull Request` to mark it as a draft. PR can be marked `Ready for review` when it's ready.
- [x] Tests are added/update *(if required)*
- [x] Documentation is updated/added *(if required)*