### PR TITLE
Update output for Discovery and Filter

### DIFF
--- a/src/Main.ps1
+++ b/src/Main.ps1
@@ -1,4 +1,4 @@
-function Assert-ValidAssertionName {
+﻿function Assert-ValidAssertionName {
     param([string]$Name)
     if ($Name -notmatch '^\S+$') {
         throw "Assertion name '$name' is invalid, assertion name must be a single word."
@@ -911,8 +911,14 @@ function Invoke-Pester {
             }
 
             if ('Diagnostic' -eq $PesterPreference.Output.Verbosity.Value) {
+                # Enforce the default debug-output as a minimum. This is the key difference between Detailed and Diagnostic
                 $PesterPreference.Debug.WriteDebugMessages = $true
-                $PesterPreference.Debug.WriteDebugMessagesFrom = "Discovery", "Skip", "Mock", "CodeCoverage"
+                $missingCategories = foreach ($category in @("Discovery", "Skip", "Mock", "CodeCoverage")) {
+                    if ($PesterPreference.Debug.WriteDebugMessagesFrom.Value -notcontains $category) {
+                        $category
+                    }
+                }
+                $PesterPreference.Debug.WriteDebugMessagesFrom = $PesterPreference.Debug.WriteDebugMessagesFrom.Value + @($missingCategories)
             }
 
             $plugins +=

--- a/src/Main.ps1
+++ b/src/Main.ps1
@@ -1,4 +1,4 @@
-﻿function Assert-ValidAssertionName {
+function Assert-ValidAssertionName {
     param([string]$Name)
     if ($Name -notmatch '^\S+$') {
         throw "Assertion name '$name' is invalid, assertion name must be a single word."
@@ -887,7 +887,12 @@ function Invoke-Pester {
             # preference is inherited in all subsequent calls in this session state
             # but we still pass it explicitly where practical
             if (-not $hasCallerPreference) {
-                [PesterConfiguration] $PesterPreference = $Configuration
+                if ($PSBoundParameters.ContainsKey('Configuration')) {
+                    # Advanced configuration used, merging to get new reference
+                    [PesterConfiguration] $PesterPreference = [PesterConfiguration]::Merge([PesterConfiguration]::Default, $Configuration)
+                } else {
+                    [PesterConfiguration] $PesterPreference = $Configuration
+                }
             }
             elseif ($hasCallerPreference) {
                 [PesterConfiguration] $PesterPreference = [PesterConfiguration]::Merge($callerPreference, $Configuration)

--- a/src/Main.ps1
+++ b/src/Main.ps1
@@ -1,4 +1,4 @@
-﻿function Assert-ValidAssertionName {
+function Assert-ValidAssertionName {
     param([string]$Name)
     if ($Name -notmatch '^\S+$') {
         throw "Assertion name '$name' is invalid, assertion name must be a single word."
@@ -907,7 +907,7 @@ function Invoke-Pester {
 
             if ('Diagnostic' -eq $PesterPreference.Output.Verbosity.Value) {
                 $PesterPreference.Debug.WriteDebugMessages = $true
-                $PesterPreference.Debug.WriteDebugMessagesFrom = "Discovery", "Skip", "Filter", "Mock", "CodeCoverage"
+                $PesterPreference.Debug.WriteDebugMessagesFrom = "Discovery", "Skip", "Mock", "CodeCoverage"
             }
 
             $plugins +=

--- a/src/Main.ps1
+++ b/src/Main.ps1
@@ -1,4 +1,4 @@
-function Assert-ValidAssertionName {
+﻿function Assert-ValidAssertionName {
     param([string]$Name)
     if ($Name -notmatch '^\S+$') {
         throw "Assertion name '$name' is invalid, assertion name must be a single word."

--- a/src/Pester.RSpec.ps1
+++ b/src/Pester.RSpec.ps1
@@ -384,7 +384,7 @@ function New-PesterConfiguration {
       Default value: $false
 
       WriteDebugMessagesFrom: Write Debug messages from a given source, WriteDebugMessages must be set to true for this to work. You can use like wildcards to get messages from multiple sources, as well as * to get everything.
-      Default value: @('Discovery', 'Skip', 'Filter', 'Mock', 'CodeCoverage')
+      Default value: @('Discovery', 'Skip', 'Mock', 'CodeCoverage')
 
       ShowNavigationMarkers: Write paths after every block and test, for easy navigation in VSCode.
       Default value: $false

--- a/src/Pester.Runtime.ps1
+++ b/src/Pester.Runtime.ps1
@@ -893,7 +893,6 @@ function Discover-Test {
         Invoke-PluginStep -Plugins $state.Plugin -Step DiscoveryStart -Context @{
             BlockContainers = $BlockContainer
             Configuration   = $state.PluginConfiguration
-            Filter          = $Filter
         } -ThrowOnFailure
     }
 
@@ -1016,6 +1015,7 @@ function Discover-Test {
             FocusedTests    = $focusedTests
             Duration        = $totalDiscoveryDuration.Elapsed
             Configuration   = $state.PluginConfiguration
+            Filter          = $Filter
         } -ThrowOnFailure
     }
 

--- a/src/Pester.Runtime.ps1
+++ b/src/Pester.Runtime.ps1
@@ -1705,9 +1705,6 @@ function Test-ShouldRun {
     # item is excluded when any of the exclude tags match
     $tagFilter = $Filter.ExcludeTag
     if ($tagFilter -and 0 -ne $tagFilter.Count) {
-        if ($PesterPreference.Debug.WriteDebugMessages.Value) {
-            Write-PesterDebugMessage -Scope Filter "($fullDottedPath) There is '$($tagFilter -join ", ")' exclude tag filter."
-        }
         foreach ($f in $tagFilter) {
             foreach ($t in $Item.Tag) {
                 if ($t -like $f) {
@@ -1768,9 +1765,6 @@ function Test-ShouldRun {
     # test is included when it has tags and the any of the tags match
     $tagFilter = $Filter.Tag
     if ($tagFilter -and 0 -ne $tagFilter.Count) {
-        if ($PesterPreference.Debug.WriteDebugMessages.Value) {
-            Write-PesterDebugMessage -Scope Filter "($fullDottedPath) There is '$($tagFilter -join ", ")' include tag filter."
-        }
         $anyIncludeFilters = $true
         if ($null -eq $Item.Tag -or 0 -eq $Item.Tag) {
             if ($PesterPreference.Debug.WriteDebugMessages.Value) {

--- a/src/csharp/Pester/DebugConfiguration.cs
+++ b/src/csharp/Pester/DebugConfiguration.cs
@@ -32,7 +32,7 @@ namespace Pester
         {
             ShowFullErrors = new BoolOption("Show full errors including Pester internal stack.", false);
             WriteDebugMessages = new BoolOption("Write Debug messages to screen.", false);
-            WriteDebugMessagesFrom = new StringArrayOption("Write Debug messages from a given source, WriteDebugMessages must be set to true for this to work. You can use like wildcards to get messages from multiple sources, as well as * to get everything.", new string[] { "Discovery", "Skip", "Filter", "Mock", "CodeCoverage" });
+            WriteDebugMessagesFrom = new StringArrayOption("Write Debug messages from a given source, WriteDebugMessages must be set to true for this to work. You can use like wildcards to get messages from multiple sources, as well as * to get everything.", new string[] { "Discovery", "Skip", "Mock", "CodeCoverage" });
             ShowNavigationMarkers = new BoolOption("Write paths after every block and test, for easy navigation in VSCode.", false);
             ReturnRawResultObject = new BoolOption("Returns unfiltered result object, this is for development only. Do not rely on this object for additional properties, non-public properties will be renamed without previous notice.", false);
         }

--- a/src/functions/Output.ps1
+++ b/src/functions/Output.ps1
@@ -1,4 +1,4 @@
-﻿$script:ReportStrings = DATA {
+$script:ReportStrings = DATA {
     @{
         VersionMessage    = "Pester v{0}"
         FilterMessage     = ' matching test name {0}'
@@ -505,13 +505,6 @@ function Get-WriteScreenPlugin ($Verbosity) {
         }
     }
 
-    if ($PesterPreference.Output.Verbosity.Value -in 'Detailed', 'Diagnostic') {
-        $p.ContainerDiscoveryStart = {
-            param ($Context)
-            & $SafeCommands["Write-Host"] -ForegroundColor Magenta "Discovering in $($Context.BlockContainer.Item)."
-        }
-    }
-
     $p.ContainerDiscoveryEnd = {
         param ($Context)
 
@@ -528,10 +521,6 @@ function Get-WriteScreenPlugin ($Verbosity) {
 
             & $SafeCommands["Write-Host"] -ForegroundColor Red "[-] Discovery in $($path) failed with:"
             Write-ErrorToScreen $Context.Block.ErrorRecord
-        }
-        elseif ($PesterPreference.Output.Verbosity.Value -in 'Detailed', 'Diagnostic') {
-            # todo: this is very very slow because of View-flat
-            & $SafeCommands["Write-Host"] -ForegroundColor Magenta "Found $(@(View-Flat -Block $Context.Block).Count) tests. $(ConvertTo-HumanTime $Context.Duration)"
         }
     }
 

--- a/src/functions/Output.ps1
+++ b/src/functions/Output.ps1
@@ -1,4 +1,4 @@
-$script:ReportStrings = DATA {
+﻿$script:ReportStrings = DATA {
     @{
         VersionMessage    = "Pester v{0}"
         FilterMessage     = ' matching test name {0}'
@@ -542,7 +542,13 @@ function Get-WriteScreenPlugin ($Verbosity) {
 
 
     $p.RunStart = {
-        & $SafeCommands["Write-Host"] -ForegroundColor Magenta "Running tests."
+        param ($Context)
+
+        $testsToRun = 0
+        foreach ($test in @(View-Flat -Block $Context.Blocks)) {
+            if ($test.ShouldRun) { $testsToRun++ }
+        }
+        & $SafeCommands["Write-Host"] -ForegroundColor Magenta "Running $testsToRun tests."
     }
 
     if ($PesterPreference.Output.Verbosity.Value -in 'Detailed', 'Diagnostic') {

--- a/tst/Pester.RSpec.Configuration.ts.ps1
+++ b/tst/Pester.RSpec.Configuration.ts.ps1
@@ -458,6 +458,29 @@ i -PassThru:$PassThru {
         }
     }
 
+    b "configuration modified at runtime" {
+        t "changes at runtime doesn't leak to advanced configuration object" {
+            $c = [PesterConfiguration] @{
+                Run    = @{
+                    ScriptBlock = { }
+                    PassThru    = $true
+                }
+                Output = @{
+                    Verbosity = 'Diagnostic'
+                }
+                Debug  = @{
+                    WriteDebugMessagesFrom = 'Something'
+                }
+            }
+
+            $r = Invoke-Pester -Configuration $c
+
+            # Diagnostic modifies Debug.WriteDebugMessagesFrom at runtime
+            $r.Configuration.Debug.WriteDebugMessagesFrom.Value.Count -gt 1 | Verify-True
+            'Something' -eq $c.Debug.WriteDebugMessagesFrom.Value | Verify-True
+        }
+    }
+
     b "New-PesterConfiguration" {
         t "Creates default configuration when no parameters are specified" {
             $config = New-PesterConfiguration

--- a/tst/Pester.RSpec.Output.ts.ps1
+++ b/tst/Pester.RSpec.Output.ts.ps1
@@ -145,7 +145,7 @@ i -PassThru:$PassThru {
             }
             $output = Invoke-PesterInProcess $sb -Setup $setup
             # only print the relevant part of output
-            $null, $run = $output -join "`n" -split "Discovery finished.*"
+            $null, $run = $output -join "`n" -split "Running tests."
             $run | Write-Host
 
             $describe1 = $output | Select-String -Pattern 'Describing d1\s*$'
@@ -183,7 +183,7 @@ i -PassThru:$PassThru {
             }
             $output = Invoke-PesterInProcess $sb -Setup $setup
             # only print the relevant part of output
-            $null, $run = $output -join "`n" -split "Discovery finished.*"
+            $null, $run = $output -join "`n" -split "Running tests."
             $run | Write-Host
 
             $describe1 = $output | Select-String -Pattern 'Describing d1 abc\s*$'


### PR DESCRIPTION
## PR Summary
- Removes file-specific discovery message from Detailed view. This is still available as Discovery debug-messages in Diagnostic
- Output number of tests to be executed.
- Removes redundant and noisy active tag filter debugmessages (covered in initial discovery-output in Detailed + Diagnostic), see before-image here https://github.com/pester/Pester/issues/1746#issuecomment-854043879
- Fix runtime configuration leak when using advanced configuration with `Invoke-Pester -Configuration ...`

Example of output after PR:
![image](https://user-images.githubusercontent.com/3436158/120866945-31b7f000-c591-11eb-8436-735c1a27fa0d.png)
![image](https://user-images.githubusercontent.com/3436158/120866791-ea316400-c590-11eb-9d68-5fde6593ed69.png)

Diagnostic:
![image](https://user-images.githubusercontent.com/3436158/120866986-498f7400-c591-11eb-9a10-d2668252a582.png)

![image](https://user-images.githubusercontent.com/3436158/120866878-0e8d4080-c591-11eb-8896-6fee71d5c679.png)

Fix #1552
Fix #1746 
Fix #1972

## PR Checklist

- [x] PR has meaningful title
- [x] Summary describes changes
- [x] PR is ready to be merged
  - If not, use the arrow next to `Create Pull Request` to mark it as a draft. PR can be marked `Ready for review` when it's ready.
- [x] Tests are added/update *(if required)*
- [ ] Documentation is updated/added *(if required)*