### PR TITLE
Cleanup remaining testcase param-blocks in tests

### DIFF
--- a/tst/Format.Tests.ps1
+++ b/tst/Format.Tests.ps1
@@ -20,21 +20,18 @@ Describe "Format-Collection" {
     It "Formats collection of values '<value>' to '<expected>' using comma separator" -TestCases @(
         @{ Value = (1, 2, 3); Expected = "@(1, 2, 3)" }
     ) {
-        param ($Value, $Expected)
         Format-Collection -Value $Value | Verify-Equal $Expected
     }
 
     It "Formats collection that is longer than 10 with elipsis and output remaining value count" -TestCases @(
         @{ Value = (1..20); Expected = "@(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, ...10 more)" }
     ) {
-        param ($Value, $Expected)
         Format-Collection -Value $Value | Verify-Equal $Expected
     }
 
     It "Formats collection '<value>' with `$null values to '<expected>'" -TestCases @(
         @{ Value = @('a', 'b', 'c', $null); Expected = "@('a', 'b', 'c', `$null)" }
     ) {
-        param ($Value, $Expected)
         Format-Collection -Value $Value | Verify-Equal $Expected
     }
 }
@@ -47,7 +44,6 @@ Describe "Format-Number" {
         @{ Value = [single] 1.1; },
         @{ Value = [decimal] 1.1; }
     ) {
-        param ($Value)
         Format-Number -Value $Value | Verify-Equal "1.1"
     }
 }
@@ -58,7 +54,6 @@ Describe "Format-Number" {
 #         @{ Value = ([PSCustomObject] @{Name = 'Jakub'; Age = 28}); Expected = "PSObject{Age=28; Name=Jakub}"},
 #         @{ Value = (New-Object -Type Assertions.TestType.Person -Property @{Name = 'Jakub'; Age = 28}); Expected = "Assertions.TestType.Person{Age=28; Name=Jakub}"}
 #     ) {
-#         param ($Value, $Expected)
 #         Format-Object -Value $Value | Verify-Equal $Expected
 #     }
 
@@ -71,7 +66,6 @@ Describe "Format-Number" {
 #             Expected           = "Assertions.TestType.Person{Name=Jakub}"
 #         }
 #     ) {
-#         param ($Value, $SelectedProperties, $Expected)
 #         Format-Object -Value $Value -Property $SelectedProperties | Verify-Equal $Expected
 #     }
 # }
@@ -81,7 +75,6 @@ Describe "Format-Boolean" {
         @{ Value = $true; Expected = '$true' },
         @{ Value = $false; Expected = '$false' }
     ) {
-        param($Value, $Expected)
         Format-Boolean -Value $Value | Verify-Equal $Expected
     }
 }
@@ -125,7 +118,6 @@ Describe "Format-ScriptBlock" {
 #         @{ Value = @{Z = 1; H = 1; A = 1}; Expected = '@{A=1; H=1; Z=1}' }
 #         @{ Value = @{Hash = @{Hash = 'Value'}}; Expected = '@{Hash=@{Hash=Value}}' }
 #     ) {
-#         param ($Value, $Expected)
 #         Format-Hashtable $Value | Verify-Equal $Expected
 #     }
 # }
@@ -141,7 +133,6 @@ Describe "Format-ScriptBlock" {
 #         @{ Value = New-Dictionary @{Z = 1; H = 1; A = 1}; Expected = 'Dictionary{A=1; H=1; Z=1}' }
 #         @{ Value = New-Dictionary @{Dict = ( New-Dictionary @{Dict = 'Value'})}; Expected = 'Dictionary{Dict=Dictionary{Dict=Value}}' }
 #     ) {
-#         param ($Value, $Expected)
 #         Format-Dictionary $Value | Verify-Equal $Expected
 #     }
 # }
@@ -164,7 +155,6 @@ Describe "Format-Nicely" {
         #@{ Value = @{Name = 'Jakub'; Age = 28}; Expected = '@{Age=28; Name=Jakub}' }
         #@{ Value = New-Dictionary @{Age = 28; Name = 'Jakub'}; Expected = 'Dictionary{Age=28; Name=Jakub}' }
     ) {
-        param($Value, $Expected)
         Format-Nicely -Value $Value | Verify-Equal $Expected
     }
 }
@@ -174,7 +164,6 @@ Describe "Format-Nicely" {
 #     It "Returns '<expected>' for '<type>'" -TestCases @(
 #         @{ Type = "Diagnostics.Process"; Expected = ("Id", "Name") }
 #     ) {
-#         param ($Type, $Expected)
 #         $Actual = Get-DisplayProperty -Type $Type
 #         "$Actual" | Verify-Equal "$Expected"
 #     }
@@ -187,7 +176,6 @@ Describe "Format-Type" {
         @{ Value = [string]; Expected = 'string' },
         @{ Value = $null; Expected = '<none>' }
     ) {
-        param($Value, $Expected)
         Format-Type -Value $Value | Verify-Equal $Expected
     }
 }
@@ -202,7 +190,6 @@ Describe "Get-ShortType" {
         @{ Value = [PSCustomObject] @{Name = 'Jakub' } ; Expected = 'PSObject' },
         @{ Value = [Object[]]1, 2, 3 ; Expected = 'collection' }
     ) {
-        param($Value, $Expected)
         Get-ShortType -Value $Value | Verify-Equal $Expected
     }
 }
@@ -214,7 +201,6 @@ Describe "Join-And" {
         @{ Items = @('one', 'two'); Expected = 'one and two' },
         @{ Items = @('one', 'two', 'three'); Expected = 'one, two and three' }
     ) {
-        param($Items, $Expected)
         Join-And -Items $Items | Verify-Equal $Expected
     }
 
@@ -222,7 +208,6 @@ Describe "Join-And" {
         @{ Items = @('one', 'two', 'three'); Threshold = 3; Expected = 'one, two and three' },
         @{ Items = @('one', 'two', 'three'); Threshold = 4; Expected = 'one, two, three' }
     ) {
-        param($Items, $Threshold, $Expected)
         Join-And -Items $Items -Threshold $Threshold | Verify-Equal $Expected
     }
 }

