### PR TITLE
Improve error when -HaveParameter is used with mock or alias for local function

### DIFF
--- a/src/functions/assertions/HaveParameter.ps1
+++ b/src/functions/assertions/HaveParameter.ps1
@@ -189,7 +189,21 @@
     $buts = @()
     $filters = @()
 
-    $null = $ActualValue.Parameters # necessary for PSv2
+    $null = $ActualValue.Parameters # necessary for PSv2. Keeping just in case
+    if ($null -eq $ActualValue.Parameters -and $ActualValue -is [System.Management.Automation.AliasInfo]) {
+        # PowerShell doesn't resolve alias parameters properly in Get-Command when function is defined in a local scope in a different session state.
+        # https://github.com/pester/Pester/issues/1431 and https://github.com/PowerShell/PowerShell/issues/17629
+        if ($ActualValue.Definition -match '^PesterMock_') {
+            $type = 'mock'
+            $suggestion = "'Get-Command $($ActualValue.Name) | Where-Object Parameters | Should -HaveParameter ...'"
+        } else {
+            $type = 'alias'
+            $suggestion = "using the actual command name, ex. 'Get-Command $($ActualValue.Definition) | Should -HaveParameter ...'"
+        }
+
+        throw "Could not retrieve parameters for $type $($ActualValue.Name). This is a known issue with Get-Command in PowerShell. Try $suggestion"
+    }
+
     $hasKey = $ActualValue.Parameters.PSBase.ContainsKey($ParameterName)
     $filters += "to$(if ($Negate) {" not"}) have a parameter $ParameterName"
 

--- a/src/functions/assertions/HaveParameter.ps1
+++ b/src/functions/assertions/HaveParameter.ps1
@@ -198,7 +198,7 @@
             $suggestion = "'Get-Command $($ActualValue.Name) | Where-Object Parameters | Should -HaveParameter ...'"
         } else {
             $type = 'alias'
-            $suggestion = "using the actual command name, ex. 'Get-Command $($ActualValue.Definition) | Should -HaveParameter ...'"
+            $suggestion = "using the actual command name. For example: 'Get-Command $($ActualValue.Definition) | Should -HaveParameter ...'"
         }
 
         throw "Could not retrieve parameters for $type $($ActualValue.Name). This is a known issue with Get-Command in PowerShell. Try $suggestion"

--- a/tst/functions/assertions/HaveParameter.Tests.ps1
+++ b/tst/functions/assertions/HaveParameter.Tests.ps1
@@ -462,3 +462,26 @@ InPesterModuleScope {
         }
     }
 }
+
+Describe 'Using Should -HaveParameter with alias for local function or mock' {
+    # https://github.com/pester/Pester/issues/1431
+    It 'throws when testing mock without workaround' {
+        function TestFunction($Parameter1) { }
+        Mock TestFunction {}
+
+        { Get-Command TestFunction | Should -HaveParameter 'Parameter1' } | Should -Throw -ExpectedMessage "Could not retrieve parameters for mock TestFunction. This is a known issue with Get-Command in PowerShell. Try 'Get-Command TestFunction | Where-Object Parameters | Should -HaveParameter ...'"
+
+        # Verify it works with suggested workaround
+        Get-Command TestFunction | Where-Object Parameters | Should -HaveParameter 'Parameter1'
+    }
+
+    It 'throws when testing alias for function defined in local script scope' {
+        function TestFunction2($Parameter1) { }
+        Set-Alias -Name LocalAlias -Value TestFunction2
+
+        { Get-Command LocalAlias | Should -HaveParameter 'Parameter1' } | Should -Throw -ExpectedMessage "Could not retrieve parameters for alias LocalAlias. This is a known issue with Get-Command in PowerShell. Try using the actual command name, ex. 'Get-Command TestFunction2 | Should -HaveParameter ...'"
+
+        # Verify it works with suggested workaround
+        Get-Command TestFunction2 | Should -HaveParameter 'Parameter1'
+    }
+}

--- a/tst/functions/assertions/HaveParameter.Tests.ps1
+++ b/tst/functions/assertions/HaveParameter.Tests.ps1
@@ -479,7 +479,7 @@ Describe 'Using Should -HaveParameter with alias for local function or mock' {
         function TestFunction2($Parameter1) { }
         Set-Alias -Name LocalAlias -Value TestFunction2
 
-        { Get-Command LocalAlias | Should -HaveParameter 'Parameter1' } | Should -Throw -ExpectedMessage "Could not retrieve parameters for alias LocalAlias. This is a known issue with Get-Command in PowerShell. Try using the actual command name, ex. 'Get-Command TestFunction2 | Should -HaveParameter ...'"
+        { Get-Command LocalAlias | Should -HaveParameter 'Parameter1' } | Should -Throw -ExpectedMessage "Could not retrieve parameters for alias LocalAlias. This is a known issue with Get-Command in PowerShell. Try using the actual command name. For example: 'Get-Command TestFunction2 | Should -HaveParameter ...'"
 
         # Verify it works with suggested workaround
         Get-Command TestFunction2 | Should -HaveParameter 'Parameter1'


### PR DESCRIPTION
## PR Summary
PowerShell doesn't resolve local functions properly for `AliasInfo` when function is defined in local scope in different session state. This affects use of `-HaveParameter` on a mocked command, ex. `Get-Command Should -HaveParameter mockedCommand`

Replace generic NRE with exception that suggests a workaround as this problem is unlikely to be fixed soon in PowerShell and probably not at all in Windows PowerShell.

Fix #1431

## PR Checklist

- [x] PR has meaningful title
- [x] Summary describes changes
- [x] PR is ready to be merged
  - If not, use the arrow next to `Create Pull Request` to mark it as a draft. PR can be marked `Ready for review` when it's ready.
- [x] Tests are added/update *(if required)*
- [ ] Documentation is updated/added *(if required)*