### PR TITLE
Throw in Add-ShouldOperator when max number of operators is reached

### DIFF
--- a/src/Main.ps1
+++ b/src/Main.ps1
@@ -97,6 +97,11 @@ function Add-ShouldOperator {
         return
     }
 
+    # https://github.com/pester/Pester/issues/1355 and https://github.com/PowerShell/PowerShell/issues/9372
+    if ($script:AssertionOperators.Count -ge 32) {
+        throw 'Max number of assertion operators (32) has already been reached. This limitation is due to maximum allowed parameter sets in PowerShell.'
+    }
+
     $namesToCheck = @(
         $Name
         $Alias


### PR DESCRIPTION
## PR Summary

Throws an exception when attempting to add a new operator when there's already 32 registered.

PowerShell only allows 32 parameter sets due to a `uint`-bitmask used to tag which sets a parameter is included in. This won't be fixed in Windows PowerShell and unfortunately PowerShell doesn't throw an exception due to a bug.

When the 33rd (or more) operators are added using `Add-ShouldOperator` it overflows and won't work. The new operator name will use a built-in behavior. Pester currently includes 26 operators, leaving only 6 functional slots for custom assertions per session.

Related #1355
_Issue won't be fixed until operators are used without `Should` parameter sets._

## PR Checklist

- [x] PR has meaningful title
- [x] Summary describes changes
- [x] PR is ready to be merged
  - If not, use the arrow next to `Create Pull Request` to mark it as a draft. PR can be marked `Ready for review` when it's ready.
- [ ] Tests are added/update *(if required)*
- [ ] Documentation is updated/added *(if required)*