### PR TITLE
Update InvokeVerifiable error message and add negate support

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Describe 'Remove-Cache' {
 
         Remove-Cache
 
-        Assert-MockCalled -CommandName Remove-Item -Times 1 -Exactly
+        Should -Invoke -CommandName Remove-Item -Times 1 -Exactly
     }
 }
 ```

--- a/src/functions/Mock.ps1
+++ b/src/functions/Mock.ps1
@@ -307,7 +307,7 @@ function Should-InvokeVerifiableInternal {
 
     $filteredBehaviors = [System.Collections.Generic.List[Object]]@()
     foreach ($b in $Behaviors) {
-        if ($b.Executed -eq $Negate) {
+        if ($b.Executed -eq $Negate.IsPresent) {
             $filteredBehaviors.Add($b)
         }
     }

--- a/src/functions/Mock.ps1
+++ b/src/functions/Mock.ps1
@@ -321,7 +321,7 @@ function Should-InvokeVerifiableInternal {
             if ($b.ModuleName) {
                 $message += "from inside module $($b.ModuleName) "
             }
-            if ($null -ne $b.Filter) { $message += "with ParameterFilter { $($b.Filter.ToString().Trim()) }" }
+            if ($null -ne $b.Filter) { $message += "with { $($b.Filter.ToString().Trim()) }" }
         }
 
         return [PSCustomObject] @{

--- a/src/functions/Pester.SessionState.Mock.ps1
+++ b/src/functions/Pester.SessionState.Mock.ps1
@@ -633,7 +633,7 @@ https://pester.dev/docs/commands/Assert-VerifiableMock
     Set-ScriptBlockScope -ScriptBlock $sb -SessionState $PSCmdlet.SessionState
     & $sb
 }
-function Should-InvokeVerifiable {
+function Should-InvokeVerifiable ([switch]$Negate) {
     <#
 .SYNOPSIS
 Checks if any Verifiable Mock has not been invoked. If so, this will throw an exception.
@@ -666,7 +666,7 @@ This will not throw an exception because the mock was invoked.
 
 #>
     $behaviors = @(Get-VerifiableBehaviors)
-    Should-InvokeVerifiableInternal -Behaviors $behaviors
+    Should-InvokeVerifiableInternal -Behaviors $behaviors -Negate:$Negate
 }
 
 & $script:SafeCommands['Add-ShouldOperator'] -Name InvokeVerifiable `

--- a/src/functions/Pester.SessionState.Mock.ps1
+++ b/src/functions/Pester.SessionState.Mock.ps1
@@ -72,7 +72,7 @@ The mock of the first filter to pass will be used. The exception to this
 rule are Mocks with no filters. They will always be evaluated last since
 they will act as a "catch all" mock.
 
-Mocks can be marked Verifiable. If so, the Assert-VerifiableMock command
+Mocks can be marked Verifiable. If so, the Should -InvokeVerifiable command
 can be used to check if all Verifiable mocks were actually called. If any
 verifiable mock is not called, Should -InvokeVerifiable will throw an
 exception and indicate all mocks not called.

--- a/tst/functions/Mock.Tests.ps1
+++ b/tst/functions/Mock.Tests.ps1
@@ -686,6 +686,75 @@ Describe "When Creating a Verifiable Mock that is called" {
     }
 }
 
