### PR TITLE
Add missing container-parameters to Data

### DIFF
--- a/src/Pester.Runtime.ps1
+++ b/src/Pester.Runtime.ps1
@@ -2649,7 +2649,7 @@ function Add-ContainerParameterDefaultValues ($RootBlock, $Container, $CallingFu
             }
         }
         "File" {
-            $originCommand = $PSCmdlet.SessionState.InvokeCommand.GetCommand($Container.Item.PSPath, [System.Management.Automation.CommandTypes]::ExternalScript)
+            $originCommand = $CallingFunction.SessionState.InvokeCommand.GetCommand($Container.Item.PSPath, [System.Management.Automation.CommandTypes]::ExternalScript)
             $command.Ast = $originCommand.ScriptBlock.Ast
 
             if ($callerCmd = $CallingFunction.SessionState.PSVariable.GetValue("PSCmdLet")) {
@@ -2676,10 +2676,10 @@ function Add-ContainerParameterDefaultValues ($RootBlock, $Container, $CallingFu
         }
 
         foreach ($param in $parametersToCheck) {
-            $v = $PSCmdlet.SessionState.PSVariable.Get($param)
+            $v = $CallingFunction.SessionState.PSVariable.Get($param)
             if ((-not $RootBlock.Data.ContainsKey($param)) -and $v) {
                 if ($PesterPreference.Debug.WriteDebugMessages.Value) {
-                    Write-PesterDebugMessage -Scope Discovery "Container parameter '$param' is undefined, but has default value '$($v.Value)'. Adding it to Data in Root-block for container."
+                    Write-PesterDebugMessage -Scope Discovery "Container parameter '$param' is undefined, adding to container Data with default value $(Format-Nicely $v.Value)."
                 }
                 $RootBlock.Data.Add($param, $v.Value)
             }

--- a/src/Pester.Runtime.ps1
+++ b/src/Pester.Runtime.ps1
@@ -2650,7 +2650,7 @@ function Add-MissingContainerParameters ($RootBlock, $Container, $CallingFunctio
             $v = $CallingFunction.SessionState.PSVariable.Get($param)
             if ((-not $RootBlock.Data.ContainsKey($param)) -and $v) {
                 if ($PesterPreference.Debug.WriteDebugMessages.Value) {
-                    Write-PesterDebugMessage -Scope Discovery "Container parameter '$param' is undefined, adding to container Data with default value $(Format-Nicely $v.Value)."
+                    Write-PesterDebugMessage -Scope Runtime "Container parameter '$param' is undefined, adding to container Data with default value $(Format-Nicely $v.Value)."
                 }
                 $RootBlock.Data.Add($param, $v.Value)
             }

--- a/src/Pester.Runtime.ps1
+++ b/src/Pester.Runtime.ps1
@@ -2664,7 +2664,7 @@ function Add-ContainerParameterDefaultValues ($RootBlock, $Container, $CallingFu
             # advanced function - need to filter parameters by parameterset
             foreach ($param in $command.Ast.ParamBlock.FindAll({ $args[0] -is [System.Management.Automation.Language.ParameterAst] -and $args[0].DefaultValue -and $command.Parameters -contains $args[0].Name.VariablePath.UserPath },$false)) {
                 $paramSetAttrs = $param.FindAll({ $args[0] -is [System.Management.Automation.Language.NamedAttributeArgumentAst] -and $args[0].ArgumentName -eq 'ParameterSetName'},$false)
-                if ($paramSetAttrs.Count -eq 0 -or (@($command.ParameterSetName,'__AllParameterSets') -contains $paramSetAttrs.Argument.Value)) {
+                if ($paramSetAttrs.Count -eq 0 -or $paramSetAttrs.Argument.Value -contains $command.ParameterSetName -or $paramSetAttrs.Argument.Value -contains '__AllParameterSets') {
                     $param.Name.VariablePath.UserPath
                 }
             }
@@ -2675,7 +2675,7 @@ function Add-ContainerParameterDefaultValues ($RootBlock, $Container, $CallingFu
         }
     }
 
-    foreach ($param in @($parametersToCheck)) {
+    foreach ($param in $parametersToCheck) {
         $v = $PSCmdlet.SessionState.PSVariable.Get($param)
         if ((-not $RootBlock.Data.ContainsKey($param)) -and $v) {
             if ($PesterPreference.Debug.WriteDebugMessages.Value) {

--- a/src/Pester.Runtime.ps1
+++ b/src/Pester.Runtime.ps1
@@ -2395,8 +2395,10 @@ function New-BlockContainerObject {
         [String] $Path,
         [Parameter(Mandatory, ParameterSetName = "File")]
         [System.IO.FileInfo] $File,
-        $Data = @{}
+        $Data
     )
+
+    if ($null -eq $Data) { $Data = @{} }
 
     $type, $item = switch ($PSCmdlet.ParameterSetName) {
         "ScriptBlock" { "ScriptBlock", $ScriptBlock }
@@ -2630,6 +2632,10 @@ function Add-ContainerParameterDefaultValues ($RootBlock, $Container, $CallingFu
         Ast = $null
         Parameters = $null
     }
+
+    # $CallingFunction is $PSCmdlet passed from our caller. $CallingFunction.MyInvocation.MyCommand will return Describe/Context as it's the latest advanced functions to be called at that point.
+    # $CallingFunction.SessionState however is the state used to call Context/Describe, usually the script-state, so by geting "PSCmdLet"-variable from it, we can get the last
+    # advanced function in script-state which may be the container if it was advanced (we need to verify)
 
     switch ($Container.Type) {
         "ScriptBlock" {

--- a/src/functions/Context.ps1
+++ b/src/functions/Context.ps1
@@ -95,7 +95,7 @@ https://pester.dev/docs/usage/testdrive
     if ($ExecutionContext.SessionState.PSVariable.Get('invokedViaInvokePester')) {
         if ($state.CurrentBlock.IsRoot) {
             # For undefined parameters in container, add parameter's default value to Data
-            Add-ContainerParameterDefaultValues -RootBlock $state.CurrentBlock -Container $container -SessionState $PSCmdlet.SessionState
+            Add-ContainerParameterDefaultValues -RootBlock $state.CurrentBlock -Container $container -CallingFunction $PSCmdlet
         }
 
         if ($PSBoundParameters.ContainsKey('ForEach')) {

--- a/src/functions/Context.ps1
+++ b/src/functions/Context.ps1
@@ -95,7 +95,7 @@ https://pester.dev/docs/usage/testdrive
     if ($ExecutionContext.SessionState.PSVariable.Get('invokedViaInvokePester')) {
         if ($state.CurrentBlock.IsRoot -and $state.CurrentBlock.Blocks.Count -eq 0) {
             # For undefined parameters in container, add parameter's default value to Data
-            Add-ContainerParameterDefaultValues -RootBlock $state.CurrentBlock -Container $container -CallingFunction $PSCmdlet
+            Add-MissingContainerParameters -RootBlock $state.CurrentBlock -Container $container -CallingFunction $PSCmdlet
         }
 
         if ($PSBoundParameters.ContainsKey('ForEach')) {

--- a/src/functions/Context.ps1
+++ b/src/functions/Context.ps1
@@ -93,6 +93,11 @@ https://pester.dev/docs/usage/testdrive
     }
 
     if ($ExecutionContext.SessionState.PSVariable.Get('invokedViaInvokePester')) {
+        if ($state.CurrentBlock.IsRoot) {
+            # For undefined parameters in container, add parameter's default value to Data
+            Add-ContainerParameterDefaultValues -RootBlock $state.CurrentBlock -Container $container -SessionState $PSCmdlet.SessionState
+        }
+
         if ($PSBoundParameters.ContainsKey('ForEach')) {
             if ($null -ne $ForEach -and 0 -lt @($ForEach).Count) {
                 New-ParametrizedBlock -Name $Name -ScriptBlock $Fixture -StartLine $MyInvocation.ScriptLineNumber -Tag $Tag -FrameworkData @{ CommandUsed = 'Context'; WrittenToScreen = $false } -Focus:$Focus -Skip:$Skip -Data $ForEach

--- a/src/functions/Context.ps1
+++ b/src/functions/Context.ps1
@@ -93,7 +93,7 @@ https://pester.dev/docs/usage/testdrive
     }
 
     if ($ExecutionContext.SessionState.PSVariable.Get('invokedViaInvokePester')) {
-        if ($state.CurrentBlock.IsRoot) {
+        if ($state.CurrentBlock.IsRoot -and $state.CurrentBlock.Blocks.Count -eq 0) {
             # For undefined parameters in container, add parameter's default value to Data
             Add-ContainerParameterDefaultValues -RootBlock $state.CurrentBlock -Container $container -CallingFunction $PSCmdlet
         }

--- a/src/functions/Describe.ps1
+++ b/src/functions/Describe.ps1
@@ -100,7 +100,7 @@ https://pester.dev/docs/usage/testdrive
     }
 
     if ($ExecutionContext.SessionState.PSVariable.Get('invokedViaInvokePester')) {
-        if ($state.CurrentBlock.IsRoot) {
+        if ($state.CurrentBlock.IsRoot -and $state.CurrentBlock.Blocks.Count -eq 0) {
             # For undefined parameters in container, add parameter's default value to Data
             Add-ContainerParameterDefaultValues -RootBlock $state.CurrentBlock -Container $container -CallingFunction $PSCmdlet
         }

--- a/src/functions/Describe.ps1
+++ b/src/functions/Describe.ps1
@@ -102,7 +102,7 @@ https://pester.dev/docs/usage/testdrive
     if ($ExecutionContext.SessionState.PSVariable.Get('invokedViaInvokePester')) {
         if ($state.CurrentBlock.IsRoot -and $state.CurrentBlock.Blocks.Count -eq 0) {
             # For undefined parameters in container, add parameter's default value to Data
-            Add-ContainerParameterDefaultValues -RootBlock $state.CurrentBlock -Container $container -CallingFunction $PSCmdlet
+            Add-MissingContainerParameters -RootBlock $state.CurrentBlock -Container $container -CallingFunction $PSCmdlet
         }
 
         if ($PSBoundParameters.ContainsKey('ForEach')) {

--- a/src/functions/Describe.ps1
+++ b/src/functions/Describe.ps1
@@ -99,11 +99,10 @@ https://pester.dev/docs/usage/testdrive
         }
     }
 
-
     if ($ExecutionContext.SessionState.PSVariable.Get('invokedViaInvokePester')) {
         if ($state.CurrentBlock.IsRoot) {
             # For undefined parameters in container, add parameter's default value to Data
-            Add-ContainerParameterDefaultValues -RootBlock $state.CurrentBlock -Container $container -SessionState $PSCmdlet.SessionState
+            Add-ContainerParameterDefaultValues -RootBlock $state.CurrentBlock -Container $container -CallingFunction $PSCmdlet
         }
 
         if ($PSBoundParameters.ContainsKey('ForEach')) {

--- a/src/functions/Describe.ps1
+++ b/src/functions/Describe.ps1
@@ -101,6 +101,11 @@ https://pester.dev/docs/usage/testdrive
 
 
     if ($ExecutionContext.SessionState.PSVariable.Get('invokedViaInvokePester')) {
+        if ($state.CurrentBlock.IsRoot) {
+            # For undefined parameters in container, add parameter's default value to Data
+            Add-ContainerParameterDefaultValues -RootBlock $state.CurrentBlock -Container $container -SessionState $PSCmdlet.SessionState
+        }
+
         if ($PSBoundParameters.ContainsKey('ForEach')) {
             if ($null -ne $ForEach -and 0 -lt @($ForEach).Count) {
                 New-ParametrizedBlock -Name $Name -ScriptBlock $Fixture -StartLine $MyInvocation.ScriptLineNumber -Tag $Tag -FrameworkData @{ CommandUsed = 'Describe'; WrittenToScreen = $false } -Focus:$Focus -Skip:$Skip -Data $ForEach

--- a/tst/Pester.RSpec.InNewProcess.ts.ps1
+++ b/tst/Pester.RSpec.InNewProcess.ts.ps1
@@ -88,7 +88,7 @@ i -PassThru:$PassThru {
             $testpath = Join-Path $temp "$([Guid]::NewGuid().Guid).tests.ps1"
 
             try {
-                $c = 'param([Parameter(Mandatory)]$File) Describe "d - <File>" { It "i" { 1 | Should -Be 1 } }'
+                $c = 'param([Parameter(Mandatory)]$File, $MyValue = 1) Describe "d - <File>" { It "i" { $MyValue | Should -Be 1 } }'
                 Set-Content -Path $testpath -Value $c
 
                 $sb = [scriptblock]::Create("`$global:PesterPreference = [PesterConfiguration]@{Output=@{Verbosity='Detailed'}}; & $testpath -File 'demo.ps1'")
@@ -110,7 +110,7 @@ i -PassThru:$PassThru {
             $testpath = Join-Path $temp "$([Guid]::NewGuid().Guid).tests.ps1"
 
             try {
-                $c = 'param([Parameter(Mandatory)]$File) Context "c - <File>" { It "i" { 1 | Should -Be 1 } }'
+                $c = 'param([Parameter(Mandatory)]$File, $MyValue = 1) Context "c - <File>" { It "i" { $MyValue | Should -Be 1 } }'
                 Set-Content -Path $testpath -Value $c
 
                 $sb = [scriptblock]::Create("`$global:PesterPreference = [PesterConfiguration]@{Output=@{Verbosity='Detailed'}}; & $testpath -File 'demo.ps1'")

--- a/tst/Pester.RSpec.ts.ps1
+++ b/tst/Pester.RSpec.ts.ps1
@@ -1047,9 +1047,6 @@ i -PassThru:$PassThru {
                 if ($null -ne $file -and (Test-Path $file)) {
                     Remove-Item $file -Force
                 }
-
-                # Revert changes made to
-                $global:PesterPreference = $originalPP
             }
         }
 


### PR DESCRIPTION
## PR Summary
Pester containers may use parameters to support data-driven test generation.

This scenario currently has the following limitations:
- Default values for parameters are available as variables in Discovery, but not in Run (test execution) unless passed using tricks like `Describe 'd1' -ForEach { myparam = $myparam}`. This makes debugging harder since `Debug Tests` in VSCode doesn't allow the user to provide `-Data ...` for the container (file).
- Default values are also not available in `*All/*Each` setup-blocks placed outside any Describe/Context-blocks. The `Describe -ForEach ..`-workaround above does not work for these root-scoped setup-blocks.
- Discovery and Run are inconsistent when using aliases for script parameters. Given a container with parameter "MyParam" which has a alias of "MyAlias". When invoked with `New-PesterContainer ... -Data @{ MyAlias = 123 }`:
    - In Discovery: `$MyParam` would be 123 and `$MyAlias` would not exist. This is default PowerShell-behavior.
    - In Run: `$MyParam` would not exist and `$MyAlias` would be 123. This is because Pester adds uses the provided `-Data` directly during Run.
  
This PR adds logic to detect container-parameters not defined by the user at runtime and automatically adds them to Data for the Root-block of the  container. This fixes:

- Script-parameters are always available as variables in Discovery and Run. Has default value (null or value set in Parma-block) if not provided by the user.
- Default values are available in root-scoped setup blocks.
- `$MyParam` (see example above) is also defined in Run like it is in Discovery to be more consistent and similar to normal PowerShell-function/script behavior. 


Fix #1980

## PR Checklist

- [x] PR has meaningful title
- [x] Summary describes changes
- [x] PR is ready to be merged
  - If not, use the arrow next to `Create Pull Request` to mark it as a draft. PR can be marked `Ready for review` when it's ready.
- [x] Tests are added/update *(if required)*
- [ ] Documentation is updated/added *(if required)*
