### PR TITLE
making the language a bit more specific about the enabled flags

### DIFF
--- a/src/Pester.RSpec.ps1
+++ b/src/Pester.RSpec.ps1
@@ -332,7 +332,7 @@ function New-PesterConfiguration {
       Default value: @()
 
     CodeCoverage:
-      Enabled: Enable running of CodeCoverage.
+      Enabled: Enable CodeCoverage.
       Default value: $false
 
       OutputFormat: Format to use for code coverage report. Possible values: JaCoCo, CoverageGutters
@@ -363,13 +363,13 @@ function New-PesterConfiguration {
       Default value: $true
 
     TestResult:
-      Enabled: Enable export of test results to a file.
+      Enabled: Enable the exporting of TestResults to file specified in `OutputPath`.
       Default value: $false
 
-      OutputFormat: Format to use for test result report. Possible values: NUnitXml, NUnit2.5 or JUnitXml
+      OutputFormat: Format to use for test result report. Possible ves: NUnitXml, NUnit2.5 or JUnitXml
       Default value: 'NUnitXml'
 
-      OutputPath: Path relative to the current directory where test result report is saved. Enabled has to be set to true to have test results exported
+      OutputPath: Path relative to the current directory where test result report is saved.
       Default value: 'testResults.xml'
 
       OutputEncoding: Encoding of the output file.

--- a/src/Pester.RSpec.ps1
+++ b/src/Pester.RSpec.ps1
@@ -332,7 +332,7 @@ function New-PesterConfiguration {
       Default value: @()
 
     CodeCoverage:
-      Enabled: Enable CodeCoverage.
+      Enabled: Enable running of CodeCoverage.
       Default value: $false
 
       OutputFormat: Format to use for code coverage report. Possible values: JaCoCo, CoverageGutters
@@ -363,13 +363,13 @@ function New-PesterConfiguration {
       Default value: $true
 
     TestResult:
-      Enabled: Enable TestResult.
+      Enabled: Enable export of test results to a file.
       Default value: $false
 
       OutputFormat: Format to use for test result report. Possible values: NUnitXml, NUnit2.5 or JUnitXml
       Default value: 'NUnitXml'
 
-      OutputPath: Path relative to the current directory where test result report is saved.
+      OutputPath: Path relative to the current directory where test result report is saved. Enabled has to be set to true to have test results exported
       Default value: 'testResults.xml'
 
       OutputEncoding: Encoding of the output file.

--- a/src/Pester.RSpec.ps1
+++ b/src/Pester.RSpec.ps1
@@ -366,7 +366,7 @@ function New-PesterConfiguration {
       Enabled: Enable the exporting of TestResults to file specified in `OutputPath`.
       Default value: $false
 
-      OutputFormat: Format to use for test result report. Possible ves: NUnitXml, NUnit2.5 or JUnitXml
+      OutputFormat: Format to use for test result report. Possible values: NUnitXml, NUnit2.5 or JUnitXml
       Default value: 'NUnitXml'
 
       OutputPath: Path relative to the current directory where test result report is saved.

--- a/src/csharp/Pester/TestResultConfiguration.cs
+++ b/src/csharp/Pester/TestResultConfiguration.cs
@@ -36,8 +36,8 @@ namespace Pester
 
         public TestResultConfiguration() : base("TestResult configuration.")
         {
-            Enabled = new BoolOption("Enable TestResult.", false);
-            OutputFormat = new StringOption("Format to use for test result report. Possible values: NUnitXml, NUnit2.5 or JUnitXml", "NUnitXml");
+            Enabled = new BoolOption("Enable the exporting of TestResults to file specified in `OutputPath`.", false);
+            OutputFormat = new StringOption("Format to use for test result report. Possible ves: NUnitXml, NUnit2.5 or JUnitXml", "NUnitXml");
             OutputPath = new StringOption("Path relative to the current directory where test result report is saved.", "testResults.xml");
             OutputEncoding = new StringOption("Encoding of the output file.", "UTF8");
             TestSuiteName = new StringOption("Set the name assigned to the root 'test-suite' element.", "Pester");
@@ -82,6 +82,9 @@ namespace Pester
                 }
                 else
                 {
+                    EnableIfOriginalValue(_outputFormat);
+
+
                     _outputFormat = new StringOption(_outputFormat, value?.Value);
                 }
             }
@@ -98,6 +101,8 @@ namespace Pester
                 }
                 else
                 {
+                    EnableIfOriginalValue(_outputPath);
+
                     _outputPath = new StringOption(_outputPath, value?.Value);
                 }
             }
@@ -114,6 +119,9 @@ namespace Pester
                 }
                 else
                 {
+                    EnableIfOriginalValue(_outputEncoding);
+
+
                     _outputEncoding = new StringOption(_outputEncoding, value?.Value);
                 }
             }
@@ -130,9 +138,20 @@ namespace Pester
                 }
                 else
                 {
+                    EnableIfOriginalValue(_testSuiteName);
+
                     _testSuiteName = new StringOption(_testSuiteName, value?.Value);
                 }
             }
         }
+
+        public void EnableIfOriginalValue(Option optionBeingSet)
+        {
+            if(optionBeingSet.IsOriginalValue() && Enabled.IsOriginalValue())
+            {
+                Enabled = true;
+            }
+        }
+
     }
 }

