### PR TITLE
Add formatdata to ensure list view for all sections in PesterConfiguration

### DIFF
--- a/src/Pester.psd1
+++ b/src/Pester.psd1
@@ -24,7 +24,11 @@
     # Minimum version of the Windows PowerShell engine required by this module
     PowerShellVersion = '3.0'
 
-    TypesToProcess    = @()
+    # Type files (.ps1xml) to be loaded when importing this module
+    TypesToProcess = @()
+
+    # Format files (.ps1xml) to be loaded when importing this module
+    FormatsToProcess = @('PesterConfiguration.Format.ps1xml')
 
     # Functions to export from this module
     FunctionsToExport = @(
@@ -95,7 +99,7 @@
         # It's for rebuilding PowerShellGet (and PoshCode) NuGet-style packages
         # We had to do this because it's the only place we're allowed to extend the manifest
         # https://connect.microsoft.com/PowerShell/feedback/details/421837
-        PSData                  = @{
+        PSData = @{
             # The primary categorization of this module (from the TechNet Gallery tech tree).
             Category     = "Scripting Techniques"
 

--- a/tst/PesterConfiguration.Tests.ps1
+++ b/tst/PesterConfiguration.Tests.ps1
@@ -1,0 +1,28 @@
+﻿Set-StrictMode -Version Latest
+
+Describe "PesterConfiguration.Format.ps1xml" {
+    BeforeDiscovery {
+        $configSections = [PesterConfiguration].Assembly.GetExportedTypes() | Where-Object { $_.BaseType -eq [Pester.ConfigurationSection] }
+    }
+
+    Context "Testing format data for '<_.FullName>'" -ForEach $configSections {
+        BeforeAll {
+            $section = $_
+            $formatData = Get-FormatData -TypeName $_.FullName
+            $options = @($section.GetProperties() | Where-Object { $_.PropertyType.IsSubclassOf([Pester.Option]) })
+        }
+        It 'Has a single view defined of type ListControl' {
+            $formatData | Should -Not -BeNullOrEmpty
+            $formatData.FormatViewDefinition.Count | Should -Be 1
+            $formatData.FormatViewDefinition[0].Name | Should -BeExactly $section.FullName
+            $formatData.FormatViewDefinition[0].Control | Should -BeOfType [System.Management.Automation.ListControl]
+        }
+
+        It 'View includes all options' {
+            $propertiesInView = @($formatData.FormatViewDefinition[0].Control.Entries.Items.DisplayEntry | Where-Object ValueType -eq 'Property')
+            $propertiesInView.Count | Should -Be $options.Count
+            $missingOptions = $options.Name | Where-Object { $propertiesInView.Value -notcontains $_ }
+            $missingOptions | Should -Be @()
+        }
+    }
+}


### PR DESCRIPTION
## PR Summary
Dynamically generates a ps1xml with formatdata for configuration sections in [PesterConfiguration] to ensure that all sections use list view. Currently Output and Should uses table due to less than 5 options.

```powershell
# Before
(New-PesterConfiguration).Should

ErrorAction
-----------
Controls if Should throws on error. Use 'Stop' to throw on error, or 'Continue' to fail at the end of the test. (Stop, default: Stop)

(New-PesterConfiguration).Output

Verbosity
---------
The verbosity of output, options are None, Normal, Detailed and Diagnostic. (Normal, default: Normal)

# After 
(New-PesterConfiguration).Should

ErrorAction : Controls if Should throws on error. Use 'Stop' to throw on error, or 'Continue' to fail at the end of the test. (Stop, default: Stop)

(New-PesterConfiguration).Output

Verbosity : The verbosity of output, options are None, Normal, Detailed and Diagnostic. (Normal, default: Normal)
```

## PR Checklist

- [x] PR has meaningful title
- [x] Summary describes changes
- [x] PR is ready to be merged
  - If not, use the arrow next to `Create Pull Request` to mark it as a draft. PR can be marked `Ready for review` when it's ready.
- [x] Tests are added/update *(if required)*
- [ ] Documentation is updated/added *(if required)*