### PR TITLE
Fix throwing on missing folders

### DIFF
--- a/src/Main.ps1
+++ b/src/Main.ps1
@@ -1027,7 +1027,7 @@ function Invoke-Pester {
             }
 
             if ((none $containers)) {
-                throw "No test files were found and no scriptblocks were provided."
+                throw "No test files were found and no scriptblocks were provided. Please ensure that you provided at least one path to a *$($PesterPreference.Run.TestExtension.Value) file, or a directory that contains such file.$(if ($null -ne $PesterPreference.Run.ExcludePath.Value -and 0 -lt @($PesterPreference.Run.ExcludePath.Value).Length) {" And that there is at least one file not excluded by ExcludeFile filter '$($PesterPreference.Run.ExcludePath.Value -join "', '")'."}) Or that you provided a ScriptBlock test container."
                 return
             }
 
@@ -1126,7 +1126,12 @@ function Invoke-Pester {
                     }
                 }
 
-                $stringWriter.ToString() | & $SafeCommands['Out-File'] $PesterPreference.CodeCoverage.OutputPath.Value -Encoding $PesterPreference.CodeCoverage.OutputEncoding.Value
+                if (-not (& $SafeCommands['Test-Path'] $PesterPreference.CodeCoverage.OutputPath.Value)) {
+                    $dir = & $SafeCommands['Split-Path'] $PesterPreference.CodeCoverage.OutputPath.Value
+                    $null = & $SafeCommands['New-Item'] $dir -Force -ItemType Container
+                }
+
+                $stringWriter.ToString() | & $SafeCommands['Out-File'] $PesterPreference.CodeCoverage.OutputPath.Value -Encoding $PesterPreference.CodeCoverage.OutputEncoding.Value -Force
                 if ($PesterPreference.Output.Verbosity.Value -in "Detailed", "Diagnostic") {
                     & $SafeCommands["Write-Host"] -ForegroundColor Magenta "Code Coverage result processed in $($sw.ElapsedMilliseconds) ms."
                 }

--- a/src/Main.ps1
+++ b/src/Main.ps1
@@ -1126,12 +1126,13 @@ function Invoke-Pester {
                     }
                 }
 
