### PR TITLE
Do not cleanup previous mocks in inner Invoke-Pester

### DIFF
--- a/src/Main.ps1
+++ b/src/Main.ps1
@@ -638,15 +638,16 @@ function Invoke-Pester {
         # this will inherit to child scopes and allow Describe / Context to run directly from a file or command line
         $invokedViaInvokePester = $true
 
+        if ($null -eq $state) {
+            # Cleanup any leftover mocks from previous runs, but only if we are not running in a nested Pester-run
+            # todo: move mock cleanup to BeforeAllBlockContainer when there is any?
+            Remove-MockFunctionsAndAliases -SessionState $PSCmdlet.SessionState
+        }
+
         # this will inherit to child scopes and allow Pester to run in Pester, not checking if this is
         # already defined because we want a clean state for this Invoke-Pester even if it runs inside another
         # testrun (which calls Invoke-Pester itself)
         $state = New-PesterState
-
-        # TODO: Remove all references to mock table, there should not be many.
-        $script:mockTable = @{}
-        # todo: move mock cleanup to BeforeAllBlockContainer when there is any
-        Remove-MockFunctionsAndAliases -SessionState $PSCmdlet.SessionState
 
         # store CWD so we can revert any changes at the end
         $initialPWD = $pwd.Path

--- a/src/functions/Pester.SessionState.Mock.ps1
+++ b/src/functions/Pester.SessionState.Mock.ps1
@@ -1195,7 +1195,9 @@ function Invoke-Mock {
     # if we are targeting a module use the behaviors for the current module, but if there is no default the fall back to the non-module default behavior.
     # do not fallback to non-module filtered behaviors. This is here for safety, and for compatibility when doing Mock Remove-Item {}, and then mocking in module
     # then the default mock for Remove-Item should be effective.
-    $behaviors = if ($targettingAModule) {
+
+    # using @() to always get array. This avoids null error in Invoke-MockInternal when no behaviors where found (if-else unwraps the lists)
+    $behaviors = @(if ($targettingAModule) {
         # we have default module behavior add it to the filtered behaviors if there are any
         if ($null -ne $moduleDefaultBehavior) {
             $moduleBehaviors.Add($moduleDefaultBehavior)
@@ -1217,7 +1219,7 @@ function Invoke-Mock {
         }
 
         $nonModuleBehaviors
-    }
+    })
 
     $callHistory = (Get-MockDataForCurrentScope).CallHistory
 


### PR DESCRIPTION
## PR Summary
Ignores mock cleanup on start when in a nested Invoke-Pester run.

Fix #2074

## PR Checklist

- [x] PR has meaningful title
- [x] Summary describes changes
- [x] PR is ready to be merged
  - If not, use the arrow next to `Create Pull Request` to mark it as a draft. PR can be marked `Ready for review` when it's ready.
- [x] Tests are added/update *(if required)*
- [ ] Documentation is updated/added *(if required)*