### PR TITLE
Fix broken assertions link in help

### DIFF
--- a/src/functions/assertions/Should.ps1
+++ b/src/functions/assertions/Should.ps1
@@ -90,7 +90,7 @@ function Should {
     https://pester.dev/docs/commands/Should
 
     .LINK
-    https://pester.dev/docs/assertions/assertions
+    https://pester.dev/docs/assertions
     #>
     [CmdletBinding()]
     param (


### PR DESCRIPTION
## PR Summary
Fixes a broken link in `Should` help for the custom assertions page at https://pester.dev/docs/assertions.

## PR Checklist

- [x] PR has meaningful title
- [x] Summary describes changes
- [x] PR is ready to be merged
  - If not, use the arrow next to `Create Pull Request` to mark it as a draft. PR can be marked `Ready for review` when it's ready.
- [ ] Tests are added/update *(if required)*
- [ ] Documentation is updated/added *(if required)*