### PR TITLE
Fix issue pester#2062 "Stacktrace is not filtered in non-english system languages"

### DIFF
--- a/src/functions/Output.ps1
+++ b/src/functions/Output.ps1
@@ -150,7 +150,8 @@ function Write-PesterHostMessage {
             $message = "$($message -replace '(?m)^', "$fg$bg")$($ANSIcodes.ResetAll)"
 
             & $SafeCommands['Write-Host'] -Object $message -NoNewLine:$NoNewLine
-        } else {
+        }
+        else {
             if ($RenderMode -eq 'Plaintext') {
                 if ($PSBoundParameters.ContainsKey('ForegroundColor')) {
                     $null = $PSBoundParameters.Remove('ForegroundColor')
@@ -534,7 +535,6 @@ function ConvertTo-FailureLines {
                     throw 'Generate exception on purpose'
                 }
                 catch {
-                    $PSItem.ScriptStackTrace
                     $regex = "(?<At>.*)\s(?<ScriptBlockOrFunction>\<\w+\>),\s(?<FileName>\<.+\>)\s*:\s(?<Line>\w+)\s(?<LineNumber>\w+)\z"
                     if ($PSItem.ScriptStackTrace -match $regex) {
                         $LocalizedAt = $Matches["At"]
@@ -568,7 +568,7 @@ function ConvertTo-FailureLines {
                 # no code
                 # non inlined scripts will have different paths just omit everything from the src folder
                 $path = [regex]::Escape(($PSScriptRoot | & $SafeCommands["Split-Path"]))
-                [String]$isPesterFunction = "^at .*, .*$path.*: line [0-9]*$"
+                [String]$isPesterFunction = "^{0} .*, .*{1}.*: {2} [0-9]*$" -f $internal_localizedAt, $path, $internal_localizedLine
                 [String]$isShould = "^at (Should<End>|Invoke-Assertion), .*$path.*: line [0-9]*$"
             }
             # end PESTER_BUILD

--- a/src/functions/Output.ps1
+++ b/src/functions/Output.ps1
@@ -535,7 +535,7 @@ function ConvertTo-FailureLines {
                 }
                 catch {
                     $PSItem.ScriptStackTrace
-                    $regex = "(?<At>.*)\s(?<ScriptBlockOrFunction>\<\w+\>),\s(?<FileName>\<.+\>)\s:\s(?<Line>\w+)\s(?<LineNumber>\w+)\z"
+                    $regex = "(?<At>.*)\s(?<ScriptBlockOrFunction>\<\w+\>),\s(?<FileName>\<.+\>)\s*:\s(?<Line>\w+)\s(?<LineNumber>\w+)\z"
                     if ($PSItem.ScriptStackTrace -match $regex) {
                         $LocalizedAt = $Matches["At"]
                         $LocalizedLine = $Matches["Line"]


### PR DESCRIPTION
## PR Summary
Fix issue #2062 "Stacktrace is not filtered in non-english system languages"

When using StackTraceverbosity = 'Filtered', pester internals are filtered from the stack trace using regex matching.
However, Windows stack trace are localized depending on the language of the OS.
The words "At" and "Line" which can be translated (or not) depending on the language of the system.

This PR introduce an heuristic-like solution in ConvertTo-FailureLines function :

We throw an exception on purpose, then catch it in order to detect the localized strings of the stack trace.
We then feed these localized strings back to the regex for filtering pester internals.


## PR Checklist

- [X] PR has meaningful title
- [X] Summary describes changes
- [ ] PR is ready to be merged
  - If not, use the arrow next to `Create Pull Request` to mark it as a draft. PR can be marked `Ready for review` when it's ready.
- [ ] Tests are added/update *(if required)*
- [ ] Documentation is updated/added *(if required)*
