### PR TITLE
Always return to original CWD after running Pester

### DIFF
--- a/src/Main.ps1
+++ b/src/Main.ps1
@@ -1,4 +1,4 @@
-﻿function Assert-ValidAssertionName {
+function Assert-ValidAssertionName {
     param([string]$Name)
     if ($Name -notmatch '^\S+$') {
         throw "Assertion name '$name' is invalid, assertion name must be a single word."
@@ -633,6 +633,9 @@ function Invoke-Pester {
         $script:mockTable = @{}
         # todo: move mock cleanup to BeforeAllBlockContainer when there is any
         Remove-MockFunctionsAndAliases -SessionState $PSCmdlet.SessionState
+
+        # store CWD so we can revert any changes at the end
+        & $SafeCommands['Push-Location'] -StackName 'Pester'
     }
 
     end {
@@ -1213,6 +1216,9 @@ function Invoke-Pester {
                 exit -1
             }
         }
+
+        # go back to original CWD
+        & $SafeCommands['Pop-Location'] -StackName 'Pester'
 
         # exit with exit code if we fail and even if we succeed, otherwise we could inherit
         # exit code of some other app end exit with it's exit code instead with ours

--- a/tst/Pester.RSpec.ts.ps1
+++ b/tst/Pester.RSpec.ts.ps1
@@ -1,4 +1,4 @@
-﻿param ([switch] $PassThru)
+param ([switch] $PassThru)
 
 Get-Module Pester.Runtime, Pester.Utility, P, Pester, Axiom, Stack | Remove-Module
 
@@ -2425,6 +2425,25 @@ i -PassThru:$PassThru {
             $r.Containers[1].Blocks[0].Tests[0].Passed | Verify-True
             $r.Containers[1].Blocks[0].Tests[0].ErrorRecord.FullyQualifiedErrorID | Verify-Equal 'PesterTestSkipped'
             $r.Containers[1].Blocks[0].Tests[0].ErrorRecord.TargetObject.Message | Verify-Equal "Skipped due to previous failure at 'a.b' and Run.SkipRemainingOnFailure set to 'Run'"
+        }
+    }
+
+    b 'Changes to CWD are reverted on exit' {
+        t 'when executed normally' {
+            $beforePWD = $pwd.Path
+
+            $sb = {
+                Describe 'd' {
+                    It 'i' {
+                        Set-Location '../'
+                        1 | Should -Be 1
+                    }
+                }
+            }
+
+            $container = New-PesterContainer -ScriptBlock $sb
+            Invoke-Pester -Container $container -Output None
+            $pwd.Path | Verify-Equal $beforePWD
         }
     }
 }


### PR DESCRIPTION
Returns to the original PWD/CWD at end of `Invoke-Pester` in case test code has changed it.

Fix #2076

## PR Checklist

- [x] PR has meaningful title
- [x] Summary describes changes
- [x] PR is ready to be merged
  - If not, use the arrow next to `Create Pull Request` to mark it as a draft. PR can be marked `Ready for review` when it's ready.
- [x] Tests are added/update *(if required)*
- [ ] Documentation is updated/added *(if required)*