### PR TITLE
Avoid nested array when using Should -ActualValue

### DIFF
--- a/src/Pester.Utility.ps1
+++ b/src/Pester.Utility.ps1
@@ -394,3 +394,10 @@ function Fold-Run {
         }
     }
 }
+
+function IsPSEnumerable($Object) {
+    # https://github.com/pester/Pester/issues/1200#issuecomment-493043683
+    # PowerShell doesn't consider all IEnumerable an enumerable, ex. string is excluded.
+    $enumerator = [System.Management.Automation.LanguagePrimitives]::GetEnumerator($Object)
+    return $null -ne $enumerator
+}

--- a/src/functions/assertions/Should.ps1
+++ b/src/functions/assertions/Should.ps1
@@ -120,7 +120,14 @@ function Should {
     }
 
     process {
-        $inputArray.Add($ActualValue)
+        # If array was provided using -ActualValue @(1,2,3), unroll like pipeline for consistent behaviour
+        if (-not $PSCmdlet.MyInvocation.ExpectingInput -and (IsPSEnumerable -Object $ActualValue)) {
+            foreach ($object in $ActualValue) {
+                $inputArray.Add($object)
+            }
+        } else {
+            $inputArray.Add($ActualValue)
+        }
     }
 
     end {

--- a/tst/functions/assertions/Should.Tests.ps1
+++ b/tst/functions/assertions/Should.Tests.ps1
@@ -28,6 +28,12 @@ InPesterModuleScope {
             @($item1, $item2) | Should -Not -BeNullOrEmpty
         }
 
+        It 'works consistenly with array-input using pipeline or -ActualValue' {
+            # https://github.com/pester/Pester/issues/2314
+            @(1, 2, 3) | Should -Be -ExpectedValue @(1, 2, 3)
+            Should -Be -ActualValue @(1, 2, 3) -ExpectedValue @(1, 2, 3)
+        }
+
         It "can handle exception thrown assertions" {
             { foo } | Should -Throw
         }


### PR DESCRIPTION
## PR Summary
**Possible breaking change!**

If an enumerable was provided with `Should -ActualValue ..` instead of pipeline, unroll to be consistent with pipeline-input.

Fix #2314
Might also solve this: https://github.com/pester/Pester/issues/1234#issuecomment-748627991

## PR Checklist

- [x] PR has meaningful title
- [x] Summary describes changes
- [ ] PR is ready to be merged
  - If not, use the arrow next to `Create Pull Request` to mark it as a draft. PR can be marked `Ready for review` when it's ready.
- [x] Tests are added/update *(if required)*
- [ ] Documentation is updated/added *(if required)*