### PR TITLE
Added FileContentMatchMultilineExactly should assertion

### DIFF
--- a/src/functions/assertions/FileContentMatchMultilineExactly.ps1
+++ b/src/functions/assertions/FileContentMatchMultilineExactly.ps1
@@ -1,0 +1,79 @@
+﻿function Should-FileContentMatchMultilineExactly($ActualValue, $ExpectedContent, [switch] $Negate, [String] $Because) {
+    <#
+.SYNOPSIS
+As opposed to FileContentMatch and FileContentMatchExactly operators,
+FileContentMatchMultilineExactly presents content of the file being tested as one string object,
+so that the case sensitive expression you are comparing it to can consist of several lines.
+
+When using FileContentMatchMultilineExactly operator, '^' and '$' represent the beginning and end
+of the whole file, instead of the beginning and end of a line.
+
+.EXAMPLE
+$Content = "I am the first line.`nI am the second line."
+Set-Content -Path TestDrive:\file.txt -Value $Content -NoNewline
+'TestDrive:\file.txt' | Should -FileContentMatchMultilineExactly "first line.`nI am"
+
+This specified content across multiple lines case sensitively matches the file contents, and the test passes.
+
+.EXAMPLE
+'TestDrive:\file.txt' | Should -FileContentMatchMultilineExactly "First line.`nI am"
+
+Using the file from Example 1, this specified content across multiple lines does not case sensitively match,
+because the 'F' on the first line is capitalized. This test fails.
+
+.EXAMPLE
+'TestDrive:\file.txt' | Should -FileContentMatchMultilineExactly 'first line\.\r?\nI am'
+
+Using the file from Example 1, this RegEx pattern case sensitively matches the file contents, and the test passes.
+
+.EXAMPLE
+'TestDrive:\file.txt' | Should -FileContentMatchMultilineExactly '^I am the first.*\n.*second line\.$'
+
+Using the file from Example 1, this RegEx pattern also case sensitively matches, and this test also passes.
+
+.EXAMPLE
+'TestDrive:\file.txt' | Should -FileContentMatchMultilineExactly '^am the first line\.$'
+
+Using the file from Example 1, FileContentMatchMultilineExactly uses the '^' symbol to case sensitively match the start of the file,
+so '^am' is invalid here because the start of the file is '^I am'. This test fails.
+
+.EXAMPLE
+'TestDrive:\file.txt' | Should -FileContentMatchMultilineExactly '^I am the first line\.$'
+
+Using the file from Example 1, FileContentMatchMultilineExactly uses the '$' symbol to case sensitively match the end of the file,
+not the end of any single line within the file. This test also fails.
+#>
+    $succeeded = [bool] ((& $SafeCommands['Get-Content'] $ActualValue -Delimiter ([char]0)) -cmatch $ExpectedContent)
+
+    if ($Negate) {
+        $succeeded = -not $succeeded
+    }
+
+    $failureMessage = ''
+
+    if (-not $succeeded) {
+        if ($Negate) {
+            $failureMessage = NotShouldFileContentMatchMultilineExactlyFailureMessage -ActualValue $ActualValue -ExpectedContent $ExpectedContent -Because $Because
+        }
+        else {
+            $failureMessage = ShouldFileContentMatchMultilineExactlyFailureMessage -ActualValue $ActualValue -ExpectedContent $ExpectedContent -Because $Because
+        }
+    }
+
+    return [PSCustomObject] @{
+        Succeeded      = $succeeded
+        FailureMessage = $failureMessage
+    }
+}
+
+function ShouldFileContentMatchMultilineExactlyFailureMessage($ActualValue, $ExpectedContent, $Because) {
+    return "Expected $(Format-Nicely $ExpectedContent) to be case sensitively found in file $(Format-Nicely $ActualValue),$(Format-Because $Because) but it was not found."
+}
+
+function NotShouldFileContentMatchMultilineExactlyFailureMessage($ActualValue, $ExpectedContent, $Because) {
+    return "Expected $(Format-Nicely $ExpectedContent) to not be case sensitively found in file $(Format-Nicely $ActualValue),$(Format-Because $Because) but it was found."
+}
+
+& $script:SafeCommands['Add-ShouldOperator'] -Name         FileContentMatchMultilineExactly `
+    -InternalName Should-FileContentMatchMultilineExactly `
+    -Test         ${function:Should-FileContentMatchMultilineExactly}

