### PR TITLE
Added Pester version message to detailed and diagnostic output

### DIFF
--- a/src/functions/Output.ps1
+++ b/src/functions/Output.ps1
@@ -132,7 +132,7 @@ function Write-PesterStart {
         #     $message += $ReportStrings.TagMessage -f "$($PesterState.TagFilter)"
         # }
 
-        & $SafeCommands['Write-Host'] $message -Foreground $ReportTheme.Foreground
+        & $SafeCommands['Write-Host'] -ForegroundColor Magenta $message
     }
 }
 

--- a/src/functions/Output.ps1
+++ b/src/functions/Output.ps1
@@ -1,5 +1,6 @@
 ﻿$script:ReportStrings = DATA {
     @{
+        VersionMessage    = "Pester v{0}"
         StartMessage      = "Executing all tests in '{0}'"
         FilterMessage     = ' matching test name {0}'
         TagMessage        = ' with Tags {0}'
@@ -108,7 +109,15 @@ function Write-PesterStart {
             }
         }
 
-        $message = $ReportStrings.StartMessage -f (Format-PesterPath $hash.Files -Delimiter $OFS)
+        $moduleInfo = $MyInvocation.MyCommand.ScriptBlock.Module
+        $moduleVersion = $moduleInfo.Version.ToString()
+        if ($moduleInfo.PrivateData.PSData.Prerelease) {
+            $moduleVersion += "-$($moduleInfo.PrivateData.PSData.Prerelease)"
+        }
+        $message = $ReportStrings.VersionMessage -f $moduleVersion
+        $message += [Environment]::NewLine
+
+        $message += $ReportStrings.StartMessage -f (Format-PesterPath $hash.Files -Delimiter $OFS)
 
         $message = "$message$(if (0 -lt $hash.ScriptBlocks) { ", and in $($hash.ScriptBlocks) scriptblocks." })"
         # todo write out filters that are applied
@@ -477,11 +486,11 @@ function Get-WriteScreenPlugin ($Verbosity) {
         Name = 'WriteScreen'
     }
 
-    if ("Detailed" -eq $Verbosity) {
+    if ($Verbosity -in 'Detailed', 'Diagnostic') {
         $p.Start = {
             param ($Context)
 
-            # Write-PesterStart $Context
+            Write-PesterStart $Context
         }
     }
 


### PR DESCRIPTION
## PR Summary
Fix for #1342.

Added the pester version for detailed and diagnostic view as shown below. 

### Detailed

![detailed](https://user-images.githubusercontent.com/20082136/120167678-61898f80-c241-11eb-9705-739c13fafb6e.PNG)

### Diagnostic

![diagnostic](https://user-images.githubusercontent.com/20082136/120167693-664e4380-c241-11eb-8214-92cbd6d85b6c.PNG)

This leverages a lot of the previous code from @KirkMunro in https://github.com/pester/Pester/pull/1343/files. It just excludes the ascii art and outputs the pester version(including pre-release if any) above the start message. Let me know if this should be merged and edited from that instead, I just copied over some of the relevant code into this commit. 

## PR Checklist

- [x] PR has meaningful title
- [x] Summary describes changes
- [x] PR is ready to be merged
  - If not, use the arrow next to `Create Pull Request` to mark it as a draft. PR can be marked `Ready for review` when it's ready.
- [x] Tests are added/update *(if required)*
- [x] Documentation is updated/added *(if required)*

<!-- Before you continue, please review [Contributing to Pester](https://pester.dev/docs/contributing/introduction).

Our continuous integration system doesn't send any notifications about failed tests. Please return to the opened pull request (after ~60 minutes) to check if everything is OK. -->