--- a/tst/Pester.Tests.ps1
+++ b/tst/Pester.Tests.ps1
@@ -451,8 +451,6 @@ InModuleScope -ModuleName Pester {
             @{ Filter = "Unit"; Collection = "Low", "Medium", "High" }
             @{ Filter = "*Unit*"; Collection = "Low", "Medium", "High" }
         ) {
-            param($Filter, $Collection)
-
             Contain-AnyStringLike -Filter $Filter -Collection $Collection |
                 Should -BeFalse
         }
@@ -465,8 +463,6 @@ InModuleScope -ModuleName Pester {
             @{ Filter = "Low", "Medium"; Collection = "Low", "Medium", "High" }
             @{ Filter = "l*"; Collection = "Low", "Medium", "High" }
         ) {
-            param($Filter, $Collection)
-
             Contain-AnyStringLike -Filter $Filter -Collection $Collection |
                 Should -BeTrue
         }

--- a/tst/TypeClass.Tests.ps1
+++ b/tst/TypeClass.Tests.ps1
@@ -25,7 +25,6 @@ Describe "Is-Value" {
         @{ Value = @(1) },
         @{ Value = { abc } }
     ) {
-        param($Value)
         Is-Value -Value $Value | Verify-True
     }
 
@@ -40,7 +39,6 @@ Describe "Is-Value" {
         @{ Value = [type] },
         @{ Value = (New-Object -TypeName Diagnostics.Process) }
     ) {
-        param($Value)
         Is-Value -Value $Value | Verify-False
     }
 }
@@ -55,7 +53,6 @@ Describe "Is-DecimalNumber" {
         @{ Value = [single] 1.1; },
         @{ Value = [decimal] 1.1; }
     ) {
-        param ($Value)
         Is-DecimalNumber -Value $Value | Verify-True
     }
 
@@ -70,7 +67,6 @@ Describe "Is-ScriptBlock" {
         @{ Value = { abc } },
         @{ Value = { Get-Process } }
     ) {
-        param ($Value)
         Is-ScriptBlock -Value $Value | Verify-True
     }
 
@@ -80,7 +76,6 @@ Describe "Is-ScriptBlock" {
         @{ Value = 'abc' },
         @{ Value = [Type] }
     ) {
-        param ($Value)
         Is-ScriptBlock -Value $Value | Verify-False
     }
 }
