### PR TITLE
Quote input string in BeNullOrEmpty error

### DIFF
--- a/src/functions/assertions/BeNullOrEmpty.ps1
+++ b/src/functions/assertions/BeNullOrEmpty.ps1
@@ -1,5 +1,5 @@
 ﻿
-function Should-BeNullOrEmpty([object[]] $ActualValue, [switch] $Negate, [string] $Because) {
+function Should-BeNullOrEmpty($ActualValue, [switch] $Negate, [string] $Because) {
     <#
     .SYNOPSIS
     Checks values for null or empty (strings).
@@ -30,6 +30,7 @@ function Should-BeNullOrEmpty([object[]] $ActualValue, [switch] $Negate, [string
     }
     elseif ($ActualValue.Count -eq 1) {
         $expandedValue = $ActualValue[0]
+        $singleValue = $true
         if ($expandedValue -is [hashtable]) {
             $succeeded = $expandedValue.Count -eq 0
         }
@@ -52,7 +53,8 @@ function Should-BeNullOrEmpty([object[]] $ActualValue, [switch] $Negate, [string
             $failureMessage = NotShouldBeNullOrEmptyFailureMessage -Because $Because
         }
         else {
-            $failureMessage = ShouldBeNullOrEmptyFailureMessage -ActualValue $ActualValue -Because $Because
+            $valueToFormat = if ($singleValue) { $expandedValue } else { $ActualValue }
+            $failureMessage = ShouldBeNullOrEmptyFailureMessage -ActualValue $valueToFormat -Because $Because
         }
     }
 

--- a/tst/functions/assertions/BeNullOrEmpty.Tests.ps1
+++ b/tst/functions/assertions/BeNullOrEmpty.Tests.ps1
@@ -33,6 +33,11 @@ InPesterModuleScope {
             $err = { 1 | Should -BeNullOrEmpty -Because 'reason' } | Verify-AssertionFailed
             $err.Exception.Message | Verify-Equal 'Expected $null or empty, because reason, but got 1.'
         }
+
+        It 'returns the correct assertion message for single string' {
+            $err = { 'empty' | Should -BeNullOrEmpty -Because 'reason' } | Verify-AssertionFailed
+            $err.Exception.Message | Verify-Equal 'Expected $null or empty, because reason, but got ''empty''.'
+        }
     }
 
     Describe "Should -Not -BeNullOrEmpty" {


### PR DESCRIPTION
## PR Summary
Fix missing quotes when single string is passed to `Should -BeNullOrEmpty`.

/cc @johlju 

## PR Checklist

- [x] PR has meaningful title
- [x] Summary describes changes
- [x] PR is ready to be merged
  - If not, use the arrow next to `Create Pull Request` to mark it as a draft. PR can be marked `Ready for review` when it's ready.
- [x] Tests are added/update *(if required)*
- [ ] Documentation is updated/added *(if required)*