### PR TITLE
Don't run Get-CimInstance on Nanoserver

### DIFF
--- a/src/functions/Pester.SafeCommands.ps1
+++ b/src/functions/Pester.SafeCommands.ps1
@@ -82,9 +82,9 @@ $script:SafeCommands = @{
 # It shouldn't be fatal if neither of those cmdlets exists, however
 # some NanoServer/PS images contain a non-functioning version of Get-CimInstance
 # so don't even try it if we're on one of those images.
-
 $NanoServerRegistryKey = 'HKLM:\Software\Microsoft\Windows NT\CurrentVersion\Server\ServerLevels'
-$NanoServer = (Get-ItemPropertyValue  $NanoServerRegistryKey -Name NanoServer -ErrorAction Ignore) -eq 1
+$NanoServerRegistryKeyValue = (Get-ItemPropertyValue $NanoServerRegistryKey -Name NanoServer -ErrorAction Ignore)
+$NanoServer = $NanoServerRegistryKeyValue -eq 1
 
 if (-not $NanoServer -and ($cim = & $Get_Command -Name Get-CimInstance -Module CimCmdlets -CommandType Cmdlet -ErrorAction Ignore)) {
     $script:SafeCommands['Get-CimInstance'] = $cim

--- a/src/functions/Pester.SafeCommands.ps1
+++ b/src/functions/Pester.SafeCommands.ps1
@@ -84,7 +84,7 @@ $script:SafeCommands = @{
 # so don't even try it if we're on one of those images.
 $NanoServerRegistryKey = & $SafeCommands['Get-ItemProperty'] -Path 'HKLM:\Software\Microsoft\Windows NT\CurrentVersion\Server\ServerLevels' -ErrorAction Ignore
 $NanoServerRegistryKeyValue = $NanoServerRegistryKey | & $SafeCommands['ForEach-Object'] -MemberName NanoServer -ErrorAction Ignore
-$NanoServer = $NanoServerRegistryKeyValue -eq 1
+$NanoServer = 1 -eq $NanoServerRegistryKeyValue
 
 if (-not $NanoServer -and ($cim = & $Get_Command -Name Get-CimInstance -Module CimCmdlets -CommandType Cmdlet -ErrorAction Ignore)) {
     $script:SafeCommands['Get-CimInstance'] = $cim

--- a/src/functions/Pester.SafeCommands.ps1
+++ b/src/functions/Pester.SafeCommands.ps1
@@ -83,7 +83,7 @@ $script:SafeCommands = @{
 # some NanoServer/PS images contain a non-functioning version of Get-CimInstance
 # so don't even try it if we're on one of those images.
 $NanoServerRegistryKey = & $SafeCommands['Get-ItemProperty'] -Path 'HKLM:\Software\Microsoft\Windows NT\CurrentVersion\Server\ServerLevels' -ErrorAction Ignore
-$NanoServerRegistryKeyValue = $NanoServerRegistryKey | & $SafeCommands['ForEach-Object'] -MemberName NanoServer
+$NanoServerRegistryKeyValue = $NanoServerRegistryKey | & $SafeCommands['ForEach-Object'] -MemberName NanoServer -ErrorAction Ignore
 $NanoServer = $NanoServerRegistryKeyValue -eq 1
 
 if (-not $NanoServer -and ($cim = & $Get_Command -Name Get-CimInstance -Module CimCmdlets -CommandType Cmdlet -ErrorAction Ignore)) {

--- a/src/functions/Pester.SafeCommands.ps1
+++ b/src/functions/Pester.SafeCommands.ps1
@@ -82,8 +82,8 @@ $script:SafeCommands = @{
 # It shouldn't be fatal if neither of those cmdlets exists, however
 # some NanoServer/PS images contain a non-functioning version of Get-CimInstance
 # so don't even try it if we're on one of those images.
-$NanoServerRegistryKey = 'HKLM:\Software\Microsoft\Windows NT\CurrentVersion\Server\ServerLevels'
-$NanoServerRegistryKeyValue = (Get-ItemPropertyValue $NanoServerRegistryKey -Name NanoServer -ErrorAction Ignore)
+$NanoServerRegistryKey = & $SafeCommands['Get-ItemProperty'] -Path 'HKLM:\Software\Microsoft\Windows NT\CurrentVersion\Server\ServerLevels' -ErrorAction Ignore
+$NanoServerRegistryKeyValue = $NanoServerRegistryKey | & $SafeCommands['ForEach-Object'] -MemberName NanoServer
 $NanoServer = $NanoServerRegistryKeyValue -eq 1
 
 if (-not $NanoServer -and ($cim = & $Get_Command -Name Get-CimInstance -Module CimCmdlets -CommandType Cmdlet -ErrorAction Ignore)) {


### PR DESCRIPTION
## PR Summary
Fix #2181

Pester will try to run `Get-CimInstance` when `Invoke-Pester` is run with `-OutputFile`. This fails on Nanoserver images with `Microsoft.Management.Infrastructure.CimException: FAILED`. This PR essentially removes `Get-CimInstance` from the list of `SafeCommands` if a Nanoserver installation is detected.


## PR Checklist
- [x] PR has meaningful title
- [x] Summary describes changes
- [x] PR is ready to be merged
  - If not, use the arrow next to `Create Pull Request` to mark it as a draft. PR can be marked `Ready for review` when it's ready.
- [ ] Tests are added/update *(if required)*
- [ ] Documentation is updated/added *(if required)*