### PR TITLE
Bump macOS 10.15 to 12 in CI test stage

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -81,11 +81,11 @@ stages:
             PS7_Ubuntu_20_04:
               vmImage: ubuntu-20.04
               pwsh: true
-            PS7_macOS_10_15:
-              vmImage: macOS-10.15
-              pwsh: true
             PS7_macOS_11:
               vmImage: macOS-11
+              pwsh: true
+            PS7_macOS_12:
+              vmImage: macOS-12
               pwsh: true
             PS7_Windows_Server2019:
               vmImage: windows-2019


### PR DESCRIPTION
## PR Summary
macOS 10.15 image is deprecated in Azure Pipelines. Updating test matrix to use macOS 11 + 12 (latest)

> Deprecation will begin on 5/31/2022 and the image will be fully unsupported by 12/1/22

https://github.com/actions/runner-images/issues/5583

## PR Checklist

- [x] PR has meaningful title
- [x] Summary describes changes
- [x] PR is ready to be merged
  - If not, use the arrow next to `Create Pull Request` to mark it as a draft. PR can be marked `Ready for review` when it's ready.
- [ ] Tests are added/update *(if required)*
- [ ] Documentation is updated/added *(if required)*