### PR TITLE
Allow -Mandatory:$false and -HasArgumentCompleter:$false in HaveParameter assertion

### DIFF
--- a/src/functions/assertions/HaveParameter.ps1
+++ b/src/functions/assertions/HaveParameter.ps1
@@ -17,8 +17,13 @@
 
         This test passes, because it expected the parameter URI to exist and to
         be mandatory.
+    .EXAMPLE
+        Get-Command "Invoke-WebRequest" | Should -HaveParameter Method -Mandatory:$false
+
+        This test passes, because it expected the parameter Method to exist and to
+        not be mandatory/required.
     .NOTES
-        The attribute [ArgumentCompleter] was added with PSv5. Previouse this
+        The attribute [ArgumentCompleter] was added with PSv5. Previous this
         assertion will not be able to use the -HasArgumentCompleter parameter
         if the attribute does not exist.
     #>

--- a/src/functions/assertions/HaveParameter.ps1
+++ b/src/functions/assertions/HaveParameter.ps1
@@ -258,19 +258,30 @@
             }
         }
 
-        if ($HasArgumentCompleter) {
+        if ($PSBoundParameters.ContainsKey('HasArgumentCompleter')) {
             $testArgumentCompleter = $attributes | & $SafeCommands['Where-Object'] { $_ -is [ArgumentCompleter] }
 
             if (-not $testArgumentCompleter) {
                 $testArgumentCompleter = Get-ArgumentCompleter -CommandName $ActualValue.Name -ParameterName $ParameterName
             }
-            $filters += "has ArgumentCompletion"
+            $filters += "with$(if ($Negate -or $HasArgumentCompleter -eq $false) {'out'}) ArgumentCompletion"
 
-            if (-not $Negate -and -not $testArgumentCompleter) {
-                $buts += "has no ArgumentCompletion"
+            if ($Negate) {
+                if ($HasArgumentCompleter -and $testArgumentCompleter) {
+                    # -Not -HasArgumentCompleter but it did
+                    $buts += 'it has ArgumentCompletion'
+                }
+                # -Not -HasArgumentCompleter:$false ignored as it makes no sense to use
             }
-            elseif ($Negate -and $testArgumentCompleter) {
-                $buts += "has ArgumentCompletion"
+            else {
+                if ($HasArgumentCompleter -and -not $testArgumentCompleter ) {
+                    # -HasArgumentCompleter but it did not
+                    $buts += 'it has no ArgumentCompletion'
+                }
+                elseif (-not $HasArgumentCompleter -and $testArgumentCompleter) {
+                    # -HasArgumentCompleter:$false but it did
+                    $buts += 'it has ArgumentCompletion'
+                }
             }
         }
 

--- a/tst/functions/assertions/HaveParameter.Tests.ps1
+++ b/tst/functions/assertions/HaveParameter.Tests.ps1
@@ -151,6 +151,14 @@ InPesterModuleScope {
                 param($ParameterName)
                 Get-Command "Invoke-DummyFunction" | Should -HaveParameter $ParameterName -HasArgumentCompleter
             }
+
+            It 'passes if the parameter <ParameterName> matches explicit -HasArgumentCompleter:<HasArgumentCompleter>' -TestCases @(
+                @{ParameterName = 'ParamWithArgumentCompleter'; HasArgumentCompleter = $true }
+                @{ParameterName = 'ParamWithRegisteredArgumentCompleter'; HasArgumentCompleter = $true }
+                @{ParameterName = 'MandatoryParam'; HasArgumentCompleter = $false }
+            ) {
+                Get-Command 'Invoke-DummyFunction' | Should -HaveParameter $ParameterName -HasArgumentCompleter:$HasArgumentCompleter
+            }
         }
 
         It "passes if the parameter <ParameterName> has a default value '<ExpectedValue>'" -TestCases @(
@@ -249,6 +257,14 @@ InPesterModuleScope {
             ) {
                 param($ParameterName)
                 { Get-Command "Invoke-DummyFunction" | Should -HaveParameter $ParameterName -HasArgumentCompleter } | Verify-AssertionFailed
+            }
+
+            It 'fails if the parameter <ParameterName> exists but does not match explicit -HasArgumentCompleter:<HasArgumentCompleter>' -TestCases @(
+                @{ParameterName = 'MandatoryParam'; HasArgumentCompleter = $true }
+                @{ParameterName = 'ParamWithArgumentCompleter'; HasArgumentCompleter = $false }
+                @{ParameterName = 'ParamWithRegisteredArgumentCompleter'; HasArgumentCompleter = $false }
+            ) {
+                { Get-Command 'Invoke-DummyFunction' | Should -HaveParameter $ParameterName -HasArgumentCompleter:$HasArgumentCompleter } | Verify-AssertionFailed
             }
         }
 

--- a/tst/functions/assertions/HaveParameter.Tests.ps1
+++ b/tst/functions/assertions/HaveParameter.Tests.ps1
@@ -1,4 +1,4 @@
-﻿Set-StrictMode -Version Latest
+Set-StrictMode -Version Latest
 
 InPesterModuleScope {
 
@@ -123,6 +123,13 @@ InPesterModuleScope {
             Get-Command "Invoke-DummyFunction" | Should -HaveParameter $ParameterName -Mandatory
         }
 
+        It "passes if the parameter <ParameterName> matches explicit -Mandatory:<Mandatory>" -TestCases @(
+            @{ParameterName = "MandatoryParam"; Mandatory = $true }
+            @{ParameterName = 'ParamWithNotNullOrEmptyValidation'; Mandatory = $false }
+        ) {
+            Get-Command 'Invoke-DummyFunction' | Should -HaveParameter $ParameterName -Mandatory:$Mandatory
+        }
+
         It "passes if the parameter <ParameterName> is of type <ExpectedType>" -TestCases @(
             @{ParameterName = "MandatoryParam"; ExpectedType = [System.Object] }
             @{ParameterName = "ParamWithNotNullOrEmptyValidation"; ExpectedType = [DateTime] }
@@ -210,6 +217,13 @@ InPesterModuleScope {
         ) {
             param($ParameterName)
             { Get-Command "Invoke-DummyFunction" | Should -HaveParameter $ParameterName -Mandatory } | Verify-AssertionFailed
+        }
+
+        It 'fails if the parameter <ParameterName> exists but does not match explicit -Mandatory:<Mandatory>' -TestCases @(
+            @{ParameterName = 'MandatoryParam'; Mandatory = $false }
+            @{ParameterName = 'ParamWithNotNullOrEmptyValidation'; Mandatory = $true }
+        ) {
+            { Get-Command 'Invoke-DummyFunction' | Should -HaveParameter $ParameterName -Mandatory:$Mandatory } | Verify-AssertionFailed
         }
 
         It "fails if the parameter <ParameterName> is not of type <ExpectedType> or does not exist" -TestCases @(

--- a/tst/functions/assertions/HaveParameter.Tests.ps1
+++ b/tst/functions/assertions/HaveParameter.Tests.ps1
@@ -1,4 +1,4 @@
-Set-StrictMode -Version Latest
+﻿Set-StrictMode -Version Latest
 
 InPesterModuleScope {
 
@@ -324,6 +324,11 @@ InPesterModuleScope {
             $err.Exception.Message | Verify-Equal "Expected command Invoke-DummyFunction to have a parameter ParamWithNotNullOrEmptyValidation, which is mandatory, but it wasn't mandatory."
         }
 
+        It 'returns the correct assertion message when parameter MandatoryParam is mandatory with -Mandatory explicitly set to false' {
+            $err = { Get-Command 'Invoke-DummyFunction' | Should -HaveParameter MandatoryParam -Mandatory:$false } | Verify-AssertionFailed
+            $err.Exception.Message | Verify-Equal "Expected command Invoke-DummyFunction to have a parameter MandatoryParam, which is not mandatory, but it was mandatory."
+        }
+
         It "returns the correct assertion message when parameter ParamWithNotNullOrEmptyValidation is not mandatory, of the wrong type and has a different default value than expected" {
             $err = { Get-Command "Invoke-DummyFunction" | Should -HaveParameter ParamWithNotNullOrEmptyValidation -Mandatory -Type [TimeSpan] -DefaultValue "wrong value" -Because 'of reasons' } | Verify-AssertionFailed
             $err.Exception.Message | Verify-Equal "Expected command Invoke-DummyFunction to have a parameter ParamWithNotNullOrEmptyValidation, which is mandatory, of type [System.TimeSpan] and the default value to be 'wrong value', because of reasons, but it wasn't mandatory, it was of type [System.DateTime] and the default value was '(Get-Date)'."
@@ -332,7 +337,12 @@ InPesterModuleScope {
         if ($PSVersionTable.PSVersion.Major -ge 5) {
             It "returns the correct assertion message when parameter ParamWithNotNullOrEmptyValidation is not mandatory, of the wrong type, has a different default value than expected and has no ArgumentCompleter" {
                 $err = { Get-Command "Invoke-DummyFunction" | Should -HaveParameter ParamWithNotNullOrEmptyValidation -Mandatory -Type [TimeSpan] -DefaultValue "wrong value" -HasArgumentCompleter -Because 'of reasons' } | Verify-AssertionFailed
-                $err.Exception.Message | Verify-Equal "Expected command Invoke-DummyFunction to have a parameter ParamWithNotNullOrEmptyValidation, which is mandatory, of type [System.TimeSpan], the default value to be 'wrong value' and has ArgumentCompletion, because of reasons, but it wasn't mandatory, it was of type [System.DateTime], the default value was '(Get-Date)' and has no ArgumentCompletion."
+                $err.Exception.Message | Verify-Equal "Expected command Invoke-DummyFunction to have a parameter ParamWithNotNullOrEmptyValidation, which is mandatory, of type [System.TimeSpan], the default value to be 'wrong value' and with ArgumentCompletion, because of reasons, but it wasn't mandatory, it was of type [System.DateTime], the default value was '(Get-Date)' and it has no ArgumentCompletion."
+            }
+
+            It 'returns the correct assertion message when parameter ParamWithArgumentCompleter has ArgumentCompletion with -HasArgumentCompleter explicitly set to false' {
+                $err = { Get-Command 'Invoke-DummyFunction' | Should -HaveParameter ParamWithArgumentCompleter -HasArgumentCompleter:$false } | Verify-AssertionFailed
+                $err.Exception.Message | Verify-Equal 'Expected command Invoke-DummyFunction to have a parameter ParamWithArgumentCompleter, without ArgumentCompletion, but it has ArgumentCompletion.'
             }
         }
     }
@@ -509,12 +519,12 @@ InPesterModuleScope {
         }
 
         if ($PSVersionTable.PSVersion.Major -ge 5) {
-            It "returns the correct assertion message when parameter ParamWithNotNullOrEmptyValidation is not mandatory, of the wrong type, has a different default value than expected and has no ArgumentCompleter" -TestCases @(
+            It "returns the correct assertion message when parameter ParamWithNotNullOrEmptyValidation is not mandatory, of the wrong type, has a different default value than expected and has unexpected ArgumentCompleter" -TestCases @(
                 @{ParameterName = "ParamWithArgumentCompleter"; ExpectedType = "System.String"; ExpectedValue = "./.git" }
                 @{ParameterName = "ParamWithRegisteredArgumentCompleter"; ExpectedType = "System.String"; ExpectedValue = "./.git" }
             ) {
                 $err = { Get-Command "Invoke-DummyFunction" | Should -Not -HaveParameter $ParameterName -Type $ExpectedType -DefaultValue $ExpectedValue -HasArgumentCompleter -Because 'of reasons' } | Verify-AssertionFailed
-                $err.Exception.Message | Verify-Equal "Expected command Invoke-DummyFunction to not have a parameter $ParameterName, not of type [$ExpectedType], the default value not to be '$ExpectedValue' and has ArgumentCompletion, because of reasons, but it was of type [$ExpectedType], the default value was '$ExpectedValue' and has ArgumentCompletion."
+                $err.Exception.Message | Verify-Equal "Expected command Invoke-DummyFunction to not have a parameter $ParameterName, not of type [$ExpectedType], the default value not to be '$ExpectedValue' and without ArgumentCompletion, because of reasons, but it was of type [$ExpectedType], the default value was '$ExpectedValue' and it has ArgumentCompletion."
             }
         }
     }


### PR DESCRIPTION
## PR Summary
Enables `Should -HaveParameter` to test that a parameter actually exists, but was **not** mandatory and/or did **not** have argument completer.

Currently this was only covered by `Should -Not -HaveParameter abc -Mandatory -HasArgumentCompleter` which would also pass if the parameter was missing, requiring a leading `Should -HaveParameter abc` assertion to avoid false positive.

The change does not break existing syntax and `-SwitchParam:$false` syntax is compatible a bool-parameter should it be changed in the future. So I don't believe this commits us to anything in the future that would require us to wait for new Should/Assert.

Fix #2105

## PR Checklist

- [x] PR has meaningful title
- [x] Summary describes changes
- [x] PR is ready to be merged
  - If not, use the arrow next to `Create Pull Request` to mark it as a draft. PR can be marked `Ready for review` when it's ready.
- [x] Tests are added/update *(if required)*
- [x] Documentation is updated/added *(if required)*