### PR TITLE
Support mocking and execution in manifest modules

### DIFF
--- a/src/functions/Mock.ps1
+++ b/src/functions/Mock.ps1
@@ -613,7 +613,7 @@ function Resolve-Command {
             $SessionState = $callerSessionState
         }
         else {
-            $module = Get-ScriptModule -ModuleName $ModuleName -ErrorAction Stop
+            $module = Get-CompatibleModule -ModuleName $ModuleName -ErrorAction Stop
             if ($PesterPreference.Debug.WriteDebugMessages.Value) {
                 Write-PesterDebugMessage -Scope Mock "Found module $($module.Name) version $($module.Version)."
             }
@@ -1604,7 +1604,7 @@ function Remove-MockFunctionsAndAliases ($SessionState) {
     Set-ScriptBlockScope -SessionState $SessionState -ScriptBlock $ScriptBlock
     & $ScriptBlock $Get_Alias $Get_Command $Remove_Item
 
-    # clean up also in all loaded script modules
+    # clean up also in all loaded script and manifest modules
     $modules = & $script:SafeCommands['Get-Module']
     foreach ($module in $modules) {
         # we cleaned up in module on the start of this method without overhead of moving to module scope
@@ -1615,7 +1615,7 @@ function Remove-MockFunctionsAndAliases ($SessionState) {
         # some script modules aparently can have no session state
         # https://github.com/PowerShell/PowerShell/blob/658837323599ab1c7a81fe66fcd43f7420e4402b/src/System.Management.Automation/engine/runtime/Operations/MiscOps.cs#L51-L55
         # https://github.com/pester/Pester/issues/1921
-        if ('Script' -eq $module.ModuleType -and $null -ne $module.SessionState) {
+        if ('Script', 'Manifest' -contains $module.ModuleType -and $null -ne $module.SessionState) {
             & ($module) $ScriptBlock $Get_Alias $Get_Command $Remove_Item
         }
     }

--- a/src/functions/Pester.SessionState.Mock.ps1
+++ b/src/functions/Pester.SessionState.Mock.ps1
@@ -77,9 +77,9 @@ function Mock {
     verifiable mock is not called, Should -InvokeVerifiable will throw an
     exception and indicate all mocks not called.
 
-    If you wish to mock commands that are called from inside a script module,
-    you can do so by using the -ModuleName parameter to the Mock command. This
-    injects the mock into the specified module. If you do not specify a
+    If you wish to mock commands that are called from inside a script or manifest
+    module, you can do so by using the -ModuleName parameter to the Mock command.
+    This injects the mock into the specified module. If you do not specify a
     module name, the mock will be created in the same scope as the test script.
     You may mock the same command multiple times, in different scopes, as needed.
     Each module's mock maintains a separate call history and verified status.

--- a/tst/functions/InModuleScope.Tests.ps1
+++ b/tst/functions/InModuleScope.Tests.ps1
@@ -67,7 +67,7 @@ Describe "Executing test code inside a module" {
     }
 }
 
-Describe "Get-ScriptModule behavior" {
+Describe 'Get-CompatibleModule behavior' {
 
     Context "When attempting to mock a command in a non-existent module" {
 

--- a/tst/functions/InModuleScope.Tests.ps1
+++ b/tst/functions/InModuleScope.Tests.ps1
@@ -67,18 +67,62 @@ Describe "Executing test code inside a module" {
     }
 }
 
-Describe 'Get-CompatibleModule behavior' {
+Describe 'Get-CompatibleModule' {
 
-    Context "When attempting to mock a command in a non-existent module" {
+    Context 'when module name matches imported script module' {
+        It 'should return a single ModuleInfo object' {
+            $moduleInfo = InPesterModuleScope { Get-CompatibleModule -ModuleName Pester }
+            $moduleInfo | Should -Not -BeNullOrEmpty
+            $moduleInfo.Count | Should -Be 1
+            $moduleInfo.Name | Should -Be 'Pester'
+            $moduleInfo.ModuleType | Should -Be 'Script'
+        }
+    }
 
-        It "should throw an exception" {
-            {
-                Mock -CommandName "Invoke-MyMethod" `
-                    -ModuleName  "MyNonExistentModule" `
-                    -MockWith { write-host "my mock called!" }
-            } | Should -Throw "No modules named 'MyNonExistentModule' are currently loaded."
+    Context 'when module name matches imported manifest module' {
+        BeforeAll {
+            $moduleName = 'testManifestModule'
+            $moduleManifestPath = "TestDrive:/$moduleName.psd1"
+            New-ModuleManifest -Path $moduleManifestPath
+            Import-Module $moduleManifestPath -Force
         }
 
+        AfterAll {
+            Get-Module $moduleName -ErrorAction SilentlyContinue | Remove-Module
+            Remove-Item $moduleManifestPath -Force -ErrorAction SilentlyContinue
+        }
+
+        It 'should return a single ModuleInfo object' {
+            $moduleInfo = InPesterModuleScope { Get-CompatibleModule -ModuleName testManifestModule }
+            $moduleInfo | Should -Not -BeNullOrEmpty
+            $moduleInfo.Count | Should -Be 1
+            $moduleInfo.Name | Should -Be 'testManifestModule'
+            $moduleInfo.ModuleType | Should -Be 'Manifest'
+        }
+    }
+
+    Context 'when module name does not resolve to imported module' {
+        It "should throw an exception" {
+            $sb = { InPesterModuleScope { Get-CompatibleModule -ModuleName MyNonExistentModule } }
+            $sb | Should -Throw "No modules named 'MyNonExistentModule' are currently loaded."
+        }
+    }
+
+    Context 'when module name matches multiple imported modules' {
+        BeforeAll {
+            Get-Module 'MyDuplicateModule' -ErrorAction SilentlyContinue | Remove-Module
+            New-Module -Name 'MyDuplicateModule' { } | Import-Module -Force
+            New-Module -Name 'MyDuplicateModule' { } | Import-Module -Force
+        }
+
+        AfterAll {
+            Get-Module 'MyDuplicateModule' -ErrorAction SilentlyContinue | Remove-Module
+        }
+
+        It "should throw an exception" {
+            $sb = { InPesterModuleScope { Get-CompatibleModule -ModuleName MyDuplicateModule } }
+            $sb | Should -Throw "Multiple script modules named 'MyDuplicateModule' are currently loaded. Make sure to remove any extra copies of the module from your session before testing."
+        }
     }
 
 }


### PR DESCRIPTION
## PR Summary

Adds support for manifest module to `Mock`, `Should -Invoke` and `InModuleScope`.

Fix #1456 
Fix #933 

## PR Checklist

- [x] PR has meaningful title
- [x] Summary describes changes
- [x] PR is ready to be merged
  - If not, use the arrow next to `Create Pull Request` to mark it as a draft. PR can be marked `Ready for review` when it's ready.
- [x] Tests are added/update *(if required)*
- [ ] Documentation is updated/added *(if required)*