### PR TITLE
Fix slow interactive execution

### DIFF
--- a/src/functions/Describe.ps1
+++ b/src/functions/Describe.ps1
@@ -146,7 +146,7 @@ function Invoke-Interactively ($CommandUsed, $ScriptName, $SessionState, $BoundP
         $invokePester = {
             param($private:Path, $private:ScriptParameters, $private:Out_Null)
             $private:c = New-PesterContainer -Path $Path -Data $ScriptParameters
-            Invoke-Pester -Container $c Path | & $Out_Null
+            Invoke-Pester -Container $c | & $Out_Null
         }
 
         # get PSBoundParameters from caller script to allow interactive execution of parameterized tests.


### PR DESCRIPTION
## PR Summary
Part of a variable name was left by accident in `Invoke-Interactively` when implementing support for parameters with interactive execution in #1787. This causes a slow recursive file search for "Path". 

Related https://github.com/pester/Pester/issues/2076#issuecomment-914688702

## PR Checklist

- [x] PR has meaningful title
- [x] Summary describes changes
- [x] PR is ready to be merged
  - If not, use the arrow next to `Create Pull Request` to mark it as a draft. PR can be marked `Ready for review` when it's ready.
- [ ] Tests are added/update *(if required)*
- [ ] Documentation is updated/added *(if required)*
