### PR TITLE
Add option to disable TestDrive and TestRegistry

### DIFF
--- a/src/Main.ps1
+++ b/src/Main.ps1
@@ -933,10 +933,13 @@ function Invoke-Pester {
                 # and that way output can consume the fixed object that decorator
                 # decorated, not nice but works
                 Get-RSpecObjectDecoratorPlugin
-                Get-TestDrivePlugin
             )
 
-            if ("Windows" -eq (GetPesterOs)) {
+            if ($PesterPreference.TestDrive.Enabled.Value) {
+                $plugins += @(Get-TestDrivePlugin)
+            }
+
+            if ($PesterPreference.TestRegistry.Enabled.Value -and "Windows" -eq (GetPesterOs)) {
                 $plugins += @(Get-TestRegistryPlugin)
             }
 

--- a/src/Pester.RSpec.ps1
+++ b/src/Pester.RSpec.ps1
@@ -398,6 +398,14 @@ function New-PesterConfiguration {
 
       StackTraceVerbosity: The verbosity of stacktrace output, options are None, FirstLine, Filtered and Full.
       Default value: 'Filtered'
+
+    TestDrive:
+      Enabled: Enable TestDrive.
+      Default value: $true
+
+    TestRegistry:
+      Enabled: Enable TestRegistry.
+      Default value: $true
     ```
 
     .PARAMETER Hashtable

--- a/src/csharp/Pester/PesterConfiguration.cs
+++ b/src/csharp/Pester/PesterConfiguration.cs
@@ -33,6 +33,8 @@ public class PesterConfiguration
         cfg.Should = ShouldConfiguration.ShallowClone(configuration.Should);
         cfg.Debug = DebugConfiguration.ShallowClone(configuration.Debug);
         cfg.Output = OutputConfiguration.ShallowClone(configuration.Output);
+        cfg.TestDrive = TestDriveConfiguration.ShallowClone(configuration.TestDrive);
+        cfg.TestRegistry = TestRegistryConfiguration.ShallowClone(configuration.TestRegistry);
         return cfg;
     }
 
@@ -46,6 +48,8 @@ public class PesterConfiguration
         cfg.Should = Merger.Merge(configuration.Should, @override.Should);
         cfg.Debug = Merger.Merge(configuration.Debug, @override.Debug);
         cfg.Output = Merger.Merge(configuration.Output, @override.Output);
+        cfg.TestDrive = Merger.Merge(configuration.TestDrive, @override.TestDrive);
+        cfg.TestRegistry = Merger.Merge(configuration.TestRegistry, @override.TestRegistry);
         return cfg;
     }
 
@@ -53,13 +57,15 @@ public class PesterConfiguration
     {
         if (configuration != null)
         {
-            Run = new RunConfiguration(configuration.GetIDictionaryOrNull("Run"));
-            Filter = new FilterConfiguration(configuration.GetIDictionaryOrNull("Filter"));
-            CodeCoverage = new CodeCoverageConfiguration(configuration.GetIDictionaryOrNull("CodeCoverage"));
-            TestResult = new TestResultConfiguration(configuration.GetIDictionaryOrNull("TestResult"));
-            Should = new ShouldConfiguration(configuration.GetIDictionaryOrNull("Should"));
-            Debug = new DebugConfiguration(configuration.GetIDictionaryOrNull("Debug"));
-            Output = new OutputConfiguration(configuration.GetIDictionaryOrNull("Output"));
+            Run = new RunConfiguration(configuration.GetIDictionaryOrNull(nameof(Run)));
+            Filter = new FilterConfiguration(configuration.GetIDictionaryOrNull(nameof(Filter)));
+            CodeCoverage = new CodeCoverageConfiguration(configuration.GetIDictionaryOrNull(nameof(CodeCoverage)));
+            TestResult = new TestResultConfiguration(configuration.GetIDictionaryOrNull(nameof(TestResult)));
+            Should = new ShouldConfiguration(configuration.GetIDictionaryOrNull(nameof(Should)));
+            Debug = new DebugConfiguration(configuration.GetIDictionaryOrNull(nameof(Debug)));
+            Output = new OutputConfiguration(configuration.GetIDictionaryOrNull(nameof(Output)));
+            TestDrive = new TestDriveConfiguration(configuration.GetIDictionaryOrNull(nameof(TestDrive)));
+            TestRegistry = new TestRegistryConfiguration(configuration.GetIDictionaryOrNull(nameof(TestRegistry)));
         }
     }
 
@@ -72,6 +78,8 @@ public class PesterConfiguration
         Should = new ShouldConfiguration();
         Debug = new DebugConfiguration();
         Output = new OutputConfiguration();
+        TestDrive = new TestDriveConfiguration();
+        TestRegistry = new TestRegistryConfiguration();
     }
 
     public RunConfiguration Run { get; set; }
@@ -81,4 +89,6 @@ public class PesterConfiguration
     public ShouldConfiguration Should { get; set; }
     public DebugConfiguration Debug { get; set; }
     public OutputConfiguration Output { get; set; }
+    public TestDriveConfiguration TestDrive { get; set; }
+    public TestRegistryConfiguration TestRegistry { get; set; }
 }

--- a/src/csharp/Pester/TestDriveConfiguration.cs
+++ b/src/csharp/Pester/TestDriveConfiguration.cs
@@ -1,0 +1,44 @@
+﻿using System.Collections;
+
+namespace Pester
+{
+    public class TestDriveConfiguration : ConfigurationSection
+    {
+        private BoolOption _enabled;
+
+        public static TestDriveConfiguration Default { get { return new TestDriveConfiguration(); } }
+
+        public static TestDriveConfiguration ShallowClone(TestDriveConfiguration configuration)
+        {
+            return Cloner.ShallowClone(configuration);
+        }
+        public TestDriveConfiguration() : base("TestDrive configuration.")
+        {
+            Enabled = new BoolOption("Enable TestDrive.", true);
+        }
+
+        public TestDriveConfiguration(IDictionary configuration) : this()
+        {
+            if (configuration != null)
+            {
+                Enabled = configuration.GetValueOrNull<bool>(nameof(Enabled)) ?? Enabled;
+            }
+        }
+
+        public BoolOption Enabled
+        {
+            get { return _enabled; }
+            set
+            {
+                if (_enabled == null)
+                {
+                    _enabled = value;
+                }
+                else
+                {
+                    _enabled = new BoolOption(_enabled, value.Value);
+                }
+            }
+        }
+    }
+}

--- a/src/csharp/Pester/TestRegistryConfiguration.cs
+++ b/src/csharp/Pester/TestRegistryConfiguration.cs
@@ -1,0 +1,44 @@
+﻿using System.Collections;
+
+namespace Pester
+{
+    public class TestRegistryConfiguration : ConfigurationSection
+    {
+        private BoolOption _enabled;
+
+        public static TestRegistryConfiguration Default { get { return new TestRegistryConfiguration(); } }
+
+        public static TestRegistryConfiguration ShallowClone(TestRegistryConfiguration configuration)
+        {
+            return Cloner.ShallowClone(configuration);
+        }
+        public TestRegistryConfiguration() : base("TestRegistry configuration.")
+        {
+            Enabled = new BoolOption("Enable TestRegistry.", true);
+        }
+
+        public TestRegistryConfiguration(IDictionary configuration) : this()
+        {
+            if (configuration != null)
+            {
+                Enabled = configuration.GetValueOrNull<bool>(nameof(Enabled)) ?? Enabled;
+            }
+        }
+
+        public BoolOption Enabled
+        {
+            get { return _enabled; }
+            set
+            {
+                if (_enabled == null)
+                {
+                    _enabled = value;
+                }
+                else
+                {
+                    _enabled = new BoolOption(_enabled, value.Value);
+                }
+            }
+        }
+    }
+}

--- a/tst/Pester.RSpec.Configuration.ts.ps1
+++ b/tst/Pester.RSpec.Configuration.ts.ps1
@@ -160,6 +160,14 @@ i -PassThru:$PassThru {
         t "Debug.ShowNavigationMarkers is `$false" {
             [PesterConfiguration]::Default.Debug.ShowNavigationMarkers.Value | Verify-False
         }
+
+        t "TestDrive.Enabled is `$true" {
+            [PesterConfiguration]::Default.TestDrive.Enabled.Value | Verify-True
+        }
+
+        t "TestRegistry.Enabled is `$true" {
+            [PesterConfiguration]::Default.TestRegistry.Enabled.Value | Verify-True
+        }
     }
 
     b "Assignment" {

--- a/tst/functions/Pester.TestDrive.ts.ps1
+++ b/tst/functions/Pester.TestDrive.ts.ps1
@@ -63,5 +63,27 @@ i -PassThru:$PassThru {
             $r.Containers[0].Blocks[0].Tests[0].Result | Verify-Equal "Passed"
             $r.Result | Verify-Equal "Passed"
         }
+
+        t "TestDrive can be disabled" {
+            $sb = {
+                Describe "d" {
+                    It "i" {
+                        'TestDrive:\' | Should -Not -Exist  -Because "TestDrive is disabled in configuration"
+                    }
+                }
+            }
+
+            $r = Invoke-Pester -Configuration ([PesterConfiguration]@{
+                    TestDrive = @{
+                        Enabled = $false
+                    }
+                    Run       = @{
+                        ScriptBlock = $sb
+                        PassThru    = $true
+                    }
+                })
+            $r.Containers[0].Blocks[0].Tests[0].Result | Verify-Equal "Passed"
+            $r.Result | Verify-Equal "Passed"
+        }
     }
 }

