### PR TITLE
Exclude docs and support files from triggering CI

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,9 +1,39 @@
 trigger:
-  - main
-  - rel/*
+  branches:
+    include:
+      - main
+      - rel/*
+  paths:
+    exclude:
+      - .devcontainer
+      - .github
+      - .vscode
+      - docs
+      - images
+      - BACKERS.md
+      - CODE_OF_CONDUCT.md
+      - CONTRIBUTING.md
+      - README.md
+      - SECURITY.md
+      - SUPPORT.md
 pr:
-  - main
-  - rel/*
+  branches:
+    include:
+      - main
+      - rel/*
+  paths:
+    exclude:
+      - .devcontainer
+      - .github
+      - .vscode
+      - docs
+      - images
+      - BACKERS.md
+      - CODE_OF_CONDUCT.md
+      - CONTRIBUTING.md
+      - README.md
+      - SECURITY.md
+      - SUPPORT.md
 
 variables:
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1


### PR DESCRIPTION
## PR Summary
Add path exclusions for docs and supportfiles in azure pipeline to avoid unnecessary CI runs. 

## PR Checklist

- [x] PR has meaningful title
- [x] Summary describes changes
- [x] PR is ready to be merged
  - If not, use the arrow next to `Create Pull Request` to mark it as a draft. PR can be marked `Ready for review` when it's ready.
- [ ] Tests are added/update *(if required)*
- [ ] Documentation is updated/added *(if required)*