### PR TITLE
Fix duplicate key exception in Should-InvokeInternal debug logging

### DIFF
--- a/src/functions/Mock.ps1
+++ b/src/functions/Mock.ps1
@@ -396,8 +396,10 @@ function Should-InvokeInternal {
     if ($PesterPreference.Debug.WriteDebugMessages.Value) {
         $preExistingFilterVariables = @{}
         foreach ($v in $filter.Ast.FindAll( { $args[0] -is [System.Management.Automation.Language.VariableExpressionAst] }, $true)) {
-            if ($existingVar = $SessionState.PSVariable.Get($v.VariablePath.UserPath)) {
-                $preExistingFilterVariables.Add($v.VariablePath.UserPath, $existingVar.Value)
+            if (-not $preExistingFilterVariables.ContainsKey($v.VariablePath.UserPath)) {
+                if ($existingVar = $SessionState.PSVariable.Get($v.VariablePath.UserPath)) {
+                    $preExistingFilterVariables.Add($v.VariablePath.UserPath, $existingVar.Value)
+                }
             }
         }
 


### PR DESCRIPTION
## PR Summary
When `Debug.WriteDebugMessages` is enabled, providing a parameter filter to `Should -Invoke` referencing an existing variable multiple times will cause a dict key already exist exception. This PR adds a check to avoid adding the same conflicting variable twice.

Fix #2123 

## PR Checklist

- [x] PR has meaningful title
- [x] Summary describes changes
- [x] PR is ready to be merged
  - If not, use the arrow next to `Create Pull Request` to mark it as a draft. PR can be marked `Ready for review` when it's ready.
- [ ] Tests are added/update *(if required)*
- [ ] Documentation is updated/added *(if required)*