### PR TITLE
Block direct modification of Value-property in configuration options

### DIFF
--- a/src/csharp/Pester/GenericOption.cs
+++ b/src/csharp/Pester/GenericOption.cs
@@ -34,7 +34,7 @@ namespace Pester
 
         public T Default { get; private set; }
         public string Description { get; private set; }
-        public T Value { get; set; }
+        public T Value { get; private set; }
 
         public override string ToString()
         {

--- a/tst/Pester.RSpec.Configuration.ts.ps1
+++ b/tst/Pester.RSpec.Configuration.ts.ps1
@@ -236,6 +236,23 @@ i -PassThru:$PassThru {
             Verify-Equal $path[0].ToString() -Actual $config.Run.Path.Value[0]
             Verify-Equal $path[1].ToString() -Actual $config.Run.Path.Value[1]
         }
+
+        t "Modifying the private Default property of an option throws" {
+            $config = [PesterConfiguration]::Default
+            { $config.Run.Path.Default = 'invalid' } | Verify-Throw
+        }
+
+        t "Modifying the private Value property of an option throws" {
+            $config = [PesterConfiguration]::Default
+            { $config.Run.Path.Value = 'invalid' } | Verify-Throw
+        }
+
+        t "IsOriginalValue returns false after change even if same as default" {
+            $config = [PesterConfiguration]::Default
+            $config.Run.Path.IsOriginalValue() | Verify-True
+            $config.Run.Path = $config.Run.Path.Default
+            $config.Run.Path.IsOriginalValue() | Verify-False
+        }
     }
 
     b "Cloning" {


### PR DESCRIPTION
## PR Summary
Makes the setter of Value-property in configuration options private. This is done because modifying `Value` directly won't flip the internal `_isOriginalValue`-flag used to detect whether a user has modified the option. This is important to know which values to override when merging configuration.

Fix #1971

**Possible breaking change:** Users may create their advanced configurations by modifying Value directly because it has been possible or because it can be easier in certain scenarios, ex.


```powershell
$c.Debug.WriteDebugMessagesFrom.Value += 'MyForgottenCategory'
# vs after PR
$c.Debug.WriteDebugMessagesFrom = $c.Debug.WriteDebugMessagesFrom.Value + @('MyForgottenCategory')
```


## PR Checklist

- [x] PR has meaningful title
- [x] Summary describes changes
- [x] PR is ready to be merged
  - If not, use the arrow next to `Create Pull Request` to mark it as a draft. PR can be marked `Ready for review` when it's ready.
- [x] Tests are added/update *(if required)*
- [ ] Documentation is updated/added *(if required)*