### PR TITLE
Added Filter.ExcludeLine option

### DIFF
--- a/src/Main.ps1
+++ b/src/Main.ps1
@@ -1015,6 +1015,7 @@ function Invoke-Pester {
                 -Tag $PesterPreference.Filter.Tag.Value `
                 -ExcludeTag $PesterPreference.Filter.ExcludeTag.Value `
                 -Line $PesterPreference.Filter.Line.Value `
+                -ExcludeLine $PesterPreference.Filter.ExcludeLine.Value `
                 -FullName $PesterPreference.Filter.FullName.Value
 
             $containers = @()

--- a/src/Pester.RSpec.ps1
+++ b/src/Pester.RSpec.ps1
@@ -322,6 +322,9 @@ function New-PesterConfiguration {
       Line: Filter by file and scriptblock start line, useful to run parsed tests programatically to avoid problems with expanded names. Example: 'C:\tests\file1.Tests.ps1:37'
       Default value: @()
 
+      ExcludeLine: Exclude by file and scriptblock start line, takes precedence over Line.
+      Default value: @()
+
       FullName: Full name of test with -like wildcards, joined by dot. Example: '*.describe Get-Item.test1'
       Default value: @()
 

--- a/src/Pester.Runtime.ps1
+++ b/src/Pester.Runtime.ps1
@@ -1721,6 +1721,21 @@ function Test-ShouldRun {
         }
     }
 
+    $excludeLineFilter = $Filter.ExcludeLine
+
+    $line = "$(if ($Item.ScriptBlock.File) { $Item.ScriptBlock.File } else { $Item.ScriptBlock.Id }):$($Item.StartLine)" -replace '\\', '/'
+    if ($excludeLineFilter -and 0 -ne $excludeLineFilter.Count) {
+        foreach ($l in $excludeLineFilter -replace '\\', '/') {
+            if ($l -eq $line) {
+                if ($PesterPreference.Debug.WriteDebugMessages.Value) {
+                    Write-PesterDebugMessage -Scope Filter "($fullDottedPath) $($Item.ItemType) is excluded, because its path:line '$line' matches line filter '$excludeLineFilter'."
+                }
+                $result.Exclude = $true
+                return $result
+            }
+        }
+    }
+
     # - place exclude filters above this line and include below this line
 
     $lineFilter = $Filter.Line

--- a/src/Pester.Runtime.ps1
+++ b/src/Pester.Runtime.ps1
@@ -2286,14 +2286,16 @@ function New-FilterObject {
         [String[]] $FullName,
         [String[]] $Tag,
         [String[]] $ExcludeTag,
-        [String[]] $Line
+        [String[]] $Line,
+        [String[]] $ExcludeLine
     )
 
     [PSCustomObject] @{
-        FullName   = $FullName
-        Tag        = $Tag
-        ExcludeTag = $ExcludeTag
-        Line       = $Line
+        FullName    = $FullName
+        Tag         = $Tag
+        ExcludeTag  = $ExcludeTag
+        Line        = $Line
+        ExcludeLine = $ExcludeLine
     }
 }
 

--- a/src/Pester.Runtime.ps1
+++ b/src/Pester.Runtime.ps1
@@ -1729,8 +1729,10 @@ function Test-ShouldRun {
             if ($l -eq $line) {
                 if ($PesterPreference.Debug.WriteDebugMessages.Value) {
                     Write-PesterDebugMessage -Scope Filter "($fullDottedPath) $($Item.ItemType) is excluded, because its path:line '$line' matches line filter '$excludeLineFilter'."
+                    Write-PesterDebugMessage -Scope Filter "($fullDottedPath) $($Item.ItemType) is explicitly excluded, because it matched line filter, and will run even if -Skip is specified on it. Any skipped children will still be skipped."
                 }
                 $result.Exclude = $true
+                $result.Explicit = $true
                 return $result
             }
         }

--- a/src/csharp/Pester/FilterConfiguration.cs
+++ b/src/csharp/Pester/FilterConfiguration.cs
@@ -24,6 +24,7 @@ namespace Pester
         private StringArrayOption _tag;
         private StringArrayOption _excludeTag;
         private StringArrayOption _line;
+        private StringArrayOption _excludeLine;
         private StringArrayOption _fullName;
 
         public static FilterConfiguration Default { get { return new FilterConfiguration(); } }
