### PR TITLE
Support profiling Pester with CC using Profiler v3.1 or v4

### DIFF
--- a/src/csharp/Pester/Tracing/CodeCoverageTracer.cs
+++ b/src/csharp/Pester/Tracing/CodeCoverageTracer.cs
@@ -102,5 +102,13 @@ namespace Pester.Tracing
 
             lineColumn[key2] = points;
         }
+
+#pragma warning disable IDE0060
+        // Profiler v3.1 compatible overload
+        public void Trace(IScriptExtent extent, ScriptBlock _, int __) => Trace(null, extent, _, __);
+
+        // Profiler v4 compatible overload
+        public void Trace(IScriptExtent extent, ScriptBlock _, int __, string ___, string ____) => Trace(null, extent, _, __);
+#pragma warning restore IDE0060
     }
 }


### PR DESCRIPTION
## PR Summary

Add overloads to `Trace()` to be compatible with expected API in Profiler v3.1 and v4.
Enables profiling with Profiler v3.1 and v4 on Pester with tracer-based CC enabled.

Requires https://github.com/nohwnd/Profiler/pull/60 for Profiler v4 compatibility as it's implementation of `ExternalTraceAdapter` is currently broken.

Fix #2185

## PR Checklist

- [x] PR has meaningful title
- [x] Summary describes changes
- [ ] PR is ready to be merged
  - If not, use the arrow next to `Create Pull Request` to mark it as a draft. PR can be marked `Ready for review` when it's ready.
- [ ] Tests are added/update *(if required)*
- [ ] Documentation is updated/added *(if required)*