### PR TITLE
Replace alias and positional parameter usage in Coverage.ps1

### DIFF
--- a/src/functions/Coverage.ps1
+++ b/src/functions/Coverage.ps1
@@ -986,15 +986,15 @@ function Get-JaCoCoReportXml {
                         desc = '()'
                         line = $method.FirstLine
                     })
-                Add-JaCoCoCounter Instruction $method $methodElement
-                Add-JaCoCoCounter Line $method $methodElement
-                Add-JaCoCoCounter Method $method $methodElement
+                Add-JaCoCoCounter -Type 'Instruction' -Data $method -Parent $methodElement
+                Add-JaCoCoCounter -Type 'Line' -Data $method -Parent $methodElement
+                Add-JaCoCoCounter -Type 'Method' -Data $method -Parent $methodElement
             }
 
-            Add-JaCoCoCounter Instruction $class $classElement
-            Add-JaCoCoCounter Line $class $classElement
-            Add-JaCoCoCounter Method $class $classElement
-            Add-JaCoCoCounter Class $class $classElement
+            Add-JaCoCoCounter -Type 'Instruction' -Data $class -Parent $classElement
+            Add-JaCoCoCounter -Type 'Line' -Data $class -Parent $classElement
+            Add-JaCoCoCounter -Type 'Method' -Data $class -Parent $classElement
+            Add-JaCoCoCounter -Type 'Class' -Data $class -Parent $classElement
         }
 
         foreach ($file in $package.Classes.Keys) {
@@ -1019,22 +1019,22 @@ function Get-JaCoCoReportXml {
                     })
             }
 
-            Add-JaCoCoCounter Instruction $class $sourceFileElement
-            Add-JaCoCoCounter Line $class $sourceFileElement
-            Add-JaCoCoCounter Method $class $sourceFileElement
-            Add-JaCoCoCounter Class $class $sourceFileElement
+            Add-JaCoCoCounter -Type 'Instruction' -Data $class -Parent $sourceFileElement
+            Add-JaCoCoCounter -Type 'Line' -Data $class -Parent $sourceFileElement
+            Add-JaCoCoCounter -Type 'Method' -Data $class -Parent $sourceFileElement
+            Add-JaCoCoCounter -Type 'Class' -Data $class -Parent $sourceFileElement
         }
 
-        Add-JaCoCoCounter Instruction $package $packageElement
-        Add-JaCoCoCounter Line $package $packageElement
-        Add-JaCoCoCounter Method $package $packageElement
-        Add-JaCoCoCounter Class $package $packageElement
+        Add-JaCoCoCounter -Type 'Instruction' -Data $package -Parent $packageElement
+        Add-JaCoCoCounter -Type 'Line' -Data $package -Parent $packageElement
+        Add-JaCoCoCounter -Type 'Method' -Data $package -Parent $packageElement
+        Add-JaCoCoCounter -Type 'Class' -Data $package -Parent $packageElement
     }
 
-    Add-JaCoCoCounter Instruction $report $reportElement
-    Add-JaCoCoCounter Line $report $reportElement
-    Add-JaCoCoCounter Method $report $reportElement
-    Add-JaCoCoCounter Class $report $reportElement
+    Add-JaCoCoCounter -Type 'Instruction' -Data $report -Parent $reportElement
+    Add-JaCoCoCounter -Type 'Line' -Data $report -Parent $reportElement
+    Add-JaCoCoCounter -Type 'Method' -Data $report -Parent $reportElement
+    Add-JaCoCoCounter -Type 'Class' -Data $report -Parent $reportElement
 
     # There is no pretty way to insert the Doctype, as microsoft has deprecated the DTD stuff.
     $jaCoCoReportDocType = '<!DOCTYPE report PUBLIC "-//JACOCO//DTD Report 1.1//EN" "report.dtd">'

--- a/src/functions/Coverage.ps1
+++ b/src/functions/Coverage.ps1
@@ -955,7 +955,7 @@ function Get-JaCoCoReportXml {
             }
         }
 