@@ -39,6 +40,7 @@ namespace Pester
                 Tag = configuration.GetArrayOrNull<string>("Tag") ?? Tag;
                 ExcludeTag = configuration.GetArrayOrNull<string>("ExcludeTag") ?? ExcludeTag;
                 Line = configuration.GetArrayOrNull<string>("Line") ?? Line;
+                ExcludeLine = configuration.GetArrayOrNull<string>("ExcludeLine") ?? ExcludeLine;
                 FullName = configuration.GetArrayOrNull<string>("FullName") ?? FullName;
             }
         }
@@ -47,6 +49,7 @@ namespace Pester
             Tag = new StringArrayOption("Tags of Describe, Context or It to be run.", new string[0]);
             ExcludeTag = new StringArrayOption("Tags of Describe, Context or It to be excluded from the run.", new string[0]);
             Line = new StringArrayOption(@"Filter by file and scriptblock start line, useful to run parsed tests programatically to avoid problems with expanded names. Example: 'C:\tests\file1.Tests.ps1:37'", new string[0]);
+            ExcludeLine = new StringArrayOption("Exclude by file and scriptblock start line, takes precedence over Line.", new string[0]);
             FullName = new StringArrayOption("Full name of test with -like wildcards, joined by dot. Example: '*.describe Get-Item.test1'", new string[0]);
         }
 
@@ -93,6 +96,22 @@ namespace Pester
                 else
                 {
                     _line = new StringArrayOption(_line, value?.Value);
+                }
+            }
+        }
+
+        public StringArrayOption ExcludeLine
+        {
+            get { return _excludeLine; }
+            set
+            {
+                if (_excludeLine == null)
+                {
+                    _excludeLine = value;
+                }
+                else
+                {
+                    _excludeLine = new StringArrayOption(_excludeLine, value?.Value);
                 }
             }
         }

--- a/tst/Pester.Runtime.ts.ps1
+++ b/tst/Pester.Runtime.ts.ps1
@@ -477,7 +477,7 @@ i -PassThru:$PassThru {
             $actual.Exclude | Verify-False
         }
 
