### PR TITLE
Make InModuleScope-parameters available as variables in scriptblock

### DIFF
--- a/src/functions/InModuleScope.ps1
+++ b/src/functions/InModuleScope.ps1
@@ -71,6 +71,7 @@
         [HashTable]
         $Parameters = @{},
 
+        [object[]]
         $ArgumentList = @()
     )
 
@@ -92,7 +93,7 @@
         $private:______parameters = $private:______inmodule_parameters.Parameters
 
         if ($private:______parameters.Count -gt 0) {
-            & $private:______inmodule_parameters.ScriptBlock @private:______parameters @private:______arguments
+            & $private:______inmodule_parameters.ScriptBlock @private:______arguments @private:______parameters
         }
         else {
             # Not splatting parameters to avoid polluting args
@@ -103,9 +104,9 @@
     if ($PesterPreference.Debug.WriteDebugMessages.Value) {
         $hasParams = 0 -lt $Parameters.Count
         $hasArgs = 0 -lt $ArgumentList.Count
-        $arguments = $($(if ($hasArgs) { foreach ($a in $ArgumentList) { "'$($a)'" } }) -join ", ")
-        $params = $(if ($hasParams) { foreach ($p in $Parameters.GetEnumerator()) { "$($p.Key) = $($p.Value)" } }) -join ", "
-        Write-PesterDebugMessage -Scope Runtime -Message "Running scriptblock { $scriptBlock } in module $($ModuleName)$(if ($hasParams) { " with parameters: $params" })$(if ($hasArgs) { "$(if ($hasParams) { ' and' }) with arguments: $arguments" })."
+        $inmoduleArguments = $($(if ($hasArgs) { foreach ($a in $ArgumentList) { "'$($a)'" } }) -join ", ")
+        $inmoduleParameters = $(if ($hasParams) { foreach ($p in $Parameters.GetEnumerator()) { "$($p.Key) = $($p.Value)" } }) -join ", "
+        Write-PesterDebugMessage -Scope Runtime -Message "Running scriptblock { $scriptBlock } in module $($ModuleName)$(if ($hasParams) { " with parameters: $inmoduleParameters" })$(if ($hasArgs) { "$(if ($hasParams) { ' and' }) with arguments: $inmoduleArguments" })."
     }
 
     Set-ScriptBlockScope -ScriptBlock $ScriptBlock -SessionState $sessionState

--- a/src/functions/InModuleScope.ps1
+++ b/src/functions/InModuleScope.ps1
@@ -95,12 +95,8 @@
             ${Set Dynamic Parameter Variable}
         )
 
-        # This script block exists to hold variables without polluting the test script's current scope.
-        # Dynamic parameters in functions, for some reason, only exist in $PSBoundParameters instead
-        # of being assigned a local variable the way static parameters do.  By calling Set-DynamicParameterVariable,
-        # we create these variables for the caller's use in a Parameter Filter or within the mock itself, and
-        # by doing it inside this temporary script block, those variables don't stick around longer than they
-        # should.
+        # This script block is used to create variables for provided parameters that
+        # the real scriptblock can inherit. Makes defining a param-block optional.
 
         & ${Set Dynamic Parameter Variable} -SessionState ${Session State} -Parameters $___Parameters___
 

