### PR TITLE
Add support for multiple aliases (-Alias) to Should -HaveParameter

### DIFF
--- a/src/functions/assertions/HaveParameter.ps1
+++ b/src/functions/assertions/HaveParameter.ps1
@@ -5,7 +5,7 @@
     [String]$DefaultValue,
     [Switch]$Mandatory,
     [Switch]$HasArgumentCompleter,
-    [String]$Alias,
+    [String[]]$Alias,
     [Switch]$Negate,
     [String]$Because ) {
     <#
@@ -264,14 +264,16 @@
         }
 
         if ($Alias) {
-            $testPresenceOfAlias = $ActualValue.Parameters[$ParameterName].Aliases -contains $Alias
-            $filters += "to$(if ($Negate) {" not"}) have an alias '$Alias'"
+            foreach ($AliasValue in $Alias) {
+                $testPresenceOfAlias = $ActualValue.Parameters[$ParameterName].Aliases -contains $AliasValue
+                $filters += "to$(if ($Negate) {" not"}) have an alias '$AliasValue'"
 
-            if (-not $Negate -and -not $testPresenceOfAlias) {
-                $buts += "it didn't have an alias '$Alias'"
-            }
-            elseif ($Negate -and $testPresenceOfAlias) {
-                $buts += "it had an alias '$Alias'"
+                if (-not $Negate -and -not $testPresenceOfAlias) {
+                    $buts += "it didn't have an alias '$AliasValue'"
+                }
+                elseif ($Negate -and $testPresenceOfAlias) {
+                    $buts += "it had an alias '$AliasValue'"
+                }
             }
         }
     }

--- a/src/functions/assertions/HaveParameter.ps1
+++ b/src/functions/assertions/HaveParameter.ps1
@@ -264,15 +264,26 @@
         }
 
         if ($Alias) {
+
+            $filters += "with$(if ($Negate) {'out'}) alias$(if ($Alias.Count -ge 2) {'es'}) $(Join-And ($Alias -replace '^|$', "'"))"
+            $faultyAliases = @()
             foreach ($AliasValue in $Alias) {
                 $testPresenceOfAlias = $ActualValue.Parameters[$ParameterName].Aliases -contains $AliasValue
-                $filters += "to$(if ($Negate) {" not"}) have an alias '$AliasValue'"
-
                 if (-not $Negate -and -not $testPresenceOfAlias) {
-                    $buts += "it didn't have an alias '$AliasValue'"
+                    $faultyAliases += $AliasValue
                 }
                 elseif ($Negate -and $testPresenceOfAlias) {
-                    $buts += "it had an alias '$AliasValue'"
+                    $faultyAliases += $AliasValue
+                }
+            }
+            if($faultyAliases.Count -ge 1) {
+                $aliases = $(Join-And ($faultyAliases -replace '^|$', "'"))
+                $singular = $faultyAliases.Count -eq 1
+                if($Negate) {
+                    $buts += "it has $(if($singular) {"an alias"} else {"the aliases"} ) $aliases"
+                }
+                else {
+                    $buts += "it didn't have $(if($singular) {"an alias"} else {"the aliases"} ) $aliases"
                 }
             }
         }

--- a/tst/functions/Add-ShouldOperator.ts.ps1
+++ b/tst/functions/Add-ShouldOperator.ts.ps1
@@ -6,14 +6,12 @@ Import-Module $PSScriptRoot\..\p.psm1 -DisableNameChecking
 Import-Module $PSScriptRoot\..\axiom\Axiom.psm1 -DisableNameChecking
 
 if (-not $NoBuild) { & "$PSScriptRoot\..\..\build.ps1" }