-        t "Given a test with file path and line number it excludes it when it matches the exclude lines filter" {
+        t "Given a test with file path and line number it excludes it when it matches the ExcludeLine filter" {
             $t = New-TestObject -Name "test1" -ScriptBlock ($sb = { "test" }) -StartLine $sb.StartPosition.StartLine
 
             $excludeLines = "$($sb.File):$($sb.StartPosition.StartLine)"
@@ -489,7 +489,7 @@ i -PassThru:$PassThru {
             $actual.Exclude | Verify-True
         }
 
-        t "Given a test with file path and line number it excludes it when it matches the exclude lines filter even when line filter is already set" {
+        t "Given a test with file path and line number it overrides the Line filter when it matches the ExcludeLine filter" {
             $t = New-TestObject -Name "test1" -ScriptBlock ($sb = { "test" }) -StartLine $sb.StartPosition.StartLine
 
             $includeLines = "$($sb.File):$($sb.StartPosition.StartLine)"
@@ -502,7 +502,7 @@ i -PassThru:$PassThru {
             $actual.Exclude | Verify-True
         }
 
-        t "Given two tests with file paths and line numbers it excludes them when they match the exclude lines filter" {
+        t "Given two tests with file paths and line numbers it excludes both they match the ExcludeLine filter" {
             $sb = {
                 New-Block "block1" {
                     New-Test "test1" { "a" }
@@ -528,7 +528,7 @@ i -PassThru:$PassThru {
             $actual2.Exclude | Verify-True
         }
 
-        t "Given two tests with file paths and line numbers it includes the first one and excludes the second one when both filters are set" {
+        t "Given two tests with file paths and line numbers it includes the first one from Line filter and excludes second one from ExcludeLine filter" {
             $sb = {
                 New-Block "block1" {
                     New-Test "test1" { "a" }
@@ -555,7 +555,7 @@ i -PassThru:$PassThru {
             $actual2.Exclude | Verify-True
         }
 
-        t "Given multiple tests with file paths and line numbers it includes the lines that match the lines filter and excludes when overriden with the exclude filter" {
+        t "Given multiple tests with file paths and line numbers it includes the lines that match the Line filter and excludes when overriden with the ExcludeLine filter" {
             $sb = {
                 New-Block "block1" {
                     New-Test "test1" { "a" }
@@ -686,7 +686,7 @@ i -PassThru:$PassThru {
             $actual3.Exclude | Verify-True
         }
 
-        t "Given multiple tests with file paths and line numbers it includes nested blocks but excludes selected tests" {
+        t "Given multiple tests with file paths and line numbers it includes nested blocks but excludes selected tests within blocks" {
             $sb = {
                 # Describe
                 New-Block "block1" {


### PR DESCRIPTION
<!-- Thank you for contributing to Pester! -->

## PR Summary
<!-- Please describe what your pull request fixes, or how it improves Pester.

If your pull request resolves a reported issue, please mention it by using `Fix #<issue_number>` on a new line, this will close the linked issue automatically when this PR is merged. For more info see: [Closing issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/).

If your pull request integrates Pester with another system, please tell us how the change can be tested. -->

Fix #1992

I've included a `Filter.ExcludeLine` option. 

### Sample Test

```pwsh
Describe "block1" { #Line 1
    It "Test1" { #Line 2
        $true | Should -BeTrue
    }
    Context "block2" { #Line 5
        It "Test2" { # Line 6
            $true | Should -BeTrue
        }
        It "Test3" { #Line 9
            $true | Should -BeTrue
        }
    }
}
```

### Setup Code

```pwsh
$pesterConfig = [PesterConfiguration] @{
    Run = @{
        Container = New-PesterContainer -Path C:\Users\Armaan\Documents\powershell-dev\sample.Tests.ps1
    }
    Output = @{
        Verbosity = "Diagnostic"
    }
}
```

### Test 1

Include Context block
Exclude Test2

```pwsh
$pesterConfig.Filter.Line = "C:\Users\Armaan\Documents\powershell-dev\sample.Tests.ps1:5"
$pesterConfig.Filter.ExcludeLine = "C:\Users\Armaan\Documents\powershell-dev\sample.Tests.ps1:6"
Invoke-Pester -Configuration $pesterConfig
```

### Output 1

Only Test 3 is run

![test1](https://user-images.githubusercontent.com/20082136/123506784-5f341d00-d6a9-11eb-9d24-503e4901bb8f.PNG)

### Test 2

Include Describe, Context and Test2
Exclude Test2

```pwsh
$pesterConfig.Filter.Line = "C:\Users\Armaan\Documents\powershell-dev\sample.Tests.ps1:1", "C:\Users\Armaan\Documents\powershell-dev\sample.Tests.ps1:5", "C:\Users\Armaan\Documents\powershell-dev\sample.Tests.ps1:6"
$pesterConfig.Filter.ExcludeLine = "C:\Users\Armaan\Documents\powershell-dev\sample.Tests.ps1:6"
Invoke-Pester -Configuration $pesterConfig
```

### Output 2

Only Test1 and Test3 are run

![test2](https://user-images.githubusercontent.com/20082136/123506873-bafea600-d6a9-11eb-8c8b-271aee22f181.PNG)

### Test 3

Include Describe
Exclude Context

```pwsh
$pesterConfig.Filter.Line = "C:\Users\Armaan\Documents\powershell-dev\sample.Tests.ps1:1"
$pesterConfig.Filter.ExcludeLine = "C:\Users\Armaan\Documents\powershell-dev\sample.Tests.ps1:5"
Invoke-Pester -Configuration $pesterConfig
```

### Output 3

Only Test1 is run

![test3](https://user-images.githubusercontent.com/20082136/123506927-192b8900-d6aa-11eb-8fd7-a11924b3d83f.PNG)

cc @JustinGrote

## PR Checklist

- [x] PR has meaningful title
- [x] Summary describes changes
- [x] PR is ready to be merged
  - If not, use the arrow next to `Create Pull Request` to mark it as a draft. PR can be marked `Ready for review` when it's ready.
- [x] Tests are added/update *(if required)*
- [x] Documentation is updated/added *(if required)*

<!-- Before you continue, please review [Contributing to Pester](https://pester.dev/docs/contributing/introduction).

Our continuous integration system doesn't send any notifications about failed tests. Please return to the opened pull request (after ~60 minutes) to check if everything is OK. -->
