### PR TITLE
Update ExpandedPath before executing tests and blocks

### DIFF
--- a/src/Pester.Runtime.ps1
+++ b/src/Pester.Runtime.ps1
@@ -319,6 +319,9 @@ function Invoke-Block ($previousBlock) {
                 $block.ExecutedAt = [DateTime]::Now
                 $block.Executed = $true
 
+                # update ExpandedPath to included expanded parent name in case this fails in setup
+                if (-not $block.IsRoot) { $block.ExpandedPath = "$($block.Parent.ExpandedPath).$($block.Name)" }
+
                 if ($PesterPreference.Debug.WriteDebugMessages.Value) {
                     Write-PesterDebugMessage -Scope Runtime "Executing body of block '$($block.Name)'"
                 }
@@ -577,6 +580,9 @@ function Invoke-TestItem {
                 Configuration = $state.PluginConfiguration
             }
         }
+
+        # update ExpandedPath to included expanded parent name in case this fails in setup
+        $Test.ExpandedPath = "$($block.ExpandedPath).$($Test.Name)"
 
         if ($Test.Skip) {
             if ($PesterPreference.Debug.WriteDebugMessages.Value) {

--- a/src/Pester.Runtime.ps1
+++ b/src/Pester.Runtime.ps1
@@ -320,7 +320,7 @@ function Invoke-Block ($previousBlock) {
                 $block.Executed = $true
 
                 # update ExpandedPath to included expanded parent name in case this fails in setup
-                if (-not $block.IsRoot) { $block.ExpandedPath = "$($block.Parent.ExpandedPath).$($block.Name)" }
+                if (-not $block.Parent.IsRoot) { $block.ExpandedPath = "$($block.Parent.ExpandedPath).$($block.Name)" }
 
                 if ($PesterPreference.Debug.WriteDebugMessages.Value) {
                     Write-PesterDebugMessage -Scope Runtime "Executing body of block '$($block.Name)'"


### PR DESCRIPTION
## PR Summary
Update `ExpandedPath` prior to executing a block or test. This will help identify a block or test that was either skipped or failed during setup as parent blocks will be expanded in the path..

Fix #2220

## PR Checklist

- [x] PR has meaningful title
- [x] Summary describes changes
- [x] PR is ready to be merged
  - If not, use the arrow next to `Create Pull Request` to mark it as a draft. PR can be marked `Ready for review` when it's ready.
- [x] Tests are added/update *(if required)*
- [ ] Documentation is updated/added *(if required)*