### PR TITLE
Add support for assigning lists to StringArrayOption

### DIFF
--- a/src/csharp/Pester/StringArrayOption.cs
+++ b/src/csharp/Pester/StringArrayOption.cs
@@ -1,5 +1,6 @@
-﻿using System.Linq;
-using System.Management.Automation;
+﻿using System.Management.Automation;
+using System.Collections;
+using System.Collections.Generic;
 
 // those types implement Pester configuration in a way that allows it to show information about each item
 // in the powershell console without making it difficult to use. there are two tricks being used:
@@ -47,7 +48,7 @@ namespace Pester
 
         }
 
-        public StringArrayOption(object[] value) : base("", new string[0], value.Select(oneValue => oneValue.ToString()).ToArray())
+        public StringArrayOption(IList value) : base("", new string[0], GetStringArray(value))
         {
 
         }
@@ -63,10 +64,23 @@ namespace Pester
             return new StringArrayOption(string.Empty, array, array);
         }
 
-        public static implicit operator StringArrayOption (PathInfo pathInfo)
+        public static implicit operator StringArrayOption(PathInfo pathInfo)
         {
             var array = new[] { pathInfo?.ToString() };
             return new StringArrayOption(string.Empty, array, array);
+        }
+
+        private static string[] GetStringArray(IList values)
+        {
+            var strings = new List<string>(values.Count);
+
+            for (var i = 0; i < values.Count; i++)
+            {
+                string path = values[i]?.ToString();
+                strings.Add(path);
+            }
+            
+            return strings.ToArray();
         }
     }
 }

--- a/tst/Pester.RSpec.Configuration.ts.ps1
+++ b/tst/Pester.RSpec.Configuration.ts.ps1
@@ -244,6 +244,45 @@ i -PassThru:$PassThru {
             Verify-Equal $path[0].ToString() -Actual $config.Run.Path.Value[0]
         }
 
+        t 'StringArrayOption can be assigned an arraylist' {
+            $expectedPaths = [System.Collections.ArrayList]@('one', 'two', 'three')
+            $config = [PesterConfiguration]::Default
+            $config.Run.Path = $expectedPaths
+            $config.Run.Path.Value[0] | Verify-Equal $expectedPaths[0]
+            $config.Run.Path.Value[1] | Verify-Equal $expectedPaths[1]
+            $config.Run.Path.Value[2] | Verify-Equal $expectedPaths[2]
+        }
+
+        t 'StringArrayOption can be assigned an arraylist from hashtable' {
+            $expectedPaths = [System.Collections.ArrayList]@('one', 'two', 'three')
+            $config = [PesterConfiguration]@{ Run = @{ Path = $expectedPaths } }
+            $config.Run.Path.Value[0] | Verify-Equal $expectedPaths[0]
+            $config.Run.Path.Value[1] | Verify-Equal $expectedPaths[1]
+            $config.Run.Path.Value[2] | Verify-Equal $expectedPaths[2]
+        }
+
+        t 'StringArrayOption can be assigned array of FileInfo and DirectoryInfo' {
+            $file = Get-Item -Path "$PSScriptRoot/Pester.RSpec.Configuration.ts.ps1"
+            $directory = Get-Item -Path "$PSScriptRoot/testProjects"
+            $expectedPaths = @('myFile.ps1', $file, $directory)
+            $config = [PesterConfiguration]::Default
+            $config.Run.Path = $expectedPaths
+            $config.Run.Path.Value[0] | Verify-Equal $expectedPaths[0]
+            $config.Run.Path.Value[1] | Verify-Equal $expectedPaths[1].FullName
+            $config.Run.Path.Value[2] | Verify-Equal $expectedPaths[2].FullName
+        }
+
+        t 'StringArrayOption can be assigned array of FileInfo and DirectoryInfo from hashtable' {
+            $file = Get-Item -Path "$PSScriptRoot/Pester.RSpec.Configuration.ts.ps1"
+            $directory = Get-Item -Path "$PSScriptRoot/testProjects"
+            $expectedPaths = @('myFile.ps1', $file, $directory)
+            $config = [PesterConfiguration]::Default
+            $config.Run.Path = $expectedPaths
+            $config.Run.Path.Value[0] | Verify-Equal $expectedPaths[0]
+            $config.Run.Path.Value[1] | Verify-Equal $expectedPaths[1].FullName
+            $config.Run.Path.Value[2] | Verify-Equal $expectedPaths[2].FullName
+        }
+
         t "StringArrayOption can be assigned PSCustomObjects in object array" {
             $path = (Join-Path (Split-Path $PWD) (Split-Path $PWD -Leaf)), (Join-Path (Split-Path $PWD) (Split-Path $PWD -Leaf)) | Resolve-Path
             $config = [PesterConfiguration]@{ Run = @{ Path = $path } }

--- a/tst/PesterConfiguration.Tests.ps1
+++ b/tst/PesterConfiguration.Tests.ps1
@@ -51,12 +51,3 @@ Describe "PesterConfiguration.Format.ps1xml" {
         }
     }
 }
-
-Describe 'PesterConfiguration' {
-    It 'should convert arraylists' {
-        $expectedPaths = @('one', 'two', 'three')
-        $pathList = [Collections.ArrayList]$expectedPaths
-        $config = [PesterConfiguration]@{ Run = @{ Path = $pathList } }
-        $config.Run.Path.Value | Should -Be $expectedPaths
-    }
-}


### PR DESCRIPTION
## PR Summary

Follow-up to #2101 which enabled use of lists when assigning ex. `Run.Path` from hashtable.
This PR enables assigning lists to an existing configuration-object, ex `$c.Run.Path = [arraylist]@()`.

Fix #2100

## PR Checklist

- [x] PR has meaningful title
- [x] Summary describes changes
- [x] PR is ready to be merged
  - If not, use the arrow next to `Create Pull Request` to mark it as a draft. PR can be marked `Ready for review` when it's ready.
- [x] Tests are added/update *(if required)*
- [ ] Documentation is updated/added *(if required)*