--- a/src/csharp/Pester/TestResultConfiguration.cs
+++ b/src/csharp/Pester/TestResultConfiguration.cs
@@ -36,7 +36,7 @@ namespace Pester
 
         public TestResultConfiguration() : base("TestResult configuration.")
         {
-            Enabled = new BoolOption("Enable the exporting of TestResults to file specified in `OutputPath`.", false);
+            Enabled = new BoolOption("Enable the saving of TestResults to a file specified in `OutputPath`.", false);
             OutputFormat = new StringOption("Format to use for test result report. Possible values: NUnitXml, NUnit2.5 or JUnitXml", "NUnitXml");
             OutputPath = new StringOption("Path relative to the current directory where test result report is saved.", "testResults.xml");
             OutputEncoding = new StringOption("Encoding of the output file.", "UTF8");

--- a/src/csharp/Pester/TestResultConfiguration.cs
+++ b/src/csharp/Pester/TestResultConfiguration.cs
@@ -37,7 +37,7 @@ namespace Pester
         public TestResultConfiguration() : base("TestResult configuration.")
         {
             Enabled = new BoolOption("Enable the exporting of TestResults to file specified in `OutputPath`.", false);
-            OutputFormat = new StringOption("Format to use for test result report. Possible ves: NUnitXml, NUnit2.5 or JUnitXml", "NUnitXml");
+            OutputFormat = new StringOption("Format to use for test result report. Possible values: NUnitXml, NUnit2.5 or JUnitXml", "NUnitXml");
             OutputPath = new StringOption("Path relative to the current directory where test result report is saved.", "testResults.xml");
             OutputEncoding = new StringOption("Encoding of the output file.", "UTF8");
             TestSuiteName = new StringOption("Set the name assigned to the root 'test-suite' element.", "Pester");
@@ -147,7 +147,7 @@ namespace Pester
 
         public void EnableIfOriginalValue(Option optionBeingSet)
         {
-            if(optionBeingSet.IsOriginalValue() && Enabled.IsOriginalValue())
+            if (optionBeingSet.IsOriginalValue() && Enabled.IsOriginalValue())
             {
                 Enabled = true;
             }

--- a/src/csharp/PesterTests/UnitTest1.cs
+++ b/src/csharp/PesterTests/UnitTest1.cs
@@ -9,8 +9,11 @@ namespace PesterTests
         public void Test1()
         {
             var c = PesterConfiguration.Default;
-            c.Filter.FullName = null;
-            c.Run.Path = null;
+            c.TestResult.Enabled = false;
+            c.TestResult.OutputPath = "sfsfs";
+
+            Assert.False(c.TestResult.Enabled.Value);
+
         }
     }
 }

--- a/tst/Pester.RSpec.Configuration.ts.ps1
+++ b/tst/Pester.RSpec.Configuration.ts.ps1
@@ -268,6 +268,38 @@ i -PassThru:$PassThru {
             $config.Run.Path = $config.Run.Path.Default
             $config.Run.Path.IsOriginalValue() | Verify-False
         }
+
+        t "TestResult.Enabled is set if TestResult.OutputPath not originalValue even with the Default value" {
+            $config = [PesterConfiguration]::Default
+            $config.TestResult.Enabled.Value | Verify-False
+            $config.TestResult.OutputPath = $config.TestResult.OutputPath.Default
+            $config.TestResult.Enabled.Value | Verify-True
+        }
+        t "TestResult.Enabled is set if TestResult.OutputFormat not originalValue even with the Default value" {
+            $config = [PesterConfiguration]::Default
+            $config.TestResult.Enabled.Value | Verify-False
+            $config.TestResult.OutputFormat = $config.TestResult.OutputFormat.Default
+            $config.TestResult.Enabled.Value | Verify-True
+        }
+        t "TestResult.Enabled is set if TestResult.OutputEncoding not originalValue even with the Default value" {
+            $config = [PesterConfiguration]::Default
+            $config.TestResult.Enabled.Value | Verify-False
+            $config.TestResult.OutputEncoding = $config.TestResult.OutputEncoding.Default
+            $config.TestResult.Enabled.Value | Verify-True
+        }
+        t "TestResult.Enabled is set if TestResult.TestSuiteName not originalValue even with the Default value" {
+            $config = [PesterConfiguration]::Default
+            $config.TestResult.Enabled.Value | Verify-False
+            $config.TestResult.TestSuiteName = $config.TestResult.TestSuiteName.Default
+            $config.TestResult.Enabled.Value | Verify-True
+        }
+        t "TestResult.Enabled is not set if TestResult.TestSuiteName not originalValue but TestResult.Enabled has been changed" {
+            $config = [PesterConfiguration]::Default
+            $config.TestResult.Enabled.Value | Verify-False
+            $config.TestResult.Enabled = $false
+            $config.TestResult.TestSuiteName = $config.TestResult.TestSuiteName.Default
+            $config.TestResult.Enabled.Value | Verify-False
+        }
     }
 
     b "Cloning" {


### PR DESCRIPTION
## PR Summary
Makes the docs more explicit about the need to set the enabled flag.
#2036

If your pull request integrates Pester with another system, please tell us how the change can be tested. -->

## PR Checklist

- [x] PR has meaningful title
- [x] Summary describes changes
- [x] PR is ready to be merged
- [x] Tests are added/update *(if required)*
- [x] Documentation is updated/added *(if required)*