--- a/tst/functions/assertions/FileContentMatchMultilineExactly.Tests.ps1
+++ b/tst/functions/assertions/FileContentMatchMultilineExactly.Tests.ps1
@@ -1,0 +1,73 @@
+﻿Set-StrictMode -Version Latest
+
+InPesterModuleScope {
+    Describe "Should -FileContentMatchMultilineExactly" {
+        Context "when testing file contents" {
+            BeforeAll {
+                "this is line 1$([System.Environment]::NewLine)this is line 2$([System.Environment]::NewLine)Pester is awesome" |
+                    Set-Content "TestDrive:\test.txt"
+            }
+
+            It "returns true if the file case sensitively matches the specified content on one line" {
+                "TestDrive:\test.txt" | Should -FileContentMatchMultilineExactly "Pester"
+            }
+
+            It "returns false if the file case sensitively matches the specified content on one line" {
+                "TestDrive:\test.txt" | Should -Not -FileContentMatchMultilineExactly "pester"
+            }
+
+            It "returns true if the file case sensitively matches the specified content across multiple lines" {
+                "TestDrive:\test.txt" | Should -FileContentMatchMultilineExactly "line 2$([System.Environment]::NewLine)Pester"
+            }
+
+            It "returns false if the file case sensitively matches the specified content across multiple lines" {
+                "TestDrive:\test.txt" | Should -Not -FileContentMatchMultilineExactly "line 2$([System.Environment]::NewLine)pester"
+            }
+
+            It "returns false if the file does not contain the specified content" {
+                "TestDrive:\test.txt" | Should -Not -FileContentMatchMultilineExactly "Pastor"
+            }
+        }
+
+        Context "When testing file contents using regular expressions" {
+            BeforeAll {
+                $Content = "I am the first line.$([System.Environment]::NewLine)I am the second line."
+                Set-Content -Path TestDrive:\file.txt -Value $Content -NoNewline
+            }
+
+            It "returns true if the file case sensitively matches the specified RegEx pattern" {
+                'TestDrive:\file.txt' | Should -FileContentMatchMultilineExactly 'first line\.\r?\nI am'
+            }
+
+            It "returns true if the file case sensitively matches the specified RegEx pattern using '^' and '$'" {
+                'TestDrive:\file.txt' | Should -FileContentMatchMultilineExactly '^I am the first.*\n.*second line\.$'
+            }
+
+            It "return false if the specified RegEx pattern uses '^' incorrecty to case sensitively match the start of the file" {
+                'TestDrive:\file.txt' | Should -Not -FileContentMatchMultilineExactly '^am the first line\.$'
+            }
+
+            It "return false if the specified RegEx pattern uses '$' incorrecty to case sensitively match the end of the file" {
+                'TestDrive:\file.txt' | Should -Not -FileContentMatchMultilineExactly '^I am the first line\.$'
+            }
+        }
+
+        It 'returns correct assertion message' {
+            $path = 'TestDrive:\file.txt'
+            'abc' | Set-Content -Path $path
+
+            $err = { $path | Should -FileContentMatchMultilineExactly 'g' -Because 'reason' } | Verify-AssertionFailed
+            $err.Exception.Message | Verify-Equal "Expected 'g' to be case sensitively found in file 'TestDrive:\file.txt', because reason, but it was not found."
+        }
+    }
+
+    Describe "Should -Not -FileContentMatchMultilineExactly" {
+        It 'returns correct assertion message' {
+            $path = 'TestDrive:\file.txt'
+            'abc' | Set-Content -Path $path
+
+            $err = { $path | Should -Not -FileContentMatchMultilineExactly 'a' -Because 'reason' } | Verify-AssertionFailed
+            $err.Exception.Message | Verify-Equal "Expected 'a' to not be case sensitively found in file 'TestDrive:\file.txt', because reason, but it was found."
+        }
+    }
+}

--- a/tst/functions/assertions/FileContentMatchMultilineExactly.Tests.ps1
+++ b/tst/functions/assertions/FileContentMatchMultilineExactly.Tests.ps1
@@ -32,7 +32,7 @@ InPesterModuleScope {
         Context "When testing file contents using regular expressions" {
             BeforeAll {
                 $Content = "I am the first line.$([System.Environment]::NewLine)I am the second line."
-                Set-Content -Path TestDrive:\file.txt -Value $Content -NoNewline
+                Set-Content -Path TestDrive:\file.txt -Value $Content
             }
 
             It "returns true if the file case sensitively matches the specified RegEx pattern" {
@@ -40,7 +40,7 @@ InPesterModuleScope {
             }
 
             It "returns true if the file case sensitively matches the specified RegEx pattern using '^' and '$'" {
-                'TestDrive:\file.txt' | Should -FileContentMatchMultilineExactly '^I am the first.*\n.*second line\.$'
+                'TestDrive:\file.txt' | Should -FileContentMatchMultilineExactly "^I am the first.*\.\r?\n.*second line\.\r?\n$"
             }
 
             It "return false if the specified RegEx pattern uses '^' incorrecty to case sensitively match the start of the file" {


### PR DESCRIPTION
<!-- Thank you for contributing to Pester! -->

## PR Summary
Fix #1605

Added a FileContentMatchMultilineExactly assertion to case sensitively match text on multiple lines.

### sample.txt

```
$var1 = Line one BLAH Blah blAH
$var2 = Line two BLAH Blah blAH 
$var3 = Line three BLAH Blah blAH
```

### sample-multiline-tests.Tests.ps1

```pwsh
BeforeAll {
    $matchstring = @'
$var1 = Line one blah blah blah
$var2 = Line two blah blah blah 
$var3 = Line three blah blah blah
'@

    $file = Get-ChildItem -Path $PSScriptRoot/sample.txt
}

Describe "Should -FileContentMatchMultiline" {
    It "Case insensitively match all lines" {
        $file | Should -FileContentMatchMultiline $([regex]::escape($matchString))
    }
}

Describe "Should -FileContentMatchMultilineExactly" {
    It "Case sensitively match all lines" {
        $file | Should -FileContentMatchMultilineExactly $([regex]::escape($matchString))
    }
}

```

### Output

![multiline](https://user-images.githubusercontent.com/20082136/126063070-da986a23-53b9-49f4-bc56-0ccdaf69d966.PNG)

cc @efie45

## PR Checklist

- [x] PR has meaningful title
- [x] Summary describes changes
- [x] PR is ready to be merged
  - If not, use the arrow next to `Create Pull Request` to mark it as a draft. PR can be marked `Ready for review` when it's ready.
- [x] Tests are added/update *(if required)*
- [x] Documentation is updated/added *(if required)*

<!-- Before you continue, please review [Contributing to Pester](https://pester.dev/docs/contributing/introduction).

Our continuous integration system doesn't send any notifications about failed tests. Please return to the opened pull request (after ~60 minutes) to check if everything is OK. -->
