### PR TITLE
Add Should-example for exception-assertion

### DIFF
--- a/src/functions/assertions/Should.ps1
+++ b/src/functions/assertions/Should.ps1
@@ -103,6 +103,15 @@ function Should {
 
     .EXAMPLE
     $planets.Name | Should -Be $Expected
+
+    .EXAMPLE
+    ```powershell
+    Context "We want to ensure an exception is thrown when expected" {
+        It "Throws the exception" {
+            { Get-Application -Name Blarg } | Should -Throw "Application 'Blarg' not found"
+        }
+    }
+    ```
 #>
 
     [CmdletBinding()]


### PR DESCRIPTION
## PR Summary
Adds Should-example for exception assertion made by @robhalevt to source.
Was added directly to docs-repo were it would be lost during the next build of command reference-docs.

Fix pester/docs#181

## PR Checklist

- [x] PR has meaningful title
- [x] Summary describes changes
- [x] PR is ready to be merged
  - If not, use the arrow next to `Create Pull Request` to mark it as a draft. PR can be marked `Ready for review` when it's ready.
- [ ] Tests are added/update *(if required)*
- [x] Documentation is updated/added *(if required)*