### PR TITLE
Update New-PesterConfiguration help

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -159,10 +159,19 @@ foreach ($l in $f) {
         $null = $sbf.AppendLine("$l`n")
         $generated = $true
         $margin = $matches.margin
+        $null = $sbf.AppendLine("$margin``````")
 
-        foreach ($l in ($generatedConfig -split "`n")) {
+        $generatedLines = @($generatedConfig -split "`n")
+        for ($i=0; $i -lt $generatedLines.Count; $i++) {
+            $l = $generatedLines[$i]
             $m = if ($l) { $margin } else { $null }
-            $null = $sbf.AppendLine("$m$l")
+
+            if ($i -eq $generatedLines.Count-1) {
+                #last line should be blank - replace with codeblock end
+                $null = $sbf.AppendLine("$margin```````n")
+            } else {
+                $null = $sbf.AppendLine("$m$l")
+            }
         }
     }
     elseif ($generated -and ($l -match "^\s*(.PARAMETER|.EXAMPLE).*")) {

--- a/src/Main.ps1
+++ b/src/Main.ps1
@@ -349,6 +349,7 @@ function Invoke-Pester {
 
     .PARAMETER CodeCoverageOutputFile
     (Deprecated v4)
+    Replace with ConfigurationProperty CodeCoverage.OutputPath
     The path where Invoke-Pester will save formatted code coverage results file.
     The path must include the location and name of the folder and file name with
     a required extension (usually the xml).
@@ -356,13 +357,13 @@ function Invoke-Pester {
 
     .PARAMETER CodeCoverageOutputFileEncoding
     (Deprecated v4)
-    Replace with ConfigurationProperty CodeCoverage.CodeCoverageOutputFileEncoding
+    Replace with ConfigurationProperty CodeCoverage.OutputEncoding
     Sets the output encoding of CodeCoverageOutputFileFormat
     Default is utf8
 
     .PARAMETER CodeCoverageOutputFileFormat
     (Deprecated v4)
-    Replace with ConfigurationProperty CodeCoverage.CodeCoverageOutputFileFormat
+    Replace with ConfigurationProperty CodeCoverage.OutputFormat
     The name of a code coverage report file format.
     Default value is: JaCoCo.
     Currently supported formats are:
@@ -390,7 +391,7 @@ function Invoke-Pester {
 
     .PARAMETER EnableExit
     (Deprecated v4)
-    Replace with ConfigurationProperty Run.EnableExit
+    Replace with ConfigurationProperty Run.Exit
     Will cause Invoke-Pester to exit with a exit code equal to the number of failed
     tests once all tests have been run. Use this to "fail" a build when any tests fail.
 
@@ -415,7 +416,7 @@ function Invoke-Pester {
 
     .PARAMETER OutputFile
     (Deprecated v4)
-    Replace with ConfigurationProperty TestResult.OutputFile
+    Replace with ConfigurationProperty TestResult.OutputPath
     The path where Invoke-Pester will save formatted test results log file.
     The path must include the location and name of the folder and file name with
     the xml extension.

--- a/src/Pester.RSpec.ps1
+++ b/src/Pester.RSpec.ps1
@@ -271,20 +271,21 @@ function Get-RSpecObjectDecoratorPlugin () {
 function New-PesterConfiguration {
     <#
     .SYNOPSIS
-    Creates a new [PesterConfiguration] object for advanced configuration of Invoke-Pester.
+    Creates a new PesterConfiguration object for advanced configuration of Invoke-Pester.
 
     .DESCRIPTION
-    The New-PesterConfiguration function creates a new [PesterConfiguration] object
+    The New-PesterConfiguration function creates a new PesterConfiguration-object
     to enable advanced configurations for runnings tests using Invoke-Pester.
 
     Without parameters, the function generates a configuration-object with default
-    options. The returned [PesterConfiguration] object can be modified to suit your
+    options. The returned PesterConfiguration-object can be modified to suit your
     requirements.
 
     Calling New-PesterConfiguration is equivalent to calling [PesterConfiguration]::Default which was used in early versions of Pester 5.
 
     Sections and options:
 
+    ```
     Run:
       Path: Directories to be searched for tests, paths directly to test files, or combination of both.
       Default value: @('.')
@@ -393,10 +394,11 @@ function New-PesterConfiguration {
     Output:
       Verbosity: The verbosity of output, options are None, Normal, Detailed and Diagnostic.
       Default value: 'Normal'
+    ```
 
     .PARAMETER Hashtable
     Override the default values for the options defined in the provided dictionary/hashtable.
-    Inspect a default [PesterConfiguration] object to learn about the schema and
+    See Description in this help or inspect a PesterConfiguration-object to learn about the schema and
     available options.
 
     .EXAMPLE
@@ -407,18 +409,18 @@ function New-PesterConfiguration {
     Invoke-Pester -Configuration $c
     ```
 
-    Creates a default [PesterConfiguration] object and changes the Run.PassThru option
+    Creates a default PesterConfiguration-object and changes the Run.PassThru option
     to return the result object after the test run. The configuration object is
     provided to Invoke-Pester to alter the default behaviour.
 
     .EXAMPLE
     ```powershell
     $MyOptions = @{
-        Run = @{ # <- Run configuration.
-            PassThru = $true # <- Return result object after finishing the test run.
+        Run = @{ # Run configuration.
+            PassThru = $true # Return result object after finishing the test run.
         }
-        Filter = @{ # <- Filter configuration
-            Tag = "Core","Integration" # <- Run only Describe/Context/It-blocks with 'Core' or 'Integration' tags
+        Filter = @{ # Filter configuration
+            Tag = "Core","Integration" # Run only Describe/Context/It-blocks with 'Core' or 'Integration' tags
         }
     }
 


### PR DESCRIPTION
> Also noticed that we should wrap the auto-generated pesterconfiguration-docs in a codeblock to keep it's format. Will look into that in pester-repo incl. updating the help for Hashtable-parameter to mention that all options are visible in description (no longer need to inspect).

Source https://github.com/pester/docs/pull/112#pullrequestreview-659872259

Wraps generated config-docs in markdown codeblock to keep formatting on website. Also updates some of the help text