### PR TITLE
fix mocking for enum-param with validaterange

### DIFF
--- a/tst/functions/Mock.Tests.ps1
+++ b/tst/functions/Mock.Tests.ps1
@@ -2751,6 +2751,30 @@ Describe 'RemoveParameterValidation' {
     }
 }
 
+Describe 'Mocking function with enum parameters and ValidateRange-attributes' {
+    # https://github.com/pester/Pester/issues/1496
+    # Bug in PowerShell. ProxyCommand-generation breaks ValidateRange-attributes for enum-parameters
+
+    BeforeAll {
+        function Test-EnumValidation {
+            param(
+                [ValidateSet([Microsoft.PowerShell.ExecutionPolicy]::Unrestricted, [Microsoft.PowerShell.ExecutionPolicy]::Undefined)]
+                [Microsoft.PowerShell.ExecutionPolicy]$MyParam1,
+
+                [Parameter(ParameterSetName = 'SomeSet')]
+                [ValidateRange([Microsoft.PowerShell.ExecutionPolicy]::Unrestricted, [Microsoft.PowerShell.ExecutionPolicy]::Undefined)]
+                [Microsoft.PowerShell.ExecutionPolicy]$MyParam2
+            )
+        }
+
+        Mock -CommandName 'Test-EnumValidation' -MockWith { 'mock' }
+    }
+
+    It 'Should execute the mocked command successfully' {
+        Test-EnumValidation | Should -Be 'mock'
+    }
+}
+
 Describe "Running Mock with ModuleName in test scope" {
     BeforeAll {
         Get-Module "test" -ErrorAction SilentlyContinue | Remove-Module


### PR DESCRIPTION
## PR Summary
Mocking a command with enum-type parameter with `[ValidateRange()]` attribute currently fails `"Cannot find an overload for ".ctor" and the argument count: "0"."` due to a bug in the ProxyCommand-generator in PowerShell. This PR parses the generated param-block to detect and fix the broken validation.

Fix #1496

## PR Checklist

- [x] PR has meaningful title
- [x] Summary describes changes
- [ ] PR is ready to be merged
  - If not, use the arrow next to `Create Pull Request` to mark it as a draft. PR can be marked `Ready for review` when it's ready.
- [x] Tests are added/update *(if required)*
- [ ] Documentation is updated/added *(if required)*