+Describe "When calling Should -Not -InvokeVerifiable" {
+    Context 'All Verifiable Mocks is called' {
+        BeforeAll {
+            Mock FunctionUnderTest -Verifiable -parameterFilter { $param1 -eq "one" }
+            FunctionUnderTest "one"
+
+            try {
+                Should -Not -InvokeVerifiable
+            }
+            Catch {
+                $result = $_
+            }
+        }
+
+        It "Should throw" {
+            #$result.Exception.Message | Should -Be "$([System.Environment]::NewLine) Expected ModuleFunctionUnderTest in module TestModule to be called with `$param1 -eq `"one`""
+            1 | Should -Be 2
+        }
+    }
+
+    Context 'Some Verifiable Mocks is called' {
+        BeforeAll {
+            Mock FunctionUnderTest -Verifiable -parameterFilter { $param1 -eq "one" }
+            Mock FunctionUnderTest -Verifiable
+            FunctionUnderTest "one"
+
+            try {
+                Should -Not -InvokeVerifiable
+            }
+            Catch {
+                $result = $_
+            }
+        }
+
+        It "Should throw" {
+            #$result.Exception.Message | Should -Be "$([System.Environment]::NewLine) Expected ModuleFunctionUnderTest in module TestModule to be called with `$param1 -eq `"one`""
+            1 | Should -Be 2
+        }
+    }
+
+    Context 'No Verifiable Mocks exists' {
+        BeforeAll {
+            Mock FunctionUnderTest -Verifiable -parameterFilter { $param1 -eq "one" }
+
+            try {
+                Should -Not -InvokeVerifiable
+            }
+            Catch {
+                $result = $_
+            }
+        }
+
+        It "Should throw" {
+            #$result.Exception.Message | Should -Be "$([System.Environment]::NewLine) Expected ModuleFunctionUnderTest in module TestModule to be called with `$param1 -eq `"one`""
+            1 | Should -Be 2
+        }
+    }
+
+    Context 'None of the Verifiable Mocks is called' {
+        BeforeAll {
+            Mock FunctionUnderTest -Verifiable -parameterFilter { $param1 -eq "one" }
+        }
+
+        It "Should not throw" {
+            { Should -Not -InvokeVerifiable } | Should -Not -Throw
+        }
+    }
+}
+
 Describe "When Calling Should -Invoke 0 without exactly" {
     BeforeAll {
         Mock FunctionUnderTest {}

--- a/tst/functions/Mock.Tests.ps1
+++ b/tst/functions/Mock.Tests.ps1
@@ -629,7 +629,7 @@ Describe "When Applying multiple Mocks on a single command where one has no filt
     }
 }
 
-Describe "When Creating a Verifiable Mock that is not called" {
+Describe "When Creating Verifiable Mock that is not called" {
     Context "In the test script's scope" {
         It "Should throw" {
             Mock FunctionUnderTest { return "I am a verifiable test" } -Verifiable -parameterFilter { $param1 -eq "one" }
@@ -642,7 +642,7 @@ Describe "When Creating a Verifiable Mock that is not called" {
                 $result = $_
             }
 
-            $result.Exception.Message | Should -Be "$([System.Environment]::NewLine) Expected FunctionUnderTest to be called with `$param1 -eq `"one`""
+            $result.Exception.Message | Should -Be "$([System.Environment]::NewLine)Expected all verifiable mocks to be called, but these were not:$([System.Environment]::NewLine) Command FunctionUnderTest with { `$param1 -eq `"one`" }"
         }
     }
 
@@ -666,12 +666,30 @@ Describe "When Creating a Verifiable Mock that is not called" {
         }
 
         It "Should throw" {
-            $result.Exception.Message | Should -Be "$([System.Environment]::NewLine) Expected ModuleFunctionUnderTest in module TestModule to be called with `$param1 -eq `"one`""
+            $result.Exception.Message | Should -Be "$([System.Environment]::NewLine)Expected all verifiable mocks to be called, but these were not:$([System.Environment]::NewLine) Command ModuleFunctionUnderTest from inside module TestModule with { `$param1 -eq `"one`" }"
         }
 
         AfterAll {
             Remove-Module TestModule -Force
         }
+    }
+}
+
+Describe "When Creating multiple Verifiable Mocks that are not called" {
+    It "Should throw and list all commands" {
+        Mock FunctionUnderTest { return "I am a verifiable test" } -Verifiable -ParameterFilter { $param1 -eq "one" }
+        Mock FunctionUnderTest { return "I am another verifiable test" } -Verifiable -ParameterFilter { $param1 -eq "two" }
+        Mock FunctionUnderTest { return "I am probably called" } -Verifiable -ParameterFilter { $param1 -eq "three" }
+        FunctionUnderTest "three" | Out-Null
+        $result = $null
+        try {
+            Should -InvokeVerifiable
+        }
+        catch {
+            $result = $_
+        }
+
+        $result.Exception.Message | Should -Be "$([System.Environment]::NewLine)Expected all verifiable mocks to be called, but these were not:$([System.Environment]::NewLine) Command FunctionUnderTest with { `$param1 -eq `"one`" }$([System.Environment]::NewLine) Command FunctionUnderTest with { `$param1 -eq `"two`" }"
     }
 }
 
