### PR TITLE
Update devcontainer to NET 6.0 SDK and Powershell 7.2

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -3,8 +3,8 @@
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
 
-# See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.145.0/containers/dotnetcore/.devcontainer/base.Dockerfile
+# See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.209.5/containers/dotnet/.devcontainer/base.Dockerfile
 
-# [Choice] .NET Core version: 3.1, 2.1
-ARG VARIANT="3.1"
-FROM mcr.microsoft.com/vscode/devcontainers/dotnetcore:0-${VARIANT}
+# [Choice] .NET version: 6.0, 5.0, 3.1, 6.0-bullseye, 5.0-bullseye, 3.1-bullseye, 6.0-focal, 5.0-focal, 3.1-focal
+ARG VARIANT="6.0-focal"
+FROM mcr.microsoft.com/vscode/devcontainers/dotnet:0-${VARIANT}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,18 +1,17 @@
 // For format details, see https://aka.ms/vscode-remote/devcontainer.json or this file's README at:
-// https://github.com/microsoft/vscode-dev-containers/tree/v0.145.0/containers/dotnetcore
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.209.5/containers/dotnet
 {
-	"name": "Pester C# (.NET Core) w/ PowerShell",
+	"name": "Pester",
 	"build": {
 		"dockerfile": "Dockerfile",
 		"args": {
-			// Update 'VARIANT' to pick a .NET Core version: 2.1, 3.1
-			"VARIANT": "3.1"
+			// Update 'VARIANT' to pick a .NET Core version: 3.1, 5.0, 6.0
+			// Append -bullseye or -focal to pin to an OS version. Using focal (Ubuntu) for pwsh support
+			"VARIANT": "6.0-focal"
 		}
 	},
 	// Set *default* container specific settings.json values on container create.
-	"settings": {
-		"terminal.integrated.shell.linux": "/bin/bash"
-	},
+	"settings": {},
 	// Add the IDs of extensions you want installed when the container is created.
 	"extensions": [
 		"ms-vscode.powershell",


### PR DESCRIPTION
## PR Summary
Updating devcontainer to use latest LTS-versions for NET SDK (6.0) and PowerShell (7.2).
Using Ubuntu 20.04 (focal) to be fully supported for PowerShell and match Azure DevOps-images.

## PR Checklist

- [x] PR has meaningful title
- [x] Summary describes changes
- [x] PR is ready to be merged
  - If not, use the arrow next to `Create Pull Request` to mark it as a draft. PR can be marked `Ready for review` when it's ready.
- [ ] Tests are added/update *(if required)*
- [ ] Documentation is updated/added *(if required)*
