### PR TITLE
Add -Because to Should -Invoke and -InvokeVerifiable

### DIFF
--- a/src/functions/Mock.ps1
+++ b/src/functions/Mock.ps1
@@ -303,7 +303,8 @@ function Should-InvokeVerifiableInternal {
     param(
         [Parameter(Mandatory)]
         $Behaviors,
-        [switch]$Negate
+        [switch] $Negate,
+        [string] $Because
     )
 
     $filteredBehaviors = [System.Collections.Generic.List[Object]]@()
@@ -314,8 +315,8 @@ function Should-InvokeVerifiableInternal {
     }
 
     if ($filteredBehaviors.Count -gt 0) {
-        if ($Negate) { $message = "$([System.Environment]::NewLine)Expected no verifiable mocks to be called, but these were:" }
-        else { $message = "$([System.Environment]::NewLine)Expected all verifiable mocks to be called, but these were not:" }
+        if ($Negate) { $message = "$([System.Environment]::NewLine)Expected no verifiable mocks to be called,$(Format-Because $Because) but these were:" }
+        else { $message = "$([System.Environment]::NewLine)Expected all verifiable mocks to be called,$(Format-Because $Because) but these were not:" }
 
         foreach ($b in $filteredBehaviors) {
             $message += "$([System.Environment]::NewLine) Command $($b.CommandName) "

--- a/src/functions/Mock.ps1
+++ b/src/functions/Mock.ps1
@@ -343,18 +343,19 @@ function Should-InvokeInternal {
         [Parameter(Mandatory = $true)]
         [hashtable] $ContextInfo,
 
-        [int]$Times = 1,
+        [int] $Times = 1,
 
         [Parameter(ParameterSetName = 'ParameterFilter')]
-        [ScriptBlock]$ParameterFilter = { $True },
+        [ScriptBlock] $ParameterFilter = { $True },
 
         [Parameter(ParameterSetName = 'ExclusiveFilter', Mandatory = $true)]
         [scriptblock] $ExclusiveFilter,
 
         [string] $ModuleName,
 
-        [switch]$Exactly,
-        [switch]$Negate,
+        [switch] $Exactly,
+        [switch] $Negate,
+        [string] $Because,
 
         [Parameter(Mandatory)]
         [Management.Automation.SessionState] $SessionState,
@@ -453,13 +454,13 @@ function Should-InvokeInternal {
         if ($matchingCalls.Count -eq $Times -and ($Exactly -or !$PSBoundParameters.ContainsKey("Times"))) {
             return [PSCustomObject] @{
                 Succeeded      = $false
-                FailureMessage = "Expected ${commandName}${moduleMessage} not to be called exactly $Times times"
+                FailureMessage = "Expected ${commandName}${moduleMessage} not to be called exactly $Times times,$(Format-Because $Because) but it was"
             }
         }
         elseif ($matchingCalls.Count -ge $Times -and !$Exactly) {
             return [PSCustomObject] @{
                 Succeeded      = $false
-                FailureMessage = "Expected ${commandName}${moduleMessage} to be called less than $Times times but was called $($matchingCalls.Count) times"
+                FailureMessage = "Expected ${commandName}${moduleMessage} to be called less than $Times times,$(Format-Because $Because) but was called $($matchingCalls.Count) times"
             }
         }
     }
@@ -467,19 +468,19 @@ function Should-InvokeInternal {
         if ($matchingCalls.Count -ne $Times -and ($Exactly -or ($Times -eq 0))) {
             return [PSCustomObject] @{
                 Succeeded      = $false
-                FailureMessage = "Expected ${commandName}${moduleMessage} to be called $Times times exactly but was called $($matchingCalls.Count) times"
+                FailureMessage = "Expected ${commandName}${moduleMessage} to be called $Times times exactly,$(Format-Because $Because) but was called $($matchingCalls.Count) times"
             }
         }
         elseif ($matchingCalls.Count -lt $Times) {
             return [PSCustomObject] @{
                 Succeeded      = $false
-                FailureMessage = "Expected ${commandName}${moduleMessage} to be called at least $Times times but was called $($matchingCalls.Count) times"
+                FailureMessage = "Expected ${commandName}${moduleMessage} to be called at least $Times times,$(Format-Because $Because) but was called $($matchingCalls.Count) times"
             }
         }
         elseif ($filterIsExclusive -and $nonMatchingCalls.Count -gt 0) {
             return [PSCustomObject] @{
                 Succeeded      = $false
-                FailureMessage = "Expected ${commandName}${moduleMessage} to only be called with with parameters matching the specified filter, but $($nonMatchingCalls.Count) non-matching calls were made"
+                FailureMessage = "Expected ${commandName}${moduleMessage} to only be called with with parameters matching the specified filter,$(Format-Because $Because) but $($nonMatchingCalls.Count) non-matching calls were made"
             }
         }
     }

--- a/src/functions/Pester.SessionState.Mock.ps1
+++ b/src/functions/Pester.SessionState.Mock.ps1
@@ -630,7 +630,7 @@ function Assert-VerifiableMock {
     Set-ScriptBlockScope -ScriptBlock $sb -SessionState $PSCmdlet.SessionState
     & $sb
 }
-function Should-InvokeVerifiable ([switch]$Negate) {
+function Should-InvokeVerifiable ([switch] $Negate, [string] $Because) {
     <#
     .SYNOPSIS
     Checks if any Verifiable Mock has not been invoked. If so, this will throw an exception.
@@ -662,7 +662,7 @@ function Should-InvokeVerifiable ([switch]$Negate) {
     This will not throw an exception because the mock was invoked.
     #>
     $behaviors = @(Get-VerifiableBehaviors)
-    Should-InvokeVerifiableInternal -Behaviors $behaviors -Negate:$Negate
+    Should-InvokeVerifiableInternal @PSBoundParameters -Behaviors $behaviors
 }
 
 & $script:SafeCommands['Add-ShouldOperator'] -Name InvokeVerifiable `

--- a/tst/functions/Mock.Tests.ps1
+++ b/tst/functions/Mock.Tests.ps1
@@ -777,7 +777,7 @@ Describe "When Calling Should -Invoke 0 without exactly" {
     }
 
     It "Should throw if mock was called" {
-        $result.Exception.Message | Should -Be "Expected FunctionUnderTest to be called 0 times exactly but was called 1 times"
+        $result.Exception.Message | Should -Be 'Expected FunctionUnderTest to be called 0 times exactly, but was called 1 times'
     }
 
     It "Should not throw if mock was not called" {
@@ -799,7 +799,7 @@ Describe "When Calling Should -Not -Invoke without exactly" {
     }
 
     It "Should throw if mock was called once" {
-        $result.Exception.Message | Should -Be "Expected FunctionUnderTest not to be called exactly 1 times"
+        $result.Exception.Message | Should -Be "Expected FunctionUnderTest not to be called exactly 1 times, but it was"
     }
 
     It "Should not throw if mock was not called" {
@@ -845,7 +845,7 @@ Describe "When Calling Should -Not -Invoke [Times] without exactly" {
             $result = $_
         }
 
-        $result.Exception.Message | Should -Be "Expected FunctionUnderTest to be called less than $Times times but was called $MockCalls times"
+        $result.Exception.Message | Should -Be "Expected FunctionUnderTest to be called less than $Times times, but was called $MockCalls times"
     }
 }
 
@@ -864,7 +864,7 @@ Describe "When Calling Should -Invoke with exactly" {
     }
 
     It "Should throw if mock was not called the number of times specified" {
-        $result.Exception.Message | Should -Be "Expected FunctionUnderTest to be called 3 times exactly but was called 2 times"
+        $result.Exception.Message | Should -Be "Expected FunctionUnderTest to be called 3 times exactly, but was called 2 times"
     }
 
     It "Should not throw if mock was called the number of times specified" {
@@ -886,7 +886,7 @@ Describe "When Calling Should -Not -Invoke with exactly" {
     }
 
     It "Should throw if mock was called" {
-        $result.Exception.Message | Should -Be "Expected FunctionUnderTest not to be called exactly 1 times"
+        $result.Exception.Message | Should -Be "Expected FunctionUnderTest not to be called exactly 1 times, but it was"
     }
 
     It "Should not throw if mock was not called" {
@@ -933,7 +933,7 @@ Describe "When Calling Should -Not -Invoke [Times] with exactly" {
             $result = $_
         }
 
-        $result.Exception.Message | Should -Be "Expected FunctionUnderTest not to be called exactly $Times times"
+        $result.Exception.Message | Should -Be "Expected FunctionUnderTest not to be called exactly $Times times, but it was"
     }
 }
 
@@ -947,7 +947,7 @@ Describe "When Calling Should -Invoke without exactly" {
 
     It "Should throw if mock was not called at least the number of times specified" {
         $scriptBlock = { Should -Invoke FunctionUnderTest 4 -Scope Describe }
-        $scriptBlock | Should -Throw "Expected FunctionUnderTest to be called at least 4 times but was called 3 times"
+        $scriptBlock | Should -Throw "Expected FunctionUnderTest to be called at least 4 times, but was called 3 times"
     }
 
     It "Should not throw if mock was called at least the number of times specified" {


### PR DESCRIPTION
## PR Summary
Adds support for `-Because` in `-Invoke` and `-InvokeVerifiable` to be able to customize generic mock assert errors.

`Should -Invoke` already included the parameter, but the internal method didn't support it and threw a `ParameterBindingException`.

Fix #2121
Fix #2228

## PR Checklist

- [x] PR has meaningful title
- [x] Summary describes changes
- [x] PR is ready to be merged
  - If not, use the arrow next to `Create Pull Request` to mark it as a draft. PR can be marked `Ready for review` when it's ready.
- [x] Tests are added/update *(if required)*
- [ ] Documentation is updated/added *(if required)*