### PR TITLE
Adds default parameter set to New-MockObject

### DIFF
--- a/src/functions/New-MockObject.ps1
+++ b/src/functions/New-MockObject.ps1
@@ -63,7 +63,7 @@ https://pester.dev/docs/usage/mocking
 #>
     [CmdletBinding(DefaultParameterSetName = "Type")]
     param (
-        [Parameter(ParameterSetName = "Type", Mandatory)]
+        [Parameter(ParameterSetName = "Type", Mandatory, Position = 0)]
         [ValidateNotNullOrEmpty()]
         [type]$Type,
         [Parameter(ParameterSetName = "InputObject", Mandatory)]

--- a/src/functions/New-MockObject.ps1
+++ b/src/functions/New-MockObject.ps1
@@ -61,7 +61,7 @@ https://pester.dev/docs/commands/New-MockObject
 https://pester.dev/docs/usage/mocking
 
 #>
-
+    [CmdletBinding(DefaultParameterSetName = "Type")]
     param (
         [Parameter(ParameterSetName = "Type", Mandatory)]
         [ValidateNotNullOrEmpty()]

--- a/tst/functions/New-MockObject.Tests.ps1
+++ b/tst/functions/New-MockObject.Tests.ps1
@@ -30,6 +30,11 @@ Describe 'New-MockObject' {
         $mockObject.GetName() | Should -Be 'Jakub'
     }
 
+    It 'Default parameter set is Type for backwards compatibility' {
+        $type = 'Microsoft.PowerShell.Commands.Language'
+        { New-MockObject $type } | Should -Not -Throw
+    }
+
     Context 'Methods' {
         It "Adds a method to the object" {
             $o = New-Object -TypeName 'System.Diagnostics.Process'


### PR DESCRIPTION
## PR Summary

Fix #2158 

Adds `DefaultParameterSetName` value to `New-MockObject` for backwards compatibility for versions before `5.3.0`.

## PR Checklist

- [x] PR has meaningful title
- [x] Summary describes changes
- [x] PR is ready to be merged
- [x] Tests are added/update
- [ ] ~Documentation is updated/added~ *(not required)*
