### PR TITLE
Fix Profiler code coverage in all loops

### DIFF
--- a/src/functions/Coverage.ps1
+++ b/src/functions/Coverage.ps1
@@ -1204,8 +1204,7 @@ function Get-TracerHitLocation ($command) {
         # we also must avoid selecting a parent that is too high, otherwise we might mark code that was not covered as covered.
         if ($parent -is [System.Management.Automation.Language.IfStatementAst] -or
             $parent -is [System.Management.Automation.Language.ScriptBlockAst] -or
-            $parent -is [System.Management.Automation.Language.ForStatementAst] -or
-            $parent -is [System.Management.Automation.Language.ForEachStatementAst] -or
+            $parent -is [System.Management.Automation.Language.LoopStatementAst] -or
             $parent -is [System.Management.Automation.Language.SwitchStatementAst] -or
             $parent -is [System.Management.Automation.Language.TryStatementAst] -or
             $parent -is [System.Management.Automation.Language.CatchClauseAst]) {

--- a/tst/CoverageTestFile.ps1
+++ b/tst/CoverageTestFile.ps1
@@ -114,6 +114,7 @@ finally {
     $aaa = $true
 }
 
+$findIf = $true
 while ($findIf) {
     [string]$PartialText = "AAA"
     $findIf = $false

--- a/tst/CoverageTestFile.ps1
+++ b/tst/CoverageTestFile.ps1
@@ -113,3 +113,8 @@ catch {
 finally {
     $aaa = $true
 }
+
+while ($findIf) {
+    [string]$PartialText = "AAA"
+    $findIf = $false
+}


### PR DESCRIPTION
## PR Summary
Fix profiler code coverage in all loops, by making Loop ast the exclusion, instead of naming out the loop types specifically.