### PR TITLE
Update Example to reference the correct variable

### DIFF
--- a/src/Pester.RSpec.ps1
+++ b/src/Pester.RSpec.ps1
@@ -405,7 +405,7 @@ function New-PesterConfiguration {
     $config = New-PesterConfiguration
     $config.Run.PassThru = $true
 
-    Invoke-Pester -Configuration $c
+    Invoke-Pester -Configuration $config
     ```
 
     Creates a default [PesterConfiguration] object and changes the Run.PassThru option


### PR DESCRIPTION
Updated to reference the correct variable.  As requested in https://github.com/pester/docs/pull/114

<!-- Thank you for contributing to Pester! -->

## PR Summary

Correcting a mistake in the documentation.  The example references $c when it should reference $config
<!-- Please describe what your pull request fixes, or how it improves Pester.

If your pull request resolves a reported issue, please mention it by using `Fix #<issue_number>` on a new line, this will close the linked issue automatically when this PR is merged. For more info see: [Closing issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/).

If your pull request integrates Pester with another system, please tell us how the change can be tested. -->


## PR Checklist

- [x] PR has meaningful title
- [x] Summary describes changes
- [x] PR is ready to be merged
  - If not, use the arrow next to `Create Pull Request` to mark it as a draft. PR can be marked `Ready for review` when it's ready.
- [ ] Tests are added/update *(if required)*
- [x] Documentation is updated/added *(if required)*

<!-- Before you continue, please review [Contributing to Pester](https://pester.dev/docs/contributing/introduction).

Our continuous integration system doesn't send any notifications about failed tests. Please return to the opened pull request (after ~60 minutes) to check if everything is OK. -->