-                if (-not (& $SafeCommands['Test-Path'] $PesterPreference.CodeCoverage.OutputPath.Value)) {
-                    $dir = & $SafeCommands['Split-Path'] $PesterPreference.CodeCoverage.OutputPath.Value
+                $resolvedPath = $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($PesterPreference.CodeCoverage.OutputPath.Value)
+                if (-not (& $SafeCommands['Test-Path'] $resolvedPath)) {
+                    $dir = & $SafeCommands['Split-Path'] $resolvedPath
                     $null = & $SafeCommands['New-Item'] $dir -Force -ItemType Container
                 }
 
-                $stringWriter.ToString() | & $SafeCommands['Out-File'] $PesterPreference.CodeCoverage.OutputPath.Value -Encoding $PesterPreference.CodeCoverage.OutputEncoding.Value -Force
+                $stringWriter.ToString() | & $SafeCommands['Out-File'] $resolvedPath -Encoding $PesterPreference.CodeCoverage.OutputEncoding.Value -Force
                 if ($PesterPreference.Output.Verbosity.Value -in "Detailed", "Diagnostic") {
                     & $SafeCommands["Write-Host"] -ForegroundColor Magenta "Code Coverage result processed in $($sw.ElapsedMilliseconds) ms."
                 }

--- a/src/functions/TestResults.ps1
+++ b/src/functions/TestResults.ps1
@@ -16,6 +16,10 @@ function GetFullPath ([string]$Path) {
     $Folder = & $SafeCommands['Split-Path'] -Path $Path -Parent
     $File = & $SafeCommands['Split-Path'] -Path $Path -Leaf
 
+    if (-not (& $SafeCommands['Test-Path'] $Folder)) {
+        $null = & $SafeCommands['New-Item'] $Folder -ItemType Container -Force
+    }
+
     if ( -not ([String]::IsNullOrEmpty($Folder))) {
         $FolderResolved = & $SafeCommands['Resolve-Path'] -Path $Folder
     }

--- a/src/functions/TestResults.ps1
+++ b/src/functions/TestResults.ps1
@@ -16,11 +16,11 @@ function GetFullPath ([string]$Path) {
     $Folder = & $SafeCommands['Split-Path'] -Path $Path -Parent
     $File = & $SafeCommands['Split-Path'] -Path $Path -Leaf
 
-    if (-not (& $SafeCommands['Test-Path'] $Folder)) {
-        $null = & $SafeCommands['New-Item'] $Folder -ItemType Container -Force
-    }
-
     if ( -not ([String]::IsNullOrEmpty($Folder))) {
+        if (-not (& $SafeCommands['Test-Path'] $Folder)) {
+            $null = & $SafeCommands['New-Item'] $Folder -ItemType Container -Force
+        }
+
         $FolderResolved = & $SafeCommands['Resolve-Path'] -Path $Folder
     }
     else {

--- a/tst/Pester.RSpec.Coverage.ts.ps1
+++ b/tst/Pester.RSpec.Coverage.ts.ps1
@@ -27,7 +27,7 @@ if ($PSVersionTable.PSVersion.Major -eq 3) {
 
 i -PassThru:$PassThru {
     b "Coverage with Breakpoints and with Tracer" {
-        t "Coverage is the same when breakpoints are used as when they are not used" {
+        dt "Coverage is the same when breakpoints are used as when they are not used" {
             $sb = {
                 Describe 'VSCode Output Test' {
                     It 'Single error' {
@@ -71,6 +71,9 @@ i -PassThru:$PassThru {
             # $c.CodeCoverage.OutputPath = "coverage-with-breakpoints.xml"
             $bb = Invoke-Pester -Configuration $c
 
+
+            $bb | Verify-NotNull
+            $pp | Verify-NotNull
 
             Write-Host "is different?: $($bb.CodeCoverage.CommandsMissed.Count -ne $pp.CodeCoverage.CommandsMissed.Count)"
             Write-Host "is less?: $($bb.CodeCoverage.CommandsMissed.Count -lt $pp.CodeCoverage.CommandsMissed.Count)"

--- a/tst/Pester.RSpec.Coverage.ts.ps1
+++ b/tst/Pester.RSpec.Coverage.ts.ps1
@@ -27,7 +27,7 @@ if ($PSVersionTable.PSVersion.Major -eq 3) {
 
 i -PassThru:$PassThru {
     b "Coverage with Breakpoints and with Tracer" {
-        dt "Coverage is the same when breakpoints are used as when they are not used" {
+        t "Coverage is the same when breakpoints are used as when they are not used" {
             $sb = {
                 Describe 'VSCode Output Test' {
                     It 'Single error' {

--- a/tst/Pester.RSpec.Coverage.ts.ps1
+++ b/tst/Pester.RSpec.Coverage.ts.ps1
@@ -249,4 +249,41 @@ i -PassThru:$PassThru {
             Get-HitLocation $b | Verify-Location $b
         }
     }
+
+    b "Coverage result creates missing folder" {
+        t "Coverage result will create the destination folder if it is missing" {
+            # https://github.com/pester/Pester/issues/1875 point 2
+            $sb = {
+                Describe 'VSCode Output Test' {
+                    It 'Single error' {
+                        . "$PSScriptRoot/CoverageTestFile.ps1"
+                    }
+                }
+            }
+
+            $c = New-PesterConfiguration
+
+            $c.Run.Container = New-PesterContainer -ScriptBlock $sb
+            $c.Run.PassThru = $true
+
+            $c.Output.Verbosity = "Detailed"
+
+            $c.CodeCoverage.Enabled = $true
+            $c.CodeCoverage.Path = "$PSScriptRoot/CoverageTestFile.ps1"
+            $c.CodeCoverage.UseBreakpoints = $true
+            $dir = [IO.Path]::GetTempPath() + "/nonExistingDirectory" + [Guid]::NewGuid()
+            $c.CodeCoverage.OutputPath = "$dir/coverage.xml"
+
+            try {
+                $r = Invoke-Pester -Configuration $c
+            }
+            finally {
+                if (Test-Path $dir) {
+                    Remove-Item $dir -Force -Recurse
+                }
+            }
+
+            $r.Result | Verify-Equal 'Passed'
+        }
+    }
 }

--- a/tst/p.psm1
+++ b/tst/p.psm1
@@ -120,7 +120,7 @@ function t {
                 # otherwise show the assertion message and stacktrace to keep the noise
                 # on test failure low
                 if ([Exception] -ne $_.Exception.GetType()) {
-                    Write-Host "ERROR: - $Name -> $($_| Out-String) "  -ForegroundColor Black -BackgroundColor Red
+                    Write-Host "[n] ERROR: - $Name -> $($_| Out-String) "  -ForegroundColor Black -BackgroundColor Red
                     $(Get-FullStackTrace $_) -split [Environment]::NewLine | foreach {
                         Write-Host " " -NoNewline
                         Write-Host " $_ "  -NoNewline -ForegroundColor Black -BackgroundColor Red


### PR DESCRIPTION
<!-- Thank you for contributing to Pester! -->

## PR Summary

Fix throwing on missing folders for TestResults and Coverage. And improve error message for no files.

Fix #1875

## PR Checklist

- [x] PR has meaningful title
- [x] Summary describes changes
- [x] PR is ready to be merged
  - If not, use the arrow next to `Create Pull Request` to mark it as a draft. PR can be marked `Ready for review` when it's ready.
- [x] Tests are added/update *(if required)*
- [ ] Documentation is updated/added *(if required)*

<!-- Before you continue, please review [Contributing to Pester](https://pester.dev/docs/contributing/introduction).

Our continuous integration system doesn't send any notifications about failed tests. Please return to the opened pull request (after ~60 minutes) to check if everything is OK. -->
