### PR TITLE
Updates to comment help and examples

### DIFF
--- a/src/Main.ps1
+++ b/src/Main.ps1
@@ -14,37 +14,32 @@ function Assert-ValidAssertionAlias {
 
 function Add-ShouldOperator {
     <#
-.SYNOPSIS
+    .SYNOPSIS
     Register a Should Operator with Pester
-.DESCRIPTION
+    .DESCRIPTION
     This function allows you to create custom Should assertions.
-.PARAMETER Name
+    .PARAMETER Name
     The name of the assertion. This will become a Named Parameter of Should.
-.PARAMETER Test
+    .PARAMETER Test
     The test function. The function must return a PSObject with a [Bool]succeeded and a [string]failureMessage property.
-.PARAMETER Alias
+    .PARAMETER Alias
     A list of aliases for the Named Parameter.
-.PARAMETER SupportsArrayInput
+    .PARAMETER SupportsArrayInput
     Does the test function support the passing an array of values to test.
-.PARAMETER InternalName
+    .PARAMETER InternalName
     If -Name is different from the actual function name, record the actual function name here.
     Used by Get-ShouldOperator to pull function help.
-.EXAMPLE
+    .EXAMPLE
     ```powershell
-    function BeAwesome($ActualValue, [switch] $Negate)
-    {
-
+    function BeAwesome($ActualValue, [switch] $Negate) {
         [bool] $succeeded = $ActualValue -eq 'Awesome'
         if ($Negate) { $succeeded = -not $succeeded }
 
-        if (-not $succeeded)
-        {
-            if ($Negate)
-            {
+        if (-not $succeeded) {
+            if ($Negate) {
                 $failureMessage = "{$ActualValue} is Awesome"
             }
-            else
-            {
+            else {
                 $failureMessage = "{$ActualValue} is not Awesome"
             }
         }
@@ -55,16 +50,18 @@ function Add-ShouldOperator {
         }
     }
 
-    Add-ShouldOperator -Name  BeAwesome `
-                        -Test  $function:BeAwesome `
-                        -Alias 'BA'
+    Add-ShouldOperator -Name BeAwesome `
+        -Test $function:BeAwesome `
+        -Alias 'BA'
 
-    PS C:\> "bad" | should -BeAwesome
+    PS C:\> "bad" | Should -BeAwesome
     {bad} is not Awesome
     ```
-.LINK
+
+    Example of how to create a simple custom assertion that checks if the input string is 'Awesome'
+    .LINK
     https://pester.dev/docs/commands/Add-ShouldOperator
-#>
+    #>
     [CmdletBinding()]
     param (
         [Parameter(Mandatory = $true)]
@@ -1279,7 +1276,6 @@ function New-PesterOption {
     .LINK
     Invoke-Pester
     #>
-
     [CmdletBinding()]
     param (
         [switch] $IncludeVSCodeMarker,

--- a/src/Pester.RSpec.ps1
+++ b/src/Pester.RSpec.ps1
@@ -463,8 +463,6 @@ function New-PesterConfiguration {
 
     .LINK
     https://pester.dev/docs/commands/Invoke-Pester
-
-
     #>
     [CmdletBinding()]
     param(

--- a/src/functions/Context.ps1
+++ b/src/functions/Context.ps1
@@ -1,70 +1,73 @@
 ﻿function Context {
     <#
-.SYNOPSIS
-Provides logical grouping of It blocks within a single Describe block.
+    .SYNOPSIS
+    Provides logical grouping of It blocks within a single Describe block.
 
-.DESCRIPTION
-Provides logical grouping of It blocks within a single Describe block.
-Any Mocks defined inside a Context are removed at the end of the Context scope,
-as are any files or folders added to the TestDrive during the Context block's
-execution. Any BeforeEach or AfterEach blocks defined inside a Context also only
-apply to tests within that Context .
+    .DESCRIPTION
+    Provides logical grouping of It blocks within a single Describe block.
+    Any Mocks defined inside a Context are removed at the end of the Context scope,
+    as are any files or folders added to the TestDrive during the Context block's
+    execution. Any BeforeEach or AfterEach blocks defined inside a Context also only
+    apply to tests within that Context .
 
-.PARAMETER Name
-The name of the Context. This is a phrase describing a set of tests within a describe.
+    .PARAMETER Name
+    The name of the Context. This is a phrase describing a set of tests within a describe.
 
-.PARAMETER Tag
-Optional parameter containing an array of strings. When calling Invoke-Pester,
-it is possible to specify a -Tag parameter which will only execute Context blocks
-containing the same Tag.
+    .PARAMETER Tag
+    Optional parameter containing an array of strings. When calling Invoke-Pester,
+    it is possible to specify a -Tag parameter which will only execute Context blocks
+    containing the same Tag.
 
-.PARAMETER Fixture
-Script that is executed. This may include setup specific to the context
-and one or more It blocks that validate the expected outcomes.
+    .PARAMETER Fixture
+    Script that is executed. This may include setup specific to the context
+    and one or more It blocks that validate the expected outcomes.
 
-.PARAMETER ForEach
-Allows data driven tests to be written.
-Takes an array of data and generates one block for each item in the array, and makes the item
-available as $_ in all child blocks. When the array is an array of hashtables, it additionally
-defines each key in the hashatble as variable.
+    .PARAMETER ForEach
+    Allows data driven tests to be written.
+    Takes an array of data and generates one block for each item in the array, and makes the item
+    available as $_ in all child blocks. When the array is an array of hashtables, it additionally
+    defines each key in the hashatble as variable.
 
-.EXAMPLE
-```powershell
-function Add-Numbers($a, $b) {
-    return $a + $b
-}
-
-Describe "Add-Numbers" {
-    Context "when root does not exist" {
-        It "..." {
-            # ...
+    .EXAMPLE
+    ```powershell
+    BeforeAll {
+        function Add-Numbers($a, $b) {
+            return $a + $b
         }
     }
 
-    Context "when root does exist" {
-        It "..." {
-            # ...
+    Describe 'Add-Numbers' {
+        Context 'when adding positive values' {
+            It '...' {
+                # ...
+            }
         }
-        It "..." {
-            # ...
+
+        Context 'when adding negative values' {
+            It '...' {
+                # ...
+            }
+            It '...' {
+                # ...
+            }
         }
     }
-}
-```
+    ```
 
-.LINK
-https://pester.dev/docs/commands/Context
+    Example of how to use Context for grouping different tests
 
-.LINK
-https://pester.dev/docs/usage/test-file-structure
+    .LINK
+    https://pester.dev/docs/commands/Context
 
-.LINK
-https://pester.dev/docs/usage/mocking
+    .LINK
+    https://pester.dev/docs/usage/test-file-structure
 
-.LINK
-https://pester.dev/docs/usage/testdrive
+    .LINK
+    https://pester.dev/docs/usage/mocking
 
-#>
+    .LINK
+    https://pester.dev/docs/usage/testdrive
+    #>
     param(
         [Parameter(Mandatory = $true, Position = 0)]
         [string] $Name,

--- a/src/functions/Describe.ps1
+++ b/src/functions/Describe.ps1
@@ -1,76 +1,80 @@
 ﻿function Describe {
     <#
-.SYNOPSIS
-Creates a logical group of tests.
+    .SYNOPSIS
+    Creates a logical group of tests.
 
-.DESCRIPTION
-Creates a logical group of tests. All Mocks, TestDrive and TestRegistry contents
-defined within a Describe block are scoped to that Describe; they
-will no longer be present when the Describe block exits.  A Describe
-block may contain any number of Context and It blocks.
+    .DESCRIPTION
+    Creates a logical group of tests. All Mocks, TestDrive and TestRegistry contents
+    defined within a Describe block are scoped to that Describe; they
+    will no longer be present when the Describe block exits.  A Describe
+    block may contain any number of Context and It blocks.
 
-.PARAMETER Name
-The name of the test group. This is often an expressive phrase describing
-the scenario being tested.
+    .PARAMETER Name
+    The name of the test group. This is often an expressive phrase describing
+    the scenario being tested.
 
-.PARAMETER Fixture
-The actual test script. If you are following the AAA pattern (Arrange-Act-Assert),
-this typically holds the arrange and act sections. The Asserts will also lie
-in this block but are typically nested each in its own It block. Assertions are
-typically performed by the Should command within the It blocks.
+    .PARAMETER Fixture
+    The actual test script. If you are following the AAA pattern (Arrange-Act-Assert),
+    this typically holds the arrange and act sections. The Asserts will also lie
+    in this block but are typically nested each in its own It block. Assertions are
+    typically performed by the Should command within the It blocks.
 
-.PARAMETER Tag
-Optional parameter containing an array of strings. When calling Invoke-Pester,
-it is possible to specify a -Tag parameter which will only execute Describe blocks
-containing the same Tag.
+    .PARAMETER Tag
+    Optional parameter containing an array of strings. When calling Invoke-Pester,
+    it is possible to specify a -Tag parameter which will only execute Describe blocks
+    containing the same Tag.
 
-.PARAMETER ForEach
-Allows data driven tests to be written.
-Takes an array of data and generates one block for each item in the array, and makes the item
-available as $_ in all child blocks. When the array is an array of hashtables, it additionally
-defines each key in the hashatble as variable.
+    .PARAMETER ForEach
+    Allows data driven tests to be written.
+    Takes an array of data and generates one block for each item in the array, and makes the item
+    available as $_ in all child blocks. When the array is an array of hashtables, it additionally
+    defines each key in the hashatble as variable.
 
-.EXAMPLE
-```powershell
-function Add-Numbers($a, $b) {
-    return $a + $b
-}
-
-Describe "Add-Numbers" {
-    It "adds positive numbers" {
-        $sum = Add-Numbers 2 3
-        $sum | Should -Be 5
+    .EXAMPLE
+    ```powershell
+    BeforeAll {
+        function Add-Numbers($a, $b) {
+            return $a + $b
+        }
     }
 
-    It "adds negative numbers" {
-        $sum = Add-Numbers (-2) (-2)
-        $sum | Should -Be (-4)
+    Describe "Add-Numbers" {
+        It "adds positive numbers" {
+            $sum = Add-Numbers 2 3
+            $sum | Should -Be 5
+        }
+
+        It "adds negative numbers" {
+            $sum = Add-Numbers (-2) (-2)
+            $sum | Should -Be (-4)
+        }
+
+        It "adds one negative number to positive number" {
+            $sum = Add-Numbers (-2) 2
+            $sum | Should -Be 0
+        }
+
+        It "concatenates strings if given strings" {
+            $sum = Add-Numbers two three
+            $sum | Should -Be "twothree"
+        }
     }
+    ```
 
-    It "adds one negative number to positive number" {
-        $sum = Add-Numbers (-2) 2
-        $sum | Should -Be 0
-    }
+    Using Describe to group tests logically at the root of the script/container
 
-    It "concatenates strings if given strings" {
-        $sum = Add-Numbers two three
-        $sum | Should -Be "twothree"
-    }
-}
-```
+    .LINK
+    https://pester.dev/docs/commands/Describe
 
-.LINK
-https://pester.dev/docs/commands/Describe
+    .LINK
+    https://pester.dev/docs/usage/test-file-structure
 
-.LINK
-https://pester.dev/docs/usage/test-file-structure
+    .LINK
+    https://pester.dev/docs/usage/mocking
 
-.LINK
-https://pester.dev/docs/usage/mocking
-
-.LINK
-https://pester.dev/docs/usage/testdrive
-#>
+    .LINK
+    https://pester.dev/docs/usage/testdrive
+    #>
 
     param(
         [Parameter(Mandatory = $true, Position = 0)]

--- a/src/functions/Get-ShouldOperator.ps1
+++ b/src/functions/Get-ShouldOperator.ps1
@@ -32,7 +32,6 @@
 
     .LINK
     https://pester.dev/docs/commands/Should
-
     #>
     [CmdletBinding()]
     param ()

--- a/src/functions/In.ps1
+++ b/src/functions/In.ps1
@@ -12,12 +12,11 @@
     .PARAMETER Path
     The path that the execute block will be executed in.
 
-    .PARAMETER execute
+    .PARAMETER ScriptBlock
     The script to be executed in the path provided.
 
     .LINK
     https://github.com/pester/Pester/wiki/In
-
     #>
     [CmdletBinding(DefaultParameterSetName = "Default")]
     param(

--- a/src/functions/InModuleScope.ps1
+++ b/src/functions/InModuleScope.ps1
@@ -1,37 +1,36 @@
 ﻿function InModuleScope {
     <#
-.SYNOPSIS
-   Allows you to execute parts of a test script within the
-   scope of a PowerShell script module.
-.DESCRIPTION
-   By injecting some test code into the scope of a PowerShell
-   script module, you can use non-exported functions, aliases
-   and variables inside that module, to perform unit tests on
-   its internal implementation.
+    .SYNOPSIS
+    Allows you to execute parts of a test script within the
+    scope of a PowerShell script module.
+    .DESCRIPTION
+    By injecting some test code into the scope of a PowerShell
+    script module, you can use non-exported functions, aliases
+    and variables inside that module, to perform unit tests on
+    its internal implementation.
 
-   InModuleScope may be used anywhere inside a Pester script,
-   either inside or outside a Describe block.
-.PARAMETER ModuleName
-   The name of the module into which the test code should be
-   injected. This module must already be loaded into the current
-   PowerShell session.
-.PARAMETER ScriptBlock
-   The code to be executed within the script module.
-.PARAMETER Parameters
-   A optional hashtable of parameters to be passed to the scriptblock.
-   Parameters are automatically made available as variables in the scriptblock.
-.PARAMETER ArgumentList
-   A optional list of arguments to be passed to the scriptblock.
-.EXAMPLE
+    InModuleScope may be used anywhere inside a Pester script,
+    either inside or outside a Describe block.
+    .PARAMETER ModuleName
+    The name of the module into which the test code should be
+    injected. This module must already be loaded into the current
+    PowerShell session.
+    .PARAMETER ScriptBlock
+    The code to be executed within the script module.
+    .PARAMETER Parameters
+    A optional hashtable of parameters to be passed to the scriptblock.
+    Parameters are automatically made available as variables in the scriptblock.
+    .PARAMETER ArgumentList
+    A optional list of arguments to be passed to the scriptblock.
+
+    .EXAMPLE
     ```powershell
     # The script module:
-    function PublicFunction
-    {
+    function PublicFunction {
         # Does something
     }
 
-    function PrivateFunction
-    {
+    function PrivateFunction {
         return $true
     }
 
@@ -55,16 +54,14 @@
     "PublicFunction".  Using InModuleScope allowed this call to
     "PrivateFunction" to work successfully.
 
-.EXAMPLE
+    .EXAMPLE
     ```powershell
     # The script module:
-    function PublicFunction
-    {
+    function PublicFunction {
         # Does something
     }
 
-    function PrivateFunction ($MyParam)
-    {
+    function PrivateFunction ($MyParam) {
         return $MyParam
     }
 
@@ -101,10 +98,9 @@
     No variables from the outside are available inside the scriptblock without explicitly passing
     them in using `-Parameters` or `-ArgumentList`.
 
-.LINK
+    .LINK
     https://pester.dev/docs/commands/InModuleScope
-#>
-
+    #>
     [CmdletBinding()]
     param (
         [Parameter(Mandatory = $true)]

--- a/src/functions/It.ps1
+++ b/src/functions/It.ps1
@@ -1,119 +1,125 @@
 ﻿function It {
     <#
-.SYNOPSIS
-Validates the results of a test inside of a Describe block.
+    .SYNOPSIS
+    Validates the results of a test inside of a Describe block.
 
-.DESCRIPTION
-The It command is intended to be used inside of a Describe or Context Block.
-If you are familiar with the AAA pattern (Arrange-Act-Assert), the body of
-the It block is the appropriate location for an assert. The convention is to
-assert a single expectation for each It block. The code inside of the It block
-should throw a terminating error if the expectation of the test is not met and
-thus cause the test to fail. The name of the It block should expressively state
-the expectation of the test.
+    .DESCRIPTION
+    The It command is intended to be used inside of a Describe or Context Block.
+    If you are familiar with the AAA pattern (Arrange-Act-Assert), the body of
+    the It block is the appropriate location for an assert. The convention is to
+    assert a single expectation for each It block. The code inside of the It block
+    should throw a terminating error if the expectation of the test is not met and
+    thus cause the test to fail. The name of the It block should expressively state
+    the expectation of the test.
 
-In addition to using your own logic to test expectations and throw exceptions,
-you may also use Pester's Should command to perform assertions in plain language.
+    In addition to using your own logic to test expectations and throw exceptions,
+    you may also use Pester's Should command to perform assertions in plain language.
 
-You can intentionally mark It block result as inconclusive by using Set-TestInconclusive
-command as the first tested statement in the It block.
+    You can intentionally mark It block result as inconclusive by using Set-TestInconclusive
+    command as the first tested statement in the It block.
 
-.PARAMETER Name
-An expressive phrase describing the expected test outcome.
+    .PARAMETER Name
+    An expressive phrase describing the expected test outcome.
 
-.PARAMETER Test
-The script block that should throw an exception if the
-expectation of the test is not met.If you are following the
-AAA pattern (Arrange-Act-Assert), this typically holds the
-Assert.
+    .PARAMETER Test
+    The script block that should throw an exception if the
+    expectation of the test is not met.If you are following the
+    AAA pattern (Arrange-Act-Assert), this typically holds the
+    Assert.
 
-.PARAMETER Pending
-Use this parameter to explicitly mark the test as work-in-progress/not implemented/pending when you
-need to distinguish a test that fails because it is not finished yet from a tests
-that fail as a result of changes being made in the code base. An empty test, that is a
-test that contains nothing except whitespace or comments is marked as Pending by default.
+    .PARAMETER Pending
+    Use this parameter to explicitly mark the test as work-in-progress/not implemented/pending when you
+    need to distinguish a test that fails because it is not finished yet from a tests
+    that fail as a result of changes being made in the code base. An empty test, that is a
+    test that contains nothing except whitespace or comments is marked as Pending by default.
 
-.PARAMETER Skip
-Use this parameter to explicitly mark the test to be skipped. This is preferable to temporarily
-commenting out a test, because the test remains listed in the output. Use the Strict parameter
-of Invoke-Pester to force all skipped tests to fail.
+    .PARAMETER Skip
+    Use this parameter to explicitly mark the test to be skipped. This is preferable to temporarily
+    commenting out a test, because the test remains listed in the output. Use the Strict parameter
+    of Invoke-Pester to force all skipped tests to fail.
 
-.PARAMETER TestCases
-Optional array of hashtable (or any IDictionary) objects.  If this parameter is used,
-Pester will call the test script block once for each table in the TestCases array,
-splatting the dictionary to the test script block as input.  If you want the name of
-the test to appear differently for each test case, you can embed tokens into the Name
-parameter with the syntax 'Adds numbers <A> and <B>' (assuming you have keys named A and B
-in your TestCases hashtables.)
+    .PARAMETER TestCases
+    Optional array of hashtable (or any IDictionary) objects.  If this parameter is used,
+    Pester will call the test script block once for each table in the TestCases array,
+    splatting the dictionary to the test script block as input.  If you want the name of
+    the test to appear differently for each test case, you can embed tokens into the Name
+    parameter with the syntax 'Adds numbers <A> and <B>' (assuming you have keys named A and B
+    in your TestCases hashtables.)
 
-.PARAMETER Tag
-Optional parameter containing an array of strings. When calling Invoke-Pester,
-it is possible to include or exclude tests containing the same Tag.
+    .PARAMETER Tag
+    Optional parameter containing an array of strings. When calling Invoke-Pester,
+    it is possible to include or exclude tests containing the same Tag.
 
-.EXAMPLE
-```powershell
-function Add-Numbers($a, $b) {
-    return $a + $b
-}
-
-Describe "Add-Numbers" {
-    It "adds positive numbers" {
-        $sum = Add-Numbers 2 3
-        $sum | Should -Be 5
+    .EXAMPLE
+    ```powershell
+    BeforeAll {
+        function Add-Numbers($a, $b) {
+            return $a + $b
+        }
     }
 
-    It "adds negative numbers" {
-        $sum = Add-Numbers (-2) (-2)
-        $sum | Should -Be (-4)
+    Describe "Add-Numbers" {
+        It "adds positive numbers" {
+            $sum = Add-Numbers 2 3
+            $sum | Should -Be 5
+        }
+
+        It "adds negative numbers" {
+            $sum = Add-Numbers (-2) (-2)
+            $sum | Should -Be (-4)
+        }
+
+        It "adds one negative number to positive number" {
+            $sum = Add-Numbers (-2) 2
+            $sum | Should -Be 0
+        }
+
+        It "concatenates strings if given strings" {
+            $sum = Add-Numbers two three
+            $sum | Should -Be "twothree"
+        }
+    }
+    ```
+
+    Example of a simple Pester file. It-blocks are used to define the different tests.
+
+    .EXAMPLE
+    ```powershell
+    function Add-Numbers($a, $b) {
+        return $a + $b
     }
 
-    It "adds one negative number to positive number" {
-        $sum = Add-Numbers (-2) 2
-        $sum | Should -Be 0
+    Describe "Add-Numbers" {
+        $testCases = @(
+            @{ a = 2;     b = 3;       expectedResult = 5 }
+            @{ a = -2;    b = -2;      expectedResult = -4 }
+            @{ a = -2;    b = 2;       expectedResult = 0 }
+            @{ a = 'two'; b = 'three'; expectedResult = 'twothree' }
+        )
+
+        It 'Correctly adds <a> and <b> to get <expectedResult>' -TestCases $testCases {
+            $sum = Add-Numbers $a $b
+            $sum | Should -Be $expectedResult
+        }
     }
+    ```
 
-    It "concatenates strings if given strings" {
-        $sum = Add-Numbers two three
-        $sum | Should -Be "twothree"
-    }
-}
-```
+    Using It with -TestCases to run the same tests with different parameters and expected results.
+    Each hashtable in the `$testCases`-array generates one tests to a total of four. Each key-value pair in the
+    current hashtable are made available as variables inside It.
 
-.EXAMPLE
-```powershell
-function Add-Numbers($a, $b) {
-    return $a + $b
-}
+    .LINK
+    https://pester.dev/docs/commands/It
 
-Describe "Add-Numbers" {
-    $testCases = @(
-        @{ a = 2;     b = 3;       expectedResult = 5 }
-        @{ a = -2;    b = -2;      expectedResult = -4 }
-        @{ a = -2;    b = 2;       expectedResult = 0 }
-        @{ a = 'two'; b = 'three'; expectedResult = 'twothree' }
-    )
+    .LINK
+    https://pester.dev/docs/commands/Describe
 
-    It 'Correctly adds <a> and <b> to get <expectedResult>' -TestCases $testCases {
-        param ($a, $b, $expectedResult)
+    .LINK
+    https://pester.dev/docs/commands/Context
 
-        $sum = Add-Numbers $a $b
-        $sum | Should -Be $expectedResult
-    }
-}
-```
-
-.LINK
-https://pester.dev/docs/commands/It
-
-.LINK
-https://pester.dev/docs/commands/Describe
-
-.LINK
-https://pester.dev/docs/commands/Context
-
-.LINK
-https://pester.dev/docs/commands/Set-ItResult
-#>
+    .LINK
+    https://pester.dev/docs/commands/Set-ItResult
+    #>
     [CmdletBinding(DefaultParameterSetName = 'Normal')]
     param(
         [Parameter(Mandatory = $true, Position = 0)]

--- a/src/functions/New-MockObject.ps1
+++ b/src/functions/New-MockObject.ps1
@@ -1,69 +1,75 @@
 ﻿function New-MockObject {
     <#
-.SYNOPSIS
-This function instantiates a .NET object from a type.
+    .SYNOPSIS
+    This function instantiates a .NET object from a type.
 
-.DESCRIPTION
-Using the New-MockObject you can mock an object based on .NET type.
+    .DESCRIPTION
+    Using the New-MockObject you can mock an object based on .NET type.
 
-An .NET assembly for the particular type must be available in the system and loaded.
+    An .NET assembly for the particular type must be available in the system and loaded.
 
-.PARAMETER Type
-The .NET type to create. This creates the object without calling any of its constructors or initializers. Use this to instantiate an object that does not have a public constructor. If your object has a constructor, or is giving you errors, try using the constructor and provide the object using the InputObject parameter to decorate it.
+    .PARAMETER Type
+    The .NET type to create. This creates the object without calling any of its constructors or initializers. Use this to instantiate an object that does not have a public constructor. If your object has a constructor, or is giving you errors, try using the constructor and provide the object using the InputObject parameter to decorate it.
 
-.PARAMETER InputObject
-An already constructed object to decorate. Use New-Object or ::new to create it.
+    .PARAMETER InputObject
+    An already constructed object to decorate. Use New-Object or ::new to create it.
 
-.PARAMETER Properties
-Properties to define, specified as a hashtable, in format @{ PropertyName = value }.
+    .PARAMETER Properties
+    Properties to define, specified as a hashtable, in format @{ PropertyName = value }.
 
-.PARAMETER Methods
-Methods to define, specified as a hashtable, in format @{ MethodName = scriptBlock }.
+    .PARAMETER Methods
+    Methods to define, specified as a hashtable, in format @{ MethodName = scriptBlock }.
 
-ScriptBlock can define param block, and it will receive arguments that were provided to the function call based on order.
+    ScriptBlock can define param block, and it will receive arguments that were provided to the function call based on order.
 
-Method overloads are not supported because ScriptMethods are used to decorate the object, and ScriptMethods do not support method overloads.
+    Method overloads are not supported because ScriptMethods are used to decorate the object, and ScriptMethods do not support method overloads.
 
-For each method a property named _MethodName is defined which holds history of the invocations of the method and the arguments that were provided.
+    For each method a property named _MethodName (if using default -MethodHistoryPrefix) is defined which holds history of the invocations of the method and the arguments that were provided.
 
-.PARAMETER MethodHistoryPrefix
-Prefix for the history-property created for each mocked method. Default is '_' which would create the property ' _MethodName'.
+    .PARAMETER MethodHistoryPrefix
+    Prefix for the history-property created for each mocked method. Default is '_' which would create the property ' _MethodName'.
 
-.EXAMPLE
-```powershell
-$obj = New-MockObject -Type 'System.Diagnostics.Process'
-$obj.GetType().FullName
-    System.Diagnostics.Process
-```
+    .EXAMPLE
+    ```powershell
+    $obj = New-MockObject -Type 'System.Diagnostics.Process'
+    $obj.GetType().FullName
+        System.Diagnostics.Process
+    ```
 
-.EXAMPLE
-```powershell
-$obj = New-MockObject -Type 'System.Diagnostics.Process' -Properties @{ Id = 123 }
-```
+    Creates a mock of a process-object with default property-values.
 
-.EXAMPLE
-```powershell
-$obj = New-MockObject -Type 'System.Diagnostics.Process' -Methods @{ Kill = { param($entireProcessTree) "killed" } }
-$obj.Kill()
-$obj.Kill($true)
-$obj.Kill($false)
+    .EXAMPLE
+    ```powershell
+    $obj = New-MockObject -Type 'System.Diagnostics.Process' -Properties @{ Id = 123 }
+    ```
 
-$obj._Kill
+    Create a mock of a process-object with the Id-property specified.
 
-Call Arguments
----- ---------
-   1 {}
-   2 {True}
-   3 {False}
-```
+    .EXAMPLE
+    ```powershell
+    $obj = New-MockObject -Type 'System.Diagnostics.Process' -Methods @{ Kill = { param($entireProcessTree) "killed" } }
+    $obj.Kill()
+    $obj.Kill($true)
+    $obj.Kill($false)
 
-.LINK
-https://pester.dev/docs/commands/New-MockObject
+    $obj._Kill
 
-.LINK
-https://pester.dev/docs/usage/mocking
+    Call Arguments
+    ---- ---------
+    1 {}
+    2 {True}
+    3 {False}
+    ```
 
-#>
+    Create a mock of a process-object and mocks the object's Kill()-method. The mocked method will keep a history
+    of any call and the associated arguments in a key named <_<MethodName
+
+    .LINK
+    https://pester.dev/docs/commands/New-MockObject
+
+    .LINK
+    https://pester.dev/docs/usage/mocking
+    #>
     [CmdletBinding(DefaultParameterSetName = "Type")]
     param (
         [Parameter(ParameterSetName = "Type", Mandatory, Position = 0)]

--- a/src/functions/Pester.SessionState.Mock.ps1
+++ b/src/functions/Pester.SessionState.Mock.ps1
@@ -1,4 +1,4 @@
-﻿# session state bound functions that act as endpoints,
+# session state bound functions that act as endpoints,
 # so the internal funtions can make their session state
 # consumption explicit and are testable (also prevents scrolling past
 # the whole documentation :D )
@@ -50,178 +50,175 @@ function Get-MockPlugin () {
 
 function Mock {
     <#
-.SYNOPSIS
-Mocks the behavior of an existing command with an alternate
-implementation.
+    .SYNOPSIS
+    Mocks the behavior of an existing command with an alternate
+    implementation.
 
-.DESCRIPTION
-This creates new behavior for any existing command within the scope of a
-Describe or Context block. The function allows you to specify a script block
-that will become the command's new behavior.
+    .DESCRIPTION
+    This creates new behavior for any existing command within the scope of a
+    Describe or Context block. The function allows you to specify a script block
+    that will become the command's new behavior.
 
-Optionally, you may create a Parameter Filter which will examine the
-parameters passed to the mocked command and will invoke the mocked
-behavior only if the values of the parameter values pass the filter. If
-they do not, the original command implementation will be invoked instead
-of a mock.
+    Optionally, you may create a Parameter Filter which will examine the
+    parameters passed to the mocked command and will invoke the mocked
+    behavior only if the values of the parameter values pass the filter. If
+    they do not, the original command implementation will be invoked instead
+    of a mock.
 
-You may create multiple mocks for the same command, each using a different
-ParameterFilter. ParameterFilters will be evaluated in reverse order of
-their creation. The last one created will be the first to be evaluated.
-The mock of the first filter to pass will be used. The exception to this
-rule are Mocks with no filters. They will always be evaluated last since
-they will act as a "catch all" mock.
+    You may create multiple mocks for the same command, each using a different
+    ParameterFilter. ParameterFilters will be evaluated in reverse order of
+    their creation. The last one created will be the first to be evaluated.
+    The mock of the first filter to pass will be used. The exception to this
+    rule are Mocks with no filters. They will always be evaluated last since
+    they will act as a "catch all" mock.
 
-Mocks can be marked Verifiable. If so, the Should -InvokeVerifiable command
-can be used to check if all Verifiable mocks were actually called. If any
-verifiable mock is not called, Should -InvokeVerifiable will throw an
-exception and indicate all mocks not called.
+    Mocks can be marked Verifiable. If so, the Should -InvokeVerifiable command
+    can be used to check if all Verifiable mocks were actually called. If any
+    verifiable mock is not called, Should -InvokeVerifiable will throw an
+    exception and indicate all mocks not called.
 
-If you wish to mock commands that are called from inside a script module,
-you can do so by using the -ModuleName parameter to the Mock command. This
-injects the mock into the specified module. If you do not specify a
-module name, the mock will be created in the same scope as the test script.
-You may mock the same command multiple times, in different scopes, as needed.
-Each module's mock maintains a separate call history and verified status.
+    If you wish to mock commands that are called from inside a script module,
+    you can do so by using the -ModuleName parameter to the Mock command. This
+    injects the mock into the specified module. If you do not specify a
+    module name, the mock will be created in the same scope as the test script.
+    You may mock the same command multiple times, in different scopes, as needed.
+    Each module's mock maintains a separate call history and verified status.
 
-.PARAMETER CommandName
-The name of the command to be mocked.
+    .PARAMETER CommandName
+    The name of the command to be mocked.
 
-.PARAMETER MockWith
-A ScriptBlock specifying the behavior that will be used to mock CommandName.
-The default is an empty ScriptBlock.
-NOTE: Do not specify param or dynamicparam blocks in this script block.
-These will be injected automatically based on the signature of the command
-being mocked, and the MockWith script block can contain references to the
-mocked commands parameter variables.
+    .PARAMETER MockWith
+    A ScriptBlock specifying the behavior that will be used to mock CommandName.
+    The default is an empty ScriptBlock.
+    NOTE: Do not specify param or dynamicparam blocks in this script block.
+    These will be injected automatically based on the signature of the command
+    being mocked, and the MockWith script block can contain references to the
+    mocked commands parameter variables.
 
-.PARAMETER Verifiable
-When this is set, the mock will be checked when Should -InvokeVerifiable is
-called.
+    .PARAMETER Verifiable
+    When this is set, the mock will be checked when Should -InvokeVerifiable is
+    called.
 
-.PARAMETER ParameterFilter
-An optional filter to limit mocking behavior only to usages of
-CommandName where the values of the parameters passed to the command
-pass the filter.
+    .PARAMETER ParameterFilter
+    An optional filter to limit mocking behavior only to usages of
+    CommandName where the values of the parameters passed to the command
+    pass the filter.
 
-This ScriptBlock must return a boolean value. See examples for usage.
+    This ScriptBlock must return a boolean value. See examples for usage.
 
-.PARAMETER ModuleName
-Optional string specifying the name of the module where this command
-is to be mocked.  This should be a module that _calls_ the mocked
-command; it doesn't necessarily have to be the same module which
-originally implemented the command.
+    .PARAMETER ModuleName
+    Optional string specifying the name of the module where this command
+    is to be mocked.  This should be a module that _calls_ the mocked
+    command; it doesn't necessarily have to be the same module which
+    originally implemented the command.
 
-.PARAMETER RemoveParameterType
-Optional list of parameter names that should use Object as the parameter
-type instead of the parameter type defined by the function. This relaxes the
-type requirements and allows some strongly typed functions to be mocked
-more easily.
+    .PARAMETER RemoveParameterType
+    Optional list of parameter names that should use Object as the parameter
+    type instead of the parameter type defined by the function. This relaxes the
+    type requirements and allows some strongly typed functions to be mocked
+    more easily.
 
-.PARAMETER RemoveParameterValidation
-Optional list of parameter names in the original command
-that should not have any validation rules applied. This relaxes the
-validation requirements, and allows functions that are strict about their
-parameter validation to be mocked more easily.
+    .PARAMETER RemoveParameterValidation
+    Optional list of parameter names in the original command
+    that should not have any validation rules applied. This relaxes the
+    validation requirements, and allows functions that are strict about their
+    parameter validation to be mocked more easily.
 
-.EXAMPLE
-Mock Get-ChildItem { return @{FullName = "A_File.TXT"} }
+    .EXAMPLE
+    Mock Get-ChildItem { return @{FullName = "A_File.TXT"} }
 
-Using this Mock, all calls to Get-ChildItem will return a hashtable with a FullName property returning "A_File.TXT"
+    Using this Mock, all calls to Get-ChildItem will return a hashtable with a FullName property returning "A_File.TXT"
 
-.EXAMPLE
-Mock Get-ChildItem { return @{FullName = "A_File.TXT"} } -ParameterFilter { $Path -and $Path.StartsWith($env:temp) }
+    .EXAMPLE
+    Mock Get-ChildItem { return @{FullName = "A_File.TXT"} } -ParameterFilter { $Path -and $Path.StartsWith($env:temp) }
 
-This Mock will only be applied to Get-ChildItem calls within the user's temp directory.
+    This Mock will only be applied to Get-ChildItem calls within the user's temp directory.
 
-.EXAMPLE
-Mock Set-Content {} -Verifiable -ParameterFilter { $Path -eq "some_path" -and $Value -eq "Expected Value" }
+    .EXAMPLE
+    Mock Set-Content {} -Verifiable -ParameterFilter { $Path -eq "some_path" -and $Value -eq "Expected Value" }
 
-When this mock is used, if the Mock is never invoked and Should -InvokeVerifiable is called, an exception will be thrown. The command behavior will do nothing since the ScriptBlock is empty.
+    When this mock is used, if the Mock is never invoked and Should -InvokeVerifiable is called, an exception will be thrown. The command behavior will do nothing since the ScriptBlock is empty.
 
-.EXAMPLE
-```powershell
-Mock Get-ChildItem { return @{FullName = "A_File.TXT"} } -ParameterFilter { $Path -and $Path.StartsWith($env:temp\1) }
-Mock Get-ChildItem { return @{FullName = "B_File.TXT"} } -ParameterFilter { $Path -and $Path.StartsWith($env:temp\2) }
-Mock Get-ChildItem { return @{FullName = "C_File.TXT"} } -ParameterFilter { $Path -and $Path.StartsWith($env:temp\3) }
-```
+    .EXAMPLE
+    ```powershell
+    Mock Get-ChildItem { return @{FullName = "A_File.TXT"} } -ParameterFilter { $Path -and $Path.StartsWith($env:temp\1) }
+    Mock Get-ChildItem { return @{FullName = "B_File.TXT"} } -ParameterFilter { $Path -and $Path.StartsWith($env:temp\2) }
+    Mock Get-ChildItem { return @{FullName = "C_File.TXT"} } -ParameterFilter { $Path -and $Path.StartsWith($env:temp\3) }
+    ```
 
-Multiple mocks of the same command may be used. The parameter filter determines which is invoked. Here, if Get-ChildItem is called on the "2" directory of the temp folder, then B_File.txt will be returned.
+    Multiple mocks of the same command may be used. The parameter filter determines which is invoked. Here, if Get-ChildItem is called on the "2" directory of the temp folder, then B_File.txt will be returned.
 
-.EXAMPLE
-```powershell
-Mock Get-ChildItem { return @{FullName="B_File.TXT"} } -ParameterFilter { $Path -eq "$env:temp\me" }
-Mock Get-ChildItem { return @{FullName="A_File.TXT"} } -ParameterFilter { $Path -and $Path.StartsWith($env:temp) }
+    .EXAMPLE
+    ```powershell
+    Mock Get-ChildItem { return @{FullName="B_File.TXT"} } -ParameterFilter { $Path -eq "$env:temp\me" }
+    Mock Get-ChildItem { return @{FullName="A_File.TXT"} } -ParameterFilter { $Path -and $Path.StartsWith($env:temp) }
 
-Get-ChildItem $env:temp\me
-```
+    Get-ChildItem $env:temp\me
+    ```
 
-Here, both mocks could apply since both filters will pass. A_File.TXT will be returned because it was the most recent Mock created.
+    Here, both mocks could apply since both filters will pass. A_File.TXT will be returned because it was the most recent Mock created.
 
-.EXAMPLE
-```powershell
-Mock Get-ChildItem { return @{FullName = "B_File.TXT"} } -ParameterFilter { $Path -eq "$env:temp\me" }
-Mock Get-ChildItem { return @{FullName = "A_File.TXT"} }
+    .EXAMPLE
+    ```powershell
+    Mock Get-ChildItem { return @{FullName = "B_File.TXT"} } -ParameterFilter { $Path -eq "$env:temp\me" }
+    Mock Get-ChildItem { return @{FullName = "A_File.TXT"} }
 
-Get-ChildItem c:\windows
-```
+    Get-ChildItem c:\windows
+    ```
 
-Here, A_File.TXT will be returned. Since no filter was specified, it will apply to any call to Get-ChildItem that does not pass another filter.
+    Here, A_File.TXT will be returned. Since no filter was specified, it will apply to any call to Get-ChildItem that does not pass another filter.
 
-.EXAMPLE
-```powershell
-Mock Get-ChildItem { return @{FullName = "B_File.TXT"} } -ParameterFilter { $Path -eq "$env:temp\me" }
-Mock Get-ChildItem { return @{FullName = "A_File.TXT"} }
+    .EXAMPLE
+    ```powershell
+    Mock Get-ChildItem { return @{FullName = "B_File.TXT"} } -ParameterFilter { $Path -eq "$env:temp\me" }
+    Mock Get-ChildItem { return @{FullName = "A_File.TXT"} }
 
-Get-ChildItem $env:temp\me
-```
+    Get-ChildItem $env:temp\me
+    ```
 
-Here, B_File.TXT will be returned. Even though the filterless mock was created more recently. This illustrates that filterless Mocks are always evaluated last regardless of their creation order.
+    Here, B_File.TXT will be returned. Even though the filterless mock was created more recently. This illustrates that filterless Mocks are always evaluated last regardless of their creation order.
 
-.EXAMPLE
-Mock Get-ChildItem { return @{FullName = "A_File.TXT"} } -ModuleName MyTestModule
+    .EXAMPLE
+    Mock Get-ChildItem { return @{FullName = "A_File.TXT"} } -ModuleName MyTestModule
 
-Using this Mock, all calls to Get-ChildItem from within the MyTestModule module
-will return a hashtable with a FullName property returning "A_File.TXT"
+    Using this Mock, all calls to Get-ChildItem from within the MyTestModule module
+    will return a hashtable with a FullName property returning "A_File.TXT"
 
-.EXAMPLE
-```powershell
-Get-Module -Name ModuleMockExample | Remove-Module
-New-Module -Name ModuleMockExample  -ScriptBlock {
-    function Hidden { "Internal Module Function" }
-    function Exported { Hidden }
+    .EXAMPLE
+    ```powershell
+    Get-Module -Name ModuleMockExample | Remove-Module
+    New-Module -Name ModuleMockExample  -ScriptBlock {
+        function Hidden { "Internal Module Function" }
+        function Exported { Hidden }
 
-    Export-ModuleMember -Function Exported
-} | Import-Module -Force
+        Export-ModuleMember -Function Exported
+    } | Import-Module -Force
 
-Describe "ModuleMockExample" {
+    Describe "ModuleMockExample" {
+        It "Hidden function is not directly accessible outside the module" {
+            { Hidden } | Should -Throw
+        }
 
-    It "Hidden function is not directly accessible outside the module" {
-        { Hidden } | Should -Throw
+        It "Original Hidden function is called" {
+            Exported | Should -Be "Internal Module Function"
+        }
+
+        It "Hidden is replaced with our implementation" {
+            Mock Hidden { "Mocked" } -ModuleName ModuleMockExample
+            Exported | Should -Be "Mocked"
+        }
     }
+    ```
 
-    It "Original Hidden function is called" {
-        Exported | Should -Be "Internal Module Function"
-    }
+    This example shows how calls to commands made from inside a module can be
+    mocked by using the -ModuleName parameter.
 
-    It "Hidden is replaced with our implementation" {
-        Mock Hidden { "Mocked" } -ModuleName ModuleMockExample
-        Exported | Should -Be "Mocked"
-    }
-}
-```
+    .LINK
+    https://pester.dev/docs/commands/Mock
 
-This example shows how calls to commands made from inside a module can be
-mocked by using the -ModuleName parameter.
-
-.LINK
-https://pester.dev/docs/commands/Mock
-
-.LINK
-https://pester.dev/docs/usage/mocking
-
-#>
-    # Mock
+    .LINK
+    https://pester.dev/docs/usage/mocking
+    #>
     [CmdletBinding()]
     param(
         [string]$CommandName,
@@ -611,15 +608,15 @@ function Get-MockDataForCurrentScope {
 
 function Assert-VerifiableMock {
     <#
-.SYNOPSIS
-Checks if all verifiable Mocks has been called at least once.
+    .SYNOPSIS
+    Checks if all verifiable Mocks has been called at least once.
 
-THIS COMMAND IS OBSOLETE AND WILL BE REMOVED SOMEWHERE DURING v5 LIFETIME,
-USE Should -InvokeVerifiable INSTEAD.
+    THIS COMMAND IS OBSOLETE AND WILL BE REMOVED SOMEWHERE DURING v5 LIFETIME,
+    USE Should -InvokeVerifiable INSTEAD.
 
-.LINK
-https://pester.dev/docs/commands/Assert-VerifiableMock
-#>
+    .LINK
+    https://pester.dev/docs/commands/Assert-VerifiableMock
+    #>
 
     # Should does not accept a session state, so invoking it directly would
     # make the assertion run from inside of Pester module, we move it to the
@@ -635,36 +632,35 @@ https://pester.dev/docs/commands/Assert-VerifiableMock
 }
 function Should-InvokeVerifiable ([switch]$Negate) {
     <#
-.SYNOPSIS
-Checks if any Verifiable Mock has not been invoked. If so, this will throw an exception.
+    .SYNOPSIS
+    Checks if any Verifiable Mock has not been invoked. If so, this will throw an exception.
 
-.DESCRIPTION
-This can be used in tandem with the -Verifiable switch of the Mock
-function. Mock can be used to mock the behavior of an existing command
-and optionally take a -Verifiable switch. When Should -InvokeVerifiable
-is called, it checks to see if any Mock marked Verifiable has not been
-invoked. If any mocks have been found that specified -Verifiable and
-have not been invoked, an exception will be thrown.
+    .DESCRIPTION
+    This can be used in tandem with the -Verifiable switch of the Mock
+    function. Mock can be used to mock the behavior of an existing command
+    and optionally take a -Verifiable switch. When Should -InvokeVerifiable
+    is called, it checks to see if any Mock marked Verifiable has not been
+    invoked. If any mocks have been found that specified -Verifiable and
+    have not been invoked, an exception will be thrown.
 
-.EXAMPLE
-Mock Set-Content {} -Verifiable -ParameterFilter {$Path -eq "some_path" -and $Value -eq "Expected Value"}
+    .EXAMPLE
+    Mock Set-Content {} -Verifiable -ParameterFilter {$Path -eq "some_path" -and $Value -eq "Expected Value"}
 
-{ ...some code that never calls Set-Content some_path -Value "Expected Value"... }
+    { ...some code that never calls Set-Content some_path -Value "Expected Value"... }
 
-Should -InvokeVerifiable
+    Should -InvokeVerifiable
 
-This will throw an exception and cause the test to fail.
+    This will throw an exception and cause the test to fail.
 
-.EXAMPLE
-Mock Set-Content {} -Verifiable -ParameterFilter {$Path -eq "some_path" -and $Value -eq "Expected Value"}
+    .EXAMPLE
+    Mock Set-Content {} -Verifiable -ParameterFilter {$Path -eq "some_path" -and $Value -eq "Expected Value"}
 
-Set-Content some_path -Value "Expected Value"
+    Set-Content some_path -Value "Expected Value"
 
-Should -InvokeVerifiable
+    Should -InvokeVerifiable
 
-This will not throw an exception because the mock was invoked.
-
-#>
+    This will not throw an exception because the mock was invoked.
+    #>
     $behaviors = @(Get-VerifiableBehaviors)
     Should-InvokeVerifiableInternal -Behaviors $behaviors -Negate:$Negate
 }
@@ -675,16 +671,16 @@ This will not throw an exception because the mock was invoked.
 
 function Assert-MockCalled {
     <#
-.SYNOPSIS
-Checks if a Mocked command has been called a certain number of times
-and throws an exception if it has not.
+    .SYNOPSIS
+    Checks if a Mocked command has been called a certain number of times
+    and throws an exception if it has not.
 
-THIS COMMAND IS OBSOLETE AND WILL BE REMOVED SOMEWHERE DURING v5 LIFETIME,
-USE Should -Invoke INSTEAD.
+    THIS COMMAND IS OBSOLETE AND WILL BE REMOVED SOMEWHERE DURING v5 LIFETIME,
+    USE Should -Invoke INSTEAD.
 
-.LINK
-https://pester.dev/docs/commands/Assert-MockCalled
-#>
+    .LINK
+    https://pester.dev/docs/commands/Assert-MockCalled
+    #>
     [CmdletBinding(DefaultParameterSetName = 'ParameterFilter')]
     param(
         [Parameter(Mandatory = $true, Position = 0)]
@@ -720,136 +716,134 @@ https://pester.dev/docs/commands/Assert-MockCalled
 
 function Should-Invoke {
     <#
-.SYNOPSIS
-Checks if a Mocked command has been called a certain number of times
-and throws an exception if it has not.
+    .SYNOPSIS
+    Checks if a Mocked command has been called a certain number of times
+    and throws an exception if it has not.
 
-.DESCRIPTION
-This command verifies that a mocked command has been called a certain number
-of times.  If the call history of the mocked command does not match the parameters
-passed to Should -Invoke, Should -Invoke will throw an exception.
+    .DESCRIPTION
+    This command verifies that a mocked command has been called a certain number
+    of times.  If the call history of the mocked command does not match the parameters
+    passed to Should -Invoke, Should -Invoke will throw an exception.
 
-.PARAMETER CommandName
-The mocked command whose call history should be checked.
+    .PARAMETER CommandName
+    The mocked command whose call history should be checked.
 
-.PARAMETER ModuleName
-The module where the mock being checked was injected.  This is optional,
-and must match the ModuleName that was used when setting up the Mock.
+    .PARAMETER ModuleName
+    The module where the mock being checked was injected.  This is optional,
+    and must match the ModuleName that was used when setting up the Mock.
 
-.PARAMETER Times
-The number of times that the mock must be called to avoid an exception
-from throwing.
+    .PARAMETER Times
+    The number of times that the mock must be called to avoid an exception
+    from throwing.
 
-.PARAMETER Exactly
-If this switch is present, the number specified in Times must match
-exactly the number of times the mock has been called. Otherwise it
-must match "at least" the number of times specified.  If the value
-passed to the Times parameter is zero, the Exactly switch is implied.
+    .PARAMETER Exactly
+    If this switch is present, the number specified in Times must match
+    exactly the number of times the mock has been called. Otherwise it
+    must match "at least" the number of times specified.  If the value
+    passed to the Times parameter is zero, the Exactly switch is implied.
 
-.PARAMETER ParameterFilter
-An optional filter to qualify which calls should be counted. Only those
-calls to the mock whose parameters cause this filter to return true
-will be counted.
+    .PARAMETER ParameterFilter
+    An optional filter to qualify which calls should be counted. Only those
+    calls to the mock whose parameters cause this filter to return true
+    will be counted.
 
-.PARAMETER ExclusiveFilter
-Like ParameterFilter, except when you use ExclusiveFilter, and there
-were any calls to the mocked command which do not match the filter,
-an exception will be thrown.  This is a convenient way to avoid needing
-to have two calls to Should -Invoke like this:
+    .PARAMETER ExclusiveFilter
+    Like ParameterFilter, except when you use ExclusiveFilter, and there
+    were any calls to the mocked command which do not match the filter,
+    an exception will be thrown.  This is a convenient way to avoid needing
+    to have two calls to Should -Invoke like this:
 
-Should -Invoke SomeCommand -Times 1 -ParameterFilter { $something -eq $true }
-Should -Invoke SomeCommand -Times 0 -ParameterFilter { $something -ne $true }
+    Should -Invoke SomeCommand -Times 1 -ParameterFilter { $something -eq $true }
+    Should -Invoke SomeCommand -Times 0 -ParameterFilter { $something -ne $true }
 
-.PARAMETER Scope
-An optional parameter specifying the Pester scope in which to check for
-calls to the mocked command. For RSpec style tests, Should -Invoke will find
-all calls to the mocked command in the current Context block (if present),
-or the current Describe block (if there is no active Context), by default. Valid
-values are Describe, Context and It. If you use a scope of Describe or
-Context, the command will identify all calls to the mocked command in the
-current Describe / Context block, as well as all child scopes of that block.
+    .PARAMETER Scope
+    An optional parameter specifying the Pester scope in which to check for
+    calls to the mocked command. For RSpec style tests, Should -Invoke will find
+    all calls to the mocked command in the current Context block (if present),
+    or the current Describe block (if there is no active Context), by default. Valid
+    values are Describe, Context and It. If you use a scope of Describe or
+    Context, the command will identify all calls to the mocked command in the
+    current Describe / Context block, as well as all child scopes of that block.
 
-.EXAMPLE
-Mock Set-Content {}
-
-{... Some Code ...}
-
-Should -Invoke Set-Content
-
-This will throw an exception and cause the test to fail if Set-Content is not called in Some Code.
-
-.EXAMPLE
-Mock Set-Content -parameterFilter {$path.StartsWith("$env:temp\")}
-
-{... Some Code ...}
-
-Should -Invoke Set-Content 2 { $path -eq "$env:temp\test.txt" }
-
-This will throw an exception if some code calls Set-Content on $path=$env:temp\test.txt less than 2 times
-
-.EXAMPLE
-Mock Set-Content {}
-
-{... Some Code ...}
-
-Should -Invoke Set-Content 0
-
-This will throw an exception if some code calls Set-Content at all
-
-.EXAMPLE
-Mock Set-Content {}
-
-{... Some Code ...}
-
-Should -Invoke Set-Content -Exactly 2
-
-This will throw an exception if some code does not call Set-Content Exactly two times.
-
-.EXAMPLE
-Describe 'Should -Invoke Scope behavior' {
-    Mock Set-Content { }
-
-    It 'Calls Set-Content at least once in the It block' {
-        {... Some Code ...}
-
-        Should -Invoke Set-Content -Exactly 0 -Scope It
-    }
-}
-
-Checks for calls only within the current It block.
-
-.EXAMPLE
-Describe 'Describe' {
-    Mock -ModuleName SomeModule Set-Content { }
+    .EXAMPLE
+    Mock Set-Content {}
 
     {... Some Code ...}
 
-    It 'Calls Set-Content at least once in the Describe block' {
-        Should -Invoke -ModuleName SomeModule Set-Content
+    Should -Invoke Set-Content
+
+    This will throw an exception and cause the test to fail if Set-Content is not called in Some Code.
+
+    .EXAMPLE
+    Mock Set-Content -parameterFilter {$path.StartsWith("$env:temp\")}
+
+    {... Some Code ...}
+
+    Should -Invoke Set-Content 2 { $path -eq "$env:temp\test.txt" }
+
+    This will throw an exception if some code calls Set-Content on $path=$env:temp\test.txt less than 2 times
+
+    .EXAMPLE
+    Mock Set-Content {}
+
+    {... Some Code ...}
+
+    Should -Invoke Set-Content 0
+
+    This will throw an exception if some code calls Set-Content at all
+
+    .EXAMPLE
+    Mock Set-Content {}
+
+    {... Some Code ...}
+
+    Should -Invoke Set-Content -Exactly 2
+
+    This will throw an exception if some code does not call Set-Content Exactly two times.
+
+    .EXAMPLE
+    Describe 'Should -Invoke Scope behavior' {
+        Mock Set-Content { }
+
+        It 'Calls Set-Content at least once in the It block' {
+            {... Some Code ...}
+
+            Should -Invoke Set-Content -Exactly 0 -Scope It
+        }
     }
-}
 
-Checks for calls to the mock within the SomeModule module.  Note that both the Mock
-and Should -Invoke commands use the same module name.
+    Checks for calls only within the current It block.
 
-.EXAMPLE
-Should -Invoke Get-ChildItem -ExclusiveFilter { $Path -eq 'C:\' }
+    .EXAMPLE
+    Describe 'Describe' {
+        Mock -ModuleName SomeModule Set-Content { }
 
-Checks to make sure that Get-ChildItem was called at least one time with
-the -Path parameter set to 'C:\', and that it was not called at all with
-the -Path parameter set to any other value.
+        {... Some Code ...}
 
-.NOTES
-The parameter filter passed to Should -Invoke does not necessarily have to match the parameter filter
-(if any) which was used to create the Mock.  Should -Invoke will find any entry in the command history
-which matches its parameter filter, regardless of how the Mock was created.  However, if any calls to the
-mocked command are made which did not match any mock's parameter filter (resulting in the original command
-being executed instead of a mock), these calls to the original command are not tracked in the call history.
-In other words, Should -Invoke can only be used to check for calls to the mocked implementation, not
-to the original.
+        It 'Calls Set-Content at least once in the Describe block' {
+            Should -Invoke -ModuleName SomeModule Set-Content
+        }
+    }
 
-#>
-    # Should -Invoke
+    Checks for calls to the mock within the SomeModule module.  Note that both the Mock
+    and Should -Invoke commands use the same module name.
+
+    .EXAMPLE
+    Should -Invoke Get-ChildItem -ExclusiveFilter { $Path -eq 'C:\' }
+
+    Checks to make sure that Get-ChildItem was called at least one time with
+    the -Path parameter set to 'C:\', and that it was not called at all with
+    the -Path parameter set to any other value.
+
+    .NOTES
+    The parameter filter passed to Should -Invoke does not necessarily have to match the parameter filter
+    (if any) which was used to create the Mock.  Should -Invoke will find any entry in the command history
+    which matches its parameter filter, regardless of how the Mock was created.  However, if any calls to the
+    mocked command are made which did not match any mock's parameter filter (resulting in the original command
+    being executed instead of a mock), these calls to the original command are not tracked in the call history.
+    In other words, Should -Invoke can only be used to check for calls to the mocked implementation, not
+    to the original.
+    #>
     [CmdletBinding(DefaultParameterSetName = 'ParameterFilter')]
     param(
         [Parameter(Mandatory = $true, Position = 0)]

--- a/src/functions/assertions/Be.ps1
+++ b/src/functions/assertions/Be.ps1
@@ -1,23 +1,23 @@
-﻿#Be
+#Be
 function Should-Be ($ActualValue, $ExpectedValue, [switch] $Negate, [string] $Because) {
     <#
-.SYNOPSIS
-Compares one object with another for equality
-and throws if the two objects are not the same.
+    .SYNOPSIS
+    Compares one object with another for equality
+    and throws if the two objects are not the same.
 
-.EXAMPLE
-$actual = "Actual value"
-$actual | Should -Be "actual value"
+    .EXAMPLE
+    $actual = "Actual value"
+    $actual | Should -Be "actual value"
 
-This test will pass. -Be is not case sensitive.
-For a case sensitive assertion, see -BeExactly.
+    This test will pass. -Be is not case sensitive.
+    For a case sensitive assertion, see -BeExactly.
 
-.EXAMPLE
-$actual = "Actual value"
-$actual | Should -Be "not actual value"
+    .EXAMPLE
+    $actual = "Actual value"
+    $actual | Should -Be "not actual value"
 
-This test will fail, as the two strings are not identical.
-#>
+    This test will fail, as the two strings are not identical.
+    #>
     [bool] $succeeded = ArraysAreEqual $ActualValue $ExpectedValue
 
     if ($Negate) {
@@ -72,22 +72,22 @@ function NotShouldBeFailureMessage($ActualValue, $ExpectedValue, $Because) {
 #BeExactly
 function Should-BeExactly($ActualValue, $ExpectedValue, $Because) {
     <#
-.SYNOPSIS
-Compares one object with another for equality and throws if the
-two objects are not the same. This comparison is case sensitive.
+    .SYNOPSIS
+    Compares one object with another for equality and throws if the
+    two objects are not the same. This comparison is case sensitive.
 
-.EXAMPLE
-$actual = "Actual value"
-$actual | Should -Be "Actual value"
+    .EXAMPLE
+    $actual = "Actual value"
+    $actual | Should -Be "Actual value"
 
-This test will pass. The two strings are identical.
+    This test will pass. The two strings are identical.
 
-.EXAMPLE
-$actual = "Actual value"
-$actual | Should -Be "actual value"
+    .EXAMPLE
+    $actual = "Actual value"
+    $actual | Should -Be "actual value"
 
-This test will fail, as the two strings do not match case sensitivity.
-#>
+    This test will fail, as the two strings do not match case sensitivity.
+    #>
     [bool] $succeeded = ArraysAreEqual $ActualValue $ExpectedValue -CaseSensitive
 
     if ($Negate) {

--- a/src/functions/assertions/BeGreaterThan.ps1
+++ b/src/functions/assertions/BeGreaterThan.ps1
@@ -1,14 +1,14 @@
 ﻿function Should-BeGreaterThan($ActualValue, $ExpectedValue, [switch] $Negate, [string] $Because) {
     <#
-.SYNOPSIS
-Asserts that a number (or other comparable value) is greater than an expected value.
-Uses PowerShell's -gt operator to compare the two values.
+    .SYNOPSIS
+    Asserts that a number (or other comparable value) is greater than an expected value.
+    Uses PowerShell's -gt operator to compare the two values.
 
-.EXAMPLE
-2 | Should -BeGreaterThan 0
+    .EXAMPLE
+    2 | Should -BeGreaterThan 0
 
-This test passes, as PowerShell evaluates `2 -gt 0` as true.
-#>
+    This test passes, as PowerShell evaluates `2 -gt 0` as true.
+    #>
     if ($Negate) {
         return Should-BeLessOrEqual -ActualValue $ActualValue -ExpectedValue $ExpectedValue -Negate:$false -Because $Because
     }
@@ -28,20 +28,20 @@ This test passes, as PowerShell evaluates `2 -gt 0` as true.
 
 function Should-BeLessOrEqual($ActualValue, $ExpectedValue, [switch] $Negate, [string] $Because) {
     <#
-.SYNOPSIS
-Asserts that a number (or other comparable value) is lower than, or equal to an expected value.
-Uses PowerShell's -le operator to compare the two values.
+    .SYNOPSIS
+    Asserts that a number (or other comparable value) is lower than, or equal to an expected value.
+    Uses PowerShell's -le operator to compare the two values.
 
-.EXAMPLE
-1 | Should -BeLessOrEqual 10
+    .EXAMPLE
+    1 | Should -BeLessOrEqual 10
 
-This test passes, as PowerShell evaluates `1 -le 10` as true.
+    This test passes, as PowerShell evaluates `1 -le 10` as true.
 
-.EXAMPLE
-10 | Should -BeLessOrEqual 10
+    .EXAMPLE
+    10 | Should -BeLessOrEqual 10
 
-This test also passes, as PowerShell evaluates `10 -le 10` as true.
-#>
+    This test also passes, as PowerShell evaluates `10 -le 10` as true.
+    #>
     if ($Negate) {
         return Should-BeGreaterThan -ActualValue $ActualValue -ExpectedValue $ExpectedValue -Negate:$false -Because $Because
     }

--- a/src/functions/assertions/BeIn.ps1
+++ b/src/functions/assertions/BeIn.ps1
@@ -1,14 +1,14 @@
 ﻿function Should-BeIn($ActualValue, $ExpectedValue, [switch] $Negate, [string] $Because) {
     <#
-.SYNOPSIS
-Asserts that a collection of values contain a specific value.
-Uses PowerShell's -contains operator to confirm.
+    .SYNOPSIS
+    Asserts that a collection of values contain a specific value.
+    Uses PowerShell's -contains operator to confirm.
 
-.EXAMPLE
-1 | Should -BeIn @(1,2,3,'a','b','c')
+    .EXAMPLE
+    1 | Should -BeIn @(1,2,3,'a','b','c')
 
-This test passes, as 1 exists in the provided collection.
-#>
+    This test passes, as 1 exists in the provided collection.
+    #>
     [bool] $succeeded = $ExpectedValue -contains $ActualValue
     if ($Negate) {
         $succeeded = -not $succeeded

--- a/src/functions/assertions/BeLessThan.ps1
+++ b/src/functions/assertions/BeLessThan.ps1
@@ -1,14 +1,14 @@
 ﻿function Should-BeLessThan($ActualValue, $ExpectedValue, [switch] $Negate, [string] $Because) {
     <#
-.SYNOPSIS
-Asserts that a number (or other comparable value) is lower than an expected value.
-Uses PowerShell's -lt operator to compare the two values.
+    .SYNOPSIS
+    Asserts that a number (or other comparable value) is lower than an expected value.
+    Uses PowerShell's -lt operator to compare the two values.
 
-.EXAMPLE
-1 | Should -BeLessThan 10
+    .EXAMPLE
+    1 | Should -BeLessThan 10
 
-This test passes, as PowerShell evaluates `1 -lt 10` as true.
-#>
+    This test passes, as PowerShell evaluates `1 -lt 10` as true.
+    #>
     if ($Negate) {
         return Should-BeGreaterOrEqual -ActualValue $ActualValue -ExpectedValue $ExpectedValue -Negate:$false -Because $Because
     }
@@ -28,20 +28,20 @@ This test passes, as PowerShell evaluates `1 -lt 10` as true.
 
 function Should-BeGreaterOrEqual($ActualValue, $ExpectedValue, [switch] $Negate, [string] $Because) {
     <#
-.SYNOPSIS
-Asserts that a number (or other comparable value) is greater than or equal to an expected value.
-Uses PowerShell's -ge operator to compare the two values.
+    .SYNOPSIS
+    Asserts that a number (or other comparable value) is greater than or equal to an expected value.
+    Uses PowerShell's -ge operator to compare the two values.
 
-.EXAMPLE
-2 | Should -BeGreaterOrEqual 0
+    .EXAMPLE
+    2 | Should -BeGreaterOrEqual 0
 
-This test passes, as PowerShell evaluates `2 -ge 0` as true.
+    This test passes, as PowerShell evaluates `2 -ge 0` as true.
 
-.EXAMPLE
-2 | Should -BeGreaterOrEqual 2
+    .EXAMPLE
+    2 | Should -BeGreaterOrEqual 2
 
-This test also passes, as PowerShell evaluates `2 -ge 2` as true.
-#>
+    This test also passes, as PowerShell evaluates `2 -ge 2` as true.
+    #>
     if ($Negate) {
         return Should-BeLessThan -ActualValue $ActualValue -ExpectedValue $ExpectedValue -Negate:$false -Because $Because
     }

--- a/src/functions/assertions/BeLike.ps1
+++ b/src/functions/assertions/BeLike.ps1
@@ -1,22 +1,22 @@
 ﻿function Should-BeLike($ActualValue, $ExpectedValue, [switch] $Negate, [String] $Because) {
     <#
-.SYNOPSIS
-Asserts that the actual value matches a wildcard pattern using PowerShell's -like operator.
-This comparison is not case-sensitive.
+    .SYNOPSIS
+    Asserts that the actual value matches a wildcard pattern using PowerShell's -like operator.
+    This comparison is not case-sensitive.
 
-.EXAMPLE
-$actual = "Actual value"
-$actual | Should -BeLike "actual *"
+    .EXAMPLE
+    $actual = "Actual value"
+    $actual | Should -BeLike "actual *"
 
-This test will pass. -BeLike is not case sensitive.
-For a case sensitive assertion, see -BeLikeExactly.
+    This test will pass. -BeLike is not case sensitive.
+    For a case sensitive assertion, see -BeLikeExactly.
 
-.EXAMPLE
-$actual = "Actual value"
-$actual | Should -BeLike "not actual *"
+    .EXAMPLE
+    $actual = "Actual value"
+    $actual | Should -BeLike "not actual *"
 
-This test will fail, as the first string does not match the expected value.
-#>
+    This test will fail, as the first string does not match the expected value.
+    #>
     [bool] $succeeded = $ActualValue -like $ExpectedValue
     if ($Negate) {
         $succeeded = -not $succeeded

--- a/src/functions/assertions/BeLikeExactly.ps1
+++ b/src/functions/assertions/BeLikeExactly.ps1
@@ -1,21 +1,21 @@
 ﻿function Should-BeLikeExactly($ActualValue, $ExpectedValue, [switch] $Negate, [String] $Because) {
     <#
-.SYNOPSIS
-Asserts that the actual value matches a wildcard pattern using PowerShell's -like operator.
-This comparison is case-sensitive.
+    .SYNOPSIS
+    Asserts that the actual value matches a wildcard pattern using PowerShell's -like operator.
+    This comparison is case-sensitive.
 
-.EXAMPLE
-$actual = "Actual value"
-$actual | Should -BeLikeExactly "Actual *"
+    .EXAMPLE
+    $actual = "Actual value"
+    $actual | Should -BeLikeExactly "Actual *"
 
-This test will pass, as the string matches the provided pattern.
+    This test will pass, as the string matches the provided pattern.
 
-.EXAMPLE
-$actual = "Actual value"
-$actual | Should -BeLikeExactly "actual *"
+    .EXAMPLE
+    $actual = "Actual value"
+    $actual | Should -BeLikeExactly "actual *"
 
-This test will fail, as -BeLikeExactly is case-sensitive.
-#>
+    This test will fail, as -BeLikeExactly is case-sensitive.
+    #>
     [bool] $succeeded = $ActualValue -clike $ExpectedValue
     if ($Negate) {
         $succeeded = -not $succeeded

--- a/src/functions/assertions/BeNullOrEmpty.ps1
+++ b/src/functions/assertions/BeNullOrEmpty.ps1
@@ -1,30 +1,30 @@
 ﻿
 function Should-BeNullOrEmpty([object[]] $ActualValue, [switch] $Negate, [string] $Because) {
     <#
-.SYNOPSIS
-Checks values for null or empty (strings).
-The static [String]::IsNullOrEmpty() method is used to do the comparison.
+    .SYNOPSIS
+    Checks values for null or empty (strings).
+    The static [String]::IsNullOrEmpty() method is used to do the comparison.
 
-.EXAMPLE
-$null | Should -BeNullOrEmpty
+    .EXAMPLE
+    $null | Should -BeNullOrEmpty
 
-This test will pass. $null is null.
+    This test will pass. $null is null.
 
-.EXAMPLE
-$null | Should -Not -BeNullOrEmpty
+    .EXAMPLE
+    $null | Should -Not -BeNullOrEmpty
 
-This test will fail and throw an error.
+    This test will fail and throw an error.
 
-.EXAMPLE
-@() | Should -BeNullOrEmpty
+    .EXAMPLE
+    @() | Should -BeNullOrEmpty
 
-An empty collection will pass this test.
+    An empty collection will pass this test.
 
-.EXAMPLE
-""  | Should -BeNullOrEmpty
+    .EXAMPLE
+    ""  | Should -BeNullOrEmpty
 
-An empty string will pass this test.
-#>
+    An empty string will pass this test.
+    #>
     if ($null -eq $ActualValue -or $ActualValue.Count -eq 0) {
         $succeeded = $true
     }

--- a/src/functions/assertions/BeOfType.ps1
+++ b/src/functions/assertions/BeOfType.ps1
@@ -1,31 +1,31 @@
 ﻿
 function Should-BeOfType($ActualValue, $ExpectedType, [switch] $Negate, [string]$Because) {
     <#
-.SYNOPSIS
-Asserts that the actual value should be an object of a specified type
-(or a subclass of the specified type) using PowerShell's -is operator.
+    .SYNOPSIS
+    Asserts that the actual value should be an object of a specified type
+    (or a subclass of the specified type) using PowerShell's -is operator.
 
-.EXAMPLE
-$actual = Get-Item $env:SystemRoot
-$actual | Should -BeOfType System.IO.DirectoryInfo
+    .EXAMPLE
+    $actual = Get-Item $env:SystemRoot
+    $actual | Should -BeOfType System.IO.DirectoryInfo
 
-This test passes, as $actual is a DirectoryInfo object.
+    This test passes, as $actual is a DirectoryInfo object.
 
-.EXAMPLE
-$actual | Should -BeOfType System.IO.FileSystemInfo
+    .EXAMPLE
+    $actual | Should -BeOfType System.IO.FileSystemInfo
 
-This test passes, as DirectoryInfo's base class is FileSystemInfo.
+    This test passes, as DirectoryInfo's base class is FileSystemInfo.
 
-.EXAMPLE
-$actual | Should -HaveType System.IO.FileSystemInfo
+    .EXAMPLE
+    $actual | Should -HaveType System.IO.FileSystemInfo
 
-This test passes for the same reason, but uses the -HaveType alias instead.
+    This test passes for the same reason, but uses the -HaveType alias instead.
 
-.EXAMPLE
-$actual | Should -BeOfType System.IO.FileInfo
+    .EXAMPLE
+    $actual | Should -BeOfType System.IO.FileInfo
 
-This test will fail, as FileInfo is not a base class of DirectoryInfo.
-#>
+    This test will fail, as FileInfo is not a base class of DirectoryInfo.
+    #>
     if ($ExpectedType -is [string]) {
         # parses type that is provided as a string in brackets (such as [int])
         $parsedType = ($ExpectedType -replace '^\[(.*)\]$', '$1') -as [Type]

--- a/src/functions/assertions/BeTrueOrFalse.ps1
+++ b/src/functions/assertions/BeTrueOrFalse.ps1
@@ -1,24 +1,24 @@
 ﻿function Should-BeTrue($ActualValue, [switch] $Negate, [string] $Because) {
     <#
-.SYNOPSIS
-Asserts that the value is true, or truthy.
+    .SYNOPSIS
+    Asserts that the value is true, or truthy.
 
-.EXAMPLE
-$true | Should -BeTrue
+    .EXAMPLE
+    $true | Should -BeTrue
 
-This test passes. $true is true.
+    This test passes. $true is true.
 
-.EXAMPLE
-1 | Should -BeTrue
+    .EXAMPLE
+    1 | Should -BeTrue
 
-This test passes. 1 is true.
+    This test passes. 1 is true.
 
-.EXAMPLE
-1,2,3 | Should -BeTrue
+    .EXAMPLE
+    1,2,3 | Should -BeTrue
 
-PowerShell does not enter a `If (-not @(1,2,3)) {}` block.
-This test passes as a "truthy" result.
-#>
+    PowerShell does not enter a `If (-not @(1,2,3)) {}` block.
+    This test passes as a "truthy" result.
+    #>
     if ($Negate) {
         return Should-BeFalse -ActualValue $ActualValue -Negate:$false -Because $Because
     }
@@ -38,25 +38,25 @@ This test passes as a "truthy" result.
 
 function Should-BeFalse($ActualValue, [switch] $Negate, $Because) {
     <#
-.SYNOPSIS
-Asserts that the value is false, or falsy.
+    .SYNOPSIS
+    Asserts that the value is false, or falsy.
 
-.EXAMPLE
-$false | Should -BeFalse
+    .EXAMPLE
+    $false | Should -BeFalse
 
-This test passes. $false is false.
+    This test passes. $false is false.
 
-.EXAMPLE
-0 | Should -BeFalse
+    .EXAMPLE
+    0 | Should -BeFalse
 
-This test passes. 0 is false.
+    This test passes. 0 is false.
 
-.EXAMPLE
-$null | Should -BeFalse
+    .EXAMPLE
+    $null | Should -BeFalse
 
-PowerShell does not enter a `If ($null) {}` block.
-This test passes as a "falsy" result.
-#>
+    PowerShell does not enter a `If ($null) {}` block.
+    This test passes as a "falsy" result.
+    #>
     if ($Negate) {
         return Should-BeTrue -ActualValue $ActualValue -Negate:$false -Because $Because
     }

--- a/src/functions/assertions/Contain.ps1
+++ b/src/functions/assertions/Contain.ps1
@@ -1,14 +1,14 @@
 ﻿function Should-Contain($ActualValue, $ExpectedValue, [switch] $Negate, [string] $Because) {
     <#
-.SYNOPSIS
-Asserts that collection contains a specific value.
-Uses PowerShell's -contains operator to confirm.
+    .SYNOPSIS
+    Asserts that collection contains a specific value.
+    Uses PowerShell's -contains operator to confirm.
 
-.EXAMPLE
-1,2,3 | Should -Contain 1
+    .EXAMPLE
+    1,2,3 | Should -Contain 1
 
-This test passes, as 1 exists in the provided collection.
-#>
+    This test passes, as 1 exists in the provided collection.
+    #>
     [bool] $succeeded = $ActualValue -contains $ExpectedValue
     if ($Negate) {
         $succeeded = -not $succeeded

--- a/src/functions/assertions/Exist.ps1
+++ b/src/functions/assertions/Exist.ps1
@@ -1,17 +1,17 @@
 ﻿function Should-Exist($ActualValue, [switch] $Negate, [string] $Because) {
     <#
-.SYNOPSIS
-Does not perform any comparison, but checks if the object calling Exist is present in a PS Provider.
-The object must have valid path syntax. It essentially must pass a Test-Path call.
+    .SYNOPSIS
+    Does not perform any comparison, but checks if the object calling Exist is present in a PS Provider.
+    The object must have valid path syntax. It essentially must pass a Test-Path call.
 
-.EXAMPLE
-$actual = (Dir . )[0].FullName
-Remove-Item $actual
-$actual | Should -Exist
+    .EXAMPLE
+    $actual = (Dir . )[0].FullName
+    Remove-Item $actual
+    $actual | Should -Exist
 
-`Should -Exist` calls Test-Path. Test-Path expects a file,
-returns $false because the file was removed, and fails the test.
-#>
+    `Should -Exist` calls Test-Path. Test-Path expects a file,
+    returns $false because the file was removed, and fails the test.
+    #>
     [bool] $succeeded = & $SafeCommands['Test-Path'] $ActualValue
 
     if ($Negate) {

--- a/src/functions/assertions/FileContentMatch.ps1
+++ b/src/functions/assertions/FileContentMatch.ps1
@@ -1,39 +1,39 @@
 ﻿function Should-FileContentMatch($ActualValue, $ExpectedContent, [switch] $Negate, $Because) {
     <#
-.SYNOPSIS
-Checks to see if a file contains the specified text.
-This search is not case sensitive and uses regular expressions.
+    .SYNOPSIS
+    Checks to see if a file contains the specified text.
+    This search is not case sensitive and uses regular expressions.
 
-.EXAMPLE
-Set-Content -Path TestDrive:\file.txt -Value 'I am a file.'
-'TestDrive:\file.txt' | Should -FileContentMatch 'I Am'
+    .EXAMPLE
+    Set-Content -Path TestDrive:\file.txt -Value 'I am a file.'
+    'TestDrive:\file.txt' | Should -FileContentMatch 'I Am'
 
-Create a new file and verify its content. This test passes.
-The 'I Am' regular expression (RegEx) pattern matches against the txt file contents.
-For case-sensitivity, see FileContentMatchExactly.
+    Create a new file and verify its content. This test passes.
+    The 'I Am' regular expression (RegEx) pattern matches against the txt file contents.
+    For case-sensitivity, see FileContentMatchExactly.
 
-.EXAMPLE
-'TestDrive:\file.txt' | Should -FileContentMatch '^I.*file\.$'
+    .EXAMPLE
+    'TestDrive:\file.txt' | Should -FileContentMatch '^I.*file\.$'
 
-This RegEx pattern also matches against the "I am a file." string from Example 1.
-With a matching RegEx pattern, this test also passes.
+    This RegEx pattern also matches against the "I am a file." string from Example 1.
+    With a matching RegEx pattern, this test also passes.
 
-.EXAMPLE
-'TestDrive:\file.txt' | Should -FileContentMatch 'I Am Not'
+    .EXAMPLE
+    'TestDrive:\file.txt' | Should -FileContentMatch 'I Am Not'
 
-This test fails, as the RegEx pattern does not match "I am a file."
+    This test fails, as the RegEx pattern does not match "I am a file."
 
-.EXAMPLE
-'TestDrive:\file.txt' | Should -FileContentMatch 'I.am.a.file'
+    .EXAMPLE
+    'TestDrive:\file.txt' | Should -FileContentMatch 'I.am.a.file'
 
-This test passes, because "." in RegEx matches any character including a space.
+    This test passes, because "." in RegEx matches any character including a space.
 
-.EXAMPLE
-'TestDrive:\file.txt' | Should -FileContentMatch ([regex]::Escape('I.am.a.file'))
+    .EXAMPLE
+    'TestDrive:\file.txt' | Should -FileContentMatch ([regex]::Escape('I.am.a.file'))
 
-Tip: Use [regex]::Escape("pattern") to match the exact text.
-This test fails, because "I am a file." != "I.am.a.file"
-#>
+    Tip: Use [regex]::Escape("pattern") to match the exact text.
+    This test fails, because "I am a file." != "I.am.a.file"
+    #>
     $succeeded = (@(& $SafeCommands['Get-Content'] -Encoding UTF8 $ActualValue) -match $ExpectedContent).Count -gt 0
 
     if ($Negate) {

--- a/src/functions/assertions/FileContentMatchExactly.ps1
+++ b/src/functions/assertions/FileContentMatchExactly.ps1
@@ -1,21 +1,21 @@
 ﻿function Should-FileContentMatchExactly($ActualValue, $ExpectedContent, [switch] $Negate, [String] $Because) {
     <#
-.SYNOPSIS
-Checks to see if a file contains the specified text.
-This search is case sensitive and uses regular expressions to match the text.
+    .SYNOPSIS
+    Checks to see if a file contains the specified text.
+    This search is case sensitive and uses regular expressions to match the text.
 
-.EXAMPLE
-Set-Content -Path TestDrive:\file.txt -Value 'I am a file.'
-'TestDrive:\file.txt' | Should -FileContentMatchExactly 'I am'
+    .EXAMPLE
+    Set-Content -Path TestDrive:\file.txt -Value 'I am a file.'
+    'TestDrive:\file.txt' | Should -FileContentMatchExactly 'I am'
 
-Create a new file and verify its content. This test passes.
-The 'I am' regular expression (RegEx) pattern matches against the txt file contents.
+    Create a new file and verify its content. This test passes.
+    The 'I am' regular expression (RegEx) pattern matches against the txt file contents.
 
-.EXAMPLE
-'TestDrive:\file.txt' | Should -FileContentMatchExactly 'I Am'
+    .EXAMPLE
+    'TestDrive:\file.txt' | Should -FileContentMatchExactly 'I Am'
 
-This test checks a case-sensitive pattern against the "I am a file." string from Example 1.
-Because the RegEx pattern fails to match, this test fails.
+    This test checks a case-sensitive pattern against the "I am a file." string from Example 1.
+    Because the RegEx pattern fails to match, this test fails.
 #>
     $succeeded = (@(& $SafeCommands['Get-Content'] -Encoding UTF8 $ActualValue) -cmatch $ExpectedContent).Count -gt 0
 

--- a/src/functions/assertions/FileContentMatchMultiline.ps1
+++ b/src/functions/assertions/FileContentMatchMultiline.ps1
@@ -1,30 +1,30 @@
 ﻿function Should-FileContentMatchMultiline($ActualValue, $ExpectedContent, [switch] $Negate, [String] $Because) {
     <#
-.SYNOPSIS
-As opposed to FileContentMatch and FileContentMatchExactly operators,
-FileContentMatchMultiline presents content of the file being tested as one string object,
-so that the expression you are comparing it to can consist of several lines.
+    .SYNOPSIS
+    As opposed to FileContentMatch and FileContentMatchExactly operators,
+    FileContentMatchMultiline presents content of the file being tested as one string object,
+    so that the expression you are comparing it to can consist of several lines.
 
-When using FileContentMatchMultiline operator, '^' and '$' represent the beginning and end
-of the whole file, instead of the beginning and end of a line.
+    When using FileContentMatchMultiline operator, '^' and '$' represent the beginning and end
+    of the whole file, instead of the beginning and end of a line.
 
-.EXAMPLE
-$Content = "I am the first line.`nI am the second line."
-Set-Content -Path TestDrive:\file.txt -Value $Content -NoNewline
-'TestDrive:\file.txt' | Should -FileContentMatchMultiline 'first line\.\r?\nI am'
+    .EXAMPLE
+    $Content = "I am the first line.`nI am the second line."
+    Set-Content -Path TestDrive:\file.txt -Value $Content -NoNewline
+    'TestDrive:\file.txt' | Should -FileContentMatchMultiline 'first line\.\r?\nI am'
 
-This regular expression (RegEx) pattern matches the file contents, and the test passes.
+    This regular expression (RegEx) pattern matches the file contents, and the test passes.
 
-.EXAMPLE
-'TestDrive:\file.txt' | Should -FileContentMatchMultiline '^I am the first.*\n.*second line\.$'
+    .EXAMPLE
+    'TestDrive:\file.txt' | Should -FileContentMatchMultiline '^I am the first.*\n.*second line\.$'
 
-Using the file from Example 1, this RegEx pattern also matches, and this test also passes.
+    Using the file from Example 1, this RegEx pattern also matches, and this test also passes.
 
-.EXAMPLE
-'TestDrive:\file.txt' | Should -FileContentMatchMultiline '^I am the first line\.$'
+    .EXAMPLE
+    'TestDrive:\file.txt' | Should -FileContentMatchMultiline '^I am the first line\.$'
 
-FileContentMatchMultiline uses the '$' symbol to match the end of the file,
-not the end of any single line within the file. This test fails.
+    FileContentMatchMultiline uses the '$' symbol to match the end of the file,
+    not the end of any single line within the file. This test fails.
 #>
     $succeeded = [bool] ((& $SafeCommands['Get-Content'] $ActualValue -Delimiter ([char]0)) -match $ExpectedContent)
 

--- a/src/functions/assertions/FileContentMatchMultilineExactly.ps1
+++ b/src/functions/assertions/FileContentMatchMultilineExactly.ps1
@@ -1,48 +1,48 @@
 ﻿function Should-FileContentMatchMultilineExactly($ActualValue, $ExpectedContent, [switch] $Negate, [String] $Because) {
     <#
-.SYNOPSIS
-As opposed to FileContentMatch and FileContentMatchExactly operators,
-FileContentMatchMultilineExactly presents content of the file being tested as one string object,
-so that the case sensitive expression you are comparing it to can consist of several lines.
+    .SYNOPSIS
+    As opposed to FileContentMatch and FileContentMatchExactly operators,
+    FileContentMatchMultilineExactly presents content of the file being tested as one string object,
+    so that the case sensitive expression you are comparing it to can consist of several lines.
 
-When using FileContentMatchMultilineExactly operator, '^' and '$' represent the beginning and end
-of the whole file, instead of the beginning and end of a line.
+    When using FileContentMatchMultilineExactly operator, '^' and '$' represent the beginning and end
+    of the whole file, instead of the beginning and end of a line.
 
-.EXAMPLE
-$Content = "I am the first line.`nI am the second line."
-Set-Content -Path TestDrive:\file.txt -Value $Content -NoNewline
-'TestDrive:\file.txt' | Should -FileContentMatchMultilineExactly "first line.`nI am"
+    .EXAMPLE
+    $Content = "I am the first line.`nI am the second line."
+    Set-Content -Path TestDrive:\file.txt -Value $Content -NoNewline
+    'TestDrive:\file.txt' | Should -FileContentMatchMultilineExactly "first line.`nI am"
 
-This specified content across multiple lines case sensitively matches the file contents, and the test passes.
+    This specified content across multiple lines case sensitively matches the file contents, and the test passes.
 
-.EXAMPLE
-'TestDrive:\file.txt' | Should -FileContentMatchMultilineExactly "First line.`nI am"
+    .EXAMPLE
+    'TestDrive:\file.txt' | Should -FileContentMatchMultilineExactly "First line.`nI am"
 
-Using the file from Example 1, this specified content across multiple lines does not case sensitively match,
-because the 'F' on the first line is capitalized. This test fails.
+    Using the file from Example 1, this specified content across multiple lines does not case sensitively match,
+    because the 'F' on the first line is capitalized. This test fails.
 
-.EXAMPLE
-'TestDrive:\file.txt' | Should -FileContentMatchMultilineExactly 'first line\.\r?\nI am'
+    .EXAMPLE
+    'TestDrive:\file.txt' | Should -FileContentMatchMultilineExactly 'first line\.\r?\nI am'
 
-Using the file from Example 1, this RegEx pattern case sensitively matches the file contents, and the test passes.
+    Using the file from Example 1, this RegEx pattern case sensitively matches the file contents, and the test passes.
 
-.EXAMPLE
-'TestDrive:\file.txt' | Should -FileContentMatchMultilineExactly '^I am the first.*\n.*second line\.$'
+    .EXAMPLE
+    'TestDrive:\file.txt' | Should -FileContentMatchMultilineExactly '^I am the first.*\n.*second line\.$'
 
-Using the file from Example 1, this RegEx pattern also case sensitively matches, and this test also passes.
+    Using the file from Example 1, this RegEx pattern also case sensitively matches, and this test also passes.
 
-.EXAMPLE
-'TestDrive:\file.txt' | Should -FileContentMatchMultilineExactly '^am the first line\.$'
+    .EXAMPLE
+    'TestDrive:\file.txt' | Should -FileContentMatchMultilineExactly '^am the first line\.$'
 
-Using the file from Example 1, FileContentMatchMultilineExactly uses the '^' symbol to case sensitively match the start of the file,
-so '^am' is invalid here because the start of the file is '^I am'. This test fails.
+    Using the file from Example 1, FileContentMatchMultilineExactly uses the '^' symbol to case sensitively match the start of the file,
+    so '^am' is invalid here because the start of the file is '^I am'. This test fails.
 
-.EXAMPLE
-'TestDrive:\file.txt' | Should -FileContentMatchMultilineExactly '^I am the first line\.$'
+    .EXAMPLE
+    'TestDrive:\file.txt' | Should -FileContentMatchMultilineExactly '^I am the first line\.$'
 
-Using the file from Example 1, FileContentMatchMultilineExactly uses the '$' symbol to case sensitively match the end of the file,
-not the end of any single line within the file. This test also fails.
-#>
+    Using the file from Example 1, FileContentMatchMultilineExactly uses the '$' symbol to case sensitively match the end of the file,
+    not the end of any single line within the file. This test also fails.
+    #>
     $succeeded = [bool] ((& $SafeCommands['Get-Content'] $ActualValue -Delimiter ([char]0)) -cmatch $ExpectedContent)
 
     if ($Negate) {

--- a/src/functions/assertions/HaveCount.ps1
+++ b/src/functions/assertions/HaveCount.ps1
@@ -1,14 +1,14 @@
 ﻿function Should-HaveCount($ActualValue, [int] $ExpectedValue, [switch] $Negate, [string] $Because) {
     <#
-.SYNOPSIS
-Asserts that a collection has the expected amount of items.
+    .SYNOPSIS
+    Asserts that a collection has the expected amount of items.
 
-.EXAMPLE
-1,2,3 | Should -HaveCount 3
+    .EXAMPLE
+    1,2,3 | Should -HaveCount 3
 
-This test passes, because it expected three objects, and received three.
-This is like running `@(1,2,3).Count` in PowerShell.
-#>
+    This test passes, because it expected three objects, and received three.
+    This is like running `@(1,2,3).Count` in PowerShell.
+    #>
     if ($ExpectedValue -lt 0) {
         throw [ArgumentException]"Excpected collection size must be greater than or equal to 0."
     }

--- a/src/functions/assertions/HaveParameter.ps1
+++ b/src/functions/assertions/HaveParameter.ps1
@@ -22,7 +22,6 @@
         assertion will not be able to use the -HasArgumentCompleter parameter
         if the attribute does not exist.
     #>
-
     if ($null -eq $ActualValue -or $ActualValue -isnot [Management.Automation.CommandInfo]) {
         throw "Input value must be non-null CommandInfo object. You can get one by calling Get-Command."
     }
@@ -131,7 +130,6 @@
         .NOTES
             Author: Chris Dent
         #>
-
         [CmdletBinding()]
         param (
             # Filter results by command name.

--- a/src/functions/assertions/Match.ps1
+++ b/src/functions/assertions/Match.ps1
@@ -1,28 +1,28 @@
 ﻿function Should-Match($ActualValue, $RegularExpression, [switch] $Negate, [string] $Because) {
     <#
-.SYNOPSIS
-Uses a regular expression to compare two objects.
-This comparison is not case sensitive.
+    .SYNOPSIS
+    Uses a regular expression to compare two objects.
+    This comparison is not case sensitive.
 
-.EXAMPLE
-"I am a value" | Should -Match "I Am"
+    .EXAMPLE
+    "I am a value" | Should -Match "I Am"
 
-The "I Am" regular expression (RegEx) pattern matches the provided string,
-so the test passes. For case sensitive matches, see MatchExactly.
-.EXAMPLE
-"I am a value" | Should -Match "I am a bad person" # Test will fail
+    The "I Am" regular expression (RegEx) pattern matches the provided string,
+    so the test passes. For case sensitive matches, see MatchExactly.
+    .EXAMPLE
+    "I am a value" | Should -Match "I am a bad person" # Test will fail
 
-RegEx pattern does not match the string, and the test fails.
-.EXAMPLE
-"Greg" | Should -Match ".reg" # Test will pass
+    RegEx pattern does not match the string, and the test fails.
+    .EXAMPLE
+    "Greg" | Should -Match ".reg" # Test will pass
 
-This test passes, as "." in RegEx matches any character.
-.EXAMPLE
-"Greg" | Should -Match ([regex]::Escape(".reg"))
+    This test passes, as "." in RegEx matches any character.
+    .EXAMPLE
+    "Greg" | Should -Match ([regex]::Escape(".reg"))
 
-One way to provide literal characters to Match is the [regex]::Escape() method.
-This test fails, because the pattern does not match a period symbol.
-#>
+    One way to provide literal characters to Match is the [regex]::Escape() method.
+    This test fails, because the pattern does not match a period symbol.
+    #>
     [bool] $succeeded = $ActualValue -match $RegularExpression
 
     if ($Negate) {

--- a/src/functions/assertions/MatchExactly.ps1
+++ b/src/functions/assertions/MatchExactly.ps1
@@ -1,21 +1,21 @@
 ﻿function Should-MatchExactly($ActualValue, $RegularExpression, [switch] $Negate, [string] $Because) {
     <#
-.SYNOPSIS
-Uses a regular expression to compare two objects.
-This comparison is case sensitive.
+    .SYNOPSIS
+    Uses a regular expression to compare two objects.
+    This comparison is case sensitive.
 
-.EXAMPLE
-"I am a value" | Should -MatchExactly "I am"
+    .EXAMPLE
+    "I am a value" | Should -MatchExactly "I am"
 
-The "I am" regular expression (RegEx) pattern matches the string.
-This test passes.
+    The "I am" regular expression (RegEx) pattern matches the string.
+    This test passes.
 
-.EXAMPLE
-"I am a value" | Should -MatchExactly "I Am"
+    .EXAMPLE
+    "I am a value" | Should -MatchExactly "I Am"
 
-Because MatchExactly is case sensitive, this test fails.
-For a case insensitive test, see Match.
-#>
+    Because MatchExactly is case sensitive, this test fails.
+    For a case insensitive test, see Match.
+    #>
     [bool] $succeeded = $ActualValue -cmatch $RegularExpression
 
     if ($Negate) {

--- a/src/functions/assertions/PesterThrow.ps1
+++ b/src/functions/assertions/PesterThrow.ps1
@@ -1,34 +1,34 @@
 ﻿function Should-Throw {
     <#
-.SYNOPSIS
-Checks if an exception was thrown. Enclose input in a script block.
+    .SYNOPSIS
+    Checks if an exception was thrown. Enclose input in a script block.
 
-Warning: The input object must be a ScriptBlock, otherwise it is processed outside of the assertion.
+    Warning: The input object must be a ScriptBlock, otherwise it is processed outside of the assertion.
 
-.EXAMPLE
-{ foo } | Should -Throw
+    .EXAMPLE
+    { foo } | Should -Throw
 
-Because "foo" isn't a known command, PowerShell throws an error.
-Throw confirms that an error occurred, and successfully passes the test.
+    Because "foo" isn't a known command, PowerShell throws an error.
+    Throw confirms that an error occurred, and successfully passes the test.
 
-.EXAMPLE
-{ foo } | Should -Not -Throw
+    .EXAMPLE
+    { foo } | Should -Not -Throw
 
-By using -Not with -Throw, the opposite effect is achieved.
-"Should -Not -Throw" expects no error, but one occurs, and the test fails.
+    By using -Not with -Throw, the opposite effect is achieved.
+    "Should -Not -Throw" expects no error, but one occurs, and the test fails.
 
-.EXAMPLE
-{ $foo = 1 } | Should -Throw
+    .EXAMPLE
+    { $foo = 1 } | Should -Throw
 
-Assigning a variable does not throw an error.
-If asserting "Should -Throw" but no error occurs, the test fails.
+    Assigning a variable does not throw an error.
+    If asserting "Should -Throw" but no error occurs, the test fails.
 
-.EXAMPLE
-{ $foo = 1 } | Should -Not -Throw
+    .EXAMPLE
+    { $foo = 1 } | Should -Not -Throw
 
-Assert that assigning a variable should not throw an error.
-It does not throw an error, so the test passes.
-#>
+    Assert that assigning a variable should not throw an error.
+    It does not throw an error, so the test passes.
+    #>
     param (
         [ScriptBlock] $ActualValue,
         [string] $ExpectedMessage,

--- a/src/functions/assertions/Should.ps1
+++ b/src/functions/assertions/Should.ps1
@@ -37,36 +37,6 @@ function Should {
     The actual value that was obtained in the test which should be verified against
     a expected value.
 
-    .LINK
-    https://pester.dev/docs/commands/Should
-
-    .LINK
-    https://pester.dev/docs/assertions/assertions
-
-    .EXAMPLE
-    ```powershell
-    Describe "d1" {
-        BeforeEach { $be = 1 }
-        It "i1" {
-            $be = 2
-        }
-        AfterEach { Write-Host "AfterEach: $be" }
-    }
-    ```
-
-    .EXAMPLE
-    ```powershell
-    Describe "d1" {
-        It "i1" {
-            $user = Get-User
-            $user | Should -NotBeNullOrEmpty -ErrorAction Stop
-            $user |
-                Should -HaveProperty Name -Value "Jakub" |
-                Should -HaveProperty Age  -Value 30
-        }
-    }
-    ```
-
     .EXAMPLE
     ```powershell
     Describe "d1" {
@@ -76,6 +46,8 @@ function Should {
             Should -Invoke Get-Command -Times 1 -Exactly
         }
     }
+
+    Example of creating a mock for `Get-Command` and asserting that it was called exactly one time.
     ```
 
     .EXAMPLE
@@ -92,28 +64,45 @@ function Should {
     .EXAMPLE
     $true | Should -BeFalse
 
+    Asserting that the input value is false. This would fail the test by throwing an error.
+
     .EXAMPLE
     $a | Should -Be 10
+
+    Asserting that the input value defined in $a is equal to 10.
 
     .EXAMPLE
     Should -Invoke Get-Command -Times 1 -Exactly
 
+    Asserting that the mocked `Get-Command` was called exactly one time.
+
     .EXAMPLE
-    $user | Should -NotBeNullOrEmpty -ErrorAction Stop
+    $user | Should -Not -BeNullOrEmpty
+
+    Asserting that the input value from $user is not null or empty.
 
     .EXAMPLE
     $planets.Name | Should -Be $Expected
+
+    Asserting that the value of `$planets.Name` is equal to the value defined in `$Expected`.
 
     .EXAMPLE
     ```powershell
     Context "We want to ensure an exception is thrown when expected" {
         It "Throws the exception" {
-            { Get-Application -Name Blarg } | Should -Throw "Application 'Blarg' not found"
+            { Get-Application -Name Blarg } | Should -Throw -ExpectedMessage "Application 'Blarg' not found"
         }
     }
-    ```
-#>
 
+    Asserting that `Get-Application -Name Blarg` will throw an exception with a specific message.
+    ```
+
+    .LINK
+    https://pester.dev/docs/commands/Should
+
+    .LINK
+    https://pester.dev/docs/assertions/assertions
+    #>
     [CmdletBinding()]
     param (
         [Parameter(ValueFromPipeline = $true, ValueFromRemainingArguments = $true)]

--- a/src/functions/assertions/Should.ps1
+++ b/src/functions/assertions/Should.ps1
@@ -46,9 +46,9 @@ function Should {
             Should -Invoke Get-Command -Times 1 -Exactly
         }
     }
+    ```
 
     Example of creating a mock for `Get-Command` and asserting that it was called exactly one time.
-    ```
 
     .EXAMPLE
     $true | Should -BeFalse
@@ -82,9 +82,9 @@ function Should {
             { Get-Application -Name Blarg } | Should -Throw -ExpectedMessage "Application 'Blarg' not found"
         }
     }
+    ```
 
     Asserting that `Get-Application -Name Blarg` will throw an exception with a specific message.
-    ```
 
     .LINK
     https://pester.dev/docs/commands/Should

--- a/src/functions/assertions/Should.ps1
+++ b/src/functions/assertions/Should.ps1
@@ -51,17 +51,6 @@ function Should {
     ```
 
     .EXAMPLE
-    ```powershell
-    Describe "d1" {
-        It "i1" {
-            Mock Get-Command { }
-            Get-Command -CommandName abc
-            Should -Invoke Get-Command -Times 1 -Exactly
-        }
-    }
-    ```
-
-    .EXAMPLE
     $true | Should -BeFalse
 
     Asserting that the input value is false. This would fail the test by throwing an error.


### PR DESCRIPTION
## PR Summary
General cleanup in comment-based help:
- Removed duplicate and non-working examples
- Updated some examples to Pester v5 syntax
- Lots of whitespace changes to keep same indendation
- Add missing example description

Fix #2129
Related to https://github.com/pester/docs/pull/212#issuecomment-1166529967

Tip: Review without whitepsace-changes.

## PR Checklist

- [x] PR has meaningful title
- [x] Summary describes changes
- [x] PR is ready to be merged
  - If not, use the arrow next to `Create Pull Request` to mark it as a draft. PR can be marked `Ready for review` when it's ready.
- [ ] Tests are added/update *(if required)*
- [x] Documentation is updated/added *(if required)*