### PR TITLE
Allow positional parameter in get-shouldoperator

### DIFF
--- a/src/functions/Get-ShouldOperator.ps1
+++ b/src/functions/Get-ShouldOperator.ps1
@@ -47,6 +47,7 @@ function Get-ShouldOperator {
         $RuntimeParameterDictionary = & $SafeCommands['New-Object'] System.Management.Automation.RuntimeDefinedParameterDictionary
         $AttributeCollection = & $SafeCommands['New-Object'] System.Collections.ObjectModel.Collection[System.Attribute]
         $ParameterAttribute = & $SafeCommands['New-Object'] System.Management.Automation.ParameterAttribute
+        $ParameterAttribute.Position = 0
 
         $AttributeCollection.Add($ParameterAttribute)
 

--- a/tst/functions/Get-ShouldOperator.Tests.ps1
+++ b/tst/functions/Get-ShouldOperator.Tests.ps1
@@ -45,6 +45,13 @@ InPesterModuleScope {
                     Get-ShouldOperator -Name $_ | Should -Not -BeNullOrEmpty -Because "$_ should have help"
                 }
             }
+            It 'Throws on invalid assertion-name' {
+                { Get-ShouldOperator BeHorrible } | Should -Throw -ExceptionType ([System.Management.Automation.ParameterBindingException]) -ErrorId 'ParameterArgumentValidationError,Get-ShouldOperator' -ExpectedMessage "*on parameter 'Name'*does not belong to the set*"
+            }
+
+            It 'Supports positional value' {
+                { Get-ShouldOperator Be } | Should -Not -Throw -ErrorId 'PositionalParameterNotFound,Get-ShouldOperators' -Because 'Name-parameter supports values at position 0'
+            }
         }
     }
 }


### PR DESCRIPTION
This PR allows positional value to used for Name in `Get-ShouldOperator` to make it more user-friendly so users can type e.g. `Get-ShouldOperator Be`

## PR Checklist

- [x] PR has meaningful title
- [x] Summary describes changes
- [x] PR is ready to be merged
  - If not, use the arrow next to `Create Pull Request` to mark it as a draft. PR can be marked `Ready for review` when it's ready.
- [x] Tests are added/update *(if required)*
- [ ] Documentation is updated/added *(if required)*
