### PR TITLE
Fix support for PowerShell 6.0.4

### DIFF
--- a/src/csharp/Pester/Pester.csproj
+++ b/src/csharp/Pester/Pester.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <PackageReference Include="System.Management.Automation" Version="6.1.0" />
+    <PackageReference Include="System.Management.Automation" Version="6.0.4" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net452'">

--- a/src/csharp/Pester/Pester.csproj
+++ b/src/csharp/Pester/Pester.csproj
@@ -5,6 +5,8 @@
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <!-- this version is used specifically to support as old version of PS6 as we can.
+    issue: https://github.com/pester/Pester/issues/2207 -->
     <PackageReference Include="System.Management.Automation" Version="6.0.4" />
   </ItemGroup>
 


### PR DESCRIPTION
## PR Summary
In the netstandard2.0 version of Pester.dll there is a requirement for `System.Management.Automation` 6.1.0 or later which blocks users with PowerShell 6.0.x versions from being able to load Pester. 

As there doesn't seem to be a obvious reason for 6.1.0+, this PR downgrades the package reference to the lowest available version on nuget, 6.0.4.

Fix #2207

## PR Checklist

- [x] PR has meaningful title
- [x] Summary describes changes
- [x] PR is ready to be merged
  - If not, use the arrow next to `Create Pull Request` to mark it as a draft. PR can be marked `Ready for review` when it's ready.
- [ ] Tests are added/update *(if required)*
- [ ] Documentation is updated/added *(if required)*
