### PR TITLE
Rename TestCases parameter to ForEach

### DIFF
--- a/src/functions/Context.ps1
+++ b/src/functions/Context.ps1
@@ -82,6 +82,7 @@
         # [Switch] $Focus,
         [Switch] $Skip,
 
+        [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidAssignmentToAutomaticVariable', '', Justification = 'ForEach is not used in Foreach-Object loop')]
         $ForEach
     )
 

--- a/src/functions/Describe.ps1
+++ b/src/functions/Describe.ps1
@@ -90,6 +90,7 @@
         # [Switch] $Focus,
         [Switch] $Skip,
 
+        [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidAssignmentToAutomaticVariable', '', Justification = 'ForEach is not used in Foreach-Object loop')]
         $ForEach
     )
 

--- a/src/functions/It.ps1
+++ b/src/functions/It.ps1
@@ -38,13 +38,13 @@
     commenting out a test, because the test remains listed in the output. Use the Strict parameter
     of Invoke-Pester to force all skipped tests to fail.
 
-    .PARAMETER TestCases
-    Optional array of hashtable (or any IDictionary) objects.  If this parameter is used,
-    Pester will call the test script block once for each table in the TestCases array,
-    splatting the dictionary to the test script block as input.  If you want the name of
-    the test to appear differently for each test case, you can embed tokens into the Name
+    .PARAMETER ForEach
+    (Formerly called TestCases.) Optional array of hashtable (or any IDictionary) objects.
+    If this parameter is used, Pester will call the test script block once for each table in
+    the ForEach array, splatting the dictionary to the test script block as input.  If you want
+    the name of the test to appear differently for each test case, you can embed tokens into the Name
     parameter with the syntax 'Adds numbers <A> and <B>' (assuming you have keys named A and B
-    in your TestCases hashtables.)
+    in your ForEach hashtables.)
 
     .PARAMETER Tag
     Optional parameter containing an array of strings. When calling Invoke-Pester,
@@ -97,14 +97,14 @@
             @{ a = 'two'; b = 'three'; expectedResult = 'twothree' }
         )
 
-        It 'Correctly adds <a> and <b> to get <expectedResult>' -TestCases $testCases {
+        It 'Correctly adds <a> and <b> to get <expectedResult>' -ForEach $testCases {
             $sum = Add-Numbers $a $b
             $sum | Should -Be $expectedResult
         }
     }
     ```
 
-    Using It with -TestCases to run the same tests with different parameters and expected results.
+    Using It with -ForEach to run the same tests with different parameters and expected results.
     Each hashtable in the `$testCases`-array generates one tests to a total of four. Each key-value pair in the
     current hashtable are made available as variables inside It.
 
@@ -128,8 +128,8 @@
         [Parameter(Position = 1)]
         [ScriptBlock] $Test,
 
-        [Alias("ForEach")]
-        [object[]] $TestCases,
+        [Alias("TestCases")]
+        [object[]] $ForEach,
 
         [String[]] $Tag,
 
@@ -162,9 +162,9 @@
         }
     }
 
-    if ($PSBoundParameters.ContainsKey('TestCases')) {
-        if ($null -ne $TestCases -and 0 -lt @($TestCases).Count) {
-            New-ParametrizedTest -Name $Name -ScriptBlock $Test -StartLine $MyInvocation.ScriptLineNumber -Data $TestCases -Tag $Tag -Focus:$Focus -Skip:$Skip
+    if ($PSBoundParameters.ContainsKey('ForEach')) {
+        if ($null -ne $ForEach -and 0 -lt @($ForEach).Count) {
+            New-ParametrizedTest -Name $Name -ScriptBlock $Test -StartLine $MyInvocation.ScriptLineNumber -Data $ForEach -Tag $Tag -Focus:$Focus -Skip:$Skip
         }
         else {
             # @() or $null is provided do nothing

--- a/src/functions/It.ps1
+++ b/src/functions/It.ps1
@@ -128,6 +128,7 @@
         [Parameter(Position = 1)]
         [ScriptBlock] $Test,
 
+        [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidAssignmentToAutomaticVariable', '', Justification = 'ForEach is not used in Foreach-Object loop')]
         [Alias("TestCases")]
         [object[]] $ForEach,
 


### PR DESCRIPTION
## PR Summary
Renames `-TestCases` parameter on `It` to `-ForEach` to follow documentation, and be consistent with Describe and Context. 
Fixes the docs in inline help to use that name. 

The former `-TestCases` name is made an alias.

$testCases in the examples is kept on purpose to make it easy to see what is being referred as array of hashtables. 

Fix #2310

## PR Checklist

- [x] PR has meaningful title
- [x] Summary describes changes
- [x] PR is ready to be merged
  - If not, use the arrow next to `Create Pull Request` to mark it as a draft. PR can be marked `Ready for review` when it's ready.
- [ ] Tests are added/update *(if required)*
- [x] Documentation is updated/added *(if required)*
