### PR TITLE
Bump Ubuntu 18.04 to 22.04 in CI test stage

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -75,11 +75,11 @@ stages:
           clean: all
         strategy:
           matrix:
-            PS7_Ubuntu_18_04:
-              vmImage: ubuntu-18.04
-              pwsh: true
             PS7_Ubuntu_20_04:
               vmImage: ubuntu-20.04
+              pwsh: true
+            PS7_Ubuntu_22_04:
+              vmImage: ubuntu-22.04
               pwsh: true
             PS7_macOS_10_15:
               vmImage: macOS-10.15


### PR DESCRIPTION
## PR Summary
Ubuntu 18.04 image is deprecated in Azure Pipelines. Updating test matrix to use 20.04 + 22.04 (latest)

> Deprecation will begin on 8/8/2022 and the image will be fully unsupported by 4/1/2023

https://github.com/actions/runner-images/issues/6002

## PR Checklist

- [x] PR has meaningful title
- [x] Summary describes changes
- [x] PR is ready to be merged
  - If not, use the arrow next to `Create Pull Request` to mark it as a draft. PR can be marked `Ready for review` when it's ready.
- [ ] Tests are added/update *(if required)*
- [ ] Documentation is updated/added *(if required)*