### PR TITLE
Don't throw legacy error when using Should operator after escaped linebreak

### DIFF
--- a/src/functions/assertions/Should.ps1
+++ b/src/functions/assertions/Should.ps1
@@ -106,7 +106,7 @@ function Should {
         }
 
         # A bit of Regex lets us know if the line used the old form
-        if ($myLine -match '^\s{0,}should\s{1,}(?<Operator>[^\-\@\s]+)') {
+        if ($myLine -match '^\s{0,}should[\s\`]{1,}(?<Operator>[^\-\@\s\`]+)') {
             $shouldErrorMsg = "Legacy Should syntax (without dashes) is not supported in Pester 5. Please refer to migration guide at: https://pester.dev/docs/migrations/v3-to-v4"
             throw $shouldErrorMsg
         }

--- a/tst/functions/assertions/Should.Tests.ps1
+++ b/tst/functions/assertions/Should.Tests.ps1
@@ -124,4 +124,26 @@ InPesterModuleScope {
             Get-Command Should -Syntax | Should -Not -BeNullOrEmpty
         }
     }
+
+    Describe 'Legacy syntax exception' {
+        It 'Throws when legacy syntax is used' {
+            { 1 | Should Be 1 } | Should -Throw '*Legacy Should syntax*is not supported*'
+        }
+
+        It 'Does not throw when using linebreak before operator-switch' {
+            # https://github.com/pester/Pester/issues/2138
+            1 + 1 | Should `
+                -Be 2
+        }
+
+        It 'Does not throw when using splatting' {
+            $p = @{
+                Be            = $true
+                ExpectedValue = 2
+            }
+            1 + 1 | Should @p
+        }
+
+        # will throw on positional parameters before -<Operator> but that's more obvious user error.
+    }
 }


### PR DESCRIPTION
## PR Summary
Fix false positive exception when specifying Should-operator after linebreak using backtick/escape char, ex.

```ps1
1 | Should `
    -Be 1
```

Provided as an [alternative to removing the legacy-check](https://github.com/pester/Pester/issues/2138#issuecomment-1183070814) though I'm not against removing it.

## PR Checklist

- [x] PR has meaningful title
- [x] Summary describes changes
- [ ] PR is ready to be merged
  - If not, use the arrow next to `Create Pull Request` to mark it as a draft. PR can be marked `Ready for review` when it's ready.
- [x] Tests are added/update *(if required)*
- [ ] Documentation is updated/added *(if required)*