+Import-Module $PSScriptRoot\..\..\bin\Pester.psd1
 
 i -PassThru:$PassThru {
-    # Running as P-tests to avoid corrupting other tests if more than 32 operators (parameter sets) are defined.
-    # Each b section reloads the Pester module to further avoid running into the more than 32 operators limitation for the total number of tests.
-    # See https://github.com/pester/Pester/issues/1355 and https://github.com/pester/Pester/pull/2170#issuecomment-1116423527.
+    # Running as P-tests to avoid corrupting other tests if more than 32 operators (parameter sets) are defined
+    # https://github.com/pester/Pester/issues/1355 and https://github.com/pester/Pester/pull/2170#issuecomment-1116423527
     b 'Add-ShouldOperator' {
-        Remove-Module Pester -Force -ErrorAction SilentlyContinue
-        Import-Module $PSScriptRoot\..\..\bin\Pester.psd1
         ${function:Add-ShouldOperator} = & (Get-Module Pester) { Get-Command Add-ShouldOperator }
 
         t 'Adds empty HelpMessage for Should operator without synopsis' {
@@ -70,13 +68,6 @@ i -PassThru:$PassThru {
             # Should not throw
             Add-ShouldOperator -Name MultipleAlias -Test $Function:MultipleAlias -Alias mult, multiple
         }
-
-    }
-
-    b 'Add-ShouldOperator' {
-        Remove-Module Pester -Force -ErrorAction SilentlyContinue
-        Import-Module $PSScriptRoot\..\..\bin\Pester.psd1
-        ${function:Add-ShouldOperator} = & (Get-Module Pester) { Get-Command Add-ShouldOperator }
 
         t 'Does not allow an operator with a different test to be registered using an existing name' {
             function DifferentScriptBlockA {

--- a/tst/functions/assertions/HaveParameter.Tests.ps1
+++ b/tst/functions/assertions/HaveParameter.Tests.ps1
@@ -63,7 +63,7 @@ InPesterModuleScope {
             function Invoke-DummyFunction {
                 param(
                     [Parameter(Mandatory = $true)]
-                    [Alias('First')]
+                    [Alias('First', 'Another')]
                     $MandatoryParam,
 
                     [ValidateNotNullOrEmpty()]
@@ -169,7 +169,7 @@ InPesterModuleScope {
             Get-Command "Invoke-DummyFunction" | Should -HaveParameter MandatoryParam -Alias First
         }
 
-        It "passes if the parameter MandatoryParam has an alias 'First' and an alias 'Another'" {
+        It "passes if the parameter MandatoryParam has the aliases 'First' and 'Another'" {
             Get-Command "Invoke-DummyFunction" | Should -HaveParameter MandatoryParam -Alias First, Another
         }
 

--- a/tst/functions/assertions/HaveParameter.Tests.ps1
+++ b/tst/functions/assertions/HaveParameter.Tests.ps1
@@ -8,7 +8,7 @@ InPesterModuleScope {
             function Invoke-DummyFunction {
                 param(
                     [Parameter(Mandatory = $true)]
-                    [Alias('First')]
+                    [Alias('First', 'Another')]
                     $MandatoryParam,
 
                     [ValidateNotNullOrEmpty()]
@@ -169,6 +169,10 @@ InPesterModuleScope {
             Get-Command "Invoke-DummyFunction" | Should -HaveParameter MandatoryParam -Alias First
         }
 
+        It "passes if the parameter MandatoryParam has an alias 'First' and an alias 'Another'" {
+            Get-Command "Invoke-DummyFunction" | Should -HaveParameter MandatoryParam -Alias First, Another
+        }
+
         if ($PSVersionTable.PSVersion.Major -ge 5) {
             It "passes if the parameter <ParameterName> exists, is of type <ExpectedType>, has a default value '<ExpectedValue>' and has an ArgumentCompleter" -TestCases @(
                 @{ParameterName = "ParamWithArgumentCompleter"; ExpectedType = [String]; ExpectedValue = "./.git" }
@@ -253,8 +257,18 @@ InPesterModuleScope {
             { Get-Command "Invoke-DummyFunction" | Should -HaveParameter $ParameterName -Type $ExpectedType -DefaultValue $ExpectedValue } | Verify-AssertionFailed
         }
 
-        It "passes if the parameter MandatoryParam has no alias 'Second'" {
+        It "fails if the parameter MandatoryParam has no alias 'Second'" {
             { Get-Command "Invoke-DummyFunction" | Should -HaveParameter MandatoryParam -Alias Second } | Verify-AssertionFailed
+        }
+
+        It "fails and returns the correct message if the parameter MandatoryParam has no alias 'Second' even though alias 'First' exists" {
+            $err = { Get-Command "Invoke-DummyFunction" | Should -HaveParameter MandatoryParam -Alias First, Second } | Verify-AssertionFailed
+            $err.Exception.Message | Verify-Equal "Expected command Invoke-DummyFunction to have a parameter MandatoryParam, to have an alias 'First' and to have an alias 'Second', but it didn't have an alias 'Second'."
+        }
+
+        It "fails and returns the correct message if the parameter MandatoryParam has no alias 'Second' and no alias 'Third'" {
+            $err = { Get-Command "Invoke-DummyFunction" | Should -HaveParameter MandatoryParam -Alias Second, Third } | Verify-AssertionFailed
+            $err.Exception.Message | Verify-Equal "Expected command Invoke-DummyFunction to have a parameter MandatoryParam, to have an alias 'Second' and to have an alias 'Third', but it didn't have an alias 'Second' and it didn't have an alias 'Third'."
         }
 
         if ($PSVersionTable.PSVersion.Major -ge 5) {

--- a/tst/functions/assertions/HaveParameter.Tests.ps1
+++ b/tst/functions/assertions/HaveParameter.Tests.ps1
@@ -263,12 +263,12 @@ InPesterModuleScope {
 
         It "fails and returns the correct message if the parameter MandatoryParam has no alias 'Second' even though alias 'First' exists" {
             $err = { Get-Command "Invoke-DummyFunction" | Should -HaveParameter MandatoryParam -Alias First, Second } | Verify-AssertionFailed
-            $err.Exception.Message | Verify-Equal "Expected command Invoke-DummyFunction to have a parameter MandatoryParam, to have an alias 'First' and to have an alias 'Second', but it didn't have an alias 'Second'."
+            $err.Exception.Message | Verify-Equal "Expected command Invoke-DummyFunction to have a parameter MandatoryParam, with aliases 'First' and 'Second', but it didn't have an alias 'Second'."
         }
 
         It "fails and returns the correct message if the parameter MandatoryParam has no alias 'Second' and no alias 'Third'" {
             $err = { Get-Command "Invoke-DummyFunction" | Should -HaveParameter MandatoryParam -Alias Second, Third } | Verify-AssertionFailed
-            $err.Exception.Message | Verify-Equal "Expected command Invoke-DummyFunction to have a parameter MandatoryParam, to have an alias 'Second' and to have an alias 'Third', but it didn't have an alias 'Second' and it didn't have an alias 'Third'."
+            $err.Exception.Message | Verify-Equal "Expected command Invoke-DummyFunction to have a parameter MandatoryParam, with aliases 'Second' and 'Third', but it didn't have the aliases 'Second' and 'Third'."
         }
 
         if ($PSVersionTable.PSVersion.Major -ge 5) {


### PR DESCRIPTION
## PR Summary

Add support for multiple mandatory aliases for `-HaveParameter`. `-Alias` parameter was changed from a `String` to a `String[]`.

Allows for `Should -HaveParameter Parameter -Alias Alias1, Alias2` to test if parameter `Parameter` has both the aliases `alias1` and `Alias2`. If either one is missing the assert fails.

Fix #2152

<!-- Please describe what your pull request fixes, or how it improves Pester.

## PR Checklist

- [x] PR has meaningful title
- [x] Summary describes changes
- [x] PR is ready to be merged
  - If not, use the arrow next to `Create Pull Request` to mark it as a draft. PR can be marked `Ready for review` when it's ready.
- [x] Tests are added/update *(if required)*
- [ ] Documentation is updated/added *(if required)*

<!-- Before you continue, please review [Contributing to Pester](https://pester.dev/docs/contributing/introduction).

Our continuous integration system doesn't send any notifications about failed tests. Please return to the opened pull request (after ~60 minutes) to check if everything is OK. -->
