### PR TITLE
Fix module installation in PowerShell 3 and 4

### DIFF
--- a/src/Pester.Runtime.ps1
+++ b/src/Pester.Runtime.ps1
@@ -2502,9 +2502,9 @@ function Import-Dependency {
         # that script block, and then we dot source it again to import it
         # into the caller scope, effectively defining the functions there
         $sb = {
-            param ($p)
+            param ($p, $private:Remove_Variable)
 
-            . $($p; & $SafeCommands['Remove-Variable'] -Scope Local -Name p)
+            . $($p; & $private:Remove_Variable -Scope Local -Name p)
         }
 
         $flags = [System.Reflection.BindingFlags]'Instance,NonPublic'
@@ -2515,7 +2515,7 @@ function Import-Dependency {
         $sb.GetType().GetProperty('SessionStateInternal', $flags).SetValue($sb, $SessionStateInternal, $null)
 
         # dot source the caller bound scriptblock which imports it into user scope
-        . $sb $Dependency
+        . $sb $Dependency $SafeCommands['Remove-Variable']
     }
 }
 


### PR DESCRIPTION
## PR Summary
For some reason `Install-Module` for Pester 5.1.0+ fails on PowerShell 3 and 4 while testing the module manifest due to an error in a function that's never executed. Not worth figuring out why it's invoked, but fixing the invalid reference to the `$SafeCommands`-dictionary seems to fix it.

Fix #1791

## PR Checklist

- [x] PR has meaningful title
- [x] Summary describes changes
- [x] PR is ready to be merged
  - If not, use the arrow next to `Create Pull Request` to mark it as a draft. PR can be marked `Ready for review` when it's ready.
- [ ] Tests are added/update *(if required)*
- [ ] Documentation is updated/added *(if required)*