### PR TITLE
Fix hang in New-TestRegistry when access is denied

### DIFF
--- a/src/functions/Environment.ps1
+++ b/src/functions/Environment.ps1
@@ -34,13 +34,14 @@ function Get-TempDirectory {
 
 function Get-TempRegistry {
     $pesterTempRegistryRoot = 'Microsoft.PowerShell.Core\Registry::HKEY_CURRENT_USER\Software\Pester'
-    if (-not (& $script:SafeCommands['Test-Path'] $pesterTempRegistryRoot)) {
-        try {
+    try {
+        # Test-Path returns true and doesn't throw access denied when path exists but user missing permission unless -PathType Container is used
+        if (-not (& $script:SafeCommands['Test-Path'] $pesterTempRegistryRoot -PathType Container -ErrorAction Stop)) {
             $null = & $SafeCommands['New-Item'] -Path $pesterTempRegistryRoot -ErrorAction Stop
         }
-        catch [Exception] {
-            throw ([Exception]"Was not able to create a Pester Registry key for TestRegistry", ($_.Exception))
-        }
+    }
+    catch [Exception] {
+        throw ([Exception]"Was not able to create a Pester Registry key for TestRegistry at '$pesterTempRegistryRoot'", ($_.Exception))
     }
     return $pesterTempRegistryRoot
 }


### PR DESCRIPTION
## PR Summary

When `HKCU:\Software\Pester` exists but the user doesn't have permissions, `Test-Path` will currently return true and the user get stuck in a do-until loop while trying to find a unused GUID-subkey during initialization of TestRegistry.

It's now possible to disable TestRegistry (#2008), but since it only hangs the user wouldn't know that TestRegistry was the cause.

Fix #1345

## PR Checklist

- [x] PR has meaningful title
- [x] Summary describes changes
- [x] PR is ready to be merged
  - If not, use the arrow next to `Create Pull Request` to mark it as a draft. PR can be marked `Ready for review` when it's ready.
- [ ] Tests are added/update *(if required)*
- [ ] Documentation is updated/added *(if required)*