### PR TITLE
Update issue form templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -7,7 +7,7 @@ body:
     value: |
       Thank you for using Pester and taking the time to report this issue!
       Only Pester 4.10.x and 5.x.x are supported.
-      
+
       Pester 5 introduced breaking changes and some features were removed or are not yet migrated. See [Breaking changes in v5](https://pester.dev/docs/migrations/breaking-changes-in-v5)
 - type: checkboxes
   attributes:
@@ -53,7 +53,7 @@ body:
       (Invoke-WebRequest -Uri "https://git.io/JTinj" -UseBasicParsing).Content | Invoke-Expression
       ```
   validations:
-    required: true
+    required: false
 - type: textarea
   attributes:
     label: Possible Solution?

--- a/.github/ISSUE_TEMPLATE/commandhelp_issue.yml
+++ b/.github/ISSUE_TEMPLATE/commandhelp_issue.yml
@@ -6,7 +6,7 @@ body:
   attributes:
     value: |
       Thank you for using Pester and taking the time to report this issue!
-      
+
       Command Reference-documentation on the website are generated from comment-based help in the functions and should be reported here. All other documentation issues on https://pester.dev should be reported in the [docs-repo](https://github.com/pester/docs).
 - type: checkboxes
   attributes:
@@ -23,7 +23,6 @@ body:
     options:
       - Pester (latest)
       - Web (https://pester.dev)
-      - Both
       - Other
   validations:
     required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -3,6 +3,6 @@ contact_links:
   - name: Need help?
     url: https://pester.dev/docs/contributing/introduction#where-to-get-support
     about: Join our online communities to get help with "How to do _____ with Pester?" questions.
-  - name: Documentation issue beyond Command Reference?
-    url: https://github.com/pester/docs/issues/new
-    about: Please report non-command documentation issue for https://pester.dev in the docs repo
+  - name: Documentation issues or requests beyond Command Reference?
+    url: https://github.com/pester/docs/issues/new/choose
+    about: Please report non-command documentation issues and request for https://pester.dev in the docs repo

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -7,7 +7,7 @@ body:
     value: |
       Thank you for using Pester!
       Good ideas are always welcome and there's no commitment to implement it yourself, but feel free to contribute after an initial discussion.
-      
+
       Remember to try out the latest version of Pester - maybe your request is already available. See [README](https://github.com/pester/Pester) and [Releases](https://github.com/pester/Pester/releases) for the latest updates and newest features.
 - type: checkboxes
   attributes:


### PR DESCRIPTION
## PR Summary
Minor updates to issue forms added in #2176.
- Link to docs repo for issue now point to template chooser
- Describe environment field made optional in bug report per comment in #2176 
- Removed "both" option in command help form

## PR Checklist

- [x] PR has meaningful title
- [x] Summary describes changes
- [x] PR is ready to be merged
  - If not, use the arrow next to `Create Pull Request` to mark it as a draft. PR can be marked `Ready for review` when it's ready.
- [ ] Tests are added/update *(if required)*
- [ ] Documentation is updated/added *(if required)*