### PR TITLE
Use encodedCommand in Invoke-InNewProcress for P-tests

### DIFF
--- a/tst/Pester.RSpec.InNewProcess.ts.ps1
+++ b/tst/Pester.RSpec.InNewProcess.ts.ps1
@@ -28,9 +28,10 @@ function Invoke-InNewProcess ([ScriptBlock] $ScriptBlock) {
         . $ScriptBlock
     }.ToString()
 
-    # we need to escape " with \" because otherwise the " are eaten when the process we are starting recieves them
-    $cmd = "& { $command } -PesterPath ""$PesterPath"" -ScriptBlock { $($ScriptBlock -replace '"','\"') }"
-    & $powershell -NoProfile -ExecutionPolicy Bypass -Command $cmd
+    # using base64 because we need to escape quotes in $ScriptBlock and previous method using \" stopped working in PS7.3
+    $cmd = "& { $command } -PesterPath ""$PesterPath"" -ScriptBlock { $ScriptBlock }"
+    $encodedcommand = [Convert]::ToBase64String([System.Text.Encoding]::Unicode.GetBytes($cmd))
+    & $powershell -NoProfile -ExecutionPolicy Bypass -encodedCommand $encodedcommand
 }
 
 i -PassThru:$PassThru {

--- a/tst/Pester.RSpec.Output.ts.ps1
+++ b/tst/Pester.RSpec.Output.ts.ps1
@@ -34,12 +34,11 @@ function Invoke-InNewProcess ([ScriptBlock] $ScriptBlock) {
         . $ScriptBlock
     }.ToString()
 
-    # we need to escape " with \" because otherwise the " are eaten when the process we are starting recieves them
-    $cmd = "& { $command } -PesterPath ""$PesterPath"" -ScriptBlock { $($ScriptBlock -replace '"','\"') }"
-    & $powershell -NoProfile -ExecutionPolicy Bypass -Command $cmd
+    # using base64 because we need to escape quotes in $ScriptBlock and previous method using \" stopped working in PS7.3
+    $cmd = "& { $command } -PesterPath ""$PesterPath"" -ScriptBlock { $ScriptBlock }"
+    $encodedcommand = [Convert]::ToBase64String([System.Text.Encoding]::Unicode.GetBytes($cmd))
+    & $powershell -NoProfile -ExecutionPolicy Bypass -encodedCommand $encodedcommand
 }
-
-
 
 i -PassThru:$PassThru {
     b 'Output in VSCode mode' {


### PR DESCRIPTION
## PR Summary
`Invoke-InNewProcress` helper-method in P-tests is broken in PowerShell 7.3 because 7.3 now keeps the backslash previously used to escape quotes in the provided scriptblock.

Replacing with encodedCommand (base64) to avoid version-specific logic.

Fixes broken CI mentioned in https://github.com/pester/Pester/issues/2264#issuecomment-1316554951 . Some runs use prerelease CI-images with PowerShell 7.3 which makes CI inconsistent atm.

## PR Checklist

- [x] PR has meaningful title
- [x] Summary describes changes
- [x] PR is ready to be merged
  - If not, use the arrow next to `Create Pull Request` to mark it as a draft. PR can be marked `Ready for review` when it's ready.
- [ ] Tests are added/update *(if required)*
- [ ] Documentation is updated/added *(if required)*