### PR TITLE
Remove parameter attributes in reverse in Mock

### DIFF
--- a/src/functions/Mock.ps1
+++ b/src/functions/Mock.ps1
@@ -1663,7 +1663,7 @@ function Repair-ConflictingParameters {
             $repairedMetadata.Parameters.Add($newName, $paramMetadata)
         }
 
-        $attrIndexesToRemove = [System.Collections.Generic.List[object]]@()
+        $attrIndexesToRemove = [System.Collections.Generic.List[int]]@()
 
         if ($RemoveParameterType -contains $paramMetadata.Name) {
             $paramMetadata.ParameterType = [object]
@@ -1686,6 +1686,9 @@ function Repair-ConflictingParameters {
             }
         }
 
+        # remove attributes in reverse order to avoid index shifting
+        $attrIndexesToRemove.Sort()
+        $attrIndexesToRemove.Reverse()
         foreach ($index in $attrIndexesToRemove) {
             $null = $paramMetadata.Attributes.RemoveAt($index)
         }

--- a/tst/functions/Mock.Tests.ps1
+++ b/tst/functions/Mock.Tests.ps1
@@ -693,7 +693,7 @@ Describe "When Creating multiple Verifiable Mocks that are not called" {
     It "Should throw and list all commands" {
         $result.Exception.Message | Should -Be "$([System.Environment]::NewLine)Expected all verifiable mocks to be called, but these were not:$([System.Environment]::NewLine) Command FunctionUnderTest with { `$param1 -eq `"one`" }$([System.Environment]::NewLine) Command FunctionUnderTest with { `$param1 -eq `"two`" }"
     }
-    
+
     It 'Should include reason when -Because is used' {
         try {
             Should -InvokeVerifiable -Because 'of reasons'
@@ -2861,6 +2861,23 @@ Describe 'RemoveParameterValidation' {
         Mock Test-Validation -RemoveParameterValidation Count { "mock" }
 
         Test-Validation -Count -1 | Should -Be "mock"
+    }
+}
+
+Describe 'Removing multiple attributes for same parameter' {
+    It 'Removes parameter type and validation for simple function' {
+        # Making sure attributes are removed correctly regardless of order
+        function t {
+            param(
+                [Alias('Number2')]
+                [ValidateSet(1)]
+                [PSTypeName('SomeType')]
+                $Number1
+            )
+            $Number1
+        }
+        Mock t -RemoveParameterType 'Number1' -RemoveParameterValidation 'Number1'
+        { t -Number1 2 } | Should -Not -Throw
     }
 }
 


### PR DESCRIPTION
## PR Summary
Fixing edge case where creating a mock with both `-RemoveParameterType` and `-RemoveParameterValidation` for the same parameter would not work properly if `[PSTypeName('asd')]` was defined below validation-attribute

## PR Checklist

- [x] PR has meaningful title
- [x] Summary describes changes
- [x] PR is ready to be merged
  - If not, use the arrow next to `Create Pull Request` to mark it as a draft. PR can be marked `Ready for review` when it's ready.
- [x] Tests are added/update *(if required)*
- [ ] Documentation is updated/added *(if required)*