### PR TITLE
CI Treat Errors As Warnings - ref #2295

### DIFF
--- a/src/Main.ps1
+++ b/src/Main.ps1
@@ -1055,7 +1055,7 @@ function Invoke-Pester {
             }
 
             # this is here to support Pester test runner in VSCode. Don't use it unless you are prepared to get broken in the future. And if you decide to use it, let us know in https://github.com/pester/Pester/issues/2021 so we can warn you about removing this.
-            if (defined additionalPlugins) {$plugins += $script:additionalPlugins}
+            if (defined additionalPlugins) { $plugins += $script:additionalPlugins }
 
             $filter = New-FilterObject `
                 -Tag $PesterPreference.Filter.Tag.Value `
@@ -1239,7 +1239,7 @@ function Invoke-Pester {
 
             if ($PesterPreference.Output.CIFormat.Value -in 'AzureDevops', 'GithubActions') {
                 $errorMessage = (Format-ErrorMessage @formatErrorParams) -split [Environment]::NewLine
-                Write-CIErrorToScreen -CIFormat $PesterPreference.Output.CIFormat.Value -CITreatErrorsAsWarnings:$PesterPreference.Output.CITreatErrorsAsWarnings.Value -Header $errorMessage[0] -Message $errorMessage[1..($errorMessage.Count - 1)]
+                Write-CIErrorToScreen -CIFormat $PesterPreference.Output.CIFormat.Value -CILogLevel $PesterPreference.Output.CILogLevel.Value -Header $errorMessage[0] -Message $errorMessage[1..($errorMessage.Count - 1)]
             }
             else {
                 Write-ErrorToScreen @formatErrorParams -Throw:$PesterPreference.Run.Throw.Value

--- a/src/Main.ps1
+++ b/src/Main.ps1
@@ -1239,7 +1239,7 @@ function Invoke-Pester {
 
             if ($PesterPreference.Output.CIFormat.Value -in 'AzureDevops', 'GithubActions') {
                 $errorMessage = (Format-ErrorMessage @formatErrorParams) -split [Environment]::NewLine
-                Write-CIErrorToScreen -CIFormat $PesterPreference.Output.CIFormat.Value -CITreatErrorsAsWarnings $PesterPreference.Output.CITreatErrorsAsWarnings.Value -Header $errorMessage[0] -Message $errorMessage[1..($errorMessage.Count - 1)]
+                Write-CIErrorToScreen -CIFormat $PesterPreference.Output.CIFormat.Value -CITreatErrorsAsWarnings:$PesterPreference.Output.CITreatErrorsAsWarnings.Value -Header $errorMessage[0] -Message $errorMessage[1..($errorMessage.Count - 1)]
             }
             else {
                 Write-ErrorToScreen @formatErrorParams -Throw:$PesterPreference.Run.Throw.Value

--- a/src/Main.ps1
+++ b/src/Main.ps1
@@ -1239,7 +1239,7 @@ function Invoke-Pester {
 
             if ($PesterPreference.Output.CIFormat.Value -in 'AzureDevops', 'GithubActions') {
                 $errorMessage = (Format-ErrorMessage @formatErrorParams) -split [Environment]::NewLine
-                Write-CIErrorToScreen -CIFormat $PesterPreference.Output.CIFormat.Value -Header $errorMessage[0] -Message $errorMessage[1..($errorMessage.Count - 1)]
+                Write-CIErrorToScreen -CIFormat $PesterPreference.Output.CIFormat.Value -CITreatErrorsAsWarnings $PesterPreference.Output.CITreatErrorsAsWarnings.Value -Header $errorMessage[0] -Message $errorMessage[1..($errorMessage.Count - 1)]
             }
             else {
                 Write-ErrorToScreen @formatErrorParams -Throw:$PesterPreference.Run.Throw.Value

--- a/src/Main.ps1
+++ b/src/Main.ps1
@@ -1055,7 +1055,7 @@ function Invoke-Pester {
             }
 
             # this is here to support Pester test runner in VSCode. Don't use it unless you are prepared to get broken in the future. And if you decide to use it, let us know in https://github.com/pester/Pester/issues/2021 so we can warn you about removing this.
-            if (defined additionalPlugins) { $plugins += $script:additionalPlugins }
+            if (defined additionalPlugins) {$plugins += $script:additionalPlugins}
 
             $filter = New-FilterObject `
                 -Tag $PesterPreference.Filter.Tag.Value `

--- a/src/Pester.RSpec.ps1
+++ b/src/Pester.RSpec.ps1
@@ -408,8 +408,8 @@ function New-PesterConfiguration {
       CIFormat: The CI format of error output in build logs, options are None, Auto, AzureDevops and GithubActions.
       Default value: 'Auto'
 
-      CITreatErrorsAsWarnings: When true, errors will be logged in CI as warnings.
-      Default value: $false
+      CILogLevel: The CI log level in build logs, options are Error and Warning.
+      Default value: 'Error'
 
       RenderMode: The mode used to render console output, options are Auto, Ansi, ConsoleColor and Plaintext.
       Default value: 'Auto'

--- a/src/Pester.RSpec.ps1
+++ b/src/Pester.RSpec.ps1
@@ -408,6 +408,9 @@ function New-PesterConfiguration {
       CIFormat: The CI format of error output in build logs, options are None, Auto, AzureDevops and GithubActions.
       Default value: 'Auto'
 
+      CITreatErrorsAsWarnings: When true, errors will be logged in CI as warnings.
+      Default value: $false
+
       RenderMode: The mode used to render console output, options are Auto, Ansi, ConsoleColor and Plaintext.
       Default value: 'Auto'
 

--- a/src/csharp/Pester/OutputConfiguration.cs
+++ b/src/csharp/Pester/OutputConfiguration.cs
@@ -25,7 +25,7 @@ namespace Pester
         private StringOption _verbosity;
         private StringOption _stackTraceVerbosity;
         private StringOption _ciFormat;
-        private BoolOption _ciTreatErrorsAsWarnings;
+        private StringOption _ciLogLevel;
         private StringOption _renderMode;
 
         public static OutputConfiguration Default { get { return new OutputConfiguration(); } }
@@ -41,7 +41,7 @@ namespace Pester
                 configuration.AssignObjectIfNotNull<string>(nameof(Verbosity), v => Verbosity = v);
                 configuration.AssignObjectIfNotNull<string>(nameof(StackTraceVerbosity), v => StackTraceVerbosity = v);
                 configuration.AssignObjectIfNotNull<string>(nameof(CIFormat), v => CIFormat = v);
-                configuration.AssignValueIfNotNull<bool>(nameof(CITreatErrorsAsWarnings), v => CITreatErrorsAsWarnings = v);
+                configuration.AssignObjectIfNotNull<string>(nameof(CILogLevel), v => CILogLevel = v);
                 configuration.AssignObjectIfNotNull<string>(nameof(RenderMode), v => RenderMode = v);
             }
         }
@@ -51,7 +51,7 @@ namespace Pester
             Verbosity = new StringOption("The verbosity of output, options are None, Normal, Detailed and Diagnostic.", "Normal");
             StackTraceVerbosity = new StringOption("The verbosity of stacktrace output, options are None, FirstLine, Filtered and Full.", "Filtered");
             CIFormat = new StringOption("The CI format of error output in build logs, options are None, Auto, AzureDevops and GithubActions.", "Auto");
-            CITreatErrorsAsWarnings = new BoolOption("When true, errors will be logged in CI as warnings.", false);
+            CILogLevel = new StringOption("The CI log level in build logs, options are Error and Warning.", "Error");
             RenderMode = new StringOption("The mode used to render console output, options are Auto, Ansi, ConsoleColor and Plaintext.", "Auto");
         }
 
@@ -103,18 +103,18 @@ namespace Pester
             }
         }
 
-        public BoolOption CITreatErrorsAsWarnings
+        public StringOption CILogLevel
         {
-            get { return _ciTreatErrorsAsWarnings; }
+            get { return _ciLogLevel; }
             set
             {
-                if (_ciTreatErrorsAsWarnings == null)
+                if (_ciLogLevel == null)
                 {
-                    _ciTreatErrorsAsWarnings = value;
+                    _ciLogLevel = value;
                 }
                 else
                 {
-                    _ciTreatErrorsAsWarnings = new BoolOption(_ciTreatErrorsAsWarnings, value.Value);
+                    _ciLogLevel = new StringOption(_ciLogLevel, value?.Value);
                 }
             }
         }

--- a/src/csharp/Pester/OutputConfiguration.cs
+++ b/src/csharp/Pester/OutputConfiguration.cs
@@ -25,6 +25,7 @@ namespace Pester
         private StringOption _verbosity;
         private StringOption _stackTraceVerbosity;
         private StringOption _ciFormat;
+        private BoolOption _ciTreatErrorsAsWarnings;
         private StringOption _renderMode;
 
         public static OutputConfiguration Default { get { return new OutputConfiguration(); } }
@@ -40,6 +41,7 @@ namespace Pester
                 configuration.AssignObjectIfNotNull<string>(nameof(Verbosity), v => Verbosity = v);
                 configuration.AssignObjectIfNotNull<string>(nameof(StackTraceVerbosity), v => StackTraceVerbosity = v);
                 configuration.AssignObjectIfNotNull<string>(nameof(CIFormat), v => CIFormat = v);
+                configuration.AssignValueIfNotNull<bool>(nameof(CITreatErrorsAsWarnings), v => CITreatErrorsAsWarnings = v);
                 configuration.AssignObjectIfNotNull<string>(nameof(RenderMode), v => RenderMode = v);
             }
         }
@@ -49,6 +51,7 @@ namespace Pester
             Verbosity = new StringOption("The verbosity of output, options are None, Normal, Detailed and Diagnostic.", "Normal");
             StackTraceVerbosity = new StringOption("The verbosity of stacktrace output, options are None, FirstLine, Filtered and Full.", "Filtered");
             CIFormat = new StringOption("The CI format of error output in build logs, options are None, Auto, AzureDevops and GithubActions.", "Auto");
+            CITreatErrorsAsWarnings = new BoolOption("When true, errors will be logged in CI as warnings.", false);
             RenderMode = new StringOption("The mode used to render console output, options are Auto, Ansi, ConsoleColor and Plaintext.", "Auto");
         }
 