--- a/tst/functions/InModuleScope.Tests.ps1
+++ b/tst/functions/InModuleScope.Tests.ps1
@@ -135,8 +135,7 @@ Describe 'InModuleScope arguments and parameter binding' {
     }
 
     It 'Arguments are available in scriptblock' {
-        # https://github.com/pester/Pester/pull/1957#discussion_r637772167
-        $arguments = 12345
+        $arguments = @(12345)
 
         $sb = {
             $args.Count
@@ -144,6 +143,26 @@ Describe 'InModuleScope arguments and parameter binding' {
         }
 
         InModuleScope -ModuleName TestModule2 -ArgumentList $arguments -ScriptBlock $sb | Should -Be $arguments.Count, $arguments
+    }
+
+    It 'single argument works' {
+        $sb = {
+            $args.Count
+            $args[0]
+        }
+
+        InModuleScope -ModuleName TestModule2 -ArgumentList 'hello' -ScriptBlock $sb | Should -Be 1, 'hello'
+    }
+
+    It 'array argument works' {
+        $arguments = [int[]](1, 2, 3), 'hello'
+        $sb = {
+            $args.Count
+            $args[0].Count
+            $args[1]
+        }
+
+        InModuleScope -ModuleName TestModule2 -ArgumentList $arguments -ScriptBlock $sb | Should -Be 2, 3, 'hello'
     }
 
     It 'Support $null as argument' {
@@ -155,7 +174,22 @@ Describe 'InModuleScope arguments and parameter binding' {
         InModuleScope -ModuleName TestModule2 -ArgumentList $null -ScriptBlock $sb | Should -Be 1, $null
     }
 
+    It 'Arguments are first in args when parameters are also used and no param-block exists' {
+        # https://github.com/pester/Pester/pull/1957#discussion_r637891515
+        $inModuleScopeParameters = @{
+            SomeParam = 'SomeValue'
+        }
+        $arguments = 12345
+
+        $sb = {
+            $args[0]
+        }
+
+        InModuleScope -ModuleName TestModule2 -Parameters $inModuleScopeParameters -ArgumentList $arguments -ScriptBlock $sb | Should -Be $arguments
+    }
+
     It '$args is empty when no arguments are provided' {
+        # https://github.com/pester/Pester/pull/1957#discussion_r637772167
         $sb = {
             $args.Count
         }

--- a/tst/functions/InModuleScope.Tests.ps1
+++ b/tst/functions/InModuleScope.Tests.ps1
@@ -84,11 +84,11 @@ Describe "Get-ScriptModule behavior" {
 }
 
 Describe 'InModuleScope parameter binding' {
-    # do not put this into BeforeAll this needs to be imported before calling InModuleScope
-    # that is below, because it requires the module to be loaded
 
-    Get-Module TestModule2 | Remove-Module
-    New-Module -Name TestModule2 { } | Import-Module -Force
+    BeforeAll {
+        Get-Module TestModule2 | Remove-Module
+        New-Module -Name TestModule2 { } | Import-Module -Force
+    }
 
     It 'Works with parameters while using advanced function/script' {
         # https://github.com/pester/Pester/issues/1809
@@ -154,17 +154,15 @@ Describe 'InModuleScope parameter binding' {
     }
 
     AfterAll {
-        # keep this in AfterAll so we remove the module after tests are invoked
-        # and not while the tests are discovered
         Remove-Module TestModule2 -Force
     }
 }
 
 Describe "Using variables within module scope" {
-    # do not put this into BeforeAll this needs to be imported before calling InModuleScope
-    # that is below, because it requires the module to be loaded
-    Get-Module TestModule2 | Remove-Module
-    New-Module -Name TestModule2 { } | Import-Module -Force
+    BeforeAll {
+        Get-Module TestModule2 | Remove-Module
+        New-Module -Name TestModule2 { } | Import-Module -Force
+    }
 
     It 'Only script-scoped variables should persist across InModuleScope calls' {
         $setup = {
@@ -178,8 +176,6 @@ Describe "Using variables within module scope" {
     }
 
     AfterAll {
-        # keep this in AfterAll so we remove the module after tests are invoked
-        # and not while the tests are discovered
         Remove-Module TestModule2 -Force
     }
 }

--- a/tst/functions/InModuleScope.Tests.ps1
+++ b/tst/functions/InModuleScope.Tests.ps1
@@ -197,6 +197,17 @@ Describe 'InModuleScope arguments and parameter binding' {
         InModuleScope -ModuleName TestModule2 -ScriptBlock $sb | Should -Be 0
     }
 
+    It 'Arguments bind to remaining parameters in param-block' {
+        $sb = {
+            param($param1, $param2)
+            $param1
+            $param2
+            $args.Count
+        }
+
+        InModuleScope -ModuleName TestModule2 -ScriptBlock $sb -Parameters @{ param1 = 'foo' } -ArgumentList 123 | Should -Be 'foo', 123, 0
+    }
+
     It 'internal variables used in InModuleScope wrapper does not leak into scriptblock' {
         $sb = {
             $null -eq $SessionState

--- a/tst/functions/InModuleScope.Tests.ps1
+++ b/tst/functions/InModuleScope.Tests.ps1
@@ -134,6 +134,25 @@ Describe 'InModuleScope parameter binding' {
         InModuleScope -ModuleName TestModule2 -Parameters $inModuleScopeParameters -ScriptBlock $sb -ArgumentList $myArgs | Should -Be @($inModuleScopeParameters.SomeParam, $myArgs.Count)
     }
 
+    It 'Automatically imports parameters as variables in module scope' {
+        # https://github.com/pester/Pester/issues/1603
+        $inModuleScopeParameters = @{
+            SomeParam2 = 'MyValue'
+        }
+
+        $sb = {
+            "$SomeParam2"
+        }
+
+        $sb2 = {
+            # Should return nothing. Making sure dynamic variable isn't persisted in module state.
+            "$SomeParam2"
+        }
+
+        InModuleScope -ModuleName TestModule2 -ScriptBlock $sb -Parameters $inModuleScopeParameters | Should -Be $inModuleScopeParameters.SomeParam2
+        InModuleScope -ModuleName TestModule2 -ScriptBlock $sb2 | Should -BeNullOrEmpty
+    }
+
     AfterAll {
         # keep this in AfterAll so we remove the module after tests are invoked
         # and not while the tests are discovered

--- a/tst/functions/InModuleScope.Tests.ps1
+++ b/tst/functions/InModuleScope.Tests.ps1
@@ -163,8 +163,8 @@ Describe 'InModuleScope parameter binding' {
 Describe "Using variables within module scope" {
     # do not put this into BeforeAll this needs to be imported before calling InModuleScope
     # that is below, because it requires the module to be loaded
-    Get-Module TestModule | Remove-Module
-    New-Module -Name TestModule { } | Import-Module -Force
+    Get-Module TestModule2 | Remove-Module
+    New-Module -Name TestModule2 { } | Import-Module -Force
 
     It 'Only script-scoped variables should persist across InModuleScope calls' {
         $setup = {


### PR DESCRIPTION
`InModuleScope` currently requires param-block to make parameters available by name (if not, only available as arguments). This PR add parameters as dynamic variables inside the scriptblock similar to how it works with mocks.

Fix #1603 

## PR Checklist

- [x] PR has meaningful title
- [x] Summary describes changes
- [x] PR is ready to be merged
  - If not, use the arrow next to `Create Pull Request` to mark it as a draft. PR can be marked `Ready for review` when it's ready.
- [x] Tests are added/update *(if required)*
- [x] Documentation is updated/added *(if required)*