### PR TITLE
Update CI build image and PesterTests to .NET 6

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,9 +53,9 @@ Get-Help ./build.ps1 -Detailed
 
 Pester has a C# Solution which requires .NET Framework SDKs and Developer Packs in order to compile. The targeted frameworks can be found in `src\csharp\Pester\Pester.csproj`.
 
-### Install .NET Core 3.1 SDK
+### Install .NET Core 6.0 SDK
 
-[Download Link](https://dotnet.microsoft.com/download/dotnet-core/3.1)
+[Download Link](https://dotnet.microsoft.com/download/dotnet-core/6.0)
 
 ### .Net Framework 4.5 Developer Pack
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -46,7 +46,7 @@ stages:
         workspace:
           clean: all
         pool:
-          vmImage: windows-2019
+          vmImage: windows-2022
         timeoutInMinutes: 3
         steps:
           - checkout: self

--- a/src/csharp/PesterTests/PesterTests.csproj
+++ b/src/csharp/PesterTests/PesterTests.csproj
@@ -1,16 +1,15 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
-
+    <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
-    <PackageReference Include="xunit" Version="2.4.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
-    <PackageReference Include="coverlet.collector" Version="1.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
+    <PackageReference Include="coverlet.collector" Version="3.1.2" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## PR Summary
Updates .NET SDKs and target framework to latest LTS (.NET 6.0).

- Bumps CI build vmImage from `windows-2019` (.NET 5 SDK) to `windows-2022` (.NET 6 SDK)
  - Improved performance + .NET 5.0 was end of support in May 2022.
- Updated CONTRIBUTING docs to require .NET 6 SDK
- Updates `PesterTests` from .NET Core 3.1 target to .NET 6 incl. latest dependencies
  - .NET Core 3.1 is end of support in December 2022.

XUnit-project `PesterTests` only contains one tests and isn't part of CI testing atm. Tested manually using:
`dotnet test ./src/csharp/PesterTests/PesterTests.csproj --collect:"XPlat Code Coverage"`

## PR Checklist

- [x] PR has meaningful title
- [x] Summary describes changes
- [x] PR is ready to be merged
  - If not, use the arrow next to `Create Pull Request` to mark it as a draft. PR can be marked `Ready for review` when it's ready.
- [ ] Tests are added/update *(if required)*
- [ ] Documentation is updated/added *(if required)*