### PR TITLE
Fix tracer state on cancelled Pester run with new CodeCoverage

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -150,13 +150,14 @@ if ($Clean) {
 
     # generate help for config object and insert it
     $configuration = [PesterConfiguration]::Default
+    $eol = [Environment]::NewLine
     $generatedConfig = foreach ($p in $configuration.PSObject.Properties.Name) {
         $section = $configuration.($p)
         "${p}:"
         foreach ($r in $section.PSObject.Properties.Name) {
             $option = $section.$r
             $default = Format-NicelyMini $option.Default
-            "  ${r}: $($option.Description)`n  Default value: ${default}`n"
+            "  ${r}: $($option.Description)$eol  Default value: ${default}$eol"
         }
     }
 
@@ -168,19 +169,19 @@ if ($Clean) {
     $generated = $false
     foreach ($l in $f) {
         if ($l -match '^(?<margin>\s*)Sections and options:\s*$') {
-            $null = $sbf.AppendLine("$l`n")
+            $null = $sbf.AppendLine("$l$eol")
             $generated = $true
             $margin = $matches.margin
             $null = $sbf.AppendLine("$margin``````")
 
-            $generatedLines = @($generatedConfig -split "`n")
+            $generatedLines = @($generatedConfig -split $eol)
             for ($i=0; $i -lt $generatedLines.Count; $i++) {
                 $l = $generatedLines[$i]
                 $m = if ($l) { $margin } else { $null }
 
                 if ($i -eq $generatedLines.Count-1) {
                     #last line should be blank - replace with codeblock end
-                    $null = $sbf.AppendLine("$margin```````n")
+                    $null = $sbf.AppendLine("$margin``````$eol")
                 } else {
                     $null = $sbf.AppendLine("$m$l")
                 }

--- a/src/csharp/Pester/Tracing/ExternalTracerAdapter.cs
+++ b/src/csharp/Pester/Tracing/ExternalTracerAdapter.cs
@@ -9,17 +9,43 @@ namespace Pester.Tracing
     {
         private object _tracer;
         private MethodInfo _traceMethod;
+        private int _version = 0;
+
+        public object Tracer => _tracer;
 
         public ExternalTracerAdapter(object tracer)
         {
+            // We got tracer that is not using the same types that we use here. Find a method based on the signature
+            // and use that. This enables tracers to register even when they don't take dependency on our types e.g. Pester CC tracer.
+
             _tracer = tracer ?? new NullReferenceException(nameof(tracer));
-            var traceMethod = tracer.GetType().GetMethod("Trace", new Type[] { typeof(IScriptExtent), typeof(ScriptBlock), typeof(int)  });
-            _traceMethod = traceMethod ?? throw new InvalidOperationException("The provided tracer does not have Trace method with this signature: Trace(IScriptExtent extent, ScriptBlock scriptBlock, int level)");
+            _version = 2;
+            var traceMethod = tracer.GetType().GetMethod("Trace", new Type[] {
+                typeof(string), // message
+                typeof(IScriptExtent), // extent
+                typeof(ScriptBlock), // scriptblock
+                typeof(int) }); // level
+
+            if (traceMethod == null)
+            {
+                _version = 1;
+                traceMethod = tracer.GetType().GetMethod("Trace", new Type[] {
+                typeof(string), // message
+                typeof(IScriptExtent), // extent
+                typeof(ScriptBlock), // scriptblock
+                typeof(int) }); // level
+            }
+
+            _traceMethod = traceMethod ??
+                throw new InvalidOperationException("The provided tracer does not have Trace method with this signature: Trace(string message, IScriptExtent extent, ScriptBlock scriptBlock, int level) or Trace(IScriptExtent extent, ScriptBlock scriptBlock, int level)");
         }
 
         public void Trace(string message, IScriptExtent extent, ScriptBlock scriptBlock, int level)
         {
-            _traceMethod.Invoke(_tracer, new object[] { extent, scriptBlock, level });
+            var parameters = _version == 2
+                ? new object[] { message, extent, scriptBlock, level }
+                : new object[] { extent, scriptBlock, level };
+            _traceMethod.Invoke(_tracer, parameters);
         }
     }
 }

--- a/src/functions/Coverage.ps1
+++ b/src/functions/Coverage.ps1
@@ -1091,27 +1091,42 @@ function Start-TraceScript ($Breakpoints) {
     # detect if profiler is imported and running and in that case just add us as a second tracer
     # to not disturb the profiling session
     $profilerType = "Profiler.Tracer" -as [Type]
-    if ($null -ne $profilerType -and $profilerType::IsEnabled) {
-        $profilerType::Register($tracer)
+    $registered = $false
+    $patched = $false
+
+    if ($null -ne $profilerType) {
+        # api changed in 4.0.0
+        $version = [Version] (& $SafeCommands['Get-Item'] $profilerType.Assembly.Location).VersionInfo.FileVersion
+        if (($version -lt "4.0.0" -and $profilerType::IsEnabled) -or ($version -ge "4.0.0" -and $profilerType::ShouldRegisterTracer($tracer, $true))) {
+            $patched = $false
+            $registered = $true
+            $profilerType::Register($tracer)
+        }
     }
-    else {
+
+    if (-not $registered) {
+        $patched = $true
         [Pester.Tracing.Tracer]::Patch($PSVersionTable.PSVersion.Major, $ExecutionContext, $host.UI, $tracer)
         Set-PSDebug -Trace 1
     }
 
-    $tracer
+    # true if we patched powershell and have to unpatch it later,
+    # false if we just registered to already running profiling session and just need to unregister ourselves
+    $patched, $tracer
 }
 
 function Stop-TraceScript {
-    # detect if profiler is imported and running and in that case just remove us as a second tracer
+    param ([bool] $Patched)
+
+    # if profiler is imported and running and in that case just remove us as a second tracer
     # to not disturb the profiling session
-    $profilerType = "Profiler.Tracer" -as [Type]
-    if ($null -ne $profilerType -and $profilerType::IsEnabled) {
-        $profilerType::Unregister()
-    }
-    else {
+    if ($Patched) {
         Set-PSDebug -Trace 0
         [Pester.Tracing.Tracer]::Unpatch()
+    }
+    else {
+        $profilerType = "Profiler.Tracer" -as [Type]
+        $profilerType::Unregister()
     }
 }
 

--- a/tst/functions/Coverage.Tests.ps1
+++ b/tst/functions/Coverage.Tests.ps1
@@ -144,8 +144,8 @@ InPesterModuleScope {
                     & $sb
                 }
                 else {
-                    $tracer = Start-TraceScript $breakpoints
-                    try { & $sb } finally { Stop-TraceScript }
+                    $patched, $tracer = Start-TraceScript $breakpoints
+                    try { & $sb } finally { Stop-TraceScript -Patched $patched }
                     $measure = $tracer.Hits
                 }
 
@@ -495,8 +495,8 @@ InPesterModuleScope {
                     & $testScriptPath
                 }
                 else {
-                    $tracer = Start-TraceScript $breakpoints
-                    try { & $testScriptPath } finally { Stop-TraceScript }
+                    $patched, $tracer = Start-TraceScript $breakpoints
+                    try { & $testScriptPath } finally { Stop-TraceScript -Patched $patched }
                     $measure = $tracer.Hits
                 }
 
@@ -544,8 +544,8 @@ InPesterModuleScope {
                     & $testScriptPath
                 }
                 else {
-                    $tracer = Start-TraceScript $breakpoints
-                    try { & $testScriptPath } finally { Stop-TraceScript }
+                    $patched, $tracer = Start-TraceScript $breakpoints
+                    try { & $testScriptPath } finally { Stop-TraceScript -Patched $patched }
                     $measure = $tracer.Hits
                 }
 
@@ -593,8 +593,8 @@ InPesterModuleScope {
                     & $testScriptPath
                 }
                 else {
-                    $tracer = Start-TraceScript $breakpoints
-                    try { & $testScriptPath } finally { Stop-TraceScript }
+                    $patched, $tracer = Start-TraceScript $breakpoints
+                    try { & $testScriptPath } finally { Stop-TraceScript -Patched $patched }
                     $measure = $tracer.Hits
                 }
 
@@ -641,8 +641,8 @@ InPesterModuleScope {
                     & $testScriptPath
                 }
                 else {
-                    $tracer = Start-TraceScript $breakpoints
-                    try { & $testScriptPath } finally { Stop-TraceScript }
+                    $patched, $tracer = Start-TraceScript $breakpoints
+                    try { & $testScriptPath } finally { Stop-TraceScript -Patched $patched }
                     $measure = $tracer.Hits
                 }
 
@@ -701,8 +701,8 @@ InPesterModuleScope {
                         & $testScriptPath
                     }
                     else {
-                        $tracer = Start-TraceScript $breakpoints
-                        try { & $testScriptPath } finally { Stop-TraceScript }
+                        $patched, $tracer = Start-TraceScript $breakpoints
+                        try { & $testScriptPath } finally { Stop-TraceScript -Patched $patched }
                         $measure = $tracer.Hits
                     }
 
@@ -746,8 +746,8 @@ InPesterModuleScope {
                         & $testScriptPath
                     }
                     else {
-                        $tracer = Start-TraceScript $breakpoints
-                        try { & $testScriptPath } finally { Stop-TraceScript }
+                        $patched, $tracer = Start-TraceScript $breakpoints
+                        try { & $testScriptPath } finally { Stop-TraceScript -Patched $patched }
                         $measure = $tracer.Hits
                     }
 
@@ -829,8 +829,8 @@ InPesterModuleScope {
                         & $testScriptPath
                     }
                     else {
-                        $tracer = Start-TraceScript $breakpoints
-                        try { & $testScriptPath } finally { Stop-TraceScript }
+                        $patched, $tracer = Start-TraceScript $breakpoints
+                        try { & $testScriptPath } finally { Stop-TraceScript -Patched $patched }
                         $measure = $tracer.Hits
                     }
 


### PR DESCRIPTION
<!-- Thank you for contributing to Pester! -->

## PR Summary
Fix #1989

Handle cancellation without finally better. So we don't block ourselves from running next time.


## PR Checklist

- [x] PR has meaningful title
- [x] Summary describes changes
- [x] PR is ready to be merged
  - If not, use the arrow next to `Create Pull Request` to mark it as a draft. PR can be marked `Ready for review` when it's ready.
- [ ] Tests are added/update *(if required)*
- [ ] Documentation is updated/added *(if required)*

<!-- Before you continue, please review [Contributing to Pester](https://pester.dev/docs/contributing/introduction).

Our continuous integration system doesn't send any notifications about failed tests. Please return to the opened pull request (after ~60 minutes) to check if everything is OK. -->
