### PR TITLE
Add -NoBuild for P-tests

### DIFF
--- a/test.ps1
+++ b/test.ps1
@@ -63,7 +63,7 @@ Get-Module Pester | Remove-Module
 if (-not $SkipPTests) {
     $result = @(Get-ChildItem $PSScriptRoot/tst/*.ts.ps1 -Recurse |
             foreach {
-                $r = & $_.FullName -PassThru
+                $r = & $_.FullName -PassThru -NoBuild:$NoBuild
                 if ($r.Failed -gt 0) {
                     [PSCustomObject]@{
                         FullName = $_.FullName

--- a/tst/Pester.Mock.RSpec.ts.ps1
+++ b/tst/Pester.Mock.RSpec.ts.ps1
@@ -1,11 +1,11 @@
-﻿param ([switch] $PassThru)
+﻿param ([switch] $PassThru, [switch] $NoBuild)
 
 Get-Module Pester.Runtime, Pester.Utility, P, Pester, Axiom, Stack | Remove-Module
 
 Import-Module $PSScriptRoot\p.psm1 -DisableNameChecking
 Import-Module $PSScriptRoot\axiom\Axiom.psm1 -DisableNameChecking
 
-& "$PSScriptRoot\..\build.ps1"
+if (-not $NoBuild) { & "$PSScriptRoot\..\build.ps1" }
 Import-Module $PSScriptRoot\..\bin\Pester.psd1
 
 $global:PesterPreference = [PesterConfiguration] @{

--- a/tst/Pester.RSpec.BackCompat.ts.ps1
+++ b/tst/Pester.RSpec.BackCompat.ts.ps1
@@ -1,11 +1,11 @@
-﻿param ([switch] $PassThru)
+﻿param ([switch] $PassThru, [switch] $NoBuild)
 
 Get-Module Pester.Runtime, Pester.Utility, P, Pester, Axiom, Stack | Remove-Module
 
 Import-Module $PSScriptRoot\p.psm1 -DisableNameChecking
 Import-Module $PSScriptRoot\axiom\Axiom.psm1 -DisableNameChecking
 
-& "$PSScriptRoot\..\build.ps1"
+if (-not $NoBuild) { & "$PSScriptRoot\..\build.ps1" }
 Import-Module $PSScriptRoot\..\bin\Pester.psd1
 
 $global:PesterPreference = @{

--- a/tst/Pester.RSpec.Configuration.ts.ps1
+++ b/tst/Pester.RSpec.Configuration.ts.ps1
@@ -1,11 +1,11 @@
-﻿param ([switch] $PassThru)
+﻿param ([switch] $PassThru, [switch] $NoBuild)
 
 Get-Module Pester.Runtime, Pester.Utility, P, Pester, Axiom, Stack | Remove-Module
 
 Import-Module $PSScriptRoot\p.psm1 -DisableNameChecking
 Import-Module $PSScriptRoot\axiom\Axiom.psm1 -DisableNameChecking
 
-& "$PSScriptRoot\..\build.ps1"
+if (-not $NoBuild) { & "$PSScriptRoot\..\build.ps1" }
 Import-Module $PSScriptRoot\..\bin\Pester.psd1
 
 $global:PesterPreference = @{

--- a/tst/Pester.RSpec.Coverage.ts.ps1
+++ b/tst/Pester.RSpec.Coverage.ts.ps1
@@ -1,11 +1,11 @@
-param ([switch] $PassThru)
+param ([switch] $PassThru, [switch] $NoBuild)
 
 Get-Module Pester.Runtime, Pester.Utility, P, Pester, Axiom, Stack | Remove-Module
 
 Import-Module $PSScriptRoot\p.psm1 -DisableNameChecking
 Import-Module $PSScriptRoot\axiom\Axiom.psm1 -DisableNameChecking
 
-& "$PSScriptRoot\..\build.ps1"
+if (-not $NoBuild) { & "$PSScriptRoot\..\build.ps1" }
 Import-Module $PSScriptRoot\..\bin\Pester.psd1
 
 $global:PesterPreference = @{

--- a/tst/Pester.RSpec.Demo.ts.ps1
+++ b/tst/Pester.RSpec.Demo.ts.ps1
@@ -1,11 +1,11 @@
-﻿param ([switch] $PassThru)
+﻿param ([switch] $PassThru, [switch] $NoBuild)
 
 Get-Module Pester.Runtime, Pester.Utility, P, Pester, Axiom, Stack | Remove-Module
 
 Import-Module $PSScriptRoot\p.psm1 -DisableNameChecking
 Import-Module $PSScriptRoot\axiom\Axiom.psm1 -DisableNameChecking
 
-& "$PSScriptRoot\..\build.ps1"
+if (-not $NoBuild) { & "$PSScriptRoot\..\build.ps1" }
 Import-Module $PSScriptRoot\..\bin\Pester.psd1
 
 $global:PesterPreference = [PesterConfiguration]@{

--- a/tst/Pester.RSpec.InNewProcess.ts.ps1
+++ b/tst/Pester.RSpec.InNewProcess.ts.ps1
@@ -1,11 +1,11 @@
-﻿param ([switch] $PassThru)
+﻿param ([switch] $PassThru, [switch] $NoBuild)
 
 Get-Module Pester.Runtime, Pester.Utility, P, Pester, Axiom, Stack | Remove-Module
 
 Import-Module $PSScriptRoot\p.psm1 -DisableNameChecking
 Import-Module $PSScriptRoot\axiom\Axiom.psm1 -DisableNameChecking
 
-& "$PSScriptRoot\..\build.ps1"
+if (-not $NoBuild) { & "$PSScriptRoot\..\build.ps1" }
 Import-Module $PSScriptRoot\..\bin\Pester.psd1
 
 $global:PesterPreference = @{

--- a/tst/Pester.RSpec.Junit.TestResults.ts.ps1
+++ b/tst/Pester.RSpec.Junit.TestResults.ts.ps1
@@ -1,11 +1,11 @@
-﻿param ([switch] $PassThru)
+﻿param ([switch] $PassThru, [switch] $NoBuild)
 
 Get-Module Pester.Runtime, Pester.Utility, P, Pester, Axiom, Stack | Remove-Module
 
 Import-Module $PSScriptRoot\p.psm1 -DisableNameChecking
 Import-Module $PSScriptRoot\axiom\Axiom.psm1 -DisableNameChecking
 
-& "$PSScriptRoot\..\build.ps1"
+if (-not $NoBuild) { & "$PSScriptRoot\..\build.ps1" }
 Import-Module $PSScriptRoot\..\bin\Pester.psd1
 
 $global:PesterPreference = @{

--- a/tst/Pester.RSpec.Nunit.TestResults.ts.ps1
+++ b/tst/Pester.RSpec.Nunit.TestResults.ts.ps1
@@ -1,11 +1,11 @@
-﻿param ([switch] $PassThru)
+﻿param ([switch] $PassThru, [switch] $NoBuild)
 
 Get-Module Pester.Runtime, Pester.Utility, P, Pester, Axiom, Stack | Remove-Module
 
 Import-Module $PSScriptRoot\p.psm1 -DisableNameChecking
 Import-Module $PSScriptRoot\axiom\Axiom.psm1 -DisableNameChecking
 
-& "$PSScriptRoot\..\build.ps1"
+if (-not $NoBuild) { & "$PSScriptRoot\..\build.ps1" }
 Import-Module $PSScriptRoot\..\bin\Pester.psd1
 
 $global:PesterPreference = @{

--- a/tst/Pester.RSpec.Output.ts.ps1
+++ b/tst/Pester.RSpec.Output.ts.ps1
@@ -1,11 +1,11 @@
-﻿param ([switch] $PassThru)
+﻿param ([switch] $PassThru, [switch] $NoBuild)
 
 Get-Module Pester.Runtime, Pester.Utility, P, Pester, Axiom, Stack | Remove-Module
 
 Import-Module $PSScriptRoot\p.psm1 -DisableNameChecking
 Import-Module $PSScriptRoot\axiom\Axiom.psm1 -DisableNameChecking
 
-& "$PSScriptRoot\..\build.ps1"
+if (-not $NoBuild) { & "$PSScriptRoot\..\build.ps1" }
 Import-Module $PSScriptRoot\..\bin\Pester.psd1
 
 $global:PesterPreference = @{

--- a/tst/Pester.RSpec.Pester4ResultObject.ts.ps1
+++ b/tst/Pester.RSpec.Pester4ResultObject.ts.ps1
@@ -1,4 +1,4 @@
-﻿param ([switch] $PassThru)
+﻿param ([switch] $PassThru, [switch] $NoBuild)
 # excluding this, as it produces errors because errors are processed differently between v4 and v5, but it is still useful to have around to confirm the overall shape of the result object is correct
 return (i -PassThru:$PassThru { })
 
@@ -7,7 +7,7 @@ Get-Module Pester.Runtime, Pester.Utility, P, Pester, Axiom, Stack | Remove-Modu
 Import-Module $PSScriptRoot\p.psm1 -DisableNameChecking
 Import-Module $PSScriptRoot\axiom\Axiom.psm1 -DisableNameChecking
 
-& "$PSScriptRoot\..\build.ps1"
+if (-not $NoBuild) { & "$PSScriptRoot\..\build.ps1" }
 Import-Module $PSScriptRoot\..\bin\Pester.psd1
 
 

--- a/tst/Pester.RSpec.ts.ps1
+++ b/tst/Pester.RSpec.ts.ps1
@@ -1,11 +1,11 @@
-﻿param ([switch] $PassThru)
+﻿param ([switch] $PassThru, [switch] $NoBuild)
 
 Get-Module Pester.Runtime, Pester.Utility, P, Pester, Axiom, Stack | Remove-Module
 
 Import-Module $PSScriptRoot\p.psm1 -DisableNameChecking
 Import-Module $PSScriptRoot\axiom\Axiom.psm1 -DisableNameChecking
 
-& "$PSScriptRoot\..\build.ps1"
+if (-not $NoBuild) { & "$PSScriptRoot\..\build.ps1" }
 Import-Module $PSScriptRoot\..\bin\Pester.psd1
 
 $global:PesterPreference = @{

--- a/tst/Pester.Rspec.Filtering.ts.ps1
+++ b/tst/Pester.Rspec.Filtering.ts.ps1
@@ -1,11 +1,11 @@
-﻿param ([switch] $PassThru)
+﻿param ([switch] $PassThru, [switch] $NoBuild)
 
 Get-Module Pester.Runtime, Pester.Utility, P, Pester, Axiom, Stack | Remove-Module
 
 Import-Module $PSScriptRoot\p.psm1 -DisableNameChecking
 Import-Module $PSScriptRoot\axiom\Axiom.psm1 -DisableNameChecking
 
-& "$PSScriptRoot\..\build.ps1"
+if (-not $NoBuild) { & "$PSScriptRoot\..\build.ps1" }
 Import-Module $PSScriptRoot\..\bin\Pester.psd1
 
 $global:PesterPreference = @{

--- a/tst/functions/New-Fixture.ts.ps1
+++ b/tst/functions/New-Fixture.ts.ps1
@@ -1,11 +1,11 @@
-﻿param ([switch] $PassThru)
+﻿param ([switch] $PassThru, [switch] $NoBuild)
 
 Get-Module Pester.Runtime, Pester.Utility, P, Pester, Axiom, Stack | Remove-Module
 
 Import-Module $PSScriptRoot\..\p.psm1 -DisableNameChecking
 Import-Module $PSScriptRoot\..\axiom\Axiom.psm1 -DisableNameChecking
 
-& "$PSScriptRoot\..\..\build.ps1"
+if (-not $NoBuild) { & "$PSScriptRoot\..\..\build.ps1" }
 Import-Module $PSScriptRoot\..\..\bin\Pester.psd1
 
 $global:PesterPreference = @{

--- a/tst/functions/Pester.TestDrive.ts.ps1
+++ b/tst/functions/Pester.TestDrive.ts.ps1
@@ -1,11 +1,11 @@
-﻿param ([switch] $PassThru)
+﻿param ([switch] $PassThru, [switch] $NoBuild)
 
 Get-Module Pester.Runtime, Pester.Utility, P, Pester, Axiom, Stack | Remove-Module
 
 Import-Module $PSScriptRoot\..\p.psm1 -DisableNameChecking
 Import-Module $PSScriptRoot\..\axiom\Axiom.psm1 -DisableNameChecking
 
-& "$PSScriptRoot\..\..\build.ps1"
+if (-not $NoBuild) { & "$PSScriptRoot\..\..\build.ps1" }
 Import-Module $PSScriptRoot\..\..\bin\Pester.psd1
 
 $global:PesterPreference = @{

--- a/tst/functions/Pester.TestRegistry.ts.ps1
+++ b/tst/functions/Pester.TestRegistry.ts.ps1
@@ -1,4 +1,4 @@
-﻿param ([switch] $PassThru)
+﻿param ([switch] $PassThru, [switch] $NoBuild)
 
 
 Get-Module Pester.Runtime, Pester.Utility, P, Pester, Axiom, Stack | Remove-Module
@@ -11,7 +11,7 @@ if ($PSVersionTable.PSVersion.Major -gt 5 -and -not $IsWindows) {
     return (i -PassThru:$PassThru { })
 }
 
-& "$PSScriptRoot\..\..\build.ps1"
+if (-not $NoBuild) { & "$PSScriptRoot\..\..\build.ps1" }
 Import-Module $PSScriptRoot\..\..\bin\Pester.psd1
 
 $global:PesterPreference = @{


### PR DESCRIPTION
## PR Summary
Making sure P-tests respect `-NoBuild` in `test.ps1` to enable parallell runs on Windows and Unix (devcontainer).

## PR Checklist

- [x] PR has meaningful title
- [x] Summary describes changes
- [x] PR is ready to be merged
  - If not, use the arrow next to `Create Pull Request` to mark it as a draft. PR can be marked `Ready for review` when it's ready.
- [ ] Tests are added/update *(if required)*
- [ ] Documentation is updated/added *(if required)*