### PR TITLE
Bump psmodulecache action to v5.2

### DIFF
--- a/.github/workflows/code-analysis.yml
+++ b/.github/workflows/code-analysis.yml
@@ -21,12 +21,9 @@ jobs:
         uses: actions/checkout@v2
 
       - name: PowerShell Module Cache
-        uses: potatoqualitee/psmodulecache@v4.5
+        uses: potatoqualitee/psmodulecache@v5.2
         with:
-          # This doesn't update modules, so might want to pin version later to know which we use like ConverToSARIF:1.0.0
-          # or run Update-Module on a weekly/monthly interval
-          modules-to-cache: PSScriptAnalyzer, ConvertToSARIF
-          allow-prerelease: false
+          modules-to-cache: PSScriptAnalyzer, ConvertToSARIF:1.0.0
 
       # Not using microsoft/psscriptanalyzer-action@v1.0 because we're missing psm1 in src + need to exclude generated ps1xml
       - name: Run PSScriptAnalyzer


### PR DESCRIPTION
## PR Summary
Versions below 5.1 will be deprecated by GitHub in July 2023. This version also supports module updates, but not used atm.
- Pins ConvertToSARIF to 1.0.0
- Use latest stable PSSA - updated only when cache expires

Fix #2280 

## PR Checklist

- [x] PR has meaningful title
- [x] Summary describes changes
- [ ] PR is ready to be merged
  - If not, use the arrow next to `Create Pull Request` to mark it as a draft. PR can be marked `Ready for review` when it's ready.
- [ ] Tests are added/update *(if required)*
- [ ] Documentation is updated/added *(if required)*