@@ -91,8 +86,6 @@ Describe "Is-Hashtable" {
         @{Value = @{} }
         @{Value = @{Name = "Jakub" } }
     ) {
-        param($Value)
-
         Is-Hashtable -Value $Value | Verify-True
     }
 
@@ -100,8 +93,6 @@ Describe "Is-Hashtable" {
         @{ Value = "Jakub" }
         @{ Value = 1..4 }
     ) {
-        param ($Value)
-
         Is-Hashtable -Value $Value | Verify-False
     }
 }
@@ -111,8 +102,6 @@ Describe "Is-Dictionary" {
         @{ Value = New-Object "Collections.Generic.Dictionary[string,object]" }
         @{ Value = New-Dictionary @{Name = "Jakub" } }
     ) {
-        param($Value)
-
         Is-Dictionary -Value $Value | Verify-True
     }
 
@@ -120,8 +109,6 @@ Describe "Is-Dictionary" {
         @{ Value = "Jakub" }
         @{ Value = 1..4 }
     ) {
-        param ($Value)
-
         Is-Dictionary -Value $Value | Verify-False
     }
 }
@@ -138,7 +125,6 @@ Describe "Is-Collection" {
         @{ Value = [Collections.Generic.List[Int]]([int[]](1, 2, 3)) }
         # @{ Value = (Get-Process) } <- fails in docker because there is just one process
     ) {
-        param($Value)
         Is-Collection -Value $Value | Verify-True
     }
 
@@ -171,7 +157,6 @@ Describe "Is-Collection" {
         @{ Value = (Get-Process -Id $PID) }
         @{ Value = New-Object -TypeName Diagnostics.Process }
     ) {
-        param($Value)
         Verify-NotNull $Value
         Is-Collection -Value $Value | Verify-False
     }

--- a/tst/functions/Describe.Tests.ps1
+++ b/tst/functions/Describe.Tests.ps1
@@ -132,7 +132,6 @@ InPesterModuleScope {
             )
 
             It -TestCases $cases 'Calls the test block when the test name <Description>' {
-                param ($Name)
                 DescribeImpl -Name $Name -Pester $testState -Fixture $testBlock -NoTestDrive -NoTestRegistry
                 Should -Invoke MockMe -Scope It -Exactly 1
             }
