### PR TITLE
Fix NRE when assigning null to arrayoption in hashtable

### DIFF
--- a/src/csharp/Pester/DictionaryExtensions.cs
+++ b/src/csharp/Pester/DictionaryExtensions.cs
@@ -58,7 +58,7 @@ namespace Pester
 
         public static T[] GetArrayOrNull<T>(this IDictionary dictionary, string key) where T : class
         {
-            if (!dictionary.Contains(key))
+            if (!dictionary.Contains(key) || dictionary[key] is null)
                 return null;
 
             var value = dictionary[key];

--- a/tst/Pester.RSpec.Configuration.ts.ps1
+++ b/tst/Pester.RSpec.Configuration.ts.ps1
@@ -268,6 +268,27 @@ i -PassThru:$PassThru {
             $config.Run.Path = $config.Run.Path.Default
             $config.Run.Path.IsOriginalValue() | Verify-False
         }
+
+        t "Assigning null to array option using hashtable does not throw" {
+            # https://github.com/pester/Pester/issues/2026
+            $config = [PesterConfiguration]@{ Run = @{ Path = $null } }
+            $config.Run.Path | Verify-NotNull
+        }
+
+        t "Assigning null to string option using hashtable does not throw" {
+            $config = [PesterConfiguration]@{ Run = @{ TestExtension = $null } }
+            $config.Run.TestExtension | Verify-NotNull
+        }
+
+        t "Assigning null to value option using hashtable does not throw" {
+            $config = [PesterConfiguration]@{ Run = @{ Exit = $null } }
+            $config.Run.Exit.Value | Verify-NotNull
+        }
+
+        t "Assigning null to config-section in hashtable does not throw" {
+            $config = [PesterConfiguration]@{ Run = $null }
+            $config.Run | Verify-NotNull
+        }
     }
 
     b "Cloning" {


### PR DESCRIPTION
## PR Summary
`GetArrayOrNull()` throws a NRE when value is null, ex. when `Run.Path` was set to `$null` in a hashtable. Added null-check to return before any use of `.GetType()` etc.

Fixing this hashtable-scenario because Pester ignores null-values while casting from hashtable and the error didn't make it clear which option had the problem:
```
InvalidArgument: Cannot convert value "System.Collections.Hashtable" to type "PesterConfiguration". Error: "Object reference not set to an instance of an object."
```

Fix #2026

## PR Checklist

- [x] PR has meaningful title
- [x] Summary describes changes
- [x] PR is ready to be merged
  - If not, use the arrow next to `Create Pull Request` to mark it as a draft. PR can be marked `Ready for review` when it's ready.
- [x] Tests are added/update *(if required)*
- [ ] Documentation is updated/added *(if required)*