### PR TITLE
Future improvement for coverage exclusion, fix some scan warnings

### DIFF
--- a/PSScriptAnalyzerSettings.psd1
+++ b/PSScriptAnalyzerSettings.psd1
@@ -6,5 +6,6 @@
         'PSUseShouldProcessForStateChangingFunctions'
         'PSUseApprovedVerbs'
         'Measure-SafeCommands'
+        'PSAvoidUsingWriteHost'
     )
 }

--- a/Pester.BuildAnalyzerRules/Pester.BuildAnalyzerRules.psm1
+++ b/Pester.BuildAnalyzerRules/Pester.BuildAnalyzerRules.psm1
@@ -81,7 +81,7 @@ Function Measure-ObjectCmdlets {
     .SYNOPSIS
     Should avoid usage of New/Where/Foreach/Select-Object.
     .DESCRIPTION
-    The built-in *-Object-cmdlets are slow compared to alternatives in .NET. To fix a violation of this rule, consider using an alterantive like `foreach`-keyword etc.`.
+    The built-in *-Object-cmdlets are slow compared to alternatives in .NET. To fix a violation of this rule, consider using an alternative like `foreach`-keyword etc.`.
     .EXAMPLE
     Measure-ObjectCmdlets -CommandAst $CommandAst
     .INPUTS

--- a/src/csharp/Pester/CodeCoverageConfiguration.cs
+++ b/src/csharp/Pester/CodeCoverageConfiguration.cs
@@ -26,6 +26,7 @@ namespace Pester
         private StringOption _outputPath;
         private StringOption _outputEncoding;
         private StringArrayOption _path;
+        private StringArrayOption _excludePaths;
         private BoolOption _excludeTests;
         private BoolOption _recursePaths;
         private BoolOption _useBps;
@@ -46,6 +47,7 @@ namespace Pester
             OutputPath = new StringOption("Path relative to the current directory where code coverage report is saved.", "coverage.xml");
             OutputEncoding = new StringOption("Encoding of the output file.", "UTF8");
             Path = new StringArrayOption("Directories or files to be used for codecoverage, by default the Path(s) from general settings are used, unless overridden here.", new string[0]);
+            ExcludePaths = new StringArrayOption("Directories or files to be excluded from codecoverage.", new string[0]);
             ExcludeTests = new BoolOption("Exclude tests from code coverage. This uses the TestFilter from general configuration.", true);
             RecursePaths = new BoolOption("Will recurse through directories in the Path option.", true);
             UseBreakpoints = new BoolOption("EXPERIMENTAL: When false, use Profiler based tracer to do CodeCoverage instead of using breakpoints.", true);
@@ -62,6 +64,7 @@ namespace Pester
                 OutputPath = configuration.GetObjectOrNull<string>("OutputPath") ?? OutputPath;
                 OutputEncoding = configuration.GetObjectOrNull<string>("OutputEncoding") ?? OutputEncoding;
                 Path = configuration.GetArrayOrNull<string>("Path") ?? Path;
+                ExcludePaths = configuration.GetArrayOrNull<string>("ExcludePaths") ?? ExcludePaths;
                 ExcludeTests = configuration.GetValueOrNull<bool>("ExcludeTests") ?? ExcludeTests;
                 RecursePaths = configuration.GetValueOrNull<bool>("RecursePaths") ?? RecursePaths;
                 CoveragePercentTarget = configuration.GetValueOrNull<decimal>("CoveragePercentTarget") ?? CoveragePercentTarget;
@@ -147,6 +150,22 @@ namespace Pester
                 else
                 {
                     _path = new StringArrayOption(_path, value?.Value);
+                }
+            }
+        }
+
+        public StringArrayOption ExcludePaths
+        {
+            get { return _excludePaths; }
+            set
+            {
+                if (_excludePaths == null)
+                {
+                    _excludePaths = value;
+                }
+                else
+                {
+                    _excludePaths = new StringArrayOption(_excludePaths, value?.Value);
                 }
             }
         }

--- a/src/csharp/Pester/CodeCoverageConfiguration.cs
+++ b/src/csharp/Pester/CodeCoverageConfiguration.cs
@@ -47,7 +47,7 @@ namespace Pester
             OutputPath = new StringOption("Path relative to the current directory where code coverage report is saved.", "coverage.xml");
             OutputEncoding = new StringOption("Encoding of the output file.", "UTF8");
             Path = new StringArrayOption("Directories or files to be used for codecoverage, by default the Path(s) from general settings are used, unless overridden here.", new string[0]);
-            ExcludePaths = new StringArrayOption("Directories or files to be excluded from codecoverage.", new string[0]);
+            ExcludePaths = new StringArrayOption("Directories or files to be excluded from codecoverage.  Defaults to none.", new string[0]);
             ExcludeTests = new BoolOption("Exclude tests from code coverage. This uses the TestFilter from general configuration.", true);
             RecursePaths = new BoolOption("Will recurse through directories in the Path option.", true);
             UseBreakpoints = new BoolOption("EXPERIMENTAL: When false, use Profiler based tracer to do CodeCoverage instead of using breakpoints.", true);

--- a/src/csharp/Pester/Coverage.cs
+++ b/src/csharp/Pester/Coverage.cs
@@ -23,6 +23,7 @@ namespace Pester
         public List<object> CommandsMissed = new List<object>();
         public List<object> CommandsExecuted = new List<object>();
         public List<object> FilesAnalyzed = new List<object>();
