### PR TITLE
fix ForEach casing in Context

### DIFF
--- a/src/functions/Context.ps1
+++ b/src/functions/Context.ps1
@@ -79,7 +79,7 @@ https://pester.dev/docs/usage/testdrive
         # [Switch] $Focus,
         [Switch] $Skip,
 
-        $Foreach
+        $ForEach
     )
 
     $Focus = $false


### PR DESCRIPTION
fixes vscode-powershell format issue

## PR Summary
Fix : #2110 

Fix 'ForEach' parameter casing on Context function. Wrong casing causes vscode-powershell formatter to flip between casings each time you format the PowerShell file


## PR Checklist

- [x] PR has meaningful title
- [x] Summary describes changes
- [x] PR is ready to be merged
  - If not, use the arrow next to `Create Pull Request` to mark it as a draft. PR can be marked `Ready for review` when it's ready.
- [ ] Tests are added/update *(if required)*
- [ ] Documentation is updated/added *(if required)*

<!-- Before you continue, please review [Contributing to Pester](https://pester.dev/docs/contributing/introduction).

Our continuous integration system doesn't send any notifications about failed tests. Please return to the opened pull request (after ~60 minutes) to check if everything is OK. -->