@@ -96,6 +99,22 @@ namespace Pester
                 else
                 {
                     _ciFormat = new StringOption(_ciFormat, value?.Value);
+                }
+            }
+        }
+
+        public BoolOption CITreatErrorsAsWarnings
+        {
+            get { return _ciTreatErrorsAsWarnings; }
+            set
+            {
+                if (_ciTreatErrorsAsWarnings == null)
+                {
+                    _ciTreatErrorsAsWarnings = value;
+                }
+                else
+                {
+                    _ciTreatErrorsAsWarnings = new BoolOption(_ciTreatErrorsAsWarnings, value.Value);
                 }
             }
         }

--- a/src/functions/Output.ps1
+++ b/src/functions/Output.ps1
@@ -150,7 +150,8 @@ function Write-PesterHostMessage {
             $message = "$($message -replace '(?m)^', "$fg$bg")$($ANSIcodes.ResetAll)"
 
             & $SafeCommands['Write-Host'] -Object $message -NoNewLine:$NoNewLine
-        } else {
+        }
+        else {
             if ($RenderMode -eq 'Plaintext') {
                 if ($PSBoundParameters.ContainsKey('ForegroundColor')) {
                     $null = $PSBoundParameters.Remove('ForegroundColor')
@@ -973,8 +974,8 @@ function Format-CIErrorMessage {
             Default { $logIssueType = 'error' }
         }
 
-        $headerTaskIssueError = "##vso[task.logissue type=$logIssueType] $Header"
-        $lines.Add($headerTaskIssueError)
+        $headerLoggingCommand = "##vso[task.logissue type=$logIssueType] $Header"
+        $lines.Add($headerLoggingCommand)
 
         # Add subsequent messages as errors, but do not get reported to build log
         foreach ($line in $Message) {
@@ -987,12 +988,12 @@ function Format-CIErrorMessage {
         # https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#setting-an-error-message
         # https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#setting-a-warning-message
         switch ($CILogLevel) {
-            "Error" { $headerError = "::error::$($Header.TrimStart())" }
-            "Warning" { $headerError = "::warning::$($Header.TrimStart())" }
-            Default { $headerError = "::error::$($Header.TrimStart())" }
+            "Error" { $headerWorkflowCommand = "::error::$($Header.TrimStart())" }
+            "Warning" { $headerWorkflowCommand = "::warning::$($Header.TrimStart())" }
+            Default { $headerWorkflowCommand = "::error::$($Header.TrimStart())" }
         }
 
-        $lines.Add($headerError)
+        $lines.Add($headerWorkflowCommand)
 
         # Add rest of messages inside expandable group
         # https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#grouping-log-lines

--- a/src/functions/Output.ps1
+++ b/src/functions/Output.ps1
@@ -150,8 +150,7 @@ function Write-PesterHostMessage {
             $message = "$($message -replace '(?m)^', "$fg$bg")$($ANSIcodes.ResetAll)"
 
             & $SafeCommands['Write-Host'] -Object $message -NoNewLine:$NoNewLine
-        }
-        else {
+        } else {
             if ($RenderMode -eq 'Plaintext') {
                 if ($PSBoundParameters.ContainsKey('ForegroundColor')) {
                     $null = $PSBoundParameters.Remove('ForegroundColor')

--- a/src/functions/Output.ps1
+++ b/src/functions/Output.ps1
@@ -627,7 +627,7 @@ function Get-WriteScreenPlugin ($Verbosity) {
 
             if ($PesterPreference.Output.CIFormat.Value -in 'AzureDevops', 'GithubActions') {
                 $errorMessage = (Format-ErrorMessage @formatErrorParams) -split [Environment]::NewLine
-                Write-CIErrorToScreen -CIFormat $PesterPreference.Output.CIFormat.Value -CITreatErrorsAsWarnings $PesterPreference.Output.CITreatErrorsAsWarnings.Value -Header $errorHeader -Message $errorMessage
+                Write-CIErrorToScreen -CIFormat $PesterPreference.Output.CIFormat.Value -CITreatErrorsAsWarnings:$PesterPreference.Output.CITreatErrorsAsWarnings.Value -Header $errorHeader -Message $errorMessage
             }
             else {
                 Write-PesterHostMessage -ForegroundColor $ReportTheme.Fail $errorHeader
@@ -700,7 +700,7 @@ function Get-WriteScreenPlugin ($Verbosity) {
 
             if ($PesterPreference.Output.CIFormat.Value -in 'AzureDevops', 'GithubActions') {
                 $errorMessage = (Format-ErrorMessage @formatErrorParams) -split [Environment]::NewLine
-                Write-CIErrorToScreen -CIFormat $PesterPreference.Output.CIFormat.Value -CITreatErrorsAsWarnings $PesterPreference.Output.CITreatErrorsAsWarnings.Value -Header $errorHeader -Message $errorMessage
+                Write-CIErrorToScreen -CIFormat $PesterPreference.Output.CIFormat.Value -CITreatErrorsAsWarnings:$PesterPreference.Output.CITreatErrorsAsWarnings.Value -Header $errorHeader -Message $errorMessage
             }
             else {
                 Write-PesterHostMessage -ForegroundColor $ReportTheme.Fail $errorHeader
@@ -817,7 +817,7 @@ function Get-WriteScreenPlugin ($Verbosity) {
 
                     if ($PesterPreference.Output.CIFormat.Value -in 'AzureDevops', 'GithubActions') {
                         $errorMessage = (Format-ErrorMessage @formatErrorParams) -split [Environment]::NewLine
-                        Write-CIErrorToScreen -CIFormat $PesterPreference.Output.CIFormat.Value -CITreatErrorsAsWarnings $PesterPreference.Output.CITreatErrorsAsWarnings.Value -Header "$margin[-] $out $humanTime" -Message $errorMessage
+                        Write-CIErrorToScreen -CIFormat $PesterPreference.Output.CIFormat.Value -CITreatErrorsAsWarnings:$PesterPreference.Output.CITreatErrorsAsWarnings.Value -Header "$margin[-] $out $humanTime" -Message $errorMessage
                     }
                     else {
                         Write-PesterHostMessage -ForegroundColor $ReportTheme.Fail "$margin[-] $out" -NoNewLine
@@ -920,7 +920,7 @@ function Get-WriteScreenPlugin ($Verbosity) {
 
         if ($PesterPreference.Output.CIFormat.Value -in 'AzureDevops', 'GithubActions') {
             $errorMessage = (Format-ErrorMessage @formatErrorParams) -split [Environment]::NewLine
-            Write-CIErrorToScreen -CIFormat $PesterPreference.Output.CIFormat.Value -CITreatErrorsAsWarnings $PesterPreference.Output.CITreatErrorsAsWarnings.Value -Header $errorHeader -Message $errorMessage
+            Write-CIErrorToScreen -CIFormat $PesterPreference.Output.CIFormat.Value -CITreatErrorsAsWarnings:$PesterPreference.Output.CITreatErrorsAsWarnings.Value -Header $errorHeader -Message $errorMessage
         }
         else {
             Write-PesterHostMessage -ForegroundColor $ReportTheme.BlockFail $errorHeader
@@ -1015,7 +1015,7 @@ function Write-CIErrorToScreen {
         [string] $CIFormat,
 
         [Parameter(Mandatory)]
-        [switch]$CITreatErrorsAsWarnings,
+        [switch] $CITreatErrorsAsWarnings,
 
         [Parameter(Mandatory)]
         [string] $Header,

--- a/src/functions/Output.ps1
+++ b/src/functions/Output.ps1
@@ -776,6 +776,10 @@ function Get-WriteScreenPlugin ($Verbosity) {
             throw "Unsupported CI format '$($PesterPreference.Output.CIFormat.Value)'"
         }
 
+        if ($PesterPreference.Output.CILogLevel.Value -notin 'Error', 'Warning') {
+            throw "Unsupported CI log level '$($PesterPreference.Output.CILogLevel.Value)'"
+        }
+
         $humanTime = "$(Get-HumanTime ($_test.Duration)) ($(Get-HumanTime $_test.UserDuration)|$(Get-HumanTime $_test.FrameworkDuration))"
 
         if ($PesterPreference.Debug.ShowNavigationMarkers.Value) {

--- a/tst/Pester.RSpec.Configuration.ts.ps1
+++ b/tst/Pester.RSpec.Configuration.ts.ps1
@@ -98,6 +98,10 @@ i -PassThru:$PassThru {
             [PesterConfiguration]::Default.Output.CIFormat.Value | Verify-Equal Auto
         }
 
+        t "Output.CITreatErrorsAsWarnings is `$false" {
+            [PesterConfiguration]::Default.Output.CITreatErrorsAsWarnings.Value | Verify-False
+        }
+
         t "Output.RenderMode is Auto" {
             [PesterConfiguration]::Default.Output.RenderMode.Value | Verify-Equal 'Auto'
         }
@@ -1115,6 +1119,23 @@ i -PassThru:$PassThru {
 
             $r = Invoke-Pester -Configuration $c
             $r.Configuration.Output.CIFormat.Value | Verify-Equal "None"
+        }
+
+        t "CITreatErrorsAsWarnings is `$true when set" {
+            $c = [PesterConfiguration] @{
+                Run    = @{
+                    ScriptBlock = { }
+                    PassThru    = $true
+                }
+                Output = @{
+                    Verbosity               = "None"
+                    CIFormat                = "AzureDevops"
+                    CITreatErrorsAsWarnings = $true
+                }
+            }
+
+            $r = Invoke-Pester -Configuration $c
+            $r.Configuration.Output.CITreatErrorsAsWarnings.Value | Verify-True
         }
     }
 

--- a/tst/Pester.RSpec.Configuration.ts.ps1
+++ b/tst/Pester.RSpec.Configuration.ts.ps1
@@ -1123,36 +1123,19 @@ i -PassThru:$PassThru {
     }
 
     b "Output.CILogLevel" {
-        t "Output.CILogLevel is Error when set" {
+        t "Each option can be set and updated" {
             $c = [PesterConfiguration] @{
-                Run    = @{
+                Run = @{
                     ScriptBlock = { }
                     PassThru    = $true
                 }
-                Output = @{
-                    Verbosity  = "None"
-                    CILogLevel = "Error"
-                }
             }
 
-            $r = Invoke-Pester -Configuration $c
-            $r.Configuration.Output.CILogLevel.Value | Verify-Equal 'Error'
-        }
-
-        t "Output.CILogLevel is Warning when set" {
-            $c = [PesterConfiguration] @{
-                Run    = @{
-                    ScriptBlock = { }
-                    PassThru    = $true
-                }
-                Output = @{
-                    Verbosity  = "None"
-                    CILogLevel = "Warning"
-                }
+            foreach ($option in "Error", "Warning") {
+                $c.Output.CILogLevel = $option
+                $r = Invoke-Pester -Configuration $c
+                $r.Configuration.Output.CILogLevel.Value | Verify-Equal $option
             }
-
-            $r = Invoke-Pester -Configuration $c
-            $r.Configuration.Output.CILogLevel.Value | Verify-Equal 'Warning'
         }
 
         t "Exception is thrown when incorrect option is set" {
@@ -1168,12 +1151,12 @@ i -PassThru:$PassThru {
                     PassThru    = $true
                 }
                 Output = @{
-                    CILogLevel = "Something"
+                    CIFormat = 'None'
+                    CILogLevel = 'Something'
                 }
             }
 
-            $r = Invoke-Pester -Configuration $c
-            $r.Containers[0].Blocks[0].ErrorRecord[0] | Verify-Equal "Unsupported CI log level 'Something'"
+            { Invoke-Pester -Configuration $c } | Verify-Throw
         }
     }
 

--- a/tst/Pester.RSpec.Configuration.ts.ps1
+++ b/tst/Pester.RSpec.Configuration.ts.ps1
@@ -1142,7 +1142,7 @@ i -PassThru:$PassThru {
     b 'Output.RenderMode' {
         t 'Output.RenderMode is Plaintext when set to Auto (default) and env:NO_COLOR is set' {
             $c = [PesterConfiguration] @{
-                Run = @{
+                Run    = @{
                     ScriptBlock = { }
                     PassThru    = $true
                 }
@@ -1215,7 +1215,7 @@ i -PassThru:$PassThru {
             $pesterPath = Get-Module Pester | Select-Object -ExpandProperty Path
             try {
                 $ps = [PowerShell]::Create()
-                $ps.AddCommand('Set-StrictMode').AddParameter('Version', 'Latest') > $null
+                $ps.AddCommand('Set-StrictMode').AddParameter('Version','Latest') > $null
                 $ps.AddStatement().AddScript("Import-Module '$pesterPath' -Force") > $null
                 $ps.AddStatement().AddScript('$c = [PesterConfiguration]@{Run = @{ScriptBlock={ describe "d1" { it "i1" { } } };PassThru=$true};Output=@{RenderMode="Auto"}}') > $null
                 $ps.AddStatement().AddScript('Invoke-Pester -Configuration $c') > $null
@@ -1233,7 +1233,7 @@ i -PassThru:$PassThru {
 
         t 'Each non-Auto option can be set and updated' {
             $c = [PesterConfiguration] @{
-                Run = @{
+                Run    = @{
                     ScriptBlock = { }
                     PassThru    = $true
                 }
@@ -1266,8 +1266,7 @@ i -PassThru:$PassThru {
 
             try {
                 Invoke-Pester -Configuration $c
-            }
-            catch {
+            } catch {
                 $_.Exception.Message -match "Unsupported Output.RenderMode option 'Something'" | Verify-True
             }
         }

--- a/tst/Pester.RSpec.Configuration.ts.ps1
+++ b/tst/Pester.RSpec.Configuration.ts.ps1
@@ -1149,6 +1149,7 @@ i -PassThru:$PassThru {
                 Run    = @{
                     ScriptBlock = $sb
                     PassThru    = $true
+                    Throw       = $true
                 }
                 Output = @{
                     CIFormat = 'None'

--- a/tst/Pester.RSpec.Configuration.ts.ps1
+++ b/tst/Pester.RSpec.Configuration.ts.ps1
@@ -98,8 +98,8 @@ i -PassThru:$PassThru {
             [PesterConfiguration]::Default.Output.CIFormat.Value | Verify-Equal Auto
         }
 
-        t "Output.CITreatErrorsAsWarnings is `$false" {
-            [PesterConfiguration]::Default.Output.CITreatErrorsAsWarnings.Value | Verify-False
+        t "Output.CILogLevel is Error" {
+            [PesterConfiguration]::Default.Output.CILogLevel.Value | Verify-Equal 'Error'
         }
 
         t "Output.RenderMode is Auto" {
@@ -1121,28 +1121,28 @@ i -PassThru:$PassThru {
             $r.Configuration.Output.CIFormat.Value | Verify-Equal "None"
         }
 
-        t "CITreatErrorsAsWarnings is `$true when set" {
+        t "Output.CILogLevel is Error when set" {
             $c = [PesterConfiguration] @{
                 Run    = @{
                     ScriptBlock = { }
                     PassThru    = $true
                 }
                 Output = @{
-                    Verbosity               = "None"
-                    CIFormat                = "AzureDevops"
-                    CITreatErrorsAsWarnings = $true
+                    Verbosity  = "None"
+                    CIFormat   = "AzureDevops"
+                    CILogLevel = "Error"
                 }
             }
 
             $r = Invoke-Pester -Configuration $c
-            $r.Configuration.Output.CITreatErrorsAsWarnings.Value | Verify-True
+            $r.Configuration.Output.CILogLevel.Value | Verify-Equal Error
         }
     }
 
     b 'Output.RenderMode' {
         t 'Output.RenderMode is Plaintext when set to Auto (default) and env:NO_COLOR is set' {
             $c = [PesterConfiguration] @{
-                Run    = @{
+                Run = @{
                     ScriptBlock = { }
                     PassThru    = $true
                 }
@@ -1215,7 +1215,7 @@ i -PassThru:$PassThru {
             $pesterPath = Get-Module Pester | Select-Object -ExpandProperty Path
             try {
                 $ps = [PowerShell]::Create()
-                $ps.AddCommand('Set-StrictMode').AddParameter('Version','Latest') > $null
+                $ps.AddCommand('Set-StrictMode').AddParameter('Version', 'Latest') > $null
                 $ps.AddStatement().AddScript("Import-Module '$pesterPath' -Force") > $null
                 $ps.AddStatement().AddScript('$c = [PesterConfiguration]@{Run = @{ScriptBlock={ describe "d1" { it "i1" { } } };PassThru=$true};Output=@{RenderMode="Auto"}}') > $null
                 $ps.AddStatement().AddScript('Invoke-Pester -Configuration $c') > $null
@@ -1233,7 +1233,7 @@ i -PassThru:$PassThru {
 
         t 'Each non-Auto option can be set and updated' {
             $c = [PesterConfiguration] @{
-                Run    = @{
+                Run = @{
                     ScriptBlock = { }
                     PassThru    = $true
                 }
@@ -1266,7 +1266,8 @@ i -PassThru:$PassThru {
 
             try {
                 Invoke-Pester -Configuration $c
-            } catch {
+            }
+            catch {
                 $_.Exception.Message -match "Unsupported Output.RenderMode option 'Something'" | Verify-True
             }
         }

--- a/tst/Pester.RSpec.Configuration.ts.ps1
+++ b/tst/Pester.RSpec.Configuration.ts.ps1
@@ -1136,7 +1136,7 @@ i -PassThru:$PassThru {
             }
 
             $r = Invoke-Pester -Configuration $c
-            $r.Configuration.Output.CILogLevel.Value | Verify-Equal Error
+            $r.Configuration.Output.CILogLevel.Value | Verify-Equal 'Error'
         }
 
         t "Output.CILogLevel is Warning when set" {
@@ -1152,7 +1152,7 @@ i -PassThru:$PassThru {
             }
 
             $r = Invoke-Pester -Configuration $c
-            $r.Configuration.Output.CILogLevel.Value | Verify-Equal Warning
+            $r.Configuration.Output.CILogLevel.Value | Verify-Equal 'Warning'
         }
 
         t "Exception is thrown when incorrect option is set" {

--- a/tst/Pester.RSpec.Configuration.ts.ps1
+++ b/tst/Pester.RSpec.Configuration.ts.ps1
@@ -1120,7 +1120,9 @@ i -PassThru:$PassThru {
             $r = Invoke-Pester -Configuration $c
             $r.Configuration.Output.CIFormat.Value | Verify-Equal "None"
         }
+    }
 
+    b "Output.CILogLevel" {
         t "Output.CILogLevel is Error when set" {
             $c = [PesterConfiguration] @{
                 Run    = @{
@@ -1129,13 +1131,49 @@ i -PassThru:$PassThru {
                 }
                 Output = @{
                     Verbosity  = "None"
-                    CIFormat   = "AzureDevops"
                     CILogLevel = "Error"
                 }
             }
 
             $r = Invoke-Pester -Configuration $c
             $r.Configuration.Output.CILogLevel.Value | Verify-Equal Error
+        }
+
+        t "Output.CILogLevel is Warning when set" {
+            $c = [PesterConfiguration] @{
+                Run    = @{
+                    ScriptBlock = { }
+                    PassThru    = $true
+                }
+                Output = @{
+                    Verbosity  = "None"
+                    CILogLevel = "Warning"
+                }
+            }
+
+            $r = Invoke-Pester -Configuration $c
+            $r.Configuration.Output.CILogLevel.Value | Verify-Equal Warning
+        }
+
+        t "Exception is thrown when incorrect option is set" {
+            $sb = {
+                Describe "a" {
+                    It "b" {}
+                }
+            }
+
+            $c = [PesterConfiguration] @{
+                Run    = @{
+                    ScriptBlock = $sb
+                    PassThru    = $true
+                }
+                Output = @{
+                    CILogLevel = "Something"
+                }
+            }
+
+            $r = Invoke-Pester -Configuration $c
+            $r.Containers[0].Blocks[0].ErrorRecord[0] | Verify-Equal "Unsupported CI log level 'Something'"
         }
     }
 

--- a/tst/functions/Output.Tests.ps1
+++ b/tst/functions/Output.Tests.ps1
@@ -624,11 +624,11 @@ InModuleScope -ModuleName Pester -ScriptBlock {
                     )
                 }
             ) {
-                Format-CIErrorMessage -CIFormat 'AzureDevops' -CITreatErrorsAsWarnings:$false -Header $Header -Message $Message | Should -Be $Expected
+                Format-CIErrorMessage -CIFormat 'AzureDevops' -CILogLevel 'Error' -Header $Header -Message $Message | Should -Be $Expected
             }
         }
 
-        Context "Azure Devops Error As Warning Format" {
+        Context "Azure Devops Warning Format" {
             It "Header '<header>' and Message '<message>' returns '<expected>'" -TestCases @(
                 @{
                     Header   = 'header'
@@ -648,7 +648,7 @@ InModuleScope -ModuleName Pester -ScriptBlock {
                     )
                 }
             ) {
-                Format-CIErrorMessage -CIFormat 'AzureDevops' -CITreatErrorsAsWarnings:$true -Header $Header -Message $Message | Should -Be $Expected
+                Format-CIErrorMessage -CIFormat 'AzureDevops' -CILogLevel 'Warning' -Header $Header -Message $Message | Should -Be $Expected
             }
         }
 
@@ -687,11 +687,11 @@ InModuleScope -ModuleName Pester -ScriptBlock {
                     )
                 }
             ) {
-                Format-CIErrorMessage -CIFormat 'GithubActions' -CITreatErrorsAsWarnings:$false -Header $Header -Message $Message | Should -Be $Expected
+                Format-CIErrorMessage -CIFormat 'GithubActions' -CILogLevel 'Error' -Header $Header -Message $Message | Should -Be $Expected
             }
         }
 
-        Context 'Github Actions Error As Warning Format' {
+        Context 'Github Actions Warning Format' {
             It "Header '<header>' and Message '<message>' returns '<expected>'" -TestCases @(
                 @{
                     Header   = 'header'
@@ -726,7 +726,7 @@ InModuleScope -ModuleName Pester -ScriptBlock {
                     )
                 }
             ) {
-                Format-CIErrorMessage -CIFormat 'GithubActions' -CITreatErrorsAsWarnings:$true -Header $Header -Message $Message | Should -Be $Expected
+                Format-CIErrorMessage -CIFormat 'GithubActions' -CILogLevel 'Warning' -Header $Header -Message $Message | Should -Be $Expected
             }
         }
     }

--- a/tst/functions/Output.Tests.ps1
+++ b/tst/functions/Output.Tests.ps1
@@ -624,7 +624,7 @@ InModuleScope -ModuleName Pester -ScriptBlock {
                     )
                 }
             ) {
-                Format-CIErrorMessage -CIFormat 'AzureDevops' -CITreatErrorsAsWarnings $false -Header $Header -Message $Message | Should -Be $Expected
+                Format-CIErrorMessage -CIFormat 'AzureDevops' -CITreatErrorsAsWarnings:$false -Header $Header -Message $Message | Should -Be $Expected
             }
         }
 
@@ -648,7 +648,7 @@ InModuleScope -ModuleName Pester -ScriptBlock {
                     )
                 }
             ) {
-                Format-CIErrorMessage -CIFormat 'AzureDevops' -CITreatErrorsAsWarnings $true -Header $Header -Message $Message | Should -Be $Expected
+                Format-CIErrorMessage -CIFormat 'AzureDevops' -CITreatErrorsAsWarnings:$true -Header $Header -Message $Message | Should -Be $Expected
             }
         }
 
@@ -687,7 +687,7 @@ InModuleScope -ModuleName Pester -ScriptBlock {
                     )
                 }
             ) {
-                Format-CIErrorMessage -CIFormat 'GithubActions' -CITreatErrorsAsWarnings $false -Header $Header -Message $Message | Should -Be $Expected
+                Format-CIErrorMessage -CIFormat 'GithubActions' -CITreatErrorsAsWarnings:$false -Header $Header -Message $Message | Should -Be $Expected
             }
         }
 
@@ -726,7 +726,7 @@ InModuleScope -ModuleName Pester -ScriptBlock {
                     )
                 }
             ) {
-                Format-CIErrorMessage -CIFormat 'GithubActions' -CITreatErrorsAsWarnings $true -Header $Header -Message $Message | Should -Be $Expected
+                Format-CIErrorMessage -CIFormat 'GithubActions' -CITreatErrorsAsWarnings:$true -Header $Header -Message $Message | Should -Be $Expected
             }
         }
     }

--- a/tst/functions/Output.Tests.ps1
+++ b/tst/functions/Output.Tests.ps1
@@ -624,7 +624,31 @@ InModuleScope -ModuleName Pester -ScriptBlock {
                     )
                 }
             ) {
-                Format-CIErrorMessage -CIFormat 'AzureDevops' -Header $Header -Message $Message | Should -Be $Expected
+                Format-CIErrorMessage -CIFormat 'AzureDevops' -CITreatErrorsAsWarnings $false -Header $Header -Message $Message | Should -Be $Expected
+            }
+        }
+
+        Context "Azure Devops Error As Warning Format" {
+            It "Header '<header>' and Message '<message>' returns '<expected>'" -TestCases @(
+                @{
+                    Header   = 'header'
+                    Message  = 'message'
+                    Expected = @(
+                        '##vso[task.logissue type=warning] header',
+                        '##[warning] message'
+                    )
+                }
+                @{
+                    Header   = 'header'
+                    Message  = @('message1', 'message2')
+                    Expected = @(
+                        '##vso[task.logissue type=warning] header',
+                        '##[warning] message1',
+                        '##[warning] message2'
+                    )
+                }
+            ) {
+                Format-CIErrorMessage -CIFormat 'AzureDevops' -CITreatErrorsAsWarnings $true -Header $Header -Message $Message | Should -Be $Expected
             }
         }
 
@@ -663,7 +687,46 @@ InModuleScope -ModuleName Pester -ScriptBlock {
                     )
                 }
             ) {
-                Format-CIErrorMessage -CIFormat 'GithubActions' -Header $Header -Message $Message | Should -Be $Expected
+                Format-CIErrorMessage -CIFormat 'GithubActions' -CITreatErrorsAsWarnings $false -Header $Header -Message $Message | Should -Be $Expected
+            }
+        }
+
+        Context 'Github Actions Error As Warning Format' {
+            It "Header '<header>' and Message '<message>' returns '<expected>'" -TestCases @(
+                @{
+                    Header   = 'header'
+                    Message  = 'message'
+                    Expected = @(
+                        '::warning::header',
+                        '::group::Message',
+                        'message',
+                        '::endgroup::'
+                    )
+                }
+                @{
+                    Header   = 'header'
+                    Message  = @('message1', 'message2')
+                    Expected = @(
+                        '::warning::header',
+                        '::group::Message',
+                        'message1',
+                        'message2',
+                        '::endgroup::'
+                    )
+                }
+                @{
+                    Header   = 'header'
+                    Message  = @('  message1', '  message2')
+                    Expected = @(
+                        '::warning::header',
+                        '::group::Message',
+                        'message1',
+                        'message2',
+                        '::endgroup::'
+                    )
+                }
+            ) {
+                Format-CIErrorMessage -CIFormat 'GithubActions' -CITreatErrorsAsWarnings $true -Header $Header -Message $Message | Should -Be $Expected
             }
         }
     }


### PR DESCRIPTION
<!-- Thank you for contributing to Pester! -->

## PR Summary

Added parameter 'CITreatErrorsAsWarnings' to output configuration. When true, errors will be logged in CI as warnings.

Fix #2295

## PR Checklist

- [x] PR has meaningful title
- [x] Summary describes changes
- [x] PR is ready to be merged
  - If not, use the arrow next to `Create Pull Request` to mark it as a draft. PR can be marked `Ready for review` when it's ready.
- [x] Tests are added/update *(if required)*
- [x] Documentation is updated/added *(if required)*

<!-- Before you continue, please review [Contributing to Pester](https://pester.dev/docs/contributing/introduction).

Our continuous integration system doesn't send any notifications about failed tests. Please return to the opened pull request (after ~60 minutes) to check if everything is OK. -->
