### PR TITLE
Start interactive execution from BeforeDiscovery

### DIFF
--- a/src/Main.ps1
+++ b/src/Main.ps1
@@ -1635,10 +1635,6 @@ function BeforeDiscovery {
         . $ScriptBlock
     }
     else {
-        if ($invokedInteractively) {
-            return
-        }
-        $invokedInteractively = $true
         Invoke-Interactively -CommandUsed 'BeforeDiscovery' -ScriptName $PSCmdlet.MyInvocation.ScriptName -SessionState $PSCmdlet.SessionState -BoundParameters $PSCmdlet.MyInvocation.BoundParameters
     }
 }

--- a/src/Main.ps1
+++ b/src/Main.ps1
@@ -1631,7 +1631,16 @@ function BeforeDiscovery {
         [ScriptBlock]$ScriptBlock
     )
 
-    . $ScriptBlock
+    if ($ExecutionContext.SessionState.PSVariable.Get('invokedViaInvokePester')) {
+        . $ScriptBlock
+    }
+    else {
+        if ($invokedInteractively) {
+            return
+        }
+        $invokedInteractively = $true
+        Invoke-Interactively -CommandUsed 'BeforeDiscovery' -ScriptName $PSCmdlet.MyInvocation.ScriptName -SessionState $PSCmdlet.SessionState -BoundParameters $PSCmdlet.MyInvocation.BoundParameters
+    }
 }
 
 # Adding Add-ShouldOperator because it used to be an alias in v4, and so when we now import it will take precedence over


### PR DESCRIPTION
## PR Summary
Extends interactive execution to also being triggered from root-level `BeforeDiscovery`.

This is necessary to avoid leaking variables from a `BeforeDiscovery`-block to Run-phase during interactive execution when `BeforeDiscovery` is placed before `Context\Describe` which it usually is. The variables would've been made available in Run-phase from a parent scope.

`Before-/AfterEach` throw when used in root and `Before-/AfterAll` only works when in Discovery-phase, so they're not affected.

Fix #2092

## PR Checklist

- [x] PR has meaningful title
- [x] Summary describes changes
- [x] PR is ready to be merged
  - If not, use the arrow next to `Create Pull Request` to mark it as a draft. PR can be marked `Ready for review` when it's ready.
- [x] Tests are added/update *(if required)*
- [ ] Documentation is updated/added *(if required)*