### PR TITLE
Fixes for various typos in Pester documentation and code

### DIFF
--- a/src/Main.ps1
+++ b/src/Main.ps1
@@ -672,7 +672,7 @@ function Invoke-Pester {
                 }
 
                 if ($PSBoundParameters.ContainsKey('ExcludeTagFilter')) {
-                    if ($null -ne $ExcludeTagFilter -and 0 -lt @($ExludeTagFilter).Count) {
+                    if ($null -ne $ExcludeTagFilter -and 0 -lt @($ExcludeTagFilter).Count) {
                         $Configuration.Filter.ExcludeTag = $ExcludeTagFilter
                     }
 
@@ -762,7 +762,7 @@ function Invoke-Pester {
                 }
 
                 if ($PSBoundParameters.ContainsKey('ExcludeTagFilter')) {
-                    if ($null -ne $ExcludeTagFilter -and 0 -lt @($ExludeTagFilter).Count) {
+                    if ($null -ne $ExcludeTagFilter -and 0 -lt @($ExcludeTagFilter).Count) {
                         $Configuration.Filter.ExcludeTag = $ExcludeTagFilter
                     }
 

--- a/src/Main.ps1
+++ b/src/Main.ps1
@@ -1214,10 +1214,10 @@ function Invoke-Pester {
             }
         }
 
-        # exit with exit code if we fail and even if we succeed, othwerise we could inherit
+        # exit with exit code if we fail and even if we succeed, otherwise we could inherit
         # exit code of some other app end exit with it's exit code instead with ours
         $failedCount = $run.FailedCount + $run.FailedBlocksCount + $run.FailedContainersCount
-        # alwaays set exit code. This both to:
+        # always set exit code. This both to:
         # - prevent previous commands failing with non-zero exit code from failing the run
         # - setting the exit code when there were some failed tests, blocks, or containers
         $global:LASTEXITCODE = $failedCount
@@ -1259,7 +1259,7 @@ function New-PesterOption {
     .PARAMETER Experimental
     Enables experimental features of Pester to be enabled.
     .PARAMETER ShowScopeHints
-    EXPERIMENTAL: Enables debugging output for debugging tranisition among scopes. (Experimental flag needs to be used to enable this.)
+    EXPERIMENTAL: Enables debugging output for debugging transitions among scopes. (Experimental flag needs to be used to enable this.)
 
     .INPUTS
     None
@@ -1476,7 +1476,7 @@ function ConvertTo-Pester4Result {
     versions of Pester. This function is provided as a way to convert the
     result-object into an object using the previous format. This can be
     useful as a temporary measure to easier migrate to Pester 5 without
-    having to redesign compelx CI/CD-pipelines.
+    having to redesign complex CI/CD-pipelines.
 
     .PARAMETER PesterResult
     Result object from a Pester 5-run. This can be retrieved using Invoke-Pester
@@ -1564,7 +1564,7 @@ function ConvertTo-Pester4Result {
         }
 
         # the counts here include failed blocks as tests, that's we don't use
-        # the normal properties on the reslt to count
+        # the normal properties on the result to count
 
         foreach ($r in $legacyResult.TestResult) {
             switch ($r.Result) {
@@ -1599,7 +1599,7 @@ function BeforeDiscovery {
     putting code directly inside of Describe / Context.
 
     .PARAMETER ScriptBlock
-    The ScritpBlock to run.
+    The ScriptBlock to run.
 
     .EXAMPLE
     ```powershell

--- a/src/Pester.RSpec.ps1
+++ b/src/Pester.RSpec.ps1
@@ -186,7 +186,7 @@ function PostProcess-RspecTestRun ($TestRun) {
             "NotRun"
         }
 
-        ## sumamrize
+        ## summarize
 
         # a block that has errors would write into failed blocks so we can report them
         # later we can filter this to only report errors from AfterAll
@@ -261,7 +261,7 @@ function Get-RSpecObjectDecoratorPlugin () {
         Add-RSpecTestObjectProperties $Context.Test
     } -EachBlockTeardownEnd {
         param($Context)
-        #TODO: also this is a plugin because it needs to run before the error processing kicks in (to be able to report correctly formatted errors on scrren in case teardown failure), this mixes concerns here imho, and needs to be revisited, because the error writing logic is now dependent on this plugin
+        #TODO: also this is a plugin because it needs to run before the error processing kicks in (to be able to report correctly formatted errors on screen in case teardown failure), this mixes concerns here imho, and needs to be revisited, because the error writing logic is now dependent on this plugin
         Add-RSpecBlockObjectProperties $Context.Block
     }
 }
@@ -322,7 +322,7 @@ function New-PesterConfiguration {
       ExcludeTag: Tags of Describe, Context or It to be excluded from the run.
       Default value: @()
 
-      Line: Filter by file and scriptblock start line, useful to run parsed tests programatically to avoid problems with expanded names. Example: 'C:\tests\file1.Tests.ps1:37'
+      Line: Filter by file and scriptblock start line, useful to run parsed tests programmatically to avoid problems with expanded names. Example: 'C:\tests\file1.Tests.ps1:37'
       Default value: @()
 
       ExcludeLine: Exclude by file and scriptblock start line, takes precedence over Line.
@@ -344,7 +344,7 @@ function New-PesterConfiguration {
       OutputEncoding: Encoding of the output file.
       Default value: 'UTF8'
 
-      Path: Directories or files to be used for codecoverage, by default the Path(s) from general settings are used, unless overridden here.
+      Path: Directories or files to be used for code coverage, by default the Path(s) from general settings are used, unless overridden here.
       Default value: @()
 
       ExcludeTests: Exclude tests from code coverage. This uses the TestFilter from general configuration.
@@ -615,7 +615,7 @@ function New-PesterContainer {
     .DESCRIPTION
     Pester 5 supports running tests files and scriptblocks using parameter-input.
     To use this feature, Invoke-Pester expects one or more ContainerInfo-objects
-    created using this funciton, that specify test containers in the form of paths
+    created using this function, that specify test containers in the form of paths
     to the test files or scriptblocks containing the tests directly.
 
     A optional Data-dictionary can be provided to supply the containers with any
@@ -656,8 +656,8 @@ function New-PesterContainer {
     Invoke-Pester -Container $container
     ```
 
-    This example runs Pester agianst a scriptblock. New-PesterContainer is used to genreated
-    the requried ContainerInfo-object that enables us to do this directly.
+    This example runs Pester against a scriptblock. New-PesterContainer is used to generate
+    the required ContainerInfo-object that enables us to do this directly.
 
     .LINK
     https://pester.dev/docs/commands/New-PesterContainer
@@ -679,7 +679,7 @@ function New-PesterContainer {
         [Collections.IDictionary[]] $Data
     )
 
-    # it seems that when I don't assign $Data to $dt here the foreach does not always work in 5.1 :/ some vooodo
+    # it seems that when I don't assign $Data to $dt here the foreach does not always work in 5.1 :/ some voodoo
     $dt = $Data
     # expand to ContainerInfo user can provide multiple sets of data, but ContainerInfo can hold only one
     # to keep the internal logic simple.

--- a/src/Pester.Utility.ps1
+++ b/src/Pester.Utility.ps1
@@ -272,7 +272,7 @@ function Write-PesterDebugMessage {
     )
 
     if (-not $PesterPreference.Debug.WriteDebugMessages.Value) {
-        throw "This should never happen. All calls to Write-PesterDebugMessage should be wrapped in `if` to avoid perfomace hit of allocating the message and calling the function. Inspect the call stack to know where this call came from. This can also happen if `$PesterPreference is different from the `$PesterPreference that utilities see because of incorrect scoping."
+        throw "This should never happen. All calls to Write-PesterDebugMessage should be wrapped in `if` to avoid the performance hit of allocating the message and calling the function. Inspect the call stack to know where this call came from. This can also happen if `$PesterPreference is different from the `$PesterPreference that utilities see because of incorrect scoping."
     }
 
     $messagePreference = $PesterPreference.Debug.WriteDebugMessagesFrom.Value

--- a/src/csharp/Pester/CodeCoverageConfiguration.cs
+++ b/src/csharp/Pester/CodeCoverageConfiguration.cs
@@ -45,7 +45,7 @@ namespace Pester
             OutputFormat = new StringOption("Format to use for code coverage report. Possible values: JaCoCo, CoverageGutters", "JaCoCo");
             OutputPath = new StringOption("Path relative to the current directory where code coverage report is saved.", "coverage.xml");
             OutputEncoding = new StringOption("Encoding of the output file.", "UTF8");
-            Path = new StringArrayOption("Directories or files to be used for codecoverage, by default the Path(s) from general settings are used, unless overridden here.", new string[0]);
+            Path = new StringArrayOption("Directories or files to be used for code coverage, by default the Path(s) from general settings are used, unless overridden here.", new string[0]);
             ExcludeTests = new BoolOption("Exclude tests from code coverage. This uses the TestFilter from general configuration.", true);
             RecursePaths = new BoolOption("Will recurse through directories in the Path option.", true);
             UseBreakpoints = new BoolOption("EXPERIMENTAL: When false, use Profiler based tracer to do CodeCoverage instead of using breakpoints.", true);

--- a/src/csharp/Pester/FilterConfiguration.cs
+++ b/src/csharp/Pester/FilterConfiguration.cs
@@ -48,7 +48,7 @@ namespace Pester
         {
             Tag = new StringArrayOption("Tags of Describe, Context or It to be run.", new string[0]);
             ExcludeTag = new StringArrayOption("Tags of Describe, Context or It to be excluded from the run.", new string[0]);
-            Line = new StringArrayOption(@"Filter by file and scriptblock start line, useful to run parsed tests programatically to avoid problems with expanded names. Example: 'C:\tests\file1.Tests.ps1:37'", new string[0]);
+            Line = new StringArrayOption(@"Filter by file and scriptblock start line, useful to run parsed tests programmatically to avoid problems with expanded names. Example: 'C:\tests\file1.Tests.ps1:37'", new string[0]);
             ExcludeLine = new StringArrayOption("Exclude by file and scriptblock start line, takes precedence over Line.", new string[0]);
             FullName = new StringArrayOption("Full name of test with -like wildcards, joined by dot. Example: '*.describe Get-Item.test1'", new string[0]);
         }

--- a/src/functions/InModuleScope.ps1
+++ b/src/functions/InModuleScope.ps1
@@ -84,7 +84,7 @@
             }
         }
 
-        It 'accessing whole testcase in module socpe' -TestCases @(
+        It 'accessing whole testcase in module scope' -TestCases @(
             @{ Name = 'Foo'; Bool = $true }
         ) {
             # Passes the whole testcase-dictionary available in $_ to InModuleScope

--- a/src/functions/New-MockObject.ps1
+++ b/src/functions/New-MockObject.ps1
@@ -12,7 +12,7 @@ An .NET assembly for the particular type must be available in the system and loa
 The .NET type to create. This creates the object without calling any of its constructors or initializers. Use this to instantiate an object that does not have a public constructor. If your object has a constructor, or is giving you errors, try using the constructor and provide the object using the InputObject parameter to decorate it.
 
 .PARAMETER InputObject
-And already constucted object to decorate. Use New-Object or ::new to create it.
+An already constructed object to decorate. Use New-Object or ::new to create it.
 
 .PARAMETER Properties
 Properties to define, specified as a hashtable, in format @{ PropertyName = value }.
@@ -20,7 +20,7 @@ Properties to define, specified as a hashtable, in format @{ PropertyName = valu
 .PARAMETER Methods
 Methods to define, specified as a hashtable, in format @{ MethodName = scriptBlock }.
 
-ScriptBlock can define param block, and it will recieve arguments that were provided to the function call based on order.
+ScriptBlock can define param block, and it will receive arguments that were provided to the function call based on order.
 
 Method overloads are not supported because ScriptMethods are used to decorate the object, and ScriptMethods do not support method overloads.
 

--- a/src/functions/Set-ItResult.ps1
+++ b/src/functions/Set-ItResult.ps1
@@ -23,7 +23,7 @@
     Sets the test result to skipped. Cannot be used at the same time as -Inconclusive or -Pending
 
     .PARAMETER Because
-    Similarily to failing tests, skipped and inconclusive tests should have reason. It allows
+    Similarly to failing tests, skipped and inconclusive tests should have reason. It allows
     to provide information to the user why the test is neither successful nor failed.
 
     .EXAMPLE

--- a/src/functions/SetupTeardown.ps1
+++ b/src/functions/SetupTeardown.ps1
@@ -143,7 +143,7 @@ function BeforeAll {
 
         BeforeAll and AfterAll are unique in that they apply to the entire container,
         Context or Describe block regardless of the order of the statements compared to
-        other Context or Describe blcoks at the same level.
+        other Context or Describe blocks at the same level.
 
     .PARAMETER ScriptBlock
         A scriptblock with steps to be executed during setup.
@@ -218,7 +218,7 @@ function AfterAll {
 
         BeforeAll and AfterAll are unique in that they apply to the entire container,
         Context or Describe block regardless of the order of the statements compared to
-        other Context or Describe blcoks at the same level.
+        other Context or Describe blocks at the same level.
 
     .PARAMETER ScriptBlock
         A scriptblock with steps to be executed during teardown.


### PR DESCRIPTION
<!-- Thank you for contributing to Pester! -->

## PR Summary
<!-- Please describe what your pull request fixes, or how it improves Pester.

If your pull request resolves a reported issue, please mention it by using `Fix #<issue_number>` on a new line, this will close the linked issue automatically when this PR is merged. For more info see: [Closing issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/).

If your pull request integrates Pester with another system, please tell us how the change can be tested. -->
This corrects several typos in Pester's documentation, along with some typos in the code comments.

There is a minor typo-related bug corrected by a commit in this PR too, although I do not think it is significant at all. Given how trivial it is, I did not include a test case for it.

## PR Checklist

- [x] PR has meaningful title
- [x] Summary describes changes
- [x] PR is ready to be merged
  - If not, use the arrow next to `Create Pull Request` to mark it as a draft. PR can be marked `Ready for review` when it's ready.
- [ ] Tests are added/update *(if required)*
- [ ] Documentation is updated/added *(if required)*

<!-- Before you continue, please review [Contributing to Pester](https://pester.dev/docs/contributing/introduction).

Our continuous integration system doesn't send any notifications about failed tests. Please return to the opened pull request (after ~60 minutes) to check if everything is OK. -->
