### PR TITLE
Exit invoked testfile after interactive execution

### DIFF
--- a/src/functions/Context.ps1
+++ b/src/functions/Context.ps1
@@ -115,10 +115,6 @@
         }
     }
     else {
-        if ($invokedInteractively) {
-            return
-        }
-        $invokedInteractively = $true
         Invoke-Interactively -CommandUsed 'Context' -ScriptName $PSCmdlet.MyInvocation.ScriptName -SessionState $PSCmdlet.SessionState -BoundParameters $PSCmdlet.MyInvocation.BoundParameters
     }
 }


### PR DESCRIPTION
## PR Summary
Stops execution of directly invoked testfile after interactive execution of Pester (triggered by first `Describe`, `Context` or `BeforeDiscovery`) is complete. Will reduce remaining risk of root-level code "corrupting" session [discussed here](https://github.com/pester/Pester/issues/2092#issuecomment-1184956209) to only be code before any of the three blocks mentioned above.

**Current behavior** checks that the same file wasn't just executed to avoid triggering Pester multiple times when the testfile has multiple root-level blocks.

**New behavior** exits the testfile-script using `exit` to cover logic above while also avoiding rerunning any root-level code after the first block that triggered interactive execution. Simplifies the logic in general.

This PR also removes non-invoked check in `Context` ([mentioned here](https://github.com/pester/Pester/pull/2217#issuecomment-1185037582)) and adds tests for scenarios covered by both current and new logic.

Fix #2216
Related #2217

## PR Checklist

- [x] PR has meaningful title
- [x] Summary describes changes
- [x] PR is ready to be merged
  - If not, use the arrow next to `Create Pull Request` to mark it as a draft. PR can be marked `Ready for review` when it's ready.
- [x] Tests are added/update *(if required)*
- [ ] Documentation is updated/added *(if required)*
