### PR TITLE
Increase timeout in CI build step

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -51,7 +51,7 @@ stages:
           clean: all
         pool:
           vmImage: windows-2022
-        timeoutInMinutes: 3
+        timeoutInMinutes: 5
         steps:
           - checkout: self
             fetchDepth: 1


### PR DESCRIPTION
## PR Summary
nuget restore are sometimes very slow when cache is not available. Increasing timeout in build-step to avoid unnecessary CI failures.

## PR Checklist

- [x] PR has meaningful title
- [x] Summary describes changes
- [x] PR is ready to be merged
  - If not, use the arrow next to `Create Pull Request` to mark it as a draft. PR can be marked `Ready for review` when it's ready.
- [ ] Tests are added/update *(if required)*
- [ ] Documentation is updated/added *(if required)*