### PR TITLE
Make initial Mock cleanup more performant

### DIFF
--- a/src/functions/Mock.ps1
+++ b/src/functions/Mock.ps1
@@ -1573,32 +1573,25 @@ function Test-IsClosure {
 }
 
 function Remove-MockFunctionsAndAliases ($SessionState) {
-    # when a test is terminated (e.g. by stopping at a breakpoint and then stoping the execution of the script)
-    # the aliases and bootstrap functions for the currently mocked functions will remain in place
+    # When a test is terminated (e.g. by stopping at a breakpoint and then stoping the execution of the script)
+    # the aliases and bootstrap functions for the currently mocked functions will remain in place.
     # Then on subsequent runs the bootstrap function will be picked up instead of the real command,
     # because there is still an alias associated with it, and the test will fail.
     # So before putting Pester state in place we should make sure that all Pester mocks are gone
-    # by deleting every alias pointing to a function that starts with PesterMock_. Then we also delete the
-    # bootstrap function.
+    # by deleting every alias pointing to a function that starts with PesterMock_.
+    # As a perf optimization we don't delete the bootstrap functions because running Get-Command
+    # in every loaded module has significant overhead (https://github.com/pester/Pester/discussions/2331)
+    # and the PesterMock_ function won't be picked up without an alias.
     $Get_Alias = $script:SafeCommands['Get-Alias']
-    $Get_Command = $script:SafeCommands['Get-Command']
     $Remove_Item = $script:SafeCommands['Remove-Item']
     foreach ($alias in (& $Get_Alias -Definition "PesterMock_*")) {
         & $Remove_Item "alias:/$($alias.Name)"
     }
 
-    foreach ($bootstrapFunction in (& $Get_Command -Name "PesterMock_*")) {
-        & $Remove_Item "function:/$($bootstrapFunction.Name)"
-    }
-
     $ScriptBlock = {
-        param ($Get_Alias, $Get_Command, $Remove_Item)
+        param ($Get_Alias, $Remove_Item)
         foreach ($alias in (& $Get_Alias -Definition "PesterMock_*")) {
             & $Remove_Item "alias:/$($alias.Name)"
-        }
-
-        foreach ($bootstrapFunction in (& $Get_Command -Name "PesterMock_*")) {
-            & $Remove_Item "function:/$($bootstrapFunction.Name)"
         }
     }
 
@@ -1618,7 +1611,7 @@ function Remove-MockFunctionsAndAliases ($SessionState) {
         # https://github.com/PowerShell/PowerShell/blob/658837323599ab1c7a81fe66fcd43f7420e4402b/src/System.Management.Automation/engine/runtime/Operations/MiscOps.cs#L51-L55
         # https://github.com/pester/Pester/issues/1921
         if ('Script', 'Manifest' -contains $module.ModuleType -and $null -ne $module.SessionState) {
-            & ($module) $ScriptBlock $Get_Alias $Get_Command $Remove_Item
+            & ($module) $ScriptBlock $Get_Alias $Remove_Item
         }
     }
 }
@@ -1823,13 +1816,13 @@ function Repair-EnumParameters {
     # https://github.com/PowerShell/PowerShell/issues/17546
     $ast = [System.Management.Automation.Language.Parser]::ParseInput("param($ParamBlock)", [ref]$null, [ref]$null)
     $brokenValidateRange = $ast.FindAll({
-        param($node)
-        $node -is [System.Management.Automation.Language.AttributeAst] -and
-        $node.TypeName.Name -match '(?:ValidateRange|System\.Management\.Automation\.ValidateRangeAttribute)$' -and
-        $node.NamedArguments.Count -gt 0 -and
-        # triple checking for broken argument - it won't have a value/expression
-        $node.NamedArguments.ExpressionOmitted -notcontains $false
-    }, $false)
+            param($node)
+            $node -is [System.Management.Automation.Language.AttributeAst] -and
+            $node.TypeName.Name -match '(?:ValidateRange|System\.Management\.Automation\.ValidateRangeAttribute)$' -and
+            $node.NamedArguments.Count -gt 0 -and
+            # triple checking for broken argument - it won't have a value/expression
+            $node.NamedArguments.ExpressionOmitted -notcontains $false
+        }, $false)
 
     if ($brokenValidateRange.Count -eq 0) {
         # No errors found. Return original string

--- a/src/functions/Mock.ps1
+++ b/src/functions/Mock.ps1
@@ -1590,7 +1590,7 @@ function Remove-MockFunctionsAndAliases ($SessionState) {
     }
 
     foreach ($bootstrapFunction in (& $Get_ChildItem -Name "function:/PesterMock_*")) {
-        & $Remove_Item "function:/$($bootstrapFunction.Name)"
+        & $Remove_Item "function:/$($bootstrapFunction.Name)" -Force -Confirm:$false
     }
 
     $ScriptBlock = {
@@ -1600,7 +1600,7 @@ function Remove-MockFunctionsAndAliases ($SessionState) {
         }
 
         foreach ($bootstrapFunction in (& $Get_ChildItem -Name "function:/PesterMock_*")) {
-            & $Remove_Item "function:/$($bootstrapFunction.Name)"
+            & $Remove_Item "function:/$($bootstrapFunction.Name)" -Force -Confirm:$false
         }
     }
 

--- a/src/functions/Mock.ps1
+++ b/src/functions/Mock.ps1
@@ -1590,7 +1590,7 @@ function Remove-MockFunctionsAndAliases ($SessionState) {
     }
 
     foreach ($bootstrapFunction in (& $Get_ChildItem -Name "function:/PesterMock_*")) {
-        & $Remove_Item "function:/$($bootstrapFunction.Name)" -Force -Confirm:$false
+        & $Remove_Item "function:/$($bootstrapFunction)" -Recurse -Force -Confirm:$false
     }
 
     $ScriptBlock = {
@@ -1600,7 +1600,7 @@ function Remove-MockFunctionsAndAliases ($SessionState) {
         }
 
         foreach ($bootstrapFunction in (& $Get_ChildItem -Name "function:/PesterMock_*")) {
-            & $Remove_Item "function:/$($bootstrapFunction.Name)" -Force -Confirm:$false
+            & $Remove_Item "function:/$($bootstrapFunction)" -Recurse -Force -Confirm:$false
         }
     }
 


### PR DESCRIPTION
<!-- Thank you for contributing to Pester! -->

## PR Summary

There is initial cleanup of orphaned mocks that happens in Invoke-Pester and makes sure that there are no Mock aliases in place coming from previously cancelled runs. In Pester v4 we only cleaned up the main session state, but in v5 we pick up every loaded module and clean up there. This adds up to the point where it can take several seconds (in docker container) to do this cleanup. 

This PR optimizes the cleanup to just query functions, rather than all cmdlets and filtering them.

## PR Checklist

- [x] PR has meaningful title
- [x] Summary describes changes
- [x] PR is ready to be merged
  - If not, use the arrow next to `Create Pull Request` to mark it as a draft. PR can be marked `Ready for review` when it's ready.
- [ ] Tests are added/update *(if required)* (there are no tests for this functionality in the first place imho)
- [ ] Documentation is updated/added *(if required)*

<!-- Before you continue, please review [Contributing to Pester](https://pester.dev/docs/contributing/introduction).

Our continuous integration system doesn't send any notifications about failed tests. Please return to the opened pull request (after ~60 minutes) to check if everything is OK. -->
