### PR TITLE
Fix script parameter leaking to another container with same Data

### DIFF
--- a/src/Pester.Runtime.ps1
+++ b/src/Pester.Runtime.ps1
@@ -2424,8 +2424,8 @@ function New-BlockContainerObject {
     )
 
     # Data is null or IDictionary, but all IDictionary does not work with ContainsKey()
-    # Contains requires casting to interface with ex generic dictionary.
-    # Merging to a controlled data structure to have consistent API internally
+    # Contains() requires interface-casting for some types, ex. generic dictionary.
+    # Instead we're merging to a controlled data structure to have consistent API internally
     # Also works as a shallow clone to avoid leaking default parameter values between containers with same Data
     $ContainerData = @{ }
     if ($Data -is [System.Collections.IDictionary]) {

--- a/src/Pester.Runtime.ps1
+++ b/src/Pester.Runtime.ps1
@@ -2423,7 +2423,14 @@ function New-BlockContainerObject {
         $Data
     )
 
-    if ($null -eq $Data) { $Data = @{} }
+    # Data is null or IDictionary, but all IDictionary does not work with ContainsKey()
+    # Contains requires casting to interface with ex generic dictionary.
+    # Merging to a controlled data structure to have consistent API internally
+    # Also works as a shallow clone to avoid leaking default parameter values between containers with same Data
+    $ContainerData = @{ }
+    if ($Data -is [System.Collections.IDictionary]) {
+        Merge-Hashtable -Destination $ContainerData -Source $Data
+    }
 
     $type, $item = switch ($PSCmdlet.ParameterSetName) {
         "ScriptBlock" { "ScriptBlock", $ScriptBlock }
@@ -2435,7 +2442,7 @@ function New-BlockContainerObject {
     $c = [Pester.ContainerInfo]::Create()
     $c.Type = $type
     $c.Item = $item
-    $c.Data = $Data
+    $c.Data = $ContainerData
     $c
 }
 

--- a/src/Pester.Utility.ps1
+++ b/src/Pester.Utility.ps1
@@ -194,30 +194,20 @@ function Add-DataToContext ($Destination, $Data) {
     # which will become $_, and checks if the Data is
     # expandable, otherwise it just defines $_
 
-    if ($Data.Count -eq 0) {
-        $a = 10
-    }
     if (-not $Destination.ContainsKey("_")) {
         $Destination.Add("_", $Data)
     }
 
     if ($Data -is [Collections.IDictionary]) {
-        # only add non existing keys so in case of conflict
-        # the framework name wins, as if we had explicit parameters
-        # on a scriptblock, then the parameter would also win
-        foreach ($p in $Data.GetEnumerator()) {
-            if (-not $Destination.ContainsKey($p.Key)) {
-                $Destination.Add($p.Key, $p.Value)
-            }
-        }
+        Merge-Hashtable -Destination $Destination -Source $Data
     }
 }
 
 function Merge-Hashtable ($Source, $Destination) {
+    # only add non-existing keys so in case of conflict
+    # the framework name wins, as if we had explicit parameters
+    # on a scriptblock, then the parameter would also win
     foreach ($p in $Source.GetEnumerator()) {
-        # only add non existing keys so in case of conflict
-        # the framework name wins, as if we had explicit parameters
-        # on a scriptblock, then the parameter would also win
         if (-not $Destination.ContainsKey($p.Key)) {
             $Destination.Add($p.Key, $p.Value)
         }


### PR DESCRIPTION
## PR Summary
Create own copy of `Data` per container to avoid ex. default values for script parameters leaking to the next container. Only does a shallow copy to protect the Data-dictionary.

Uses hashtable merging instead of `.Clone()` to simultaneously add support for more dictionary-types. Some dictionaries don't have `ContainsKey()` which results in an exception when adding default values for script parameters to `Data`.

Fix #2299
Fix #2073
Fix #2301 
Fix #2093

## PR Checklist

- [x] PR has meaningful title
- [x] Summary describes changes
- [x] PR is ready to be merged
  - If not, use the arrow next to `Create Pull Request` to mark it as a draft. PR can be marked `Ready for review` when it's ready.
- [x] Tests are added/update *(if required)*
- [ ] Documentation is updated/added *(if required)*