--- a/tst/functions/Pester.TestRegistry.ts.ps1
+++ b/tst/functions/Pester.TestRegistry.ts.ps1
@@ -69,5 +69,27 @@ i -PassThru:$PassThru {
             $r.Containers[0].Blocks[0].Tests[0].Result | Verify-Equal "Passed"
             $r.Result | Verify-Equal "Passed"
         }
+
+        t "TestRegistry can be disabled" {
+            $sb = {
+                Describe "d" {
+                    It "i" {
+                        'TestRegistry:\' | Should -Not -Exist  -Because "TestRegistry is disabled in configuration"
+                    }
+                }
+            }
+
+            $r = Invoke-Pester -Configuration ([PesterConfiguration]@{
+                    TestRegistry = @{
+                        Enabled = $false
+                    }
+                    Run          = @{
+                        ScriptBlock = $sb
+                        PassThru    = $true
+                    }
+                })
+            $r.Containers[0].Blocks[0].Tests[0].Result | Verify-Equal "Passed"
+            $r.Result | Verify-Equal "Passed"
+        }
     }
 }


### PR DESCRIPTION
<!-- Thank you for contributing to Pester! -->

## PR Summary

Fix #2004 
Fix #1340
Fix #1344

Add option to disable test drive and test registry. This will make the run faster if you are not using any of those capabilities. And also will allow runs that run in restricted machines such as ones that don't have access to registry.


## PR Checklist

- [x] PR has meaningful title
- [x] Summary describes changes
- [x] PR is ready to be merged
  - If not, use the arrow next to `Create Pull Request` to mark it as a draft. PR can be marked `Ready for review` when it's ready.
- [x] Tests are added/update *(if required)*
- [x] Documentation is updated/added *(if required)*