@@ -159,8 +158,6 @@ InPesterModuleScope {
             )
 
             It -TestCases $cases 'Given a filter <filter> and a test with tags <tags> the test runs, because <because>' {
-                param ($Tags, $Filter, $Because)
-
                 # figuring out what this test does is a bit difficult. Internally the tags to be used
                 # are stored in Pester state tag filter. So here we have a static  filter and
                 # we throw tests on it to see if they would run. Then we assert that a mock in the
@@ -173,8 +170,6 @@ InPesterModuleScope {
             It 'Given a filter <filter> and a test with tags <tags> that do not match it does not run the test, because <because>' -TestCases @(
                 @{ Filter = $filter; Tags = 'Low'; Because = 'none of the tags match' }
             ) {
-                param($Tags, $Filter, $Because)
-
                 DescribeImpl -Name 'Name' -Tags $Tags -Pester $testState -Fixture $testBlock -NoTestDrive -NoTestRegistry
 
                 Should -Invoke MockMe -Scope It -Exactly 0
@@ -194,8 +189,6 @@ InPesterModuleScope {
             )
 
             It -TestCases $cases 'Given a filter <filter> and a test with tags <tags> the test does not run, because <because>' {
-                param ($Tags, $Filter, $Because)
-
                 # figuring out what this test does is a bit difficult. Internally the tags to be used
                 # are stored in Pester state tag filter. So here we have a static  filter and
                 # we throw tests on it to see if they would run. Then we assert that a mock in the
@@ -208,8 +201,6 @@ InPesterModuleScope {
             It 'Given a filter <filter> and a test with tags <tags> that do not match it runs the test, because <because>' -TestCases @(
                 @{ Filter = $filter; Tags = 'Low'; Because = 'none of the tags match' }
             ) {
-                param($Tags, $Filter, $Because)
-
                 DescribeImpl -Name 'Name' -Tags $Tags -Pester $testState -Fixture $testBlock -NoTestDrive -NoTestRegistry
 
                 Should -Invoke MockMe -Scope It -Exactly 1

--- a/tst/functions/Mock.Tests.ps1
+++ b/tst/functions/Mock.Tests.ps1
@@ -817,8 +817,6 @@ Describe "When Calling Should -Not -Invoke [Times] without exactly" {
         @{ MockCalls = 2; Times = 5 }
         @{ MockCalls = 0; Times = 1 }
     ) {
-        param($MockCalls, $Times)
-
         for ($i = 0; $i -lt $MockCalls; $i++) {
             FunctionUnderTest "one"
         }
@@ -832,8 +830,6 @@ Describe "When Calling Should -Not -Invoke [Times] without exactly" {
         @{ MockCalls = 1; Times = 1 }
         @{ MockCalls = 0; Times = 0 }
     ) {
-        param($MockCalls, $Times)
-
         for ($i = 0; $i -lt $MockCalls; $i++) {
             FunctionUnderTest "one"
         }
@@ -906,8 +902,6 @@ Describe "When Calling Should -Not -Invoke [Times] with exactly" {
         @{ MockCalls = 0; Times = 1 }
         @{ MockCalls = 1; Times = 0 }
     ) {
-        param($MockCalls, $Times)
-
         for ($i = 0; $i -lt $MockCalls; $i++) {
             FunctionUnderTest "one"
         }
@@ -920,8 +914,6 @@ Describe "When Calling Should -Not -Invoke [Times] with exactly" {
         @{ MockCalls = 1; Times = 1 }
         @{ MockCalls = 0; Times = 0 }
     ) {
-        param($MockCalls, $Times)
-
         for ($i = 0; $i -lt $MockCalls; $i++) {
             FunctionUnderTest "one"
         }
@@ -2544,8 +2536,6 @@ InPesterModuleScope {
             }
 
             It 'mocks <Command> command' -TestCases $case {
-                param($Command)
-
                 Mock $Command { 'I am being mocked' }
 
                 & $Command | Should -Be 'I am being mocked'

--- a/tst/functions/Output.Tests.ps1
+++ b/tst/functions/Output.Tests.ps1
@@ -624,7 +624,6 @@ InModuleScope -ModuleName Pester -ScriptBlock {
                     )
                 }
             ) {
-                param($Header, $Message, $Expected)
                 Format-CIErrorMessage -CIFormat 'AzureDevops' -Header $Header -Message $Message | Should -Be $Expected
             }
         }
@@ -664,7 +663,6 @@ InModuleScope -ModuleName Pester -ScriptBlock {
                     )
                 }
             ) {
-                param($Header, $Message, $Expected)
                 Format-CIErrorMessage -CIFormat 'GithubActions' -Header $Header -Message $Message | Should -Be $Expected
             }
         }

--- a/tst/functions/assertions/BeTrueOrFalse.Tests.ps1
+++ b/tst/functions/assertions/BeTrueOrFalse.Tests.ps1
@@ -42,7 +42,6 @@ InPesterModuleScope {
                 @{ Value = @() }
                 @{ Value = 0 }
             ) {
-                param($Value)
                 $Value | Should -Not -BeTrue
             }
 

--- a/tst/functions/assertions/PesterThrow.Tests.ps1
+++ b/tst/functions/assertions/PesterThrow.Tests.ps1
@@ -215,10 +215,6 @@ InPesterModuleScope {
                         notMatching = 3; assertionMessage = "Expected an exception, with type [System.InvalidOperationException], with message '+mess' and with FullyQualifiedErrorId '+id' to be thrown, but the exception type was [System.ArgumentException], the message was '-mess' and the FullyQualifiedErrorId was '-id'. from ##path##:8 char:"
                     }
                 ) {
-                    param ($actualId, $actualMess, $actualType,
-                        $expectedId, $expectedMess, $expectedType,
-                        $notMatching, $assertionMessage)
-
                     $exception = New-Object ($actualType.FullName) $actualMess
                     $errorRecord = New-Object System.Management.Automation.ErrorRecord (
                         $exception,


### PR DESCRIPTION
## PR Summary
Removes the remaining param-blocks used for testcase-arguments in our tests as they're no longer needed in v5.

Related #2224 

## PR Checklist

- [x] PR has meaningful title
- [x] Summary describes changes
- [x] PR is ready to be merged
  - If not, use the arrow next to `Create Pull Request` to mark it as a draft. PR can be marked `Ready for review` when it's ready.
- [x] Tests are added/update *(if required)*
- [ ] Documentation is updated/added *(if required)*