### PR TITLE
Log conflicting variables in Should -Invoke -ParameterFilter

### DIFF
--- a/src/functions/Mock.ps1
+++ b/src/functions/Mock.ps1
@@ -400,14 +400,14 @@ function Should-InvokeInternal {
         if ($preExistingFilterVariables.Count -gt 0) {
             foreach ($p in $ContextInfo.Hook.Metadata.Parameters.GetEnumerator()) {
                 if ($preExistingFilterVariables.ContainsKey($p.Key)) {
-                    Write-PesterDebugMessage -Scope Mock -Message "! Variable `$$($p.Key) with value '$($preExistingFilterVariables[$p.Key])' exists in test and may conflict with a parameter in ParameterFilter for $CommandName resulting in false matches. Consider renaming the existing variable."
+                    Write-PesterDebugMessage -Scope Mock -Message "! Variable `$$($p.Key) with value '$($preExistingFilterVariables[$p.Key])' exists in current scope and matches a parameter in $CommandName which may cause false matches in ParameterFilter. Consider renaming the existing variable or use `$PesterBoundParameters.$($p.Key) in ParameterFilter."
                 }
 
                 $aliases = $p.Value.Aliases
                 if ($null -ne $aliases -and 0 -lt @($aliases).Count) {
                     foreach ($a in $aliases) {
                         if ($preExistingFilterVariables.ContainsKey($a)) {
-                            Write-PesterDebugMessage -Scope Mock -Message "! Variable `$$($a) with value '$($preExistingFilterVariables[$a])' exists in test and may conflict with an alias in ParameterFilter for $CommandName resulting in false matches. Consider renaming the existing variable."
+                            Write-PesterDebugMessage -Scope Mock -Message "! Variable `$$($a) with value '$($preExistingFilterVariables[$a])' exists in current scope and matches a parameter in $CommandName which may cause false matches in ParameterFilter. Consider renaming the existing variable or use `$PesterBoundParameters.$($a) in ParameterFilter."
                         }
                     }
                 }

--- a/tst/functions/Mock.Tests.ps1
+++ b/tst/functions/Mock.Tests.ps1
@@ -2798,13 +2798,15 @@ Describe "When inherited variables conflicts with parameters" {
         { Should -InvokeVerifiable } | Should -Throw
     }
 
-    It "KNOWN ISSUE: Should Invoke ParameterFilter will count false positive" {
+    It "Should Invoke ParameterFilter will count false positive for the first FunctionUnderTest call" {
         # https://github.com/pester/Pester/issues/1873
+        # this will pass the parameter filter because we define a variable param1 with the same name and value as the expected parameter value
         FunctionUnderTest | Should -Be 'default'
         FunctionUnderTest -param1 'abc' | Should -Be 'filtered'
         $param1 = 'abc'
 
         # This should show warning about conflict when in Diagnostic output (Mock debug message)
+        # about already having a variable in the scope that is the same as parameter name
         Should -Invoke FunctionUnderTest -ParameterFilter { $param1 -eq 'abc' } -Times 2 -Exactly
     }
 

--- a/tst/functions/Mock.Tests.ps1
+++ b/tst/functions/Mock.Tests.ps1
@@ -2779,3 +2779,51 @@ Describe "Debugging mocks" {
         }
     }
 }
+
+Describe "When inherited variables conflicts with parameters" {
+    BeforeAll {
+        Mock FunctionUnderTest { 'default' }
+        Mock FunctionUnderTest { 'filtered' } -ParameterFilter { $param1 -eq 'abc' } -Verifiable
+    }
+
+    It "parameterized mock should not be called due to inherited variable" {
+        $param1 = 'abc'
+        FunctionUnderTest | Should -Be 'default'
+    }
+
+    It "InvokeVerifiable should not pass due to test variable" {
+        # Uses same logic as mock execution, so should not be tricked
+        $param1 = 'abc'
+        FunctionUnderTest | Should -Be 'default'
+        { Should -InvokeVerifiable } | Should -Throw
+    }
+
+    It "KNOWN ISSUE: Should Invoke ParameterFilter will count false positive" {
+        # https://github.com/pester/Pester/issues/1873
+        FunctionUnderTest | Should -Be 'default'
+        FunctionUnderTest -param1 'abc' | Should -Be 'filtered'
+        $param1 = 'abc'
+
+        # This should show warning about conflict when in Diagnostic output (Mock debug message)
+        Should -Invoke FunctionUnderTest -ParameterFilter { $param1 -eq 'abc' } -Times 2 -Exactly
+    }
+
+    It "Invoke ParameterFilter works as expected when PesterBoundParamters is used" {
+        # Workaround mentioned in debug message warning mentioned in previous test
+        FunctionUnderTest | Should -Be 'default'
+        FunctionUnderTest -param1 'abc' | Should -Be 'filtered'
+        $param1 = 'abc'
+
+        # No warning will be shown in debug as there's no conflict
+        Should -Invoke FunctionUnderTest -ParameterFilter { $PesterBoundParameters.param1 -eq 'abc' } -Times 1 -Exactly
+    }
+
+    It "Calling mock with parameter overrides inherited variable in filter" {
+        FunctionUnderTest -param1 '123' | Should -Be 'default'
+        $param1 = 'abc'
+
+        # This should show warning about conflict when in Diagnostic output (Mock debug message)
+        Should -Invoke FunctionUnderTest -ParameterFilter { $param1 -eq 'abc' } -Times 0 -Exactly
+        Should -Invoke FunctionUnderTest -ParameterFilter { $param1 -eq 123 } -Times 1 -Exactly
+    }
+}


### PR DESCRIPTION
## PR Summary
New attempt at debug-logging variables that may cause false matches during `Should -Invoke` due to conflict with a known parameter or alias name in the mocked command.

Fix #1873
Related #1912

## PR Checklist

- [x] PR has meaningful title
- [x] Summary describes changes
- [x] PR is ready to be merged
  - If not, use the arrow next to `Create Pull Request` to mark it as a draft. PR can be marked `Ready for review` when it's ready.
- [x] Tests are added/update *(if required)*
- [ ] Documentation is updated/added *(if required)*