### PR TITLE
Azure Devops & Github Actions error logging

### DIFF
--- a/src/Main.ps1
+++ b/src/Main.ps1
@@ -917,14 +917,6 @@ function Invoke-Pester {
                 }
             }
 
-            elseif ($PesterPreference.Output.CIFormat.Value -eq 'AzureDevops' -and $env:TF_BUILD -ne 'True') {
-                $PesterPreference.Output.CIFormat = 'None'
-            }
-
-            elseif ($PesterPreference.Output.CIFormat.Value -eq 'GithubActions' -and $env:GITHUB_ACTIONS -ne 'True') {
-                $PesterPreference.Output.CIFormat = 'None'
-            }
-
             & $SafeCommands['Get-Variable'] 'Configuration' -Scope Local | Remove-Variable
 
             # $sessionState = Set-SessionStateHint -PassThru  -Hint "Caller - Captured in Invoke-Pester" -SessionState $PSCmdlet.SessionState

--- a/src/Main.ps1
+++ b/src/Main.ps1
@@ -899,7 +899,7 @@ function Invoke-Pester {
                 [PesterConfiguration] $PesterPreference = [PesterConfiguration]::Merge($callerPreference, $Configuration)
             }
 
-            if ($PesterPreference.Output.CIFormat.IsOriginalValue()) {
+            if ($PesterPreference.Output.CIFormat.IsOriginalValue() -or $PesterPreference.Output.CIFormat.Value -eq 'Auto') {
 
                 # Variable is set to 'True' if the script is being run by a build task. https://docs.microsoft.com/en-us/azure/devops/pipelines/build/variables?view=azure-devops&tabs=yaml
                 # Do not fix this to check for boolean value, the value is set to literal string 'True'

--- a/src/Main.ps1
+++ b/src/Main.ps1
@@ -1179,7 +1179,19 @@ function Invoke-Pester {
 
         }
         catch {
-            Write-ErrorToScreen $_ -Throw:$PesterPreference.Run.Throw.Value -StackTraceVerbosity:$PesterPreference.Output.StackTraceVerbosity.Value
+            $formatErrorParams = @{
+                Err                 = $_
+                StackTraceVerbosity = $PesterPreference.Output.StackTraceVerbosity.Value
+            }
+
+            if ($PesterPreference.Output.CIFormat.Value -in 'AzureDevops', 'GithubActions') {
+                $errorMessage = (Format-ErrorMessage @formatErrorParams) -split [Environment]::NewLine
+                Write-CIErrorToScreen -CIFormat $PesterPreference.Output.CIFormat.Value -Header $errorMessage[0] -Message $errorMessage[1..($errorMessage.Count - 1)]
+            }
+            else {
+                Write-ErrorToScreen @formatErrorParams -Throw:$PesterPreference.Run.Throw.Value
+            }
+
             if ($PesterPreference.Run.Exit.Value) {
                 exit -1
             }

--- a/src/Main.ps1
+++ b/src/Main.ps1
@@ -899,6 +899,20 @@ function Invoke-Pester {
                 [PesterConfiguration] $PesterPreference = [PesterConfiguration]::Merge($callerPreference, $Configuration)
             }
 
+            if ($PesterPreference.Output.CIFormat.IsOriginalValue()) {
+
+                # Variable is set to 'True' if the script is being run by a build task. https://docs.microsoft.com/en-us/azure/devops/pipelines/build/variables?view=azure-devops&tabs=yaml
+                # Do not fix this to check for boolean value, the value is set to literal string 'True'
+                if ([System.Environment]::GetEnvironmentVariable('TF_BUILD') -eq 'True') {
+                    $PesterPreference.Output.CIFormat = 'AzureDevops'
+                }
+                # Variable is set to 'True' if the script is being run by a Github Actions workflow. https://docs.github.com/en/actions/reference/environment-variables#default-environment-variables
+                # Do not fix this to check for boolean value, the value is set to literal string 'True'
+                elseif ([System.Environment]::GetEnvironmentVariable('GITHUB_ACTIONS') -eq 'True') {
+                    $PesterPreference.Output.CIFormat = 'GithubActions'
+                }
+            }
+
             & $SafeCommands['Get-Variable'] 'Configuration' -Scope Local | Remove-Variable
 
             # $sessionState = Set-SessionStateHint -PassThru  -Hint "Caller - Captured in Invoke-Pester" -SessionState $PSCmdlet.SessionState

--- a/src/Pester.RSpec.ps1
+++ b/src/Pester.RSpec.ps1
@@ -398,6 +398,9 @@ function New-PesterConfiguration {
 
       StackTraceVerbosity: The verbosity of stacktrace output, options are None, FirstLine, Filtered and Full.
       Default value: 'Filtered'
+
+      CIFormat: The CI format of output, options are None, Auto, AzureDevops and GithubActions.
+      Default value: 'Auto'
     ```
 
     .PARAMETER Hashtable

--- a/src/Pester.RSpec.ps1
+++ b/src/Pester.RSpec.ps1
@@ -399,7 +399,7 @@ function New-PesterConfiguration {
       StackTraceVerbosity: The verbosity of stacktrace output, options are None, FirstLine, Filtered and Full.
       Default value: 'Filtered'
 
-      CIFormat: The CI format of output in build logs, options are None, Auto, AzureDevops and GithubActions.
+      CIFormat: The CI format of error output in build logs, options are None, Auto, AzureDevops and GithubActions.
       Default value: 'Auto'
 
     TestDrive:

--- a/src/Pester.RSpec.ps1
+++ b/src/Pester.RSpec.ps1
@@ -399,7 +399,7 @@ function New-PesterConfiguration {
       StackTraceVerbosity: The verbosity of stacktrace output, options are None, FirstLine, Filtered and Full.
       Default value: 'Filtered'
 
-      CIFormat: The CI format of output in build logs, options are None, Auto, AzureDevops and GithubActions. Environment variable TF_BUILD(https://docs.microsoft.com/en-us/azure/devops/pipelines/build/variables?view=azure-devops&tabs=yaml#system-variables-devops-services) is automically set to true when Azure Devops is detected. Environment variable GITHUB_ACTIONS(https://docs.github.com/en/actions/reference/environment-variables#default-environment-variables) is automatically set to true when Github Actions is detected.
+      CIFormat: The CI format of output in build logs, options are None, Auto, AzureDevops and GithubActions.
       Default value: 'Auto'
 
     TestDrive:

--- a/src/Pester.RSpec.ps1
+++ b/src/Pester.RSpec.ps1
@@ -399,7 +399,7 @@ function New-PesterConfiguration {
       StackTraceVerbosity: The verbosity of stacktrace output, options are None, FirstLine, Filtered and Full.
       Default value: 'Filtered'
 
-      CIFormat: The CI format of output, options are None, Auto, AzureDevops and GithubActions.
+      CIFormat: The CI format of output in build logs, options are None, Auto, AzureDevops and GithubActions. Environment variable TF_BUILD(https://docs.microsoft.com/en-us/azure/devops/pipelines/build/variables?view=azure-devops&tabs=yaml#system-variables-devops-services) is automically set to true when Azure Devops is detected. Environment variable GITHUB_ACTIONS(https://docs.github.com/en/actions/reference/environment-variables#default-environment-variables) is automatically set to true when Github Actions is detected.
       Default value: 'Auto'
     ```
 

--- a/src/csharp/Pester/OutputConfiguration.cs
+++ b/src/csharp/Pester/OutputConfiguration.cs
@@ -46,7 +46,7 @@ namespace Pester
         {
             Verbosity = new StringOption("The verbosity of output, options are None, Normal, Detailed and Diagnostic.", "Normal");
             StackTraceVerbosity = new StringOption("The verbosity of stacktrace output, options are None, FirstLine, Filtered and Full.", "Filtered");
-            CIFormat = new StringOption("The CI format of output, options are None, Auto, AzureDevops and GithubActions.", "Auto");
+            CIFormat = new StringOption("The CI format of output in build logs, options are None, Auto, AzureDevops and GithubActions. Environment variable TF_BUILD(https://docs.microsoft.com/en-us/azure/devops/pipelines/build/variables?view=azure-devops&tabs=yaml#system-variables-devops-services) is automically set to true when Azure Devops is detected. Environment variable GITHUB_ACTIONS(https://docs.github.com/en/actions/reference/environment-variables#default-environment-variables) is automatically set to true when Github Actions is detected.", "Auto");
         }
 
         public StringOption Verbosity

--- a/src/csharp/Pester/OutputConfiguration.cs
+++ b/src/csharp/Pester/OutputConfiguration.cs
@@ -46,7 +46,7 @@ namespace Pester
         {
             Verbosity = new StringOption("The verbosity of output, options are None, Normal, Detailed and Diagnostic.", "Normal");
             StackTraceVerbosity = new StringOption("The verbosity of stacktrace output, options are None, FirstLine, Filtered and Full.", "Filtered");
-            CIFormat = new StringOption("The CI format of output in build logs, options are None, Auto, AzureDevops and GithubActions. Environment variable TF_BUILD(https://docs.microsoft.com/en-us/azure/devops/pipelines/build/variables?view=azure-devops&tabs=yaml#system-variables-devops-services) is automically set to true when Azure Devops is detected. Environment variable GITHUB_ACTIONS(https://docs.github.com/en/actions/reference/environment-variables#default-environment-variables) is automatically set to true when Github Actions is detected.", "Auto");
+            CIFormat = new StringOption("The CI format of output in build logs, options are None, Auto, AzureDevops and GithubActions.", "Auto");
         }
 
         public StringOption Verbosity

--- a/src/csharp/Pester/OutputConfiguration.cs
+++ b/src/csharp/Pester/OutputConfiguration.cs
@@ -24,6 +24,7 @@ namespace Pester
     {
         private StringOption _verbosity;
         private StringOption _stackTraceVerbosity;
+        private StringOption _ciFormat;
 
         public static OutputConfiguration Default { get { return new OutputConfiguration(); } }
         public static OutputConfiguration ShallowClone(OutputConfiguration configuration)
@@ -37,6 +38,7 @@ namespace Pester
             {
                 Verbosity = configuration.GetObjectOrNull<string>("Verbosity") ?? Verbosity;
                 StackTraceVerbosity = configuration.GetObjectOrNull<string>("StackTraceVerbosity") ?? StackTraceVerbosity;
+                CIFormat = configuration.GetObjectOrNull<string>("CIFormat") ?? CIFormat;
             }
         }
 
@@ -44,6 +46,7 @@ namespace Pester
         {
             Verbosity = new StringOption("The verbosity of output, options are None, Normal, Detailed and Diagnostic.", "Normal");
             StackTraceVerbosity = new StringOption("The verbosity of stacktrace output, options are None, FirstLine, Filtered and Full.", "Filtered");
+            CIFormat = new StringOption("The CI format of output, options are None, Auto, AzureDevops and GithubActions.", "Auto");
         }
 
         public StringOption Verbosity
@@ -74,6 +77,22 @@ namespace Pester
                 else
                 {
                     _stackTraceVerbosity = new StringOption(_stackTraceVerbosity, value?.Value);
+                }
+            }
+        }
+
+        public StringOption CIFormat
+        {
+            get { return _ciFormat; }
+            set
+            {
+                if (_ciFormat == null)
+                {
+                    _ciFormat = value;
+                }
+                else
+                {
+                    _ciFormat = new StringOption(_ciFormat, value?.Value);
                 }
             }
         }

--- a/src/csharp/Pester/OutputConfiguration.cs
+++ b/src/csharp/Pester/OutputConfiguration.cs
@@ -46,7 +46,7 @@ namespace Pester
         {
             Verbosity = new StringOption("The verbosity of output, options are None, Normal, Detailed and Diagnostic.", "Normal");
             StackTraceVerbosity = new StringOption("The verbosity of stacktrace output, options are None, FirstLine, Filtered and Full.", "Filtered");
-            CIFormat = new StringOption("The CI format of output in build logs, options are None, Auto, AzureDevops and GithubActions.", "Auto");
+            CIFormat = new StringOption("The CI format of error output in build logs, options are None, Auto, AzureDevops and GithubActions.", "Auto");
         }
 
         public StringOption Verbosity

--- a/src/functions/Output.ps1
+++ b/src/functions/Output.ps1
@@ -666,6 +666,10 @@ function Get-WriteScreenPlugin ($Verbosity) {
             throw "Unsupported level of stacktrace output '$($PesterPreference.Output.StackTraceVerbosity.Value)'"
         }
 
+        if ($PesterPreference.Output.CIFormat.Value -notin 'None', 'Auto', 'AzureDevops', 'GithubActions') {
+            throw "Unsupported CI format '$($PesterPreference.Output.CIFormat.Value)'"
+        }
+
         $humanTime = "$(Get-HumanTime ($_test.Duration)) ($(Get-HumanTime $_test.UserDuration)|$(Get-HumanTime $_test.FrameworkDuration))"
 
         if ($PesterPreference.Debug.ShowNavigationMarkers.Value) {

--- a/src/functions/Output.ps1
+++ b/src/functions/Output.ps1
@@ -522,7 +522,7 @@ function Get-WriteScreenPlugin ($Verbosity) {
 
             if ($PesterPreference.Output.CIFormat.Value -in 'AzureDevops', 'GithubActions') {
                 $errorMessage = (Format-ErrorMessage @formatErrorParams) -split [Environment]::NewLine
-                Write-CIErrorMessage -CIFormat $PesterPreference.Output.CIFormat.Value -Header $errorHeader -Message $errorMessage
+                Write-CIErrorToScreen -CIFormat $PesterPreference.Output.CIFormat.Value -Header $errorHeader -Message $errorMessage
             }
             else {
                 & $SafeCommands["Write-Host"] -ForegroundColor $ReportTheme.Fail $errorHeader
@@ -595,7 +595,7 @@ function Get-WriteScreenPlugin ($Verbosity) {
 
             if ($PesterPreference.Output.CIFormat.Value -in 'AzureDevops', 'GithubActions') {
                 $errorMessage = (Format-ErrorMessage @formatErrorParams) -split [Environment]::NewLine
-                Write-CIErrorMessage -CIFormat $PesterPreference.Output.CIFormat.Value -Header $errorHeader -Message $errorMessage
+                Write-CIErrorToScreen -CIFormat $PesterPreference.Output.CIFormat.Value -Header $errorHeader -Message $errorMessage
             }
             else {
                 & $SafeCommands["Write-Host"] -ForegroundColor $ReportTheme.Fail $errorHeader
@@ -705,7 +705,7 @@ function Get-WriteScreenPlugin ($Verbosity) {
 
                     if ($PesterPreference.Output.CIFormat.Value -in 'AzureDevops', 'GithubActions') {
                         $errorMessage = (Format-ErrorMessage @formatErrorParams) -split [Environment]::NewLine
-                        Write-CIErrorMessage -CIFormat $PesterPreference.Output.CIFormat.Value -Header "$margin[-] $out $humanTime" -Message $errorMessage
+                        Write-CIErrorToScreen -CIFormat $PesterPreference.Output.CIFormat.Value -Header "$margin[-] $out $humanTime" -Message $errorMessage
                     }
                     else {
                         & $SafeCommands['Write-Host'] -ForegroundColor $ReportTheme.Fail "$margin[-] $out" -NoNewLine
@@ -808,7 +808,7 @@ function Get-WriteScreenPlugin ($Verbosity) {
 
         if ($PesterPreference.Output.CIFormat.Value -in 'AzureDevops', 'GithubActions') {
             $errorMessage = (Format-ErrorMessage @formatErrorParams) -split [Environment]::NewLine
-            Write-CIErrorMessage -CIFormat $PesterPreference.Output.CIFormat.Value -Header $errorHeader -Message $errorMessage
+            Write-CIErrorToScreen -CIFormat $PesterPreference.Output.CIFormat.Value -Header $errorHeader -Message $errorMessage
         }
         else {
             & $SafeCommands['Write-Host'] -ForegroundColor $ReportTheme.BlockFail $errorHeader
@@ -825,7 +825,7 @@ function Get-WriteScreenPlugin ($Verbosity) {
     New-PluginObject @p
 }
 
-function Write-CIErrorMessage {
+function Write-CIErrorToScreen {
     [CmdletBinding()]
     param (
         [Parameter(Mandatory)]

--- a/src/functions/Output.ps1
+++ b/src/functions/Output.ps1
@@ -867,6 +867,27 @@ function Format-CIErrorMessage {
     return $lines
 }
 
+function Write-CIErrorToScreen {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory)]
+        [ValidateSet('AzureDevops', 'GithubActions', IgnoreCase)]
+        [string] $CIFormat,
+
+        [Parameter(Mandatory)]
+        [string] $Header,
+
+        [Parameter(Mandatory)]
+        [string[]] $Message
+    )
+
+    $errorMessage = Format-CIErrorMessage @PSBoundParameters
+
+    foreach ($line in $errorMessage) {
+        & $SafeCommands['Write-Host'] $line
+    }
+}
+
 function Format-ErrorMessage {
     [CmdletBinding()]
     param (

--- a/src/functions/Output.ps1
+++ b/src/functions/Output.ps1
@@ -842,10 +842,8 @@ function Write-CIErrorToScreen {
     # https://docs.microsoft.com/en-us/azure/devops/pipelines/scripts/logging-commands?view=azure-devops&tabs=powershell#formatting-commands
     if ($CIFormat -eq 'AzureDevops') {
 
-        if (-not [string]::IsNullOrEmpty($Header)) {
-            # Log header as task issue error, so it gets reported to build log
-            & $SafeCommands['Write-Host'] "##vso[task.logissue type=error] $Header"
-        }
+        # Log header as task issue error, so it gets reported to build log
+        & $SafeCommands['Write-Host'] "##vso[task.logissue type=error] $Header"
 
         # Log subsequent messages as normal errors that don't get reported to build log
         foreach ($line in $Message) {
@@ -856,10 +854,8 @@ function Write-CIErrorToScreen {
     # https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions
     elseif ($CIFormat -eq 'GithubActions') {
 
-        if (-not [string]::IsNullOrEmpty($Header)) {
-            # Log header as error so it gets reported to build log
-            & $SafeCommands['Write-Host'] "::error:: $Header"
-        }
+        # Log header as error so it gets reported to build log
+        & $SafeCommands['Write-Host'] "::error:: $Header"
 
         # Log subsequent messages as non-error messages
         # Github Actions doesn't support task issue errors vs normal errors like ADO above

--- a/src/functions/Output.ps1
+++ b/src/functions/Output.ps1
@@ -867,7 +867,7 @@ function Format-CIErrorMessage {
 
         # Add rest of messages inside expandable group
         # https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#grouping-log-lines
-        $lines.Add("::group::")
+        $lines.Add("::group::Message")
 
         foreach ($line in $Message) {
             $lines.Add($line)

--- a/src/functions/Output.ps1
+++ b/src/functions/Output.ps1
@@ -840,28 +840,28 @@ function Format-CIErrorMessage {
         [string[]] $Message
     )
 
-    $CIPrefixMapping = @{
+    $CIOutputMapping = @{
         'AzureDevops'   = @{
             # header task issue error, so it gets reported to build log. https://docs.microsoft.com/en-us/azure/devops/pipelines/scripts/logging-commands?view=azure-devops&tabs=powershell#example-log-an-error
-            Header  = '##vso[task.logissue type=error] '
+            Header        = "##vso[task.logissue type=error] $Header"
 
-            # message error, but doesn't get reported in build log.
-            Message = '##[error] '
+            # message error prefx, but doesn't get reported in build log. Only task issue errors get reported.
+            MessagePrefix = '##[error] '
         }
         'GithubActions' = @{
             # header error, so it gets reported to build log. https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#setting-an-error-message
-            Header  = '::error::'
+            Header        = "::error::$($Header.TrimStart())"
 
             # Extra spaces to align message with Error: header.
             # Not including ::error:: here since we won't want too much noise in build log from every message
-            Message = '    '
+            MessagePrefix = '    '
         }
     }
 
-    $lines = [System.Collections.Generic.List[string]]@("$($CIPrefixMapping.$CIFormat.Header)$Header")
+    $lines = [System.Collections.Generic.List[string]]@($CIOutputMapping.$CIFormat.Header)
 
     foreach ($line in $Message) {
-        $lines.Add("$($CIPrefixMapping.$CIFormat.Message)$line")
+        $lines.Add("$($CIOutputMapping.$CIFormat.MessagePrefix)$line")
     }
 
     return $lines

--- a/src/functions/Output.ps1
+++ b/src/functions/Output.ps1
@@ -870,7 +870,7 @@ function Format-CIErrorMessage {
         $lines.Add("::group::Message")
 
         foreach ($line in $Message) {
-            $lines.Add($line)
+            $lines.Add($line.TrimStart())
         }
 
         $lines.Add("::endgroup::")

--- a/src/functions/Output.ps1
+++ b/src/functions/Output.ps1
@@ -855,13 +855,13 @@ function Write-CIErrorToScreen {
     elseif ($CIFormat -eq 'GithubActions') {
 
         # Log header as error so it gets reported to build log
-        & $SafeCommands['Write-Host'] "::error:: $Header"
+        & $SafeCommands['Write-Host'] "::error::$($Header.TrimStart())"
 
         # Log subsequent messages as non-error messages
         # Github Actions doesn't support task issue errors vs normal errors like ADO above
         # If we log every error message then they will all be reported in the build log, which will be very noisy
         foreach ($line in $Message) {
-            & $SafeCommands['Write-Host'] $line
+            & $SafeCommands['Write-Host'] "    $line"
         }
     }
 }

--- a/tst/Pester.Mock.RSpec.ts.ps1
+++ b/tst/Pester.Mock.RSpec.ts.ps1
@@ -342,8 +342,16 @@ i -PassThru:$PassThru {
             }
 
             $r = Invoke-Pester -Configuration ([PesterConfiguration]@{
-                    Run    = @{ ScriptBlock = $sb; PassThru = $true }
-                    Should = @{ ErrorAction = 'Continue' }
+                    Run    = @{
+                        ScriptBlock = $sb
+                        PassThru    = $true
+                    }
+                    Should = @{
+                        ErrorAction = 'Continue'
+                    }
+                    Output = @{
+                        CIFormat = 'None'
+                    }
                 })
 
             $t = $r.Containers[0].Blocks[0].Tests[0]
@@ -1011,7 +1019,13 @@ i -PassThru:$PassThru {
             }
 
             $r = Invoke-Pester -Configuration ([PesterConfiguration]@{
-                    Run = @{ ScriptBlock = $sb; PassThru = $true }
+                    Run    = @{
+                        ScriptBlock = $sb
+                        PassThru    = $true
+                    }
+                    Output = @{
+                        CIFormat = 'None'
+                    }
                 })
 
             $t = $r.Containers[0].Blocks[0].Tests[0]

--- a/tst/Pester.RSpec.Configuration.ts.ps1
+++ b/tst/Pester.RSpec.Configuration.ts.ps1
@@ -627,6 +627,7 @@ i -PassThru:$PassThru {
                 }
                 Output = @{
                     StackTraceVerbosity = "Something"
+                    CIFormat            = 'None'
                 }
             }
 

--- a/tst/Pester.RSpec.Configuration.ts.ps1
+++ b/tst/Pester.RSpec.Configuration.ts.ps1
@@ -654,11 +654,14 @@ i -PassThru:$PassThru {
             $env:TF_BUILD = $true
             $env:GITHUB_ACTIONS = $false
 
-            $r = Invoke-Pester -Configuration $c
-            $r.Configuration.Output.CIFormat.Value | Verify-Equal "AzureDevops"
-
-            $env:TF_BUILD = $previousTfBuildVariable
-            $env:GITHUB_ACTIONS = $previousGithubActionsVariable
+            try {
+                $r = Invoke-Pester -Configuration $c
+                $r.Configuration.Output.CIFormat.Value | Verify-Equal "AzureDevops"
+            }
+            finally {
+                $env:TF_BUILD = $previousTfBuildVariable
+                $env:GITHUB_ACTIONS = $previousGithubActionsVariable
+            }
         }
 
         t "Output.CIFormat is AzureDevops when Auto(manually set) and TF_BUILD are set" {
@@ -679,11 +682,14 @@ i -PassThru:$PassThru {
             $env:TF_BUILD = $true
             $env:GITHUB_ACTIONS = $false
 
-            $r = Invoke-Pester -Configuration $c
-            $r.Configuration.Output.CIFormat.Value | Verify-Equal "AzureDevops"
-
-            $env:TF_BUILD = $previousTfBuildVariable
-            $env:GITHUB_ACTIONS = $previousGithubActionsVariable
+            try {
+                $r = Invoke-Pester -Configuration $c
+                $r.Configuration.Output.CIFormat.Value | Verify-Equal "AzureDevops"
+            }
+            finally {
+                $env:TF_BUILD = $previousTfBuildVariable
+                $env:GITHUB_ACTIONS = $previousGithubActionsVariable
+            }
         }
 
         t "Output.CIFormat is AzureDevops when AzureDevops(manually set) and TF_BUILD are set" {
@@ -704,11 +710,14 @@ i -PassThru:$PassThru {
             $env:TF_BUILD = $true
             $env:GITHUB_ACTIONS = $false
 
-            $r = Invoke-Pester -Configuration $c
-            $r.Configuration.Output.CIFormat.Value | Verify-Equal "AzureDevops"
-
-            $env:TF_BUILD = $previousTfBuildVariable
-            $env:GITHUB_ACTIONS = $previousGithubActionsVariable
+            try {
+                $r = Invoke-Pester -Configuration $c
+                $r.Configuration.Output.CIFormat.Value | Verify-Equal "AzureDevops"
+            }
+            finally {
+                $env:TF_BUILD = $previousTfBuildVariable
+                $env:GITHUB_ACTIONS = $previousGithubActionsVariable
+            }
         }
 
         t "Output.CIFormat is None when Auto(default) and TF_BUILD is not set" {
@@ -728,11 +737,14 @@ i -PassThru:$PassThru {
             $env:TF_BUILD = $false
             $env:GITHUB_ACTIONS = $false
 
-            $r = Invoke-Pester -Configuration $c
-            $r.Configuration.Output.CIFormat.Value | Verify-Equal "None"
-
-            $env:TF_BUILD = $previousTfBuildVariable
-            $env:GITHUB_ACTIONS = $previousGithubActionsVariable
+            try {
+                $r = Invoke-Pester -Configuration $c
+                $r.Configuration.Output.CIFormat.Value | Verify-Equal "None"
+            }
+            finally {
+                $env:TF_BUILD = $previousTfBuildVariable
+                $env:GITHUB_ACTIONS = $previousGithubActionsVariable
+            }
         }
 
         t "Output.CIFormat is GithubActions when Auto(default) and GITHUB_ACTIONS are set" {
@@ -752,11 +764,14 @@ i -PassThru:$PassThru {
             $env:TF_BUILD = $false
             $env:GITHUB_ACTIONS = $true
 
-            $r = Invoke-Pester -Configuration $c
-            $r.Configuration.Output.CIFormat.Value | Verify-Equal "GithubActions"
-
-            $env:TF_BUILD = $previousTfBuildVariable
-            $env:GITHUB_ACTIONS = $previousGithubActionsVariable
+            try {
+                $r = Invoke-Pester -Configuration $c
+                $r.Configuration.Output.CIFormat.Value | Verify-Equal "GithubActions"
+            }
+            finally {
+                $env:TF_BUILD = $previousTfBuildVariable
+                $env:GITHUB_ACTIONS = $previousGithubActionsVariable
+            }
         }
 
         t "Output.CIFormat is GithubActions when Auto(manually set) and GITHUB_ACTIONS are set" {
@@ -777,11 +792,14 @@ i -PassThru:$PassThru {
             $env:TF_BUILD = $false
             $env:GITHUB_ACTIONS = $true
 
-            $r = Invoke-Pester -Configuration $c
-            $r.Configuration.Output.CIFormat.Value | Verify-Equal "GithubActions"
-
-            $env:TF_BUILD = $previousTfBuildVariable
-            $env:GITHUB_ACTIONS = $previousGithubActionsVariable
+            try {
+                $r = Invoke-Pester -Configuration $c
+                $r.Configuration.Output.CIFormat.Value | Verify-Equal "GithubActions"
+            }
+            finally {
+                $env:TF_BUILD = $previousTfBuildVariable
+                $env:GITHUB_ACTIONS = $previousGithubActionsVariable
+            }
         }
 
         t "Output.CIFormat is GithubActions when GithubActions(manually set) and GITHUB_ACTIONS are set" {
@@ -802,11 +820,14 @@ i -PassThru:$PassThru {
             $env:TF_BUILD = $false
             $env:GITHUB_ACTIONS = $true
 
-            $r = Invoke-Pester -Configuration $c
-            $r.Configuration.Output.CIFormat.Value | Verify-Equal "GithubActions"
-
-            $env:TF_BUILD = $previousTfBuildVariable
-            $env:GITHUB_ACTIONS = $previousGithubActionsVariable
+            try {
+                $r = Invoke-Pester -Configuration $c
+                $r.Configuration.Output.CIFormat.Value | Verify-Equal "GithubActions"
+            }
+            finally {
+                $env:TF_BUILD = $previousTfBuildVariable
+                $env:GITHUB_ACTIONS = $previousGithubActionsVariable
+            }
         }
 
         t "Output.CIFormat is None when Auto(default) and GITHUB_ACTIONS is not set" {
@@ -826,11 +847,14 @@ i -PassThru:$PassThru {
             $env:TF_BUILD = $false
             $env:GITHUB_ACTIONS = $false
 
-            $r = Invoke-Pester -Configuration $c
-            $r.Configuration.Output.CIFormat.Value | Verify-Equal "None"
-
-            $env:TF_BUILD = $previousTfBuildVariable
-            $env:GITHUB_ACTIONS = $previousGithubActionsVariable
+            try {
+                $r = Invoke-Pester -Configuration $c
+                $r.Configuration.Output.CIFormat.Value | Verify-Equal "None"
+            }
+            finally {
+                $env:TF_BUILD = $previousTfBuildVariable
+                $env:GITHUB_ACTIONS = $previousGithubActionsVariable
+            }
         }
 
         t "Exception is thrown when incorrect option is set" {

--- a/tst/Pester.RSpec.Configuration.ts.ps1
+++ b/tst/Pester.RSpec.Configuration.ts.ps1
@@ -711,31 +711,6 @@ i -PassThru:$PassThru {
             $env:GITHUB_ACTIONS = $previousGithubActionsVariable
         }
 
-        t "Output.CIFormat is None when AzureDevops(manually set) and TF_BUILD is not set" {
-            $c = [PesterConfiguration] @{
-                Run    = @{
-                    ScriptBlock = { }
-                    PassThru    = $true
-                }
-                Output = @{
-                    Verbosity = "None"
-                    CIFormat  = "AzureDevops"
-                }
-            }
-
-            $previousTfBuildVariable = $env:TF_BUILD
-            $previousGithubActionsVariable = $env:GITHUB_ACTIONS
-
-            $env:TF_BUILD = $false
-            $env:GITHUB_ACTIONS = $false
-
-            $r = Invoke-Pester -Configuration $c
-            $r.Configuration.Output.CIFormat.Value | Verify-Equal "None"
-
-            $env:TF_BUILD = $previousTfBuildVariable
-            $env:GITHUB_ACTIONS = $previousGithubActionsVariable
-        }
-
         t "Output.CIFormat is None when Auto(default) and TF_BUILD is not set" {
             $c = [PesterConfiguration] @{
                 Run    = @{
@@ -829,31 +804,6 @@ i -PassThru:$PassThru {
 
             $r = Invoke-Pester -Configuration $c
             $r.Configuration.Output.CIFormat.Value | Verify-Equal "GithubActions"
-
-            $env:TF_BUILD = $previousTfBuildVariable
-            $env:GITHUB_ACTIONS = $previousGithubActionsVariable
-        }
-
-        t "Output.CIFormat is None when GithubActions(manually set) and GITHUB_ACTIONS is not set" {
-            $c = [PesterConfiguration] @{
-                Run    = @{
-                    ScriptBlock = { }
-                    PassThru    = $true
-                }
-                Output = @{
-                    Verbosity = "None"
-                    CIFormat  = "GithubActions"
-                }
-            }
-
-            $previousTfBuildVariable = $env:TF_BUILD
-            $previousGithubActionsVariable = $env:GITHUB_ACTIONS
-
-            $env:TF_BUILD = $false
-            $env:GITHUB_ACTIONS = $false
-
-            $r = Invoke-Pester -Configuration $c
-            $r.Configuration.Output.CIFormat.Value | Verify-Equal "None"
 
             $env:TF_BUILD = $previousTfBuildVariable
             $env:GITHUB_ACTIONS = $previousGithubActionsVariable

--- a/tst/Pester.RSpec.Configuration.ts.ps1
+++ b/tst/Pester.RSpec.Configuration.ts.ps1
@@ -91,6 +91,10 @@ i -PassThru:$PassThru {
             [PesterConfiguration]::Default.Output.StackTraceVerbosity.Value | Verify-Equal Filtered
         }
 
+        t "Output.CIFormat is Auto" {
+            [PesterConfiguration]::Default.Output.CIFormat.Value | Verify-Equal Auto
+        }
+
         # CodeCoverage configuration
         t "CodeCoverage.Enabled is `$false" {
             [PesterConfiguration]::Default.CodeCoverage.Enabled.Value | Verify-False
@@ -628,6 +632,261 @@ i -PassThru:$PassThru {
 
             $r = Invoke-Pester -Configuration $c
             $r.Containers[0].Blocks[0].ErrorRecord[0] | Verify-Equal "Unsupported level of stacktrace output 'Something'"
+        }
+    }
+
+    b "Output.CIFormat" {
+        t "Output.CIFormat is AzureDevops when Auto(default) and TF_BUILD are set" {
+            $c = [PesterConfiguration] @{
+                Run    = @{
+                    ScriptBlock = { }
+                    PassThru    = $true
+                }
+                Output = @{
+                    Verbosity = "None"
+                }
+            }
+
+            $previousTfBuildVariable = $env:TF_BUILD
+
+            $env:TF_BUILD = $true
+
+            $r = Invoke-Pester -Configuration $c
+            $r.Configuration.Output.CIFormat.Value | Verify-Equal "AzureDevops"
+
+            $env:TF_BUILD = $previousTfBuildVariable
+        }
+
+        t "Output.CIFormat is AzureDevops when Auto(manually set) and TF_BUILD are set" {
+            $c = [PesterConfiguration] @{
+                Run    = @{
+                    ScriptBlock = { }
+                    PassThru    = $true
+                }
+                Output = @{
+                    Verbosity = "None"
+                    CIFormat  = "Auto"
+                }
+            }
+
+            $previousTfBuildVariable = $env:TF_BUILD
+
+            $env:TF_BUILD = $true
+
+            $r = Invoke-Pester -Configuration $c
+            $r.Configuration.Output.CIFormat.Value | Verify-Equal "AzureDevops"
+
+            $env:TF_BUILD = $previousTfBuildVariable
+        }
+
+        t "Output.CIFormat is AzureDevops when AzureDevops(manually set) and TF_BUILD are set" {
+            $c = [PesterConfiguration] @{
+                Run    = @{
+                    ScriptBlock = { }
+                    PassThru    = $true
+                }
+                Output = @{
+                    Verbosity = "None"
+                    CIFormat  = "AzureDevops"
+                }
+            }
+
+            $previousTfBuildVariable = $env:TF_BUILD
+
+            $env:TF_BUILD = $true
+
+            $r = Invoke-Pester -Configuration $c
+            $r.Configuration.Output.CIFormat.Value | Verify-Equal "AzureDevops"
+
+            $env:TF_BUILD = $previousTfBuildVariable
+        }
+
+        t "Output.CIFormat is None when AzureDevops(manually set) and TF_BUILD is not set" {
+            $c = [PesterConfiguration] @{
+                Run    = @{
+                    ScriptBlock = { }
+                    PassThru    = $true
+                }
+                Output = @{
+                    Verbosity = "None"
+                    CIFormat  = "AzureDevops"
+                }
+            }
+
+            $previousTfBuildVariable = $env:TF_BUILD
+
+            $env:TF_BUILD = $false
+
+            $r = Invoke-Pester -Configuration $c
+            $r.Configuration.Output.CIFormat.Value | Verify-Equal "None"
+
+            $env:TF_BUILD = $previousTfBuildVariable
+        }
+
+        t "Output.CIFormat is None when Auto(default) and TF_BUILD is not set" {
+            $c = [PesterConfiguration] @{
+                Run    = @{
+                    ScriptBlock = { }
+                    PassThru    = $true
+                }
+                Output = @{
+                    Verbosity = "None"
+                }
+            }
+
+            $previousTfBuildVariable = $env:TF_BUILD
+
+            $env:TF_BUILD = $false
+
+            $r = Invoke-Pester -Configuration $c
+            $r.Configuration.Output.CIFormat.Value | Verify-Equal "None"
+
+            $env:TF_BUILD = $previousTfBuildVariable
+        }
+
+        t "Output.CIFormat is GithubActions when Auto(default) and GITHUB_ACTIONS are set" {
+            $c = [PesterConfiguration] @{
+                Run    = @{
+                    ScriptBlock = { }
+                    PassThru    = $true
+                }
+                Output = @{
+                    Verbosity = "None"
+                }
+            }
+
+            $previousGithubActionsVariable = $env:GITHUB_ACTIONS
+
+            $env:GITHUB_ACTIONS = $true
+
+            $r = Invoke-Pester -Configuration $c
+            $r.Configuration.Output.CIFormat.Value | Verify-Equal "GithubActions"
+
+            $env:GITHUB_ACTIONS = $previousGithubActionsVariable
+        }
+
+        t "Output.CIFormat is GithubActions when Auto(manually set) and GITHUB_ACTIONS are set" {
+            $c = [PesterConfiguration] @{
+                Run    = @{
+                    ScriptBlock = { }
+                    PassThru    = $true
+                }
+                Output = @{
+                    Verbosity = "None"
+                    CIFormat  = "Auto"
+                }
+            }
+
+            $previousGithubActionsVariable = $env:GITHUB_ACTIONS
+
+            $env:GITHUB_ACTIONS = $true
+
+            $r = Invoke-Pester -Configuration $c
+            $r.Configuration.Output.CIFormat.Value | Verify-Equal "GithubActions"
+
+            $env:GITHUB_ACTIONS = $previousGithubActionsVariable
+        }
+
+        t "Output.CIFormat is GithubActions when GithubActions(manually set) and GITHUB_ACTIONS are set" {
+            $c = [PesterConfiguration] @{
+                Run    = @{
+                    ScriptBlock = { }
+                    PassThru    = $true
+                }
+                Output = @{
+                    Verbosity = "None"
+                    CIFormat  = "GithubActions"
+                }
+            }
+
+            $previousGithubActionsVariable = $env:GITHUB_ACTIONS
+
+            $env:GITHUB_ACTIONS = $true
+
+            $r = Invoke-Pester -Configuration $c
+            $r.Configuration.Output.CIFormat.Value | Verify-Equal "GithubActions"
+
+            $env:GITHUB_ACTIONS = $previousGithubActionsVariable
+        }
+
+        t "Output.CIFormat is None when GithubActions(manually set) and GITHUB_ACTIONS is not set" {
+            $c = [PesterConfiguration] @{
+                Run    = @{
+                    ScriptBlock = { }
+                    PassThru    = $true
+                }
+                Output = @{
+                    Verbosity = "None"
+                    CIFormat  = "GithubActions"
+                }
+            }
+
+            $previousGithubActionsVariable = $env:GITHUB_ACTIONS
+
+            $env:GITHUB_ACTIONS = $false
+
+            $r = Invoke-Pester -Configuration $c
+            $r.Configuration.Output.CIFormat.Value | Verify-Equal "None"
+
+            $env:GITHUB_ACTIONS = $previousGithubActionsVariable
+        }
+
+        t "Output.CIFormat is None when Auto(default) and GITHUB_ACTIONS is not set" {
+            $c = [PesterConfiguration] @{
+                Run    = @{
+                    ScriptBlock = { }
+                    PassThru    = $true
+                }
+                Output = @{
+                    Verbosity = "None"
+                }
+            }
+
+            $previousGithubActionsVariable = $env:GITHUB_ACTIONS
+
+            $env:GITHUB_ACTIONS = $false
+
+            $r = Invoke-Pester -Configuration $c
+            $r.Configuration.Output.CIFormat.Value | Verify-Equal "None"
+
+            $env:GITHUB_ACTIONS = $previousGithubActionsVariable
+        }
+
+        t "Exception is thrown when incorrect option is set" {
+            $sb = {
+                Describe "a" {
+                    It "b" {}
+                }
+            }
+
+            $c = [PesterConfiguration] @{
+                Run    = @{
+                    ScriptBlock = $sb
+                    PassThru    = $true
+                }
+                Output = @{
+                    CIFormat = "Something"
+                }
+            }
+
+            $r = Invoke-Pester -Configuration $c
+            $r.Containers[0].Blocks[0].ErrorRecord[0] | Verify-Equal "Unsupported CI format 'Something'"
+        }
+
+        t "Output.CIFormat is None when set" {
+            $c = [PesterConfiguration] @{
+                Run    = @{
+                    ScriptBlock = { }
+                    PassThru    = $true
+                }
+                Output = @{
+                    Verbosity = "None"
+                    CIFormat  = "None"
+                }
+            }
+
+            $r = Invoke-Pester -Configuration $c
+            $r.Configuration.Output.CIFormat.Value | Verify-Equal "None"
         }
     }
 }

--- a/tst/Pester.RSpec.Configuration.ts.ps1
+++ b/tst/Pester.RSpec.Configuration.ts.ps1
@@ -648,13 +648,16 @@ i -PassThru:$PassThru {
             }
 
             $previousTfBuildVariable = $env:TF_BUILD
+            $previousGithubActionsVariable = $env:GITHUB_ACTIONS
 
             $env:TF_BUILD = $true
+            $env:GITHUB_ACTIONS = $false
 
             $r = Invoke-Pester -Configuration $c
             $r.Configuration.Output.CIFormat.Value | Verify-Equal "AzureDevops"
 
             $env:TF_BUILD = $previousTfBuildVariable
+            $env:GITHUB_ACTIONS = $previousGithubActionsVariable
         }
 
         t "Output.CIFormat is AzureDevops when Auto(manually set) and TF_BUILD are set" {
@@ -670,13 +673,16 @@ i -PassThru:$PassThru {
             }
 
             $previousTfBuildVariable = $env:TF_BUILD
+            $previousGithubActionsVariable = $env:GITHUB_ACTIONS
 
             $env:TF_BUILD = $true
+            $env:GITHUB_ACTIONS = $false
 
             $r = Invoke-Pester -Configuration $c
             $r.Configuration.Output.CIFormat.Value | Verify-Equal "AzureDevops"
 
             $env:TF_BUILD = $previousTfBuildVariable
+            $env:GITHUB_ACTIONS = $previousGithubActionsVariable
         }
 
         t "Output.CIFormat is AzureDevops when AzureDevops(manually set) and TF_BUILD are set" {
@@ -692,13 +698,16 @@ i -PassThru:$PassThru {
             }
 
             $previousTfBuildVariable = $env:TF_BUILD
+            $previousGithubActionsVariable = $env:GITHUB_ACTIONS
 
             $env:TF_BUILD = $true
+            $env:GITHUB_ACTIONS = $false
 
             $r = Invoke-Pester -Configuration $c
             $r.Configuration.Output.CIFormat.Value | Verify-Equal "AzureDevops"
 
             $env:TF_BUILD = $previousTfBuildVariable
+            $env:GITHUB_ACTIONS = $previousGithubActionsVariable
         }
 
         t "Output.CIFormat is None when AzureDevops(manually set) and TF_BUILD is not set" {
@@ -714,13 +723,16 @@ i -PassThru:$PassThru {
             }
 
             $previousTfBuildVariable = $env:TF_BUILD
+            $previousGithubActionsVariable = $env:GITHUB_ACTIONS
 
             $env:TF_BUILD = $false
+            $env:GITHUB_ACTIONS = $false
 
             $r = Invoke-Pester -Configuration $c
             $r.Configuration.Output.CIFormat.Value | Verify-Equal "None"
 
             $env:TF_BUILD = $previousTfBuildVariable
+            $env:GITHUB_ACTIONS = $previousGithubActionsVariable
         }
 
         t "Output.CIFormat is None when Auto(default) and TF_BUILD is not set" {
@@ -735,13 +747,16 @@ i -PassThru:$PassThru {
             }
 
             $previousTfBuildVariable = $env:TF_BUILD
+            $previousGithubActionsVariable = $env:GITHUB_ACTIONS
 
             $env:TF_BUILD = $false
+            $env:GITHUB_ACTIONS = $false
 
             $r = Invoke-Pester -Configuration $c
             $r.Configuration.Output.CIFormat.Value | Verify-Equal "None"
 
             $env:TF_BUILD = $previousTfBuildVariable
+            $env:GITHUB_ACTIONS = $previousGithubActionsVariable
         }
 
         t "Output.CIFormat is GithubActions when Auto(default) and GITHUB_ACTIONS are set" {
@@ -755,13 +770,16 @@ i -PassThru:$PassThru {
                 }
             }
 
+            $previousTfBuildVariable = $env:TF_BUILD
             $previousGithubActionsVariable = $env:GITHUB_ACTIONS
 
+            $env:TF_BUILD = $false
             $env:GITHUB_ACTIONS = $true
 
             $r = Invoke-Pester -Configuration $c
             $r.Configuration.Output.CIFormat.Value | Verify-Equal "GithubActions"
 
+            $env:TF_BUILD = $previousTfBuildVariable
             $env:GITHUB_ACTIONS = $previousGithubActionsVariable
         }
 
@@ -777,13 +795,16 @@ i -PassThru:$PassThru {
                 }
             }
 
+            $previousTfBuildVariable = $env:TF_BUILD
             $previousGithubActionsVariable = $env:GITHUB_ACTIONS
 
+            $env:TF_BUILD = $false
             $env:GITHUB_ACTIONS = $true
 
             $r = Invoke-Pester -Configuration $c
             $r.Configuration.Output.CIFormat.Value | Verify-Equal "GithubActions"
 
+            $env:TF_BUILD = $previousTfBuildVariable
             $env:GITHUB_ACTIONS = $previousGithubActionsVariable
         }
 
@@ -799,13 +820,16 @@ i -PassThru:$PassThru {
                 }
             }
 
+            $previousTfBuildVariable = $env:TF_BUILD
             $previousGithubActionsVariable = $env:GITHUB_ACTIONS
 
+            $env:TF_BUILD = $false
             $env:GITHUB_ACTIONS = $true
 
             $r = Invoke-Pester -Configuration $c
             $r.Configuration.Output.CIFormat.Value | Verify-Equal "GithubActions"
 
+            $env:TF_BUILD = $previousTfBuildVariable
             $env:GITHUB_ACTIONS = $previousGithubActionsVariable
         }
 
@@ -821,13 +845,16 @@ i -PassThru:$PassThru {
                 }
             }
 
+            $previousTfBuildVariable = $env:TF_BUILD
             $previousGithubActionsVariable = $env:GITHUB_ACTIONS
 
+            $env:TF_BUILD = $false
             $env:GITHUB_ACTIONS = $false
 
             $r = Invoke-Pester -Configuration $c
             $r.Configuration.Output.CIFormat.Value | Verify-Equal "None"
 
+            $env:TF_BUILD = $previousTfBuildVariable
             $env:GITHUB_ACTIONS = $previousGithubActionsVariable
         }
 
@@ -842,13 +869,16 @@ i -PassThru:$PassThru {
                 }
             }
 
+            $previousTfBuildVariable = $env:TF_BUILD
             $previousGithubActionsVariable = $env:GITHUB_ACTIONS
 
+            $env:TF_BUILD = $false
             $env:GITHUB_ACTIONS = $false
 
             $r = Invoke-Pester -Configuration $c
             $r.Configuration.Output.CIFormat.Value | Verify-Equal "None"
 
+            $env:TF_BUILD = $previousTfBuildVariable
             $env:GITHUB_ACTIONS = $previousGithubActionsVariable
         }
 

--- a/tst/Pester.RSpec.Demo.ts.ps1
+++ b/tst/Pester.RSpec.Demo.ts.ps1
@@ -207,6 +207,7 @@ i -PassThru:$PassThru {
             $configuration = [PesterConfiguration]::Default
             $configuration.Run.ScriptBlock = $sb
             $configuration.Run.PassThru = $true
+            $configuration.Output.CIFormat = 'None'
             $r = Invoke-Pester -Configuration $configuration
 
             $err = $r.Containers[0].Blocks[0].Tests[0].ErrorRecord
@@ -226,6 +227,7 @@ i -PassThru:$PassThru {
             $configuration.Run.ScriptBlock = $sb
             $configuration.Run.PassThru = $true
             $configuration.Should.ErrorAction = 'Continue'
+            $configuration.Output.CIFormat = 'None'
             $r = Invoke-Pester -Configuration $configuration
 
             $err = $r.Containers[0].Blocks[0].Tests[0].ErrorRecord
@@ -271,6 +273,7 @@ i -PassThru:$PassThru {
             $configuration = [PesterConfiguration]::Default
             $configuration.Run.ScriptBlock = $sb
             $configuration.Run.PassThru = $true
+            $configuration.Output.CIFormat = 'None'
             $r = Invoke-Pester -Configuration $configuration
 
             $r.Containers[0].Blocks[0].Tests[0].ErrorRecord.Count | Verify-Equal 2
@@ -314,6 +317,7 @@ i -PassThru:$PassThru {
             $configuration.Run.ScriptBlock = $sb
             $configuration.Run.PassThru = $true
             $configuration.Output.Verbosity = "normal"
+            $configuration.Output.CIFormat = 'None'
             $r = Invoke-Pester -Configuration $configuration
 
             $r.Containers[0].Blocks[0].Tests[3].Result | Verify-Equal "Failed"

--- a/tst/Pester.RSpec.Demo.ts.ps1
+++ b/tst/Pester.RSpec.Demo.ts.ps1
@@ -244,6 +244,7 @@ i -PassThru:$PassThru {
             $configuration.Run.ScriptBlock = $sb
             $configuration.Run.PassThru = $true
             $configuration.Should.ErrorAction = 'Continue'
+            $configuration.Output.CIFormat = 'None'
             $r = Invoke-Pester -Configuration $configuration
 
             $err = $r.Containers[0].Blocks[0].Tests[0].ErrorRecord

--- a/tst/Pester.RSpec.Output.ts.ps1
+++ b/tst/Pester.RSpec.Output.ts.ps1
@@ -142,6 +142,7 @@ i -PassThru:$PassThru {
             $setup = {
                 $PesterPreference = [PesterConfiguration]::Default
                 $PesterPreference.Output.Verbosity = 'Detailed'
+                $PesterPreference.Output.CIFormat = 'None'
             }
             $output = Invoke-PesterInProcess $sb -Setup $setup
             # only print the relevant part of output

--- a/tst/Pester.RSpec.ResultObject.ts.ps1
+++ b/tst/Pester.RSpec.ResultObject.ts.ps1
@@ -331,7 +331,10 @@ i -PassThru:$PassThru {
                     ScriptBlock = $sb
                     PassThru    = $true
                 }
-                Output = @{ Verbosity = "Normal" }
+                Output = @{
+                    Verbosity = "Normal"
+                    CIFormat  = 'None'
+                }
             }
 
             $result | Verify-NotNull

--- a/tst/functions/New-Fixture.ts.ps1
+++ b/tst/functions/New-Fixture.ts.ps1
@@ -9,8 +9,11 @@ Import-Module $PSScriptRoot\..\axiom\Axiom.psm1 -DisableNameChecking
 Import-Module $PSScriptRoot\..\..\bin\Pester.psd1
 
 $global:PesterPreference = @{
-    Debug = @{
+    Debug  = @{
         ShowFullErrors = $false
+    }
+    Output = @{
+        CIFormat = 'None'
     }
 }
 

--- a/tst/functions/Output.Tests.ps1
+++ b/tst/functions/Output.Tests.ps1
@@ -636,7 +636,7 @@ InModuleScope -ModuleName Pester -ScriptBlock {
                     Message  = 'message'
                     Expected = @(
                         '::error::header',
-                        '::group::',
+                        '::group::Message',
                         'message',
                         '::endgroup::'
                     )
@@ -646,7 +646,7 @@ InModuleScope -ModuleName Pester -ScriptBlock {
                     Message  = @('message1', 'message2')
                     Expected = @(
                         '::error::header',
-                        '::group::',
+                        '::group::Message',
                         'message1',
                         'message2',
                         '::endgroup::'

--- a/tst/functions/Output.Tests.ps1
+++ b/tst/functions/Output.Tests.ps1
@@ -652,6 +652,17 @@ InModuleScope -ModuleName Pester -ScriptBlock {
                         '::endgroup::'
                     )
                 }
+                @{
+                    Header   = 'header'
+                    Message  = @('  message1', '  message2')
+                    Expected = @(
+                        '::error::header',
+                        '::group::Message',
+                        'message1',
+                        'message2',
+                        '::endgroup::'
+                    )
+                }
             ) {
                 param($Header, $Message, $Expected)
                 Format-CIErrorMessage -CIFormat 'GithubActions' -Header $Header -Message $Message | Should -Be $Expected

--- a/tst/functions/Output.Tests.ps1
+++ b/tst/functions/Output.Tests.ps1
@@ -602,4 +602,56 @@ InModuleScope -ModuleName Pester -ScriptBlock {
             { Write-ErrorToScreen -Err $errorRecord -Throw } | Should -Throw
         }
     }
+
+    Describe Format-CIErrorMessage {
+        Context "Azure Devops Error Format" {
+            It "Header '<header>' and Message '<message>' returns '<expected>'" -TestCases @(
+                @{
+                    Header   = 'header'
+                    Message  = 'message'
+                    Expected = @(
+                        '##vso[task.logissue type=error] header',
+                        '##[error] message'
+                    )
+                }
+                @{
+                    Header   = 'header'
+                    Message  = @('message1', 'message2')
+                    Expected = @(
+                        '##vso[task.logissue type=error] header',
+                        '##[error] message1',
+                        '##[error] message2'
+                    )
+                }
+            ) {
+                param($Header, $Message, $Expected)
+                Format-CIErrorMessage -CIFormat 'AzureDevops' -Header $Header -Message $Message | Should -Be $Expected
+            }
+        }
+
+        Context 'Github Actions Error Format' {
+            It "Header '<header>' and Message '<message>' returns '<expected>'" -TestCases @(
+                @{
+                    Header   = 'header'
+                    Message  = 'message'
+                    Expected = @(
+                        '::error::header',
+                        '    message'
+                    )
+                }
+                @{
+                    Header   = 'header'
+                    Message  = @('message1', 'message2')
+                    Expected = @(
+                        '::error::header',
+                        '    message1',
+                        '    message2'
+                    )
+                }
+            ) {
+                param($Header, $Message, $Expected)
+                Format-CIErrorMessage -CIFormat 'GithubActions' -Header $Header -Message $Message | Should -Be $Expected
+            }
+        }
+    }
 }

--- a/tst/functions/Output.Tests.ps1
+++ b/tst/functions/Output.Tests.ps1
@@ -636,7 +636,9 @@ InModuleScope -ModuleName Pester -ScriptBlock {
                     Message  = 'message'
                     Expected = @(
                         '::error::header',
-                        '    message'
+                        '::group::',
+                        'message',
+                        '::endgroup::'
                     )
                 }
                 @{
@@ -644,8 +646,10 @@ InModuleScope -ModuleName Pester -ScriptBlock {
                     Message  = @('message1', 'message2')
                     Expected = @(
                         '::error::header',
-                        '    message1',
-                        '    message2'
+                        '::group::',
+                        'message1',
+                        'message2',
+                        '::endgroup::'
                     )
                 }
             ) {


### PR DESCRIPTION
<!-- Thank you for contributing to Pester! -->

## PR Summary
<!-- Please describe what your pull request fixes, or how it improves Pester.

If your pull request resolves a reported issue, please mention it by using `Fix #<issue_number>` on a new line, this will close the linked issue automatically when this PR is merged. For more info see: [Closing issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/).

If your pull request integrates Pester with another system, please tell us how the change can be tested. -->

Fix #1364.

I've added functionality to highlight CI errors in red for ADO and GithubActions. 

This is configured from the `Output.CIFormat`, which covers the following options:

- **None** -> No CI autodetection
- **Auto** -> Autodetects CI
- **AzureDevops**
- **GithubActions**

For AzureDevops, we check the `TF_BUILD` environment variable is equal to `True`.
For GithubActions, we check the `GITHUB_ACTIONS` environment variable is equal to `True`. 

For **AzureDevops** we can use `##vso[task.logissue type=error]` to highlight the error header, and `##[error]` to highlight the messages. This ensures only the error header is reported in the build log. 

For **GithubActions**, you can only set an error, so I had to limit this to just the header, as shown below. The messages are also collapsed under the header using expandable groups.

### Azure Devops Output

![ADO](https://user-images.githubusercontent.com/20082136/122637604-fc83d400-d132-11eb-88a0-ede87b9ec5c8.PNG)

### Build Log

![ADOBuildLog](https://user-images.githubusercontent.com/20082136/122637786-df9bd080-d133-11eb-93c2-fb0a0f20e62b.PNG)


### Github Actions

![GithubActions](https://user-images.githubusercontent.com/20082136/122943004-fe12fd80-d3b9-11eb-93a3-0206bec674b6.PNG)

### Build Log

![GithubActionsBuildLog](https://user-images.githubusercontent.com/20082136/122637969-b29bed80-d134-11eb-8096-88e8d895edc7.PNG)

I did testing in my own repo by running a simple github action to test out this code: https://github.com/ArmaanMcleod/TestGithubActions/actions/runs/952195814

## PR Checklist

- [x] PR has meaningful title
- [x] Summary describes changes
- [x] PR is ready to be merged
  - If not, use the arrow next to `Create Pull Request` to mark it as a draft. PR can be marked `Ready for review` when it's ready.
- [x] Tests are added/update *(if required)*
- [x] Documentation is updated/added *(if required)*

<!-- Before you continue, please review [Contributing to Pester](https://pester.dev/docs/contributing/introduction).

Our continuous integration system doesn't send any notifications about failed tests. Please return to the opened pull request (after ~60 minutes) to check if everything is OK. -->
