### PR TITLE
docs: Fix broken link to Planets example on ReadMe

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Save this code example in a file named `Get-Planet.Tests.ps1`, and run `Invoke-P
 
 Learn how to [start quick with Pester](https://pester.dev/docs/quick-start) in our docs.
 
-The example above also has an [annotated and production ready version here](Examples/Planets).
+The example above also has an [annotated and production ready version here](docs/Examples/Planets).
 
 ## Installation
 


### PR DESCRIPTION
<!-- Thank you for contributing to Pester! -->

## PR Summary
<!-- Please describe what your pull request fixes, or how it improves Pester.

If your pull request resolves a reported issue, please mention it by using `Fix #<issue_number>` on a new line, this will close the linked issue automatically when this PR is merged. For more info see: [Closing issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/).

If your pull request integrates Pester with another system, please tell us how the change can be tested. -->

This is a small PR to fix a broken link to the Planets Example on the ReadMe. It currently has a link to the old location before it was moved into the `docs` directory, and so it gives a 404 error when you navigate to it at https://github.com/pester/Pester/blob/main/Examples/Planets.

## PR Checklist

- [ x] PR has meaningful title
- [ x] Summary describes changes
- [ x] PR is ready to be merged
  - If not, use the arrow next to `Create Pull Request` to mark it as a draft. PR can be marked `Ready for review` when it's ready.
- [ x] Tests are added/update *(if required)*
- [ x] Documentation is updated/added *(if required)*

<!-- Before you continue, please review [Contributing to Pester](https://pester.dev/docs/contributing/introduction).

Our continuous integration system doesn't send any notifications about failed tests. Please return to the opened pull request (after ~60 minutes) to check if everything is OK. -->
