### PR TITLE
Enable additional plugins to be added via $additionalPlugins

### DIFF
--- a/src/Main.ps1
+++ b/src/Main.ps1
@@ -1011,7 +1011,7 @@ function Invoke-Pester {
                 $pluginConfiguration["Coverage"] = $CodeCoverage
             }
 
-            if ($SCRIPT:additionalPlugins) {$plugins += $SCRIPT:additionalPlugins}
+            if (defined $script:additionalPlugins) {$plugins += $script:additionalPlugins}
 
             $filter = New-FilterObject `
                 -Tag $PesterPreference.Filter.Tag.Value `

--- a/src/Main.ps1
+++ b/src/Main.ps1
@@ -1012,7 +1012,7 @@ function Invoke-Pester {
             }
 
             # this is here to support Pester test runner in VSCode. Don't use it unless you are prepared to get broken in the future. And if you decide to use it, let us know in https://github.com/pester/Pester/issues/2021 so we can warn you about removing this.
-            if (defined $script:additionalPlugins) {$plugins += $script:additionalPlugins}
+            if (defined additionalPlugins) {$plugins += $script:additionalPlugins}
 
             $filter = New-FilterObject `
                 -Tag $PesterPreference.Filter.Tag.Value `

--- a/src/Main.ps1
+++ b/src/Main.ps1
@@ -1011,6 +1011,7 @@ function Invoke-Pester {
                 $pluginConfiguration["Coverage"] = $CodeCoverage
             }
 
+            # this is here to support Pester test runner in VSCode. Don't use it unless you are prepared to get broken in the future. And if you decide to use it, let us know in https://github.com/pester/Pester/issues/2021 so we can warn you about removing this.
             if (defined $script:additionalPlugins) {$plugins += $script:additionalPlugins}
 
             $filter = New-FilterObject `

--- a/src/Main.ps1
+++ b/src/Main.ps1
@@ -1011,6 +1011,8 @@ function Invoke-Pester {
                 $pluginConfiguration["Coverage"] = $CodeCoverage
             }
 
+            if ($SCRIPT:additionalPlugins) {$plugins += $SCRIPT:additionalPlugins}
+
             $filter = New-FilterObject `
                 -Tag $PesterPreference.Filter.Tag.Value `
                 -ExcludeTag $PesterPreference.Filter.ExcludeTag.Value `


### PR DESCRIPTION
<!-- Thank you for contributing to Pester! -->

## PR Summary
<!-- Please describe what your pull request fixes, or how it improves Pester.

If your pull request resolves a reported issue, please mention it by using `Fix #<issue_number>` on a new line, this will close the linked issue automatically when this PR is merged. For more info see: [Closing issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/).

If your pull request integrates Pester with another system, please tell us how the change can be tested. -->

Adds support for a `$SCRIPT:additionalPlugins` to be defined to allow outside modules to contribute their own plugins via this method:

```powershell
& (gmo pester) {$f = New-PluginObject etc..; $SCRIPT:additionalPlugins = @($f)
```

See: https://github.com/pester/Pester/discussions/2011#discussioncomment-953966

## PR Checklist

- [x] PR has meaningful title
- [x] Summary describes changes
- [x] PR is ready to be merged
  - If not, use the arrow next to `Create Pull Request` to mark it as a draft. PR can be marked `Ready for review` when it's ready.
- [ ] Tests are added/update *(if required)*
- [ ] Documentation is updated/added *(if required)*

<!-- Before you continue, please review [Contributing to Pester](https://pester.dev/docs/contributing/introduction).

Our continuous integration system doesn't send any notifications about failed tests. Please return to the opened pull request (after ~60 minutes) to check if everything is OK. -->
