### PR TITLE
Limit output information for failed tests

### DIFF
--- a/src/Main.ps1
+++ b/src/Main.ps1
@@ -890,7 +890,8 @@ function Invoke-Pester {
                 if ($PSBoundParameters.ContainsKey('Configuration')) {
                     # Advanced configuration used, merging to get new reference
                     [PesterConfiguration] $PesterPreference = [PesterConfiguration]::Merge([PesterConfiguration]::Default, $Configuration)
-                } else {
+                }
+                else {
                     [PesterConfiguration] $PesterPreference = $Configuration
                 }
             }
@@ -1153,7 +1154,7 @@ function Invoke-Pester {
 
         }
         catch {
-            Write-ErrorToScreen $_ -Throw:$PesterPreference.Run.Throw.Value
+            Write-ErrorToScreen $_ -Throw:$PesterPreference.Run.Throw.Value -ShowStackTrace:$PesterPreference.Output.ShowStackTrace.Value
             if ($PesterPreference.Run.Exit.Value) {
                 exit -1
             }

--- a/src/Main.ps1
+++ b/src/Main.ps1
@@ -923,7 +923,6 @@ function Invoke-Pester {
             }
 
             if ($PesterPreference.Debug.ShowFullErrors.Value) {
-                & $SafeCommands['Write-Warning'] "Debug.ShowFullErrors is deprecated. This will be overriden with Output.StackTraceVerbosity = 'Full'."
                 $PesterPreference.Output.StackTraceVerbosity = "Full"
             }
 

--- a/src/Main.ps1
+++ b/src/Main.ps1
@@ -1154,7 +1154,7 @@ function Invoke-Pester {
 
         }
         catch {
-            Write-ErrorToScreen $_ -Throw:$PesterPreference.Run.Throw.Value -ShowStackTrace:$PesterPreference.Output.ShowStackTrace.Value
+            Write-ErrorToScreen $_ -Throw:$PesterPreference.Run.Throw.Value -StackTraceVerbosity:$PesterPreference.Output.StackTraceVerbosity.Value
             if ($PesterPreference.Run.Exit.Value) {
                 exit -1
             }

--- a/src/Main.ps1
+++ b/src/Main.ps1
@@ -922,6 +922,11 @@ function Invoke-Pester {
                 $PesterPreference.Debug.WriteDebugMessagesFrom = $PesterPreference.Debug.WriteDebugMessagesFrom.Value + @($missingCategories)
             }
 
+            if ($PesterPreference.Debug.ShowFullErrors.Value) {
+                & $SafeCommands['Write-Warning'] "Debug.ShowFullErrors is deprecated. This will be overriden with Output.StackTraceVerbosity = 'Full'."
+                $PesterPreference.Output.StackTraceVerbosity = "Full"
+            }
+
             $plugins +=
             @(
                 # decorator plugin needs to be added after output

--- a/src/Pester.RSpec.ps1
+++ b/src/Pester.RSpec.ps1
@@ -396,8 +396,8 @@ function New-PesterConfiguration {
       Verbosity: The verbosity of output, options are None, Normal, Detailed and Diagnostic.
       Default value: 'Normal'
 
-      ShowStackTrace: Controls if Output shows full stack trace.
-      Default value: $true
+      StackTraceVerbosity: The verbosity of stacktrace output, options are None, FirstLine, Filtered and Full.
+      Default value: 'Filtered'
     ```
 
     .PARAMETER Hashtable

--- a/src/Pester.RSpec.ps1
+++ b/src/Pester.RSpec.ps1
@@ -395,6 +395,9 @@ function New-PesterConfiguration {
     Output:
       Verbosity: The verbosity of output, options are None, Normal, Detailed and Diagnostic.
       Default value: 'Normal'
+
+      ShowStackTrace: Controls if Output shows full stack trace.
+      Default value: $true
     ```
 
     .PARAMETER Hashtable

--- a/src/Pester.RSpec.ps1
+++ b/src/Pester.RSpec.ps1
@@ -377,7 +377,7 @@ function New-PesterConfiguration {
       Default value: 'Stop'
 
     Debug:
-      ShowFullErrors: Show full errors including Pester internal stack.
+      ShowFullErrors: Show full errors including Pester internal stack. This property is deprecated, and if set to true it will override Output.StackTraceVerbosity to 'Full'.
       Default value: $false
 
       WriteDebugMessages: Write Debug messages to screen.

--- a/src/csharp/Pester/DebugConfiguration.cs
+++ b/src/csharp/Pester/DebugConfiguration.cs
@@ -30,7 +30,7 @@ namespace Pester
 
         public DebugConfiguration() : base("Debug configuration for Pester. ⚠ Use at your own risk!")
         {
-            ShowFullErrors = new BoolOption("Show full errors including Pester internal stack.", false);
+            ShowFullErrors = new BoolOption("Show full errors including Pester internal stack. This property is deprecated, and if set to true it will override Output.StackTraceVerbosity to 'Full'.", false);
             WriteDebugMessages = new BoolOption("Write Debug messages to screen.", false);
             WriteDebugMessagesFrom = new StringArrayOption("Write Debug messages from a given source, WriteDebugMessages must be set to true for this to work. You can use like wildcards to get messages from multiple sources, as well as * to get everything.", new string[] { "Discovery", "Skip", "Mock", "CodeCoverage" });
             ShowNavigationMarkers = new BoolOption("Write paths after every block and test, for easy navigation in VSCode.", false);

--- a/src/csharp/Pester/OutputConfiguration.cs
+++ b/src/csharp/Pester/OutputConfiguration.cs
@@ -23,7 +23,7 @@ namespace Pester
     public class OutputConfiguration : ConfigurationSection
     {
         private StringOption _verbosity;
-        private BoolOption _showStackTrace;
+        private StringOption _stackTraceVerbosity;
 
         public static OutputConfiguration Default { get { return new OutputConfiguration(); } }
         public static OutputConfiguration ShallowClone(OutputConfiguration configuration)
@@ -36,14 +36,14 @@ namespace Pester
             if (configuration != null)
             {
                 Verbosity = configuration.GetObjectOrNull<string>("Verbosity") ?? Verbosity;
-                ShowStackTrace = configuration.GetValueOrNull<bool>(nameof(ShowStackTrace)) ?? ShowStackTrace;
+                StackTraceVerbosity = configuration.GetObjectOrNull<string>("StackTraceVerbosity") ?? StackTraceVerbosity;
             }
         }
 
         public OutputConfiguration() : base("Output configuration")
         {
             Verbosity = new StringOption("The verbosity of output, options are None, Normal, Detailed and Diagnostic.", "Normal");
-            ShowStackTrace = new BoolOption("Controls if Output shows full stack trace.", true);
+            StackTraceVerbosity = new StringOption("The verbosity of stacktrace output, options are None, FirstLine, Filtered and Full.", "Filtered");
         }
 
         public StringOption Verbosity
@@ -62,18 +62,18 @@ namespace Pester
             }
         }
 
-        public BoolOption ShowStackTrace
+        public StringOption StackTraceVerbosity
         {
-            get { return _showStackTrace; }
+            get { return _stackTraceVerbosity; }
             set
             {
-                if (_showStackTrace == null)
+                if (_stackTraceVerbosity == null)
                 {
-                    _showStackTrace = value;
+                    _stackTraceVerbosity = value;
                 }
                 else
                 {
-                    _showStackTrace = new BoolOption(_showStackTrace, value.Value);
+                    _stackTraceVerbosity = new StringOption(_stackTraceVerbosity, value?.Value);
                 }
             }
         }

--- a/src/csharp/Pester/OutputConfiguration.cs
+++ b/src/csharp/Pester/OutputConfiguration.cs
@@ -23,6 +23,7 @@ namespace Pester
     public class OutputConfiguration : ConfigurationSection
     {
         private StringOption _verbosity;
+        private BoolOption _showStackTrace;
 
         public static OutputConfiguration Default { get { return new OutputConfiguration(); } }
         public static OutputConfiguration ShallowClone(OutputConfiguration configuration)
@@ -35,12 +36,14 @@ namespace Pester
             if (configuration != null)
             {
                 Verbosity = configuration.GetObjectOrNull<string>("Verbosity") ?? Verbosity;
+                ShowStackTrace = configuration.GetValueOrNull<bool>(nameof(ShowStackTrace)) ?? ShowStackTrace;
             }
         }
 
         public OutputConfiguration() : base("Output configuration")
         {
             Verbosity = new StringOption("The verbosity of output, options are None, Normal, Detailed and Diagnostic.", "Normal");
+            ShowStackTrace = new BoolOption("Controls if Output shows full stack trace.", true);
         }
 
         public StringOption Verbosity
@@ -55,6 +58,22 @@ namespace Pester
                 else
                 {
                     _verbosity = new StringOption(_verbosity, FixMinimal(value?.Value));
+                }
+            }
+        }
+
+        public BoolOption ShowStackTrace
+        {
+            get { return _showStackTrace; }
+            set
+            {
+                if (_showStackTrace == null)
+                {
+                    _showStackTrace = value;
+                }
+                else
+                {
+                    _showStackTrace = new BoolOption(_showStackTrace, value.Value);
                 }
             }
         }

--- a/src/functions/Output.ps1
+++ b/src/functions/Output.ps1
@@ -394,7 +394,7 @@ function ConvertTo-FailureLines {
         [array]::Reverse($exceptionLines)
         $lines.Message += $exceptionLines
         if ($ErrorRecord.FullyQualifiedErrorId -eq 'PesterAssertionFailed') {
-            $lines.Message += "at $($ErrorRecord.TargetObject.LineText.Trim()), $($ErrorRecord.TargetObject.File):$($ErrorRecord.TargetObject.Line)".Split([string[]]($([System.Environment]::NewLine), "`n"), [System.StringSplitOptions]::RemoveEmptyEntries)
+            $lines.Trace += "at $($ErrorRecord.TargetObject.LineText.Trim()), $($ErrorRecord.TargetObject.File):$($ErrorRecord.TargetObject.Line)".Split([string[]]($([System.Environment]::NewLine), "`n"), [System.StringSplitOptions]::RemoveEmptyEntries)
         }
 
         if ( -not ($ErrorRecord | & $SafeCommands['Get-Member'] -Name ScriptStackTrace) ) {

--- a/src/functions/Output.ps1
+++ b/src/functions/Output.ps1
@@ -781,33 +781,41 @@ function Write-ErrorToScreen {
     $out = if ($multipleErrors) {
         $c = 0
         $(foreach ($e in $Err) {
+                $errorMessageSb = [System.Text.StringBuilder]::new()
+
                 if ($null -ne $e.DisplayErrorMessage) {
-                    $errorMessage = "[$(($c++))] $($e.DisplayErrorMessage)"
+                    [void]$errorMessageSb.Append("[$(($c++))] $($e.DisplayErrorMessage)")
                 }
                 else {
-                    $errorMessage = "[$(($c++))] $($e.Exception)"
+                    [void]$errorMessageSb.Append("[$(($c++))] $($e.Exception)")
                 }
 
                 if ($null -ne $e.DisplayStackTrace -and $ShowStackTrace) {
-                    $errorMessage += [Environment]::NewLine + $e.DisplayStackTrace
+                    [void]$errorMessageSb.Append([Environment]::NewLine + $e.DisplayStackTrace)
                 }
-                $errorMessage
+
+                $errorMessageSb.ToString()
             }) -join [Environment]::NewLine
     }
     else {
+        $errorMessageSb = [System.Text.StringBuilder]::new()
+
         if ($null -ne $Err.DisplayErrorMessage) {
-            $errorMessage = $Err.DisplayErrorMessage
+            [void]$errorMessageSb.Append($Err.DisplayErrorMessage)
+
             if ($null -ne $Err.DisplayStackTrace -and $ShowStackTrace) {
-                $errorMessage += [Environment]::NewLine + $Err.DisplayStackTrace
+                [void]$errorMessageSb.Append([Environment]::NewLine + $Err.DisplayStackTrace)
             }
         }
         else {
-            $errorMessage = $Err.Exception
+            [void]$errorMessageSb.Append($Err.Exception.ToString())
+
             if ($null -ne $Err.ScriptStackTrace) {
-                $errorMessage += [Environment]::NewLine + $Err.ScriptStackTrace
+                [void]$errorMessageSb.Append([Environment]::NewLine + $Err.ScriptStackTrace)
             }
         }
-        $errorMessage
+
+        $errorMessageSb.ToString()
     }
 
     $withMargin = ($out -split [Environment]::NewLine) -replace '(?m)^', $ErrorMargin -join [Environment]::NewLine

--- a/src/functions/Output.ps1
+++ b/src/functions/Output.ps1
@@ -765,13 +765,12 @@ function Get-WriteScreenPlugin ($Verbosity) {
     New-PluginObject @p
 }
 
-function Write-ErrorToScreen {
+function Format-ErrorMessage {
     [CmdletBinding()]
     param (
         [Parameter(Mandatory)]
         $Err,
         [string] $ErrorMargin,
-        [switch] $Throw,
         [switch] $ShowStackTrace
     )
 
@@ -819,11 +818,27 @@ function Write-ErrorToScreen {
     }
 
     $withMargin = ($out -split [Environment]::NewLine) -replace '(?m)^', $ErrorMargin -join [Environment]::NewLine
+
+    return $withMargin
+}
+
+function Write-ErrorToScreen {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory)]
+        $Err,
+        [string] $ErrorMargin,
+        [switch] $Throw,
+        [switch] $ShowStackTrace
+    )
+
+    $errorMessage = Format-ErrorMessage -Err $Err -ErrorMargin:$ErrorMargin -ShowStackTrace:$ShowStackTrace
+
     if ($Throw) {
-        throw $withMargin
+        throw $errorMessage
     }
     else {
-        & $SafeCommands['Write-Host'] -ForegroundColor $ReportTheme.Fail "$withMargin"
+        & $SafeCommands['Write-Host'] -ForegroundColor $ReportTheme.Fail "$errorMessage"
     }
 }
 

--- a/src/functions/Output.ps1
+++ b/src/functions/Output.ps1
@@ -779,7 +779,7 @@ function Format-ErrorMessage {
         [Parameter(Mandatory)]
         $Err,
         [string] $ErrorMargin,
-        [string] $StackTraceVerbosity
+        [string] $StackTraceVerbosity = [PesterConfiguration]::Default.Output.StackTraceVerbosity.Value
     )
 
     $multipleErrors = 1 -lt $Err.Count
@@ -851,8 +851,7 @@ function Write-ErrorToScreen {
         $Err,
         [string] $ErrorMargin,
         [switch] $Throw,
-        [Parameter(Mandatory)]
-        [string] $StackTraceVerbosity
+        [string] $StackTraceVerbosity = [PesterConfiguration]::Default.Output.StackTraceVerbosity.Value
     )
 
     $errorMessage = Format-ErrorMessage -Err $Err -ErrorMargin:$ErrorMargin -StackTraceVerbosity:$StackTraceVerbosity

--- a/src/functions/Output.ps1
+++ b/src/functions/Output.ps1
@@ -781,7 +781,7 @@ function Write-ErrorToScreen {
     $out = if ($multipleErrors) {
         $c = 0
         $(foreach ($e in $Err) {
-                $errorMessageSb = [System.Text.StringBuilder]::new()
+                $errorMessageSb = [System.Text.StringBuilder]""
 
                 if ($null -ne $e.DisplayErrorMessage) {
                     [void]$errorMessageSb.Append("[$(($c++))] $($e.DisplayErrorMessage)")
@@ -798,7 +798,7 @@ function Write-ErrorToScreen {
             }) -join [Environment]::NewLine
     }
     else {
-        $errorMessageSb = [System.Text.StringBuilder]::new()
+        $errorMessageSb = [System.Text.StringBuilder]""
 
         if ($null -ne $Err.DisplayErrorMessage) {
             [void]$errorMessageSb.Append($Err.DisplayErrorMessage)

--- a/src/functions/Output.ps1
+++ b/src/functions/Output.ps1
@@ -510,7 +510,7 @@ function Get-WriteScreenPlugin ($Verbosity) {
             }
 
             & $SafeCommands["Write-Host"] -ForegroundColor Red "[-] Discovery in $($path) failed with:"
-            Write-ErrorToScreen $Context.Block.ErrorRecord
+            Write-ErrorToScreen $Context.Block.ErrorRecord -ShowStackTrace:$PesterPreference.Output.ShowStackTrace.Value
         }
     }
 
@@ -570,7 +570,7 @@ function Get-WriteScreenPlugin ($Verbosity) {
 
         if ($Context.Result.ErrorRecord.Count -gt 0) {
             & $SafeCommands["Write-Host"] -ForegroundColor $ReportTheme.Fail "[-] $($Context.Result.Item) failed with:"
-            Write-ErrorToScreen $Context.Result.ErrorRecord
+            Write-ErrorToScreen $Context.Result.ErrorRecord -ShowStackTrace:$PesterPreference.Output.ShowStackTrace.Value
         }
 
         if ('Normal' -eq $PesterPreference.Output.Verbosity.Value) {
@@ -666,7 +666,7 @@ function Get-WriteScreenPlugin ($Verbosity) {
                     & $SafeCommands['Write-Host'] -ForegroundColor $ReportTheme.Fail "$margin[-] $out" -NoNewLine
                     & $SafeCommands['Write-Host'] -ForegroundColor $ReportTheme.FailTime " $humanTime"
 
-                    Write-ErrorToScreen $_test.ErrorRecord -ErrorMargin $error_margin
+                    Write-ErrorToScreen $_test.ErrorRecord -ErrorMargin $error_margin -ShowStackTrace:$PesterPreference.Output.ShowStackTrace.Value
                 }
                 break
             }
@@ -753,7 +753,7 @@ function Get-WriteScreenPlugin ($Verbosity) {
 
         foreach ($e in $Context.Block.ErrorRecord) { ConvertTo-FailureLines $e }
         & $SafeCommands['Write-Host'] -ForegroundColor Red "[-] $($Context.Block.FrameworkData.CommandUsed) $($Context.Block.Path -join ".") failed"
-        Write-ErrorToScreen $Context.Block.ErrorRecord $error_margin
+        Write-ErrorToScreen $Context.Block.ErrorRecord $error_margin -ShowStackTrace:$PesterPreference.Output.ShowStackTrace.Value
     }
 
     $p.End = {

--- a/src/functions/Output.ps1
+++ b/src/functions/Output.ps1
@@ -781,36 +781,29 @@ function Write-ErrorToScreen {
     $out = if ($multipleErrors) {
         $c = 0
         $(foreach ($e in $Err) {
-                $isFormattedError = $null -ne $e.DisplayErrorMessage
-                $isDisplayStackTrace = $null -ne $e.DisplayStackTrace -and $ShowStackTrace
-
-                if ($isFormattedError) {
+                if ($null -ne $e.DisplayErrorMessage) {
                     $errorMessage = "[$(($c++))] $($e.DisplayErrorMessage)"
                 }
                 else {
                     $errorMessage = "[$(($c++))] $($e.Exception)"
                 }
 
-                if ($isDisplayStackTrace) {
+                if ($null -ne $e.DisplayStackTrace -and $ShowStackTrace) {
                     $errorMessage += [Environment]::NewLine + $e.DisplayStackTrace
                 }
                 $errorMessage
             }) -join [Environment]::NewLine
     }
     else {
-        $isFormattedError = $null -ne $Err.DisplayErrorMessage
-        $isDisplayStackTrace = $null -ne $Err.DisplayStackTrace -and $ShowStackTrace
-        $isDisplayScriptStackTrace = $null -ne $Err.ScriptStackTrace -and $ShowStackTrace
-
-        if ($isFormattedError) {
+        if ($null -ne $Err.DisplayErrorMessage) {
             $errorMessage = $Err.DisplayErrorMessage
-            if ($isDisplayStackTrace) {
+            if ($null -ne $Err.DisplayStackTrace -and $ShowStackTrace) {
                 $errorMessage += [Environment]::NewLine + $Err.DisplayStackTrace
             }
         }
         else {
             $errorMessage = $Err.Exception
-            if ($isDisplayScriptStackTrace) {
+            if ($null -ne $Err.ScriptStackTrace) {
                 $errorMessage += [Environment]::NewLine + $Err.ScriptStackTrace
             }
         }

--- a/tst/Pester.RSpec.Configuration.ts.ps1
+++ b/tst/Pester.RSpec.Configuration.ts.ps1
@@ -530,6 +530,9 @@ i -PassThru:$PassThru {
                     ScriptBlock = { }
                     PassThru    = $true
                 }
+                Debug  = @{
+                    ShowFullErrors = $false
+                }
                 Output = @{
                     Verbosity = "None"
                 }
@@ -547,6 +550,9 @@ i -PassThru:$PassThru {
                 Run    = @{
                     ScriptBlock = { }
                     PassThru    = $true
+                }
+                Debug  = @{
+                    ShowFullErrors = $false
                 }
                 Output = @{
                     Verbosity = "None"
@@ -586,6 +592,9 @@ i -PassThru:$PassThru {
                 Run    = @{
                     ScriptBlock = $sb
                     PassThru    = $true
+                }
+                Debug  = @{
+                    ShowFullErrors = $false
                 }
                 Output = @{
                     StackTraceVerbosity = "Something"

--- a/tst/Pester.RSpec.Configuration.ts.ps1
+++ b/tst/Pester.RSpec.Configuration.ts.ps1
@@ -87,8 +87,8 @@ i -PassThru:$PassThru {
             $p.Output.Verbosity.Value | Verify-Equal "Normal"
         }
 
-        t "Output.ShowStackTrace is `$true" {
-            [PesterConfiguration]::Default.Output.ShowStackTrace.Value | Verify-True
+        t "Output.StackTraceVerbosity is Filtered" {
+            [PesterConfiguration]::Default.Output.StackTraceVerbosity.Value | Verify-Equal Filtered
         }
 
         # CodeCoverage configuration
@@ -242,17 +242,17 @@ i -PassThru:$PassThru {
         t "Configuration can be shallow cloned to avoid modifying user values" {
             $user = [PesterConfiguration]::Default
             $user.Output.Verbosity = "Normal"
-            $user.Output.ShowStackTrace = $true
+            $user.Output.StackTraceVerbosity = "Filtered"
 
             $cloned = [PesterConfiguration]::ShallowClone($user)
             $cloned.Output.Verbosity = "None"
-            $cloned.Output.ShowStackTrace = $false
+            $cloned.Output.StackTraceVerbosity = "None"
 
             $user.Output.Verbosity.Value | Verify-Equal "Normal"
-            $user.Output.ShowStackTrace | Verify-True
+            $user.Output.StackTraceVerbosity.Value | Verify-Equal "Filtered"
 
             $cloned.Output.Verbosity.Value | Verify-Equal "None"
-            $cloned.Output.ShowStackTrace.Value | Verify-False
+            $cloned.Output.StackTraceVerbosity.Value | Verify-Equal "None"
         }
     }
 
@@ -260,18 +260,18 @@ i -PassThru:$PassThru {
         t "configurations can be merged" {
             $user = [PesterConfiguration]::Default
             $user.Output.Verbosity = "Normal"
-            $user.Output.ShowStackTrace = $true
+            $user.Output.StackTraceVerbosity = "Filtered"
             $user.Filter.Tag = "abc"
 
             $override = [PesterConfiguration]::Default
             $override.Output.Verbosity = "None"
-            $override.Output.ShowStackTrace = $false
+            $override.Output.StackTraceVerbosity = "None"
             $override.Run.Path = "C:\test.ps1"
 
             $result = [PesterConfiguration]::Merge($user, $override)
 
             $result.Output.Verbosity.Value | Verify-Equal "None"
-            $result.Output.ShowStackTrace.Value | Verify-False
+            $result.Output.StackTraceVerbosity.Value | Verify-Equal "None"
             $result.Run.Path.Value | Verify-Equal "C:\test.ps1"
             $result.Filter.Tag.Value | Verify-Equal "abc"
         }
@@ -279,11 +279,11 @@ i -PassThru:$PassThru {
         t "merged object is a new instance" {
             $user = [PesterConfiguration]::Default
             $user.Output.Verbosity = "Normal"
-            $user.Output.ShowStackTrace = $true
+            $user.Output.StackTraceVerbosity = "Filtered"
 
             $override = [PesterConfiguration]::Default
             $override.Output.Verbosity = "None"
-            $override.Output.ShowStackTrace = $false
+            $override.Output.StackTraceVerbosity = "None"
 
             $result = [PesterConfiguration]::Merge($user, $override)
 
@@ -294,18 +294,18 @@ i -PassThru:$PassThru {
         t "values are overwritten even if they are set to the same value as default" {
             $user = [PesterConfiguration]::Default
             $user.Output.Verbosity = "Diagnostic"
-            $user.Output.ShowStackTrace = $false
+            $user.Output.StackTraceVerbosity = "Full"
             $user.Filter.Tag = "abc"
 
             $override = [PesterConfiguration]::Default
             $override.Output.Verbosity = [PesterConfiguration]::Default.Output.Verbosity
-            $override.Output.ShowStackTrace = [PesterConfiguration]::Default.Output.ShowStackTrace
+            $override.Output.StackTraceVerbosity = [PesterConfiguration]::Default.Output.StackTraceVerbosity
 
             $result = [PesterConfiguration]::Merge($user, $override)
 
             # has the same value as default but was written so it will override
             $result.Output.Verbosity.Value | Verify-Equal "Normal"
-            $result.Output.ShowStackTrace.Value | Verify-True
+            $result.Output.StackTraceVerbosity.Value | Verify-Equal "Filtered"
             # has value different from default but was not written in override so the
             # override does not touch it
             $result.Filter.Tag.Value | Verify-Equal "abc"

--- a/tst/Pester.RSpec.Junit.TestResults.ts.ps1
+++ b/tst/Pester.RSpec.Junit.TestResults.ts.ps1
@@ -94,15 +94,19 @@ i -PassThru:$PassThru {
             $xmlTestCase.status | Verify-Equal "Failed"
             $xmlTestCase.time | Verify-XmlTime $r.Containers[0].Blocks[0].Tests[0].Duration
 
-            $failureLine = $sb.StartPosition.StartLine + 3
             $message = $xmlTestCase.failure.message -split "`n" -replace "`r"
             $message[0] | Verify-Equal "Expected strings to be the same, but they were different."
-            $message[-4] | Verify-Equal "Expected: 'Test'"
-            $message[-3] | Verify-Equal "But was:  'Testing'"
-            $message[-1] | Verify-Equal "at ""Testing"" | Should -Be ""Test"", ${PSCommandPath}:$failureLine"
+            $message[1] | Verify-Equal "Expected length: 4"
+            $message[2] | Verify-Equal "Actual length:   7"
+            $message[3] | Verify-Equal "Strings differ at index 4."
+            $message[4] | Verify-Equal "Expected: 'Test'"
+            $message[5] | Verify-Equal "But was:  'Testing'"
+            $message[6] | Verify-Equal "           ----^"
 
+            $failureLine = $sb.StartPosition.StartLine + 3
             $stackTraceText = @($xmlTestCase.failure.'#text' -split "`n" -replace "`r")
-            $stackTraceText[0] | Verify-Equal "at <ScriptBlock>, ${PSCommandPath}:$failureLine"
+            $stackTraceText[0] | Verify-Equal "at ""Testing"" | Should -Be ""Test"", ${PSCommandPath}:$failureLine"
+            $stackTraceText[1] | Verify-Equal "at <ScriptBlock>, ${PSCommandPath}:$failureLine"
         }
 
         t "should write skipped and filtered test results counts" {
@@ -158,12 +162,20 @@ i -PassThru:$PassThru {
 
             $message = $xmlTestCase.failure.message -split "`n" -replace "`r"
             $message[0] | Verify-Equal "[0] Expected strings to be the same, but they were different."
-            $message[8] | Verify-Equal "[1] RuntimeException: teardown failed"
+            $message[1] | Verify-Equal "Expected length: 4"
+            $message[2] | Verify-Equal "Actual length:   7"
+            $message[3] | Verify-Equal "Strings differ at index 4."
+            $message[4] | Verify-Equal "Expected: 'Test'"
+            $message[5] | Verify-Equal "But was:  'Testing'"
+            $message[6] | Verify-Equal "           ----^"
+            $message[7] | Verify-Equal "[1] RuntimeException: teardown failed"
 
             $sbStartLine = $sb.StartPosition.StartLine
+            $failureLine = $sb.StartPosition.StartLine + 3
             $stackTraceText = @($xmlTestCase.failure.'#text' -split "`n" -replace "`r")
-            $stackTraceText[0] | Verify-Equal "[0] at <ScriptBlock>, ${PSCommandPath}:$($sbStartLine+3)"
-            $stackTraceText[1] | Verify-Equal "[1] at <ScriptBlock>, ${PSCommandPath}:$($sbStartLine+7)"
+            $stackTraceText[0] | Verify-Equal "[0] at ""Testing"" | Should -Be ""Test"", ${PSCommandPath}:$failureLine"
+            $stackTraceText[1] | Verify-Equal "at <ScriptBlock>, ${PSCommandPath}:$($sbStartLine+3)"
+            $stackTraceText[2] | Verify-Equal "[1] at <ScriptBlock>, ${PSCommandPath}:$($sbStartLine+7)"
 
         }
 

--- a/tst/Pester.RSpec.Nunit.TestResults.ts.ps1
+++ b/tst/Pester.RSpec.Nunit.TestResults.ts.ps1
@@ -88,15 +88,19 @@ i -PassThru:$PassThru {
             $xmlTestCase.result | Verify-Equal "Failure"
             $xmlTestCase.time | Verify-XmlTime $r.Containers[0].Blocks[0].Tests[0].Duration
 
-            $failureLine = $sb.StartPosition.StartLine + 3
             $message = $xmlTestCase.failure.message -split "`n"
             $message[0] | Verify-Equal "Expected strings to be the same, but they were different."
-            $message[-4] | Verify-Equal "Expected: 'Test'"
-            $message[-3] | Verify-Equal "But was:  'Testing'"
-            $message[-1] | Verify-Equal "at ""Testing"" | Should -Be ""Test"", ${PSCommandPath}:$failureLine"
+            $message[1] | Verify-Equal "Expected length: 4"
+            $message[2] | Verify-Equal "Actual length:   7"
+            $message[3] | Verify-Equal "Strings differ at index 4."
+            $message[4] | Verify-Equal "Expected: 'Test'"
+            $message[5] | Verify-Equal "But was:  'Testing'"
+            $message[6] | Verify-Equal "           ----^"
 
-            $stackTrace = $xmlTestCase.failure.'stack-trace' -split "`n"
-            $stackTrace[0] | Verify-Equal "at <ScriptBlock>, ${PSCommandPath}:$failureLine"
+            $failureLine = $sb.StartPosition.StartLine + 3
+            $stackTraceText = $xmlTestCase.failure.'stack-trace' -split "`n"
+            $stackTraceText[0] | Verify-Equal "at ""Testing"" | Should -Be ""Test"", ${PSCommandPath}:$failureLine"
+            $stackTraceText[1] | Verify-Equal "at <ScriptBlock>, ${PSCommandPath}:$failureLine"
         }
 
         t "should write a failed test result when there are multiple errors" {
@@ -121,12 +125,20 @@ i -PassThru:$PassThru {
 
             $message = $xmlTestCase.failure.message -split "`n"
             $message[0] | Verify-Equal "[0] Expected strings to be the same, but they were different."
-            $message[8] | Verify-Equal "[1] RuntimeException: teardown failed"
+            $message[1] | Verify-Equal "Expected length: 4"
+            $message[2] | Verify-Equal "Actual length:   7"
+            $message[3] | Verify-Equal "Strings differ at index 4."
+            $message[4] | Verify-Equal "Expected: 'Test'"
+            $message[5] | Verify-Equal "But was:  'Testing'"
+            $message[6] | Verify-Equal "           ----^"
+            $message[7] | Verify-Equal "[1] RuntimeException: teardown failed"
 
             $sbStartLine = $sb.StartPosition.StartLine
-            $stackTrace = $xmlTestCase.failure.'stack-trace' -split "`n"
-            $stackTrace[0] | Verify-Equal "[0] at <ScriptBlock>, ${PSCommandPath}:$($sbStartLine+3)"
-            $stackTrace[1] | Verify-Equal "[1] at <ScriptBlock>, ${PSCommandPath}:$($sbStartLine+7)"
+            $failureLine = $sb.StartPosition.StartLine + 3
+            $stackTraceText = $xmlTestCase.failure.'stack-trace' -split "`n"
+            $stackTraceText[0] | Verify-Equal "[0] at ""Testing"" | Should -Be ""Test"", ${PSCommandPath}:$failureLine"
+            $stackTraceText[1] | Verify-Equal "at <ScriptBlock>, ${PSCommandPath}:$($sbStartLine+3)"
+            $stackTraceText[2] | Verify-Equal "[1] at <ScriptBlock>, ${PSCommandPath}:$($sbStartLine+7)"
 
         }
 

--- a/tst/functions/Output.Tests.ps1
+++ b/tst/functions/Output.Tests.ps1
@@ -241,8 +241,11 @@ InModuleScope -ModuleName Pester -ScriptBlock {
             $r.Message[3] | Should -be "Expected: 'Two'"
             $r.Message[4] | Should -be "But was:  'One'"
             $r.Message[5] | Should -be "           ^"
-            $r.Message[6] | Should -match "'One' | Should -be 'Two'"
-            $r.Message.Count | Should -be 7
+            $r.Message.Count | Should -be 6
+
+            $r.Trace[0] | Should -match "'One' | Should -be 'Two'"
+            $r.Trace[1] | Should -be "at <ScriptBlock>, ${PSCommandPath}:230"
+            $r.Trace.Count | Should -be 2
         }
         # TODO: should fails with a very weird error, probably has something to do with dynamic params...
         #         Context 'Should fails in file' {
@@ -320,7 +323,7 @@ InModuleScope -ModuleName Pester -ScriptBlock {
                         $r.Trace[0] | Should -be "at f1, ${testPath}:2"
                         $r.Trace[1] | Should -be "at f2, ${testPath}:5"
                         $r.Trace[2] | Should -be "at <ScriptBlock>, ${testPath}:7"
-                        $r.Trace[3] | Should -be "at <ScriptBlock>, ${PSCommandPath}:303"
+                        $r.Trace[3] | Should -be "at <ScriptBlock>, ${PSCommandPath}:306"
                         $r.Trace.Count | Should -be 4
                     }
                 }
@@ -331,7 +334,7 @@ InModuleScope -ModuleName Pester -ScriptBlock {
                         $r.Trace[0] | Should -be "at f1, ${testPath}:2"
                         $r.Trace[1] | Should -be "at f2, ${testPath}:5"
                         $r.Trace[2] | Should -be "at <ScriptBlock>, ${testPath}:7"
-                        $r.Trace[3] | Should -be "at <ScriptBlock>, ${PSCommandPath}:303"
+                        $r.Trace[3] | Should -be "at <ScriptBlock>, ${PSCommandPath}:306"
                         $r.Trace.Count | Should -be 4
                     }
                 }
@@ -392,7 +395,7 @@ InModuleScope -ModuleName Pester -ScriptBlock {
                 It 'produces correct trace line.' {
                     if ($hasStackTrace) {
                         $r.Trace[0] | Should -be "at <ScriptBlock>, $testPath`:10"
-                        $r.Trace[1] | Should -be "at <ScriptBlock>, $PSCommandPath`:369"
+                        $r.Trace[1] | Should -be "at <ScriptBlock>, $PSCommandPath`:372"
                         $r.Trace.Count | Should -be 2
                     }
                 }
@@ -401,7 +404,7 @@ InModuleScope -ModuleName Pester -ScriptBlock {
                 It 'produces correct trace line.' {
                     if ($hasStackTrace) {
                         $r.Trace[0] | Should -be "at <ScriptBlock>, $testPath`:10"
-                        $r.Trace[1] | Should -be "at <ScriptBlock>, $PSCommandPath`:369"
+                        $r.Trace[1] | Should -be "at <ScriptBlock>, $PSCommandPath`:372"
                         $r.Trace.Count | Should -be 2
                     }
                 }

--- a/tst/functions/Output.Tests.ps1
+++ b/tst/functions/Output.Tests.ps1
@@ -442,7 +442,7 @@ InModuleScope -ModuleName Pester -ScriptBlock {
 
     Describe Format-ErrorMessage {
         Context "Formats error messages for one error" {
-            BeforeAll {
+            BeforeEach {
                 try {
                     1 / 0
                 }
@@ -504,15 +504,10 @@ InModuleScope -ModuleName Pester -ScriptBlock {
                 $messages[0] | Should -BeExactly "Failed to divide 1/0"
                 $messages | Should -HaveCount 1
             }
-
-            AfterEach {
-                $errorRecord.DisplayErrorMessage = "Failed to divide 1/0"
-                $errorRecord.DisplayStackTrace = $stackTraceText
-            }
         }
 
         Context "Formats error messages for multiple errors" {
-            BeforeAll {
+            BeforeEach {
                 $errorRecords = @()
                 for ($i = 1; $i -lt 3; $i++) {
                     try {
@@ -587,13 +582,6 @@ InModuleScope -ModuleName Pester -ScriptBlock {
                     $messages = $errorMessage -split [Environment]::NewLine
                     $messages[0] | Should -BeExactly "Failed to divide $($i + 1)/0"
                     $messages | Should -HaveCount 1
-                }
-            }
-
-            AfterEach {
-                for ($i = 0; $i -lt $errorRecords.Count; $i++) {
-                    $errorRecords[$i].DisplayErrorMessage = "Failed to divide $($i + 1)/0"
-                    $errorRecords[$i].DisplayStackTrace = $errorRecords[$i].Exception.ToString() + "$([Environment]::NewLine)at <ScriptBlock>, ${PSCommandPath}:230"
                 }
             }
         }

--- a/tst/functions/Output.Tests.ps1
+++ b/tst/functions/Output.Tests.ps1
@@ -453,14 +453,14 @@ InModuleScope -ModuleName Pester -ScriptBlock {
                 $errorRecord | Add-Member -Name "DisplayStackTrace" -MemberType NoteProperty -Value $errorRecord.Exception.ToString()
             }
 
-            It "When ShowStackTrace is set to `$true`, it has more than one message in output" {
+            It "When ShowStackTrace is set to `$true, it has more than one message in output" {
                 $errorMessage = Format-ErrorMessage -Err $errorRecord -ShowStackTrace
                 $messages = $errorMessage -split [Environment]::NewLine
                 $messages[0] | Should -BeExactly "Failed to divide 1/0"
                 $messages.Count | Should -BeGreaterThan 1
             }
 
-            It "When ShowStackTrace is set to `$false`, it has one message in output" {
+            It "When ShowStackTrace is set to `$false, it has one message in output" {
                 $errorMessage = Format-ErrorMessage -Err $errorRecord
                 $messages = $errorMessage -split [Environment]::NewLine
                 $messages[0] | Should -BeExactly "Failed to divide 1/0"
@@ -493,14 +493,14 @@ InModuleScope -ModuleName Pester -ScriptBlock {
                 }
             }
 
-            It "When ShowStackTrace is set to `$true`, it has more than two message in output" {
+            It "When ShowStackTrace is set to `$true, it has more than two messages in output" {
                 $errorMessage = Format-ErrorMessage -Err $errorRecords -ShowStackTrace
                 $messages = $errorMessage -split [Environment]::NewLine
                 $messages[0] | Should -BeExactly "[0] Failed to divide 1/0"
                 $messages.Count | Should -BeGreaterThan 2
             }
 
-            It "When ShowStackTrace is set to `$false`, it has two messages in output" {
+            It "When ShowStackTrace is set to `$false, it has two messages in output" {
                 $errorMessage = Format-ErrorMessage -Err $errorRecords
                 $messages = $errorMessage -split [Environment]::NewLine
                 $messages[0] | Should -BeExactly "[0] Failed to divide 1/0"


### PR DESCRIPTION
## PR Summary

Fix #917

I've added a `Output.StackTraceVerbosity` option with the following levels:

**None** - All Stack trace is hidden
**FirstLine** - First line of stack trace is shown
**Filtered** - Filtered lines that belong to Pester. This is default.
**Full** - All stack trace is shown

### Sample test

```pwsh
# sample.Tests.ps1
BeforeAll {
    function Test-EvenNumber {
        [CmdletBinding()]
        param (
            [Parameter(Mandatory)]
            [int]
            $Number
        )

        $Number % 2 -eq 0
    }
}

Describe Test-EvenNumber {
    Context "Even Numbers" {
        It "<number> is even" -TestCases @(
            @{ Number = 1 },
            @{ Number = 3 },
            @{ Number = 5 }
        ) {
            param($Number)
            Test-EvenNumber -Number $Number | Should -BeTrue
        }
    }
}
```

### Sample setup code

```pwsh
$pesterConfig = [PesterConfiguration]::Default
$pesterConfig.Run.Container = New-PesterContainer -Path C:\Users\Armaan\Documents\powershell-dev\sample.Tests.ps1
$pesterConfig.Output.Verbosity = "Detailed"
Invoke-Pester -Configuration $pesterConfig
```

### None

```pwsh
$pesterConfig.Output.StackTraceVerbosity = "None"
```

![None](https://user-images.githubusercontent.com/20082136/121776334-9c8bab80-cbcf-11eb-8b0a-c8eb6b1ce437.PNG)


### FirstLine

```pwsh
$pesterConfig.Output.StackTraceVerbosity = "FirstLine"
```

![FirstLine](https://user-images.githubusercontent.com/20082136/121776336-a6151380-cbcf-11eb-9ce0-12ba03899252.PNG)

### Filtered(default)

![Filtered](https://user-images.githubusercontent.com/20082136/121776345-b2996c00-cbcf-11eb-976d-48a0d364081e.PNG)


### Full

```pwsh
$pesterConfig.Output.StackTraceVerbosity = "Full"
```

![Full](https://user-images.githubusercontent.com/20082136/121776356-be852e00-cbcf-11eb-9e6a-f9fb460e5036.PNG)

I've also include a simple deprecation notice to `Debug.ShowFullErrors`, which will override `Output.StackTraceVerbosity` to `Full`.

## PR Checklist

- [x] PR has meaningful title
- [x] Summary describes changes
- [x] PR is ready to be merged
  - If not, use the arrow next to `Create Pull Request` to mark it as a draft. PR can be marked `Ready for review` when it's ready.
- [x] Tests are added/update *(if required)*
- [x] Documentation is updated/added *(if required)*