### PR TITLE
Include expected type in exceptions when type is not resolvable

### DIFF
--- a/src/functions/assertions/BeOfType.ps1
+++ b/src/functions/assertions/BeOfType.ps1
@@ -28,9 +28,10 @@ function Should-BeOfType($ActualValue, $ExpectedType, [switch] $Negate, [string]
     #>
     if ($ExpectedType -is [string]) {
         # parses type that is provided as a string in brackets (such as [int])
-        $parsedType = ($ExpectedType -replace '^\[(.*)\]$', '$1') -as [Type]
+        $trimmedType = $ExpectedType -replace '^\[(.*)\]$', '$1'
+        $parsedType = $trimmedType -as [Type]
         if ($null -eq $parsedType) {
-            throw [ArgumentException]"Could not find type [$ParsedType]. Make sure that the assembly that contains that type is loaded."
+            throw [ArgumentException]"Could not find type [$trimmedType]. Make sure that the assembly that contains that type is loaded."
         }
 
         $ExpectedType = $parsedType

--- a/src/functions/assertions/HaveParameter.ps1
+++ b/src/functions/assertions/HaveParameter.ps1
@@ -177,9 +177,10 @@
 
     if ($Type -is [string]) {
         # parses type that is provided as a string in brackets (such as [int])
-        $parsedType = ($Type -replace '^\[(.*)\]$', '$1') -as [Type]
+        $trimmedType = $Type -replace '^\[(.*)\]$', '$1'
+        $parsedType = $trimmedType -as [Type]
         if ($null -eq $parsedType) {
-            throw [ArgumentException]"Could not find type [$ParsedType]. Make sure that the assembly that contains that type is loaded."
+            throw [ArgumentException]"Could not find type [$trimmedType]. Make sure that the assembly that contains that type is loaded."
         }
 
         $Type = $parsedType

--- a/tst/functions/assertions/BeOfType.Tests.ps1
+++ b/tst/functions/assertions/BeOfType.Tests.ps1
@@ -17,7 +17,7 @@ InPesterModuleScope {
             $err = { 5 | Should -BeOfType 'UnknownType' } | Verify-Throw
             $err.Exception | Verify-Type ([ArgumentException])
             # Verify expected type is included in error message
-            $err.Exception.Message | Should -Match 'Could not find type \[UnknownType\].'
+            $err.Exception.Message | Verify-Equal 'Could not find type [UnknownType]. Make sure that the assembly that contains that type is loaded.'
         }
 
         It "returns the correct assertion message when actual value has a real type" {
@@ -36,7 +36,7 @@ InPesterModuleScope {
             $err = { 5 | Should -Not -BeOfType 'UnknownType' } | Verify-Throw
             $err.Exception | Verify-Type ([ArgumentException])
             # Verify expected type is included in error message
-            $err.Exception.Message | Should -Match 'Could not find type \[UnknownType\].'
+            $err.Exception.Message | Verify-Equal 'Could not find type [UnknownType]. Make sure that the assembly that contains that type is loaded.'
         }
 
         It "returns the correct assertion message when actual value has a real type" {

--- a/tst/functions/assertions/BeOfType.Tests.ps1
+++ b/tst/functions/assertions/BeOfType.Tests.ps1
@@ -14,13 +14,10 @@ InPesterModuleScope {
         }
 
         It "throws argument execption if type isn't a loaded type" {
-            $err = { 5 | Should -Not -BeOfType 'UnknownType' } | Verify-Throw
-            $err.Exception | Verify-Type ([ArgumentException])
-        }
-
-        It "throws argument execption if type isn't a loaded type" {
             $err = { 5 | Should -BeOfType 'UnknownType' } | Verify-Throw
             $err.Exception | Verify-Type ([ArgumentException])
+            # Verify expected type is included in error message
+            $err.Exception.Message | Should -Match 'Could not find type \[UnknownType\].'
         }
 
         It "returns the correct assertion message when actual value has a real type" {
@@ -38,6 +35,8 @@ InPesterModuleScope {
         It "throws argument execption if type isn't a loaded type" {
             $err = { 5 | Should -Not -BeOfType 'UnknownType' } | Verify-Throw
             $err.Exception | Verify-Type ([ArgumentException])
+            # Verify expected type is included in error message
+            $err.Exception.Message | Should -Match 'Could not find type \[UnknownType\].'
         }
 
         It "returns the correct assertion message when actual value has a real type" {

--- a/tst/functions/assertions/HaveParameter.Tests.ps1
+++ b/tst/functions/assertions/HaveParameter.Tests.ps1
@@ -271,6 +271,13 @@ InPesterModuleScope {
             $err.Exception.Message | Verify-Equal "Expected command Invoke-DummyFunction to have a parameter MandatoryParam, with aliases 'Second' and 'Third', but it didn't have the aliases 'Second' and 'Third'."
         }
 
+        It "throws ArgumentException when expected type isn't a loaded type" {
+            $err = { Get-Command 'Invoke-DummyFunction' | Should -HaveParameter MandatoryParam -Type UnknownType } | Verify-Throw
+            $err.Exception | Verify-Type ([ArgumentException])
+            # Verify expected type is included in error message
+            $err.Exception.Message | Verify-Equal 'Could not find type [UnknownType]. Make sure that the assembly that contains that type is loaded.'
+        }
+
         if ($PSVersionTable.PSVersion.Major -ge 5) {
             It "fails if the parameter <ParameterName> does not exist, is not of type <ExpectedType>, has a default value other than '<ExpectedValue>' or has not an ArgumentCompleter" -TestCases @(
                 @{ParameterName = "MandatoryParam"; ExpectedType = [Object]; ExpectedValue = "" }


### PR DESCRIPTION
## PR Summary
Fix #2270

Related #2269

## PR Checklist

- [x] PR has meaningful title
- [x] Summary describes changes
- [x] PR is ready to be merged
  - If not, use the arrow next to `Create Pull Request` to mark it as a draft. PR can be marked `Ready for review` when it's ready.
- [x] Tests are added/update *(if required)*
- [ ] Documentation is updated/added *(if required)*