### PR TITLE
Add more logging to BP CC and fix case sensitive new CC

### DIFF
--- a/src/Pester.Utility.ps1
+++ b/src/Pester.Utility.ps1
@@ -261,7 +261,7 @@ function Write-PesterDebugMessage {
     [CmdletBinding(DefaultParameterSetName = "Default")]
     param (
         [Parameter(Mandatory = $true, Position = 0)]
-        [ValidateSet("Filter", "Skip", "Runtime", "RuntimeCore", "Mock", "MockCore", "Discovery", "DiscoveryCore", "SessionState", "Timing", "TimingCore", "Plugin", "PluginCore", "CodeCoverage")]
+        [ValidateSet("Filter", "Skip", "Runtime", "RuntimeCore", "Mock", "MockCore", "Discovery", "DiscoveryCore", "SessionState", "Timing", "TimingCore", "Plugin", "PluginCore", "CodeCoverage", "CodeCoverageCore")]
         [String[]] $Scope,
         [Parameter(Mandatory = $true, Position = 1, ParameterSetName = "Default")]
         [String] $Message,
@@ -311,6 +311,7 @@ function Write-PesterDebugMessage {
             "PluginCore" { "Blue" }
             "Plugin" { "Blue" }
             "CodeCoverage" { "Yellow" }
+            "CodeCoverageCore" { "Yellow" }
             default { "Cyan" }
         }
     }

--- a/src/csharp/Pester/Factory.cs
+++ b/src/csharp/Pester/Factory.cs
@@ -22,7 +22,7 @@ namespace Pester
 
         public static Dictionary<string, object> CreateDictionary()
         {
-            return new Dictionary<string, object>();
+            return new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase);
         }
 
         public static RuntimeDefinedParameterDictionary CreateRuntimeDefinedParameterDictionary() {

--- a/src/csharp/Pester/Tracing/CodeCoverageTracer.cs
+++ b/src/csharp/Pester/Tracing/CodeCoverageTracer.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Management.Automation;
 using System.Management.Automation.Language;
 
@@ -24,7 +25,7 @@ namespace Pester.Tracing
                 var key = $"{point.Line}:{point.Column}";
                 if (!Hits.ContainsKey(point.Path))
                 {
-                    var lineColumn = new Dictionary<string, List<CodeCoveragePoint>> { [key] = new List<CodeCoveragePoint> { point } };
+                    var lineColumn = new Dictionary<string, List<CodeCoveragePoint>> (StringComparer.OrdinalIgnoreCase) { [key] = new List<CodeCoveragePoint> { point } };
                     Hits.Add(point.Path, lineColumn);
                     continue;
                 }
@@ -46,11 +47,11 @@ namespace Pester.Tracing
 
         // list of what Pester figures out from the AST that we care about for CC
         // keyed as path -> line:column -> CodeCoveragePoint
-        public Dictionary<string, Dictionary<string, List<CodeCoveragePoint>>> Hits { get; } = new Dictionary<string, Dictionary<string, List<CodeCoveragePoint>>>();
+        public Dictionary<string, Dictionary<string, List<CodeCoveragePoint>>> Hits { get; } = new Dictionary<string, Dictionary<string, List<CodeCoveragePoint>>>(StringComparer.OrdinalIgnoreCase);
 
         public void Trace(string message, IScriptExtent extent, ScriptBlock _, int __)
         {
-            if (_debug && (extent?.File?.Contains(_debugFile) ?? false))
+            if (_debug && extent?.File != null && CultureInfo.InvariantCulture.CompareInfo.IndexOf(extent.File, _debugFile, CompareOptions.OrdinalIgnoreCase) >= 0)
             {
                 var f = Console.ForegroundColor;
                 try

--- a/src/functions/Coverage.ps1
+++ b/src/functions/Coverage.ps1
@@ -37,16 +37,33 @@
         }
 
         $action = if ($UseSingleHitBreakpoints) {
-            # remove itself on hit
-            { & $SafeCommands['Remove-PSBreakpoint'] -Id $_.Id }
+            # remove itself on hit scriptblock
+            {
+
+                if ($PesterPreference.Debug.WriteDebugMessages.Value) {
+                    $bp = Get-PSBreakpoint -Id $_.Id
+                    & $SafeCommands["Write-PesterDebugMessage"] -Scope CodeCoverageCore -Message "Hit breakpoint $($bp.Id) on $($bp.Line):$($bp.Column) in $($bp.Script)."
+                }
+
+                & $SafeCommands['Remove-PSBreakpoint'] -Id $_.Id
+            }
         }
         else {
             if ($null -ne $logger) {
                 & $logger "Using normal breakpoints."
             }
 
-            # empty ScriptBlock
-            {}
+            if ($PesterPreference.Debug.WriteDebugMessages.Value) {
+                # scriptblock with logging
+                {
+                    $bp = Get-PSBreakpoint -Id $_.Id
+                    & $SafeCommands["Write-PesterDebugMessage"] -Scope CodeCoverageCore -Message "Hit breakpoint $($bp.Id) on $($bp.Line):$($bp.Column) in $($bp.Script)."
+                }
+            }
+            else {
+                # empty ScriptBlock
+                {}
+            }
         }
 
         foreach ($breakpoint in $breakpoints) {


### PR DESCRIPTION
Make tracer based CC case insensitive for file paths, because PowerShell will report the path the way it is given, including any casing differences when you invoke the script using . or &.

Fix #2041 