-        $packageElement = Add-XmlElement $reportElement "package" @{
+        $packageElement = Add-XmlElement -Parent $reportElement -Name 'package' -Attributes @{
             name = ($packageName -replace "/$", "")
         }
 
@@ -969,7 +969,7 @@ function Get-JaCoCoReportXml {
                 "$commonParentLeaf/$classElementRelativePath"
             }
             $classElementName = $classElementName.Substring(0, $($classElementName.LastIndexOf(".")))
-            $classElement = Add-XmlElement $packageElement 'class' -Attributes ([ordered] @{
+            $classElement = Add-XmlElement-Parent $packageElement -Name 'class' -Attributes ([ordered] @{
                     name           = $classElementName
                     sourcefilename = if ($isGutters) {
                         & $SafeCommands["Split-Path"] $classElementRelativePath -Leaf
@@ -981,7 +981,7 @@ function Get-JaCoCoReportXml {
 
             foreach ($function in $class.Methods.Keys) {
                 $method = $class.Methods.$function
-                $methodElement = Add-XmlElement $classElement 'method' -Attributes ([ordered] @{
+                $methodElement = Add-XmlElement -Parent $classElement -Name 'method' -Attributes ([ordered] @{
                         name = $function
                         desc = '()'
                         line = $method.FirstLine
@@ -1000,7 +1000,7 @@ function Get-JaCoCoReportXml {
         foreach ($file in $package.Classes.Keys) {
             $class = $package.Classes.$file
             $classElementRelativePath = (Get-RelativePath -Path $file -RelativeTo $commonParent).Replace("\", "/")
-            $sourceFileElement = Add-XmlElement $packageElement 'sourcefile' -Attributes ([ordered] @{
+            $sourceFileElement = Add-XmlElement -Parent $packageElement -Name 'sourcefile' -Attributes ([ordered] @{
                     name = if ($isGutters) {
                         & $SafeCommands["Split-Path"] $classElementRelativePath -Leaf
                     }
@@ -1010,7 +1010,7 @@ function Get-JaCoCoReportXml {
                 })
 
             foreach ($line in $class.Lines.Keys) {
-                $null = Add-XmlElement $sourceFileElement 'line' -Attributes ([ordered] @{
+                $null = Add-XmlElement -Parent $sourceFileElement -Name 'line' -Attributes ([ordered] @{
                         nr = $line
                         mi = $class.Lines.$line.Instruction.Missed
                         ci = $class.Lines.$line.Instruction.Covered
@@ -1068,7 +1068,7 @@ function Add-JaCoCoCounter {
     if ($Data.$Type.Missed -isnot [int] -or $Data.$Type.Covered -isnot [int]) {
         throw 'Counter data expected'
     }
-    $null = Add-XmlElement $Parent 'counter' -Attributes ([ordered] @{
+    $null = Add-XmlElement -Parent $Parent -Name 'counter' -Attributes ([ordered] @{
             type    = $Type.ToUpperInvariant()
             missed  = $Data.$Type.Missed
             covered = $Data.$Type.Covered

--- a/src/functions/Coverage.ps1
+++ b/src/functions/Coverage.ps1
@@ -969,7 +969,7 @@ function Get-JaCoCoReportXml {
                 "$commonParentLeaf/$classElementRelativePath"
             }
             $classElementName = $classElementName.Substring(0, $($classElementName.LastIndexOf(".")))
-            $classElement = Add-XmlElement-Parent $packageElement -Name 'class' -Attributes ([ordered] @{
+            $classElement = Add-XmlElement -Parent $packageElement -Name 'class' -Attributes ([ordered] @{
                     name           = $classElementName
                     sourcefilename = if ($isGutters) {
                         & $SafeCommands["Split-Path"] $classElementRelativePath -Leaf

--- a/src/functions/Coverage.ps1
+++ b/src/functions/Coverage.ps1
@@ -1157,8 +1157,8 @@ function Get-TracerHitLocation ($command) {
         $c = $command
         "`n`nCommand: $c" | Write-Host
         $(for ($ast = $c; $null -ne $ast; $ast = $ast.Parent) {
-                $ast | select @{n = "type"; e = { $_.GetType().Name } } , @{n = "extent"; e = { $_.extent } }
-            } ) | ft type, extent | out-string | Write-Host
+                $ast | Select-Object @{n = 'type'; e = { $_.GetType().Name } } , @{n = 'extent'; e = { $_.extent } }
+            } ) | Format-Table type, extent | Out-String | Write-Host
     }
 
     if ($env:PESTER_CC_DEBUG -eq 1) {


### PR DESCRIPTION
## PR Summary
Code cleanup.
Replace use of alias and positional parameters in Coverage.ps1.

## PR Checklist

- [x] PR has meaningful title
- [x] Summary describes changes
- [x] PR is ready to be merged
  - If not, use the arrow next to `Create Pull Request` to mark it as a draft. PR can be marked `Ready for review` when it's ready.
- [ ] Tests are added/update *(if required)*
- [ ] Documentation is updated/added *(if required)*

<!-- Before you continue, please review [Contributing to Pester](https://pester.dev/docs/contributing/introduction).

Our continuous integration system doesn't send any notifications about failed tests. Please return to the opened pull request (after ~60 minutes) to check if everything is OK. -->
