### PR TITLE
HaveParameter is not dependent on format of param block

### DIFF
--- a/src/functions/assertions/HaveParameter.ps1
+++ b/src/functions/assertions/HaveParameter.ps1
@@ -60,11 +60,19 @@
 
         foreach ($parameter in $paramBlock.Parameters) {
             $paramInfo = & $SafeCommands['New-Object'] PSObject -Property @{
-                Name = $parameter.Name.VariablePath.UserPath
-                DefaultValue = $parameter.DefaultValue.Value
+                Name             = $parameter.Name.VariablePath.UserPath
                 DefaultValueType = $parameter.StaticType.Name
-                Type = "[$($parameter.StaticType.Name.ToLower())]"
+                Type             = "[$($parameter.StaticType.Name.ToLower())]"
             } | & $SafeCommands['Select-Object'] Name, Type, DefaultValue, DefaultValueType
+
+            if ($null -ne $parameter.DefaultValue) {
+                if ([bool](Get-Member -Name Value -InputObject $parameter.DefaultValue -MemberType Property)) {
+                    $paramInfo.DefaultValue = $parameter.DefaultValue.Value
+                }
+                else {
+                    $paramInfo.DefaultValue = $parameter.DefaultValue.Extent.Text
+                }
+            }
 
             $paramInfo
         }

--- a/src/functions/assertions/HaveParameter.ps1
+++ b/src/functions/assertions/HaveParameter.ps1
@@ -47,19 +47,21 @@
             Author: Brian West
         #>
 
-        # Find param block
+        # Find parameters
         $ast = $Command.ScriptBlock.Ast
 
         if ($null -ne $ast) {
-            $paramBlock = $ast.FindAll(
-                {
-                    param($Item)
-                    return ($Item -is [System.Management.Automation.Language.ParamBlockAst])
-                },
-                $true
-            )
+            if ($null -ne $ast.Parameters) {
+                $parameters = $ast.Parameters
+            }
+            elseif ($null -ne $ast.Body.ParamBlock) {
+                $parameters = $ast.Body.ParamBlock.Parameters
+            }
+            else {
+                return
+            }
 
-            foreach ($parameter in $paramBlock.Parameters) {
+            foreach ($parameter in $parameters) {
                 $paramInfo = & $SafeCommands['New-Object'] PSObject -Property @{
                     Name             = $parameter.Name.VariablePath.UserPath
                     DefaultValueType = $parameter.StaticType.Name

--- a/src/functions/assertions/HaveParameter.ps1
+++ b/src/functions/assertions/HaveParameter.ps1
@@ -48,7 +48,7 @@
         #>
 
         # Find param block
-        $ast = (Get-Command -Name $Command).ScriptBlock.Ast
+        $ast = (& $SafeCommands['Get-Command'] -Name $Command).ScriptBlock.Ast
 
         $paramBlock = $ast.FindAll(
             {

--- a/tst/functions/assertions/HaveParameter.Tests.ps1
+++ b/tst/functions/assertions/HaveParameter.Tests.ps1
@@ -61,15 +61,13 @@ InPesterModuleScope {
         }
         else {
             function Invoke-DummyFunction {
-                param
-                (
+                param(
                     [Parameter(Mandatory = $true)]
                     [Alias('First', 'Another')]
                     $MandatoryParam,
 
                     [ValidateNotNullOrEmpty()]
-                    [DateTime]
-                    $ParamWithNotNullOrEmptyValidation = (Get-Date),
+                    [DateTime]$ParamWithNotNullOrEmptyValidation = (Get-Date),
 
                     # argument completer is PowerShell v5+ only
                     [Parameter()]
@@ -154,6 +152,17 @@ InPesterModuleScope {
             }
         ) {
             Get-Command "Invoke-DummyFunction" | Should -HaveParameter $ParameterName -DefaultValue $ExpectedValue
+        }
+
+        It "passes if the paramblock has opening parenthesis on new line and parameter has a default value" {
+            function Test-Paramblock {
+                param
+                (
+                    $Name = 'test'
+                )
+            }
+
+            Get-Command -Name 'Test-Paramblock' | Should -HaveParameter -ParameterName 'Name' -DefaultValue 'test'
         }
 
         It "passes if the parameter <ParameterName> exists, is of type <ExpectedType> and has a default value '<ExpectedValue>'" -TestCases @(

--- a/tst/functions/assertions/HaveParameter.Tests.ps1
+++ b/tst/functions/assertions/HaveParameter.Tests.ps1
@@ -61,13 +61,15 @@ InPesterModuleScope {
         }
         else {
             function Invoke-DummyFunction {
-                param(
+                param
+                (
                     [Parameter(Mandatory = $true)]
                     [Alias('First', 'Another')]
                     $MandatoryParam,
 
                     [ValidateNotNullOrEmpty()]
-                    [DateTime]$ParamWithNotNullOrEmptyValidation = (Get-Date),
+                    [DateTime]
+                    $ParamWithNotNullOrEmptyValidation = (Get-Date),
 
                     # argument completer is PowerShell v5+ only
                     [Parameter()]


### PR DESCRIPTION
## PR Summary

Get-ParameterInfo wasn't leveraging ASTs because of previous support for PowerShell v2 and required that the opening parenthesis for the param block be on the same line as the keyword.  This change leverages ASTs for Get-ParameterInfo so that HaveParmeter is format agnostic.

Fix #2285

## PR Checklist

- [x] PR has meaningful title
- [x] Summary describes changes
- [x] PR is ready to be merged
  - If not, use the arrow next to `Create Pull Request` to mark it as a draft. PR can be marked `Ready for review` when it's ready.
- [x] Tests are added/update *(if required)*
- [x] Documentation is updated/added *(if required)*

<!-- Before you continue, please review [Contributing to Pester](https://pester.dev/docs/contributing/introduction).

Our continuous integration system doesn't send any notifications about failed tests. Please return to the opened pull request (after ~60 minutes) to check if everything is OK. -->
