### PR TITLE
Fix mock object with 2 and more methods

### DIFF
--- a/src/functions/New-MockObject.ps1
+++ b/src/functions/New-MockObject.ps1
@@ -99,11 +99,11 @@ https://pester.dev/docs/usage/mocking
             $historyName = "$($MethodHistoryPrefix)$($method.Key)"
             $mockState = $mock.PSObject.Properties.Item("__mock")
             if (-not $mockState) {
-                $mockState = @{}
-                $mock.PSObject.Properties.Add([Pester.Factory]::CreateNoteProperty("__mock", $mockState))
+                $mockState = [Pester.Factory]::CreateNoteProperty("__mock", @{});
+                $mock.PSObject.Properties.Add($mockState)
             }
 
-            $mockState[$historyName] = @{
+            $mockState.Value[$historyName] = @{
                 Count  = 0
                 Method = $method.Value
             }

--- a/tst/functions/New-MockObject.Tests.ps1
+++ b/tst/functions/New-MockObject.Tests.ps1
@@ -51,6 +51,16 @@ Describe 'New-MockObject' {
             $mockObject._Kill[-1].Call | Should -Be 2
             $mockObject._Kill[-1].Arguments | Should -Be $true
         }
+
+        It "Adds 2 methods to the object" {
+            $mockObject = New-MockObject -Type 'Net.Sockets.TcpClient' -Methods @{
+                Connect = { param($Server, $Port)"connect" };
+                Close   = { param($Server, $Port)"close" }
+            }
+
+            $mockObject.Connect() | Should -Be "connect"
+            $mockObject.Close() | Should -Be "close"
+        }
     }
 
 


### PR DESCRIPTION
When creating the mock method table for the first time, @{} was assigned into $mockState but on second method NoteProperty would be in $mockState. This lead to only one method being possible to mock, the second mock would throw, because we are indexing into NoteProperty directly, instead of into .Value on NoteProperty.

Fix #2067 