### PR TITLE
Removed StartMessage from output

### DIFF
--- a/src/functions/Output.ps1
+++ b/src/functions/Output.ps1
@@ -1,7 +1,6 @@
 ﻿$script:ReportStrings = DATA {
     @{
         VersionMessage    = "Pester v{0}"
-        StartMessage      = "Executing all tests in '{0}'"
         FilterMessage     = ' matching test name {0}'
         TagMessage        = ' with Tags {0}'
         MessageOfs        = "', '"
@@ -115,11 +114,7 @@ function Write-PesterStart {
             $moduleVersion += "-$($moduleInfo.PrivateData.PSData.Prerelease)"
         }
         $message = $ReportStrings.VersionMessage -f $moduleVersion
-        $message += [Environment]::NewLine
 
-        $message += $ReportStrings.StartMessage -f (Format-PesterPath $hash.Files -Delimiter $OFS)
-
-        $message = "$message$(if (0 -lt $hash.ScriptBlocks) { ", and in $($hash.ScriptBlocks) scriptblocks." })"
         # todo write out filters that are applied
         # if ($PesterState.TestNameFilter) {
         #     $message += $ReportStrings.FilterMessage -f "$($PesterState.TestNameFilter)"


### PR DESCRIPTION
<!-- Thank you for contributing to Pester! -->

## PR Summary
Provided a fix for #1967.

I've removed the `"Executing all tests in..."` Start message as shown below. Only the version is outputted at the start now. 

![detailed](https://user-images.githubusercontent.com/20082136/120511044-584d1e00-c40d-11eb-95f7-bddbac37e573.PNG)

## PR Checklist

- [x] PR has meaningful title
- [x] Summary describes changes
- [x] PR is ready to be merged
  - If not, use the arrow next to `Create Pull Request` to mark it as a draft. PR can be marked `Ready for review` when it's ready.
- [x] Tests are added/update *(if required)*
- [x] Documentation is updated/added *(if required)*