### PR TITLE
Fix broken link to pester.dev assertions page

### DIFF
--- a/src/functions/assertions/Should.ps1
+++ b/src/functions/assertions/Should.ps1
@@ -41,7 +41,7 @@ function Should {
     https://pester.dev/docs/commands/Should
 
     .LINK
-    https://pester.dev/docs/usage/assertions
+    https://pester.dev/docs/assertions/assertions
 
     .EXAMPLE
     ```powershell


### PR DESCRIPTION
## PR Summary

Fixes link to the pester.dev  [Assertions page](https://pester.dev/docs/assertions/assertions) for the Should command.

Ready to merge.