+        public List<object> FIlesExcluded = new List<object>();
 
         public override string ToString()
         {

--- a/src/csharp/Pester/Coverage.cs
+++ b/src/csharp/Pester/Coverage.cs
@@ -23,7 +23,7 @@ namespace Pester
         public List<object> CommandsMissed = new List<object>();
         public List<object> CommandsExecuted = new List<object>();
         public List<object> FilesAnalyzed = new List<object>();
-        public List<object> FIlesExcluded = new List<object>();
+        public List<object> FilesExcluded = new List<object>();
 
         public override string ToString()
         {

--- a/src/functions/Coverage.ps1
+++ b/src/functions/Coverage.ps1
@@ -1,5 +1,6 @@
 ﻿function Enter-CoverageAnalysis {
     [CmdletBinding()]
+    [OutputType("System.Object[]")]
     param (
         [object[]] $CodeCoverage,
         [ScriptBlock] $Logger,
@@ -87,7 +88,7 @@ function Exit-CoverageAnalysis {
     # to only get those that are not $null
     # (like if we did $breakpoints | where {$_ -ne $null})
     # so DON'T change this.
-    $breakpoints = @($CommandCoverage.Breakpoint) -ne $null
+    $breakpoints = null -ne @($CommandCoverage.Breakpoint)
     if ($breakpoints.Count -gt 0) {
         & $SafeCommands['Remove-PSBreakpoint'] -Breakpoint $breakpoints
     }
@@ -1141,7 +1142,7 @@ function Get-TracerHitLocation ($command) {
         "`n`nCommand: $c" | Write-Host
         $(for ($ast = $c; $null -ne $ast; $ast = $ast.Parent) {
                 $ast | select @{n = "type"; e = { $_.GetType().Name } } , @{n = "extent"; e = { $_.extent } }
-            } ) | ft type, extent | out-string | Write-Host
+            } ) | Format-Table type, extent | out-string | Write-Host
     }
 
     if ($env:PESTER_CC_DEBUG -eq 1) {

--- a/src/functions/Coverage.ps1
+++ b/src/functions/Coverage.ps1
@@ -88,7 +88,7 @@ function Exit-CoverageAnalysis {
     # to only get those that are not $null
     # (like if we did $breakpoints | where {$_ -ne $null})
     # so DON'T change this.
-    $breakpoints = null -ne @($CommandCoverage.Breakpoint)
+    $breakpoints = $null -ne @($CommandCoverage.Breakpoint)
     if ($breakpoints.Count -gt 0) {
         & $SafeCommands['Remove-PSBreakpoint'] -Breakpoint $breakpoints
     }

--- a/src/functions/Coverage.ps1
+++ b/src/functions/Coverage.ps1
@@ -1,6 +1,5 @@
 ﻿function Enter-CoverageAnalysis {
     [CmdletBinding()]
-    [OutputType("System.Object[]")]
     param (
         [object[]] $CodeCoverage,
         [ScriptBlock] $Logger,
@@ -105,7 +104,7 @@ function Exit-CoverageAnalysis {
     # to only get those that are not $null
     # (like if we did $breakpoints | where {$_ -ne $null})
     # so DON'T change this.
-    $breakpoints = $null -ne @($CommandCoverage.Breakpoint)
+    $breakpoints = @($CommandCoverage.Breakpoint) -ne $null
     if ($breakpoints.Count -gt 0) {
         & $SafeCommands['Remove-PSBreakpoint'] -Breakpoint $breakpoints
     }
@@ -1159,7 +1158,7 @@ function Get-TracerHitLocation ($command) {
         "`n`nCommand: $c" | Write-Host
         $(for ($ast = $c; $null -ne $ast; $ast = $ast.Parent) {
                 $ast | select @{n = "type"; e = { $_.GetType().Name } } , @{n = "extent"; e = { $_.extent } }
-            } ) | Format-Table type, extent | out-string | Write-Host
+            } ) | ft type, extent | out-string | Write-Host
     }
 
     if ($env:PESTER_CC_DEBUG -eq 1) {


### PR DESCRIPTION
<!-- Thank you for contributing to Pester! -->

## PR Summary

This introduces a new property to the csharp project CodeCoverageConfiguration.ExcludePaths.  It can be used for further implementation of configuration property in the Powershell code to exclude paths from Code Coverage results.  

Example feature for implementation would  be a script in the folder is picked up for coverage, however it is a Pester test harness script or other Powershell script not under test and not requiring coverage.

A couple minor updates for excluding Write-Host check from the scanner, spelling in the PSScriptAnalyzer custom check, fixing null check and alias scan warning.

## PR Checklist

- [ ] PR has meaningful title
- [ ] Summary describes changes
- [ ] PR is ready to be merged
  - If not, use the arrow next to `Create Pull Request` to mark it as a draft. PR can be marked `Ready for review` when it's ready.
- [ ] Tests are added/update *(if required)*
- [ ] Documentation is updated/added *(if required)*

<!-- Before you continue, please review [Contributing to Pester](https://pester.dev/docs/contributing/introduction).

Our continuous integration system doesn't send any notifications about failed tests. Please return to the opened pull request (after ~60 minutes) to check if everything is OK. -->