@@ -687,7 +705,7 @@ Describe "When Creating a Verifiable Mock that is called" {
 }
 
 Describe "When calling Should -Not -InvokeVerifiable" {
-    Context 'All Verifiable Mocks is called' {
+    Context 'All Verifiable Mocks are called' {
         BeforeAll {
             Mock FunctionUnderTest -Verifiable -parameterFilter { $param1 -eq "one" }
             FunctionUnderTest "one"
@@ -701,12 +719,11 @@ Describe "When calling Should -Not -InvokeVerifiable" {
         }
 
         It "Should throw" {
-            #$result.Exception.Message | Should -Be "$([System.Environment]::NewLine) Expected ModuleFunctionUnderTest in module TestModule to be called with `$param1 -eq `"one`""
-            1 | Should -Be 2
+            $result.Exception.Message | Should -Be "$([System.Environment]::NewLine)Expected no verifiable mocks to be called, but these were:$([System.Environment]::NewLine) Command FunctionUnderTest with { `$param1 -eq `"one`" }"
         }
     }
 
-    Context 'Some Verifiable Mocks is called' {
+    Context 'Some Verifiable Mocks are called' {
         BeforeAll {
             Mock FunctionUnderTest -Verifiable -parameterFilter { $param1 -eq "one" }
             Mock FunctionUnderTest -Verifiable
@@ -721,26 +738,17 @@ Describe "When calling Should -Not -InvokeVerifiable" {
         }
 
         It "Should throw" {
-            #$result.Exception.Message | Should -Be "$([System.Environment]::NewLine) Expected ModuleFunctionUnderTest in module TestModule to be called with `$param1 -eq `"one`""
-            1 | Should -Be 2
+            $result.Exception.Message | Should -Be "$([System.Environment]::NewLine)Expected no verifiable mocks to be called, but these were:$([System.Environment]::NewLine) Command FunctionUnderTest with { `$param1 -eq `"one`" }"
         }
     }
 
     Context 'No Verifiable Mocks exists' {
         BeforeAll {
             Mock FunctionUnderTest -Verifiable -parameterFilter { $param1 -eq "one" }
-
-            try {
-                Should -Not -InvokeVerifiable
-            }
-            Catch {
-                $result = $_
-            }
         }
 
-        It "Should throw" {
-            #$result.Exception.Message | Should -Be "$([System.Environment]::NewLine) Expected ModuleFunctionUnderTest in module TestModule to be called with `$param1 -eq `"one`""
-            1 | Should -Be 2
+        It "Should not throw" {
+            { Should -Not -InvokeVerifiable } | Should -Not -Throw
         }
     }
 


### PR DESCRIPTION
## PR Summary
Updates InvokeVerifiable assertion with negate support. `Should -Not -InvokeVerifiable` expects none of the defined verifiable mocks to be called and will fail if **any** were.

This PR also updates the error message to output all missed (called when `-Not`) mock behaviors. The previous error message only showed the first missing mock even though `Mock` command help says it should mention all.

https://github.com/pester/Pester/blob/56131fa2a0472918c7456e16c5c8a2e45b347ac8/src/functions/Pester.SessionState.Mock.ps1#L75-L78

Output before PR:
![image](https://user-images.githubusercontent.com/3436158/120939264-88e7cd00-c717-11eb-82be-fecb19449bee.png)

Output after PR:
![image](https://user-images.githubusercontent.com/3436158/120939296-b59be480-c717-11eb-9b5a-c54a904d782a.png)

Fix #1779

/cc @bchristie

## PR Checklist

- [x] PR has meaningful title
- [x] Summary describes changes
- [x] PR is ready to be merged
  - If not, use the arrow next to `Create Pull Request` to mark it as a draft. PR can be marked `Ready for review` when it's ready.
- [x] Tests are added/update *(if required)*
- [x] Documentation is updated/added *(if required)*
