### PR TITLE
Validate Should -Invoke is invoked in specified -Scope blocktype

### DIFF
--- a/src/functions/Pester.SessionState.Mock.ps1
+++ b/src/functions/Pester.SessionState.Mock.ps1
@@ -980,6 +980,11 @@ function Should-Invoke {
                 $level++
                 $i = $i.Parent
             }
+
+            if ($null -eq $i) {
+                # Reached parent of root-block which means we never called break (got a hit) in the while-loop
+                throw "Assertion is not placed directly nor nested inside a $Scope block, but -Scope $Scope is specified."
+            }
         }
     }
 

--- a/tst/functions/Mock.Tests.ps1
+++ b/tst/functions/Mock.Tests.ps1
@@ -976,6 +976,54 @@ Describe "When Calling Should -Not -Invoke -ExclusiveFilter" {
     }
 }
 
+Describe 'When Calling Should -Invoke with invalid -Scope' {
+    Context 'Using -Scope It outside of It block' {
+        BeforeAll {
+            Mock FunctionUnderTest {}
+
+            try {
+                Should -Not -Invoke FunctionUnderTest -Scope It
+            }
+            Catch {
+                $result = $_
+            }
+        }
+        It 'Should throw' {
+            $result.Exception.Message | Should -Be 'Assertion is placed outside of an It block, but -Scope It is specified.'
+        }
+    }
+
+    It 'Should throw when negative number' {
+        $scriptBlock = { Should -Not -Invoke FunctionUnderTest -Scope -1 }
+        $scriptBlock | Should -Throw "Parameter Scope must be one of 'Describe', 'Context', 'It' or a non-negative number."
+    }
+
+    It 'Should throw when unknown named block' {
+        $scriptBlock = { Should -Not -Invoke FunctionUnderTest -Scope SomethingElse }
+        $scriptBlock | Should -Throw "Parameter Scope must be one of 'Describe', 'Context', 'It' or a non-negative number."
+    }
+}
+
+Context 'When Calling Should -Invoke -Scope Describe while not inside Describe' {
+    BeforeAll {
+        Mock FunctionUnderTest {}
+    }
+    It 'Should throw' {
+        $scriptBlock = { Should -Not -Invoke FunctionUnderTest -Scope Describe }
+        $scriptBlock | Should -Throw 'Assertion is not placed directly nor nested inside a Describe block, but -Scope Describe is specified.'
+    }
+}
+
+Describe 'When Calling Should -Invoke -Scope Context while not inside Context' {
+    BeforeAll {
+        Mock FunctionUnderTest {}
+    }
+    It 'Should throw' {
+        $scriptBlock = { Should -Not -Invoke FunctionUnderTest -Scope Context }
+        $scriptBlock | Should -Throw 'Assertion is not placed directly nor nested inside a Context block, but -Scope Context is specified.'
+    }
+}
+
 Describe "When Calling Should -Invoke with pipeline-input or -ActualValue" {
     It "Should throw an error on pipeline-input" {
         $scriptBlock = { "value" | Should -Invoke -CommandName "ABC" -Scope Describe }


### PR DESCRIPTION
## PR Summary
Throw in `Should -Invoke` when ex. `-Scope Describe` is used while not inside any `Describe`-blocks.

Adds regression tests for above scenarios, `-Scope It` while not in `It` and `-Scope <negative>`.

Fix #2187

## PR Checklist

- [x] PR has meaningful title
- [x] Summary describes changes
- [x] PR is ready to be merged
  - If not, use the arrow next to `Create Pull Request` to mark it as a draft. PR can be marked `Ready for review` when it's ready.
- [x] Tests are added/update *(if required)*
- [ ] Documentation is updated/added *(if required)*