### PR TITLE
Fixed formatting for null elements in an array

### DIFF
--- a/src/Format.ps1
+++ b/src/Format.ps1
@@ -13,7 +13,14 @@ function Format-Collection ($Value, [switch]$Pretty) {
     }
     $count = $Value.Count
     $trimmed = $count -gt $Limit
-    '@(' + (($Value | & $SafeCommands['Select-Object'] -First $Limit | & $SafeCommands['ForEach-Object'] { Format-Nicely -Value $_ -Pretty:$Pretty }) -join $separator) + $(if ($trimmed) { ', ...' }) + ')'
+
+    $formattedCollection = @()
+    for ($i = 0; $i -lt [System.Math]::Min($count, $Limit); $i++) {
+        $formattedValue = Format-Nicely -Value $Value[$i] -Pretty:$Pretty
+        $formattedCollection += $formattedValue
+    }
+
+    '@(' + ($formattedCollection -join $separator) + $(if ($trimmed) { ", ...$($count - $limit) more" }) + ')'
 }
 
 function Format-Object ($Value, $Property, [switch]$Pretty) {

--- a/tst/Format.Tests.ps1
+++ b/tst/Format.Tests.ps1
@@ -24,8 +24,15 @@ Describe "Format-Collection" {
         Format-Collection -Value $Value | Verify-Equal $Expected
     }
 
-    It "Formats collection that is longer than 10 with elipsis" -TestCases @(
-        @{ Value = (1..20); Expected = "@(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, ...)" }
+    It "Formats collection that is longer than 10 with elipsis and output remaining value count" -TestCases @(
+        @{ Value = (1..20); Expected = "@(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, ...10 more)" }
+    ) {
+        param ($Value, $Expected)
+        Format-Collection -Value $Value | Verify-Equal $Expected
+    }
+
+    It "Formats collection '<value>' with `$null values to '<expected>'" -TestCases @(
+        @{ Value = @('a', 'b', 'c', $null); Expected = "@('a', 'b', 'c', `$null)" }
     ) {
         param ($Value, $Expected)
         Format-Collection -Value $Value | Verify-Equal $Expected


### PR DESCRIPTION
<!-- Thank you for contributing to Pester! -->

## PR Summary
I had some time and added a fix for #1448.

`Format-Nicely` from `Format.ps1` now formats `$null` elements to `$null` in the array output.
e.g. `Format-Collection -Value @('a', 'b', 'c', $null)` -> `@('a', 'b', 'c', $null)`

The previous behaviour would omit the `$null` value.
e.g. `Format-Collection -Value @('a', 'b', 'c', $null)` -> `@('a', 'b', 'c')`

To achieve the result from the first example, I changed the implementation to not use `Select-Object`, since it removes null values, and instead use a simple loop to format each element and join back up to a comma separated string. 

I've also changed the ellipsis to indicate how many elements have been left out with `...<leftover count>` instead of just `...`. Let me know if this needs to be tweaked or its fine to keep `...`.

## PR Checklist

- [x] PR has meaningful title
- [x] Summary describes changes
- [x] PR is ready to be merged
  - If not, use the arrow next to `Create Pull Request` to mark it as a draft. PR can be marked `Ready for review` when it's ready.
- [x] Tests are added/update *(if required)*
- [x] Documentation is updated/added *(if required)*