### PR TITLE
Fix container failure output

### DIFF
--- a/src/functions/Output.ps1
+++ b/src/functions/Output.ps1
@@ -599,7 +599,7 @@ function Get-WriteScreenPlugin ($Verbosity) {
             }
             else {
                 & $SafeCommands["Write-Host"] -ForegroundColor $ReportTheme.Fail $errorHeader
-                Write-ErrorToScreen $formatErrorParams
+                Write-ErrorToScreen @formatErrorParams
             }
         }
 
@@ -840,9 +840,13 @@ function Format-CIErrorMessage {
         [Parameter(Mandatory)]
         [string] $Header,
 
-        [Parameter(Mandatory)]
+        # [Parameter(Mandatory)]
+        # Do not make this mandatory, just providing a string array is not enough for the
+        # mandatory check to pass, it also throws when any item in the array is empty or null.
         [string[]] $Message
     )
+
+    $Message = if ($null -eq $Message) { @() } else { $Message }
 
     $lines = [System.Collections.Generic.List[string]]@()
 
@@ -889,9 +893,13 @@ function Write-CIErrorToScreen {
         [Parameter(Mandatory)]
         [string] $Header,
 
-        [Parameter(Mandatory)]
+        # [Parameter(Mandatory)]
+        # Do not make this mandatory, just providing a string array is not enough,
+        # for the mandatory check to pass, it also throws when any item in the array is empty or null.
         [string[]] $Message
     )
+
+    $PSBoundParameters.Message = if ($null -eq $Message) { @() } else { $Message }
 
     $errorMessage = Format-CIErrorMessage @PSBoundParameters
 
@@ -944,7 +952,8 @@ function Format-ErrorMessage {
         if ($null -ne $Err.DisplayErrorMessage) {
             [void]$errorMessageSb.Append($Err.DisplayErrorMessage)
 
-            if ($null -ne $Err.DisplayStackTrace -and $StackTraceVerbosity -ne 'None') {
+            # Don't try to append the stack trace when we don't have it or when we don't want it
+            if ($null -ne $Err.DisplayStackTrace -and [string]::empty -ne $Err.DisplayStackTrace.Trim() -and $StackTraceVerbosity -ne 'None') {
                 $stackTraceLines = $Err.DisplayStackTrace -split [Environment]::NewLine
 
                 if ($StackTraceVerbosity -eq 'FirstLine') {


### PR DESCRIPTION
<!-- Thank you for contributing to Pester! -->

## PR Summary

When container fails, the parameters were not splatted correctly which ends up failing when there are more than 1 errors.

When we capture an error that has not stack trace, like when Import-Module is called directly in the body of test, for module that is missing, we would append new line to the resulting error. This will fail the mandatory parameter validation for Format CI message, and throw. 

I removed appending the new line, and relaxed the parameter rule, because I don't think writing the error should fail when it has a format that is little bit unexpected.

## PR Checklist

- [x] PR has meaningful title
- [x] Summary describes changes
- [x] PR is ready to be merged
  - If not, use the arrow next to `Create Pull Request` to mark it as a draft. PR can be marked `Ready for review` when it's ready.
- [ ] Tests are added/update *(if required)*
- [ ] Documentation is updated/added *(if required)*

<!-- Before you continue, please review [Contributing to Pester](https://pester.dev/docs/contributing/introduction).

Our continuous integration system doesn't send any notifications about failed tests. Please return to the opened pull request (after ~60 minutes) to check if everything is OK. -->
