### PR TITLE
Format single item arrays as an array

### DIFF
--- a/src/Format.ps1
+++ b/src/Format.ps1
@@ -125,6 +125,11 @@ function Format-Nicely ($Value, [switch]$Pretty) {
         return Format-ScriptBlock -Value $Value
     }
 
+    # Check collection before Is-Value to format single item arrays
+    if (Is-Collection -Value $Value) {
+        return Format-Collection -Value $Value -Pretty:$Pretty
+    }
+
     if (Is-Value -Value $Value) {
         return $Value
     }
@@ -139,10 +144,6 @@ function Format-Nicely ($Value, [switch]$Pretty) {
         # no advanced formatting of objects in the first version, till I balance it
         return [string]$Value
         #return Format-Dictionary -Value $Value
-    }
-
-    if (Is-Collection -Value $Value) {
-        return Format-Collection -Value $Value -Pretty:$Pretty
     }
 
     # no advanced formatting of objects in the first version, till I balance it

--- a/tst/Format.Tests.ps1
+++ b/tst/Format.Tests.ps1
@@ -155,7 +155,8 @@ Describe "Format-Nicely" {
         @{ Value = 1; Expected = '1' },
         @{ Value = (1, 2, 3); Expected = '@(1, 2, 3)' },
         @{ Value = 1.1; Expected = '1.1' },
-        @{ Value = [int]; Expected = '[int]' }
+        @{ Value = [int]; Expected = '[int]' },
+        @{ Value = @('a'); Expected = "@('a')" }
         # @{ Value = [PSCustomObject] @{ Name = "Jakub" }; Expected = 'PSObject{Name=Jakub}' },
         #@{ Value = (Get-Process Idle); Expected = 'Diagnostics.Process{Id=0; Name=Idle}'},
         #@{ Value = (New-Object -Type Assertions.TestType.Person -Property @{Name = 'Jakub'; Age = 28}); Expected = "Assertions.TestType.Person{Age=28; Name=Jakub}"}

--- a/tst/functions/assertions/HaveCount.Tests.ps1
+++ b/tst/functions/assertions/HaveCount.Tests.ps1
@@ -35,7 +35,7 @@ InPesterModuleScope {
 
         It "returns the correct assertion message when collection is not empty" {
             $err = { @(1) | Should -HaveCount 0 -Because 'reason' } | Verify-AssertionFailed
-            $err.Exception.Message | Verify-Equal 'Expected an empty collection, because reason, but got collection with size 1 1.'
+            $err.Exception.Message | Verify-Equal 'Expected an empty collection, because reason, but got collection with size 1 @(1).'
         }
 
         It "validates the expected size to be bigger than 0" {


### PR DESCRIPTION
## PR Summary

Single item arrays are currently printed as single item without type-specific formatting because `Is-Value` expands them. Arrays with a single string or bool (more types?) will not be properly formatted.

```ps1
# Current
> Format-Nicely @('a')
a

# After
> Format-Nicely @('a')                
@('a')
```

Related #2329

## PR Checklist

- [x] PR has meaningful title
- [x] Summary describes changes
- [ ] PR is ready to be merged
  - If not, use the arrow next to `Create Pull Request` to mark it as a draft. PR can be marked `Ready for review` when it's ready.
- [x] Tests are added/update *(if required)*
- [ ] Documentation is updated/added *(if required)*