### PR TITLE
Fix Format-Collection for ICollection

### DIFF
--- a/src/Format.ps1
+++ b/src/Format.ps1
@@ -15,9 +15,13 @@ function Format-Collection ($Value, [switch]$Pretty) {
     $trimmed = $count -gt $Limit
 
     $formattedCollection = @()
-    for ($i = 0; $i -lt [System.Math]::Min($count, $Limit); $i++) {
-        $formattedValue = Format-Nicely -Value $Value[$i] -Pretty:$Pretty
+    # Using foreach to support ICollection
+    $i = 0
+    foreach ($v in $Value) {
+        if ($i -eq $Limit) { break }
+        $formattedValue = Format-Nicely -Value $v -Pretty:$Pretty
         $formattedCollection += $formattedValue
+        $i++
     }
 
     '@(' + ($formattedCollection -join $separator) + $(if ($trimmed) { ", ...$($count - $limit) more" }) + ')'

--- a/tst/Format.Tests.ps1
+++ b/tst/Format.Tests.ps1
@@ -34,6 +34,13 @@ Describe "Format-Collection" {
     ) {
         Format-Collection -Value $Value | Verify-Equal $Expected
     }
+
+    It 'Formats an ICollection' -TestCases @(
+        @{ Value = @{ 'a' = $true; 'b' = $true }.Keys; Expected = "@('a', 'b')" }
+    ) {
+        # https://github.com/pester/Pester/discussions/2263
+        Format-Collection -Value $Value | Verify-Equal $Expected
+    }
 }
 
 Describe "Format-Number" {


### PR DESCRIPTION
## PR Summary
Replace index-based `for`-loop with `foreach` in `Format-Collection` to support ICollections like `KeyCollection` (`@{}.Keys`).

Fix #2264

/cc @Kj3l

## PR Checklist

- [x] PR has meaningful title
- [x] Summary describes changes
- [x] PR is ready to be merged
  - If not, use the arrow next to `Create Pull Request` to mark it as a draft. PR can be marked `Ready for review` when it's ready.
- [x] Tests are added/update *(if required)*
- [ ] Documentation is updated/added *(if required)*