### PR TITLE
Reattach TestDrive and TestRegistry after running inner Invoke-Pester

### DIFF
--- a/src/Main.ps1
+++ b/src/Main.ps1
@@ -675,6 +675,10 @@ function Invoke-Pester {
             # todo: move mock cleanup to BeforeAllBlockContainer when there is any?
             Remove-MockFunctionsAndAliases -SessionState $PSCmdlet.SessionState
         }
+        else {
+            # this will inherit to child scopes and affect behavior of ex. TestDrive/TestRegistry
+            $runningPesterInPester = $true
+        }
 
         # this will inherit to child scopes and allow Pester to run in Pester, not checking if this is
         # already defined because we want a clean state for this Invoke-Pester even if it runs inside another
@@ -1121,7 +1125,7 @@ function Invoke-Pester {
                 Invoke-PluginStep -Plugins $Plugins -Step Start -Context @{
                     Containers               = $containers
                     Configuration            = $pluginConfiguration
-                    GlobalPluginData         = $state.PluginData
+                    GlobalPluginData         = $pluginData
                     WriteDebugMessages       = $PesterPreference.Debug.WriteDebugMessages.Value
                     Write_PesterDebugMessage = if ($PesterPreference.Debug.WriteDebugMessages.Value) { $script:SafeCommands['Write-PesterDebugMessage'] }
                 } -ThrowOnFailure
@@ -1165,8 +1169,9 @@ function Invoke-Pester {
             $steps = $Plugins.End
             if ($null -ne $steps -and 0 -lt @($steps).Count) {
                 Invoke-PluginStep -Plugins $Plugins -Step End -Context @{
-                    TestRun       = $run
-                    Configuration = $pluginConfiguration
+                    TestRun          = $run
+                    Configuration    = $pluginConfiguration
+                    GlobalPluginData = $pluginData
                 } -ThrowOnFailure
             }
 

--- a/src/functions/Environment.ps1
+++ b/src/functions/Environment.ps1
@@ -33,10 +33,16 @@ function Get-TempDirectory {
 }
 
 function Get-TempRegistry {
+    # The Pester root key is created once and then stays in place.
+    # In TestDrive we use system Temp folder, but such key exists for registry so we create our own.
+    # Removing it would cleanup remaining keys from cancelled runs, but could break parallell or nested runs, so leaving it
+
     $pesterTempRegistryRoot = 'Microsoft.PowerShell.Core\Registry::HKEY_CURRENT_USER\Software\Pester'
     try {
         # Test-Path returns true and doesn't throw access denied when path exists but user missing permission unless -PathType Container is used
         if (-not (& $script:SafeCommands['Test-Path'] $pesterTempRegistryRoot -PathType Container -ErrorAction Stop)) {
+            # Don't use -Force parameter here because that deletes the folder and creates a race condition see
+            # https://github.com/pester/Pester/issues/1181
             $null = & $SafeCommands['New-Item'] -Path $pesterTempRegistryRoot -ErrorAction Stop
         }
     }

--- a/src/functions/TestDrive.ps1
+++ b/src/functions/TestDrive.ps1
@@ -1,4 +1,4 @@
-function Get-TestDrivePlugin {
+﻿function Get-TestDrivePlugin {
     $p = @{
         Name = 'TestDrive'
     }
@@ -103,12 +103,16 @@ function New-TestDrive {
 }
 
 
-function Clear-TestDrive ([String[]]$Exclude, [string]$TestDrivePath) {
+function Clear-TestDrive {
+    param(
+        [String[]] $Exclude,
+        [string] $TestDrivePath
+    )
     if ([IO.Directory]::Exists($TestDrivePath)) {
 
         Remove-TestDriveSymbolicLinks -Path $TestDrivePath
 
-        foreach ($i in [IO.Directory]::GetFileSystemEntries($TestDrivePath, "*.*", [System.IO.SearchOption]::AllDirectories)) {
+        foreach ($i in [IO.Directory]::GetFileSystemEntries($TestDrivePath, '*.*', [System.IO.SearchOption]::AllDirectories)) {
             if ($Exclude -contains $i) {
                 continue
             }
@@ -129,7 +133,7 @@ function New-RandomTempDirectory {
 
 function Get-TestDriveChildItem ($TestDrivePath) {
     if ([IO.Directory]::Exists($TestDrivePath)) {
-        [IO.Directory]::GetFileSystemEntries($TestDrivePath, "*.*", [System.IO.SearchOption]::AllDirectories)
+        [IO.Directory]::GetFileSystemEntries($TestDrivePath, '*.*', [System.IO.SearchOption]::AllDirectories)
     }
 }
 
@@ -145,23 +149,23 @@ function Remove-TestDriveSymbolicLinks ([String] $Path) {
 
     # issue 621 was fixed before PowerShell 6.1
     # now there is an issue with calling the Delete method in recent (6.1) builds of PowerShell
-    if ( (GetPesterPSVersion) -ge 6) {
+    if ((GetPesterPSVersion) -ge 6) {
         return
     }
 
     # powershell 2-compatible
     $reparsePoint = [System.IO.FileAttributes]::ReparsePoint
-    & $SafeCommands["Get-ChildItem"] -Recurse -Path $Path |
+    & $SafeCommands['Get-ChildItem'] -Recurse -Path $Path |
         & $SafeCommands['Where-Object'] { ($_.Attributes -band $reparsePoint) -eq $reparsePoint } |
         & $SafeCommands['Foreach-Object'] { $_.Delete() }
 }
 
 function Remove-TestDrive ($TestDrivePath) {
-    $DriveName = "TestDrive"
+    $DriveName = 'TestDrive'
     $Drive = & $SafeCommands['Get-PSDrive'] -Name $DriveName -ErrorAction Ignore
     $Path = ($Drive).Root
 
-    if ($pwd -like "$DriveName*" ) {
+    if ($pwd -like "$DriveName*") {
         #will staying in the test drive cause issues?
         #TODO: review this
         & $SafeCommands['Write-Warning'] -Message "Your current path is set to ${pwd}:. You should leave ${DriveName}:\ before leaving Describe."

--- a/src/functions/TestDrive.ps1
+++ b/src/functions/TestDrive.ps1
@@ -1,10 +1,16 @@
 ﻿function Get-TestDrivePlugin {
-    New-PluginObject -Name "TestDrive" -Start {
+    $p = @{
+        Name = 'TestDrive'
+    }
+
+    $p.Start = {
         if (& $script:SafeCommands['Test-Path'] TestDrive:\) {
             & $SafeCommands['Remove-Item'] (& $SafeCommands['Get-PSDrive'] TestDrive -ErrorAction Stop).Root -Force -Recurse -Confirm:$false
             & $SafeCommands['Remove-PSDrive'] TestDrive
         }
-    } -EachBlockSetupStart {
+    }
+
+    $p.EachBlockSetupStart = {
         param($Context)
 
         if ($Context.Block.IsRoot) {
@@ -24,7 +30,9 @@
                     TestDrivePath    = $testDrivePath
                 })
         }
-    } -EachBlockTearDownEnd {
+    }
+
+    $p.EachBlockTearDownEnd = {
         param($Context)
 
         if ($Context.Block.IsRoot) {
@@ -35,6 +43,8 @@
             Clear-TestDrive -TestDrivePath $Context.Block.PluginData.TestDrive.TestDrivePath -Exclude ( $Context.Block.PluginData.TestDrive.TestDriveContent )
         }
     }
+
+    New-PluginObject @p
 }
 
 function New-TestDrive ([Switch]$PassThru, [string] $Path) {

--- a/src/functions/TestRegistry.ps1
+++ b/src/functions/TestRegistry.ps1
@@ -1,4 +1,4 @@
-function New-TestRegistry {
+﻿function New-TestRegistry {
     param(
         [string] $Path
     )
@@ -43,14 +43,14 @@ function New-TestRegistry {
 
 function Clear-TestRegistry {
     param(
-        [String[]]$Exclude,
-        [string]$TestRegistryPath
+        [String[]] $Exclude,
+        [string] $TestRegistryPath
     )
 
     # if the setup fails before we mark test registry added
     # we would be trying to teardown something that does not
     # exist and fail in Get-TestRegistryPath
-    if (-not (& $SafeCommands['Test-Path'] "TestRegistry:\")) {
+    if (-not (& $SafeCommands['Test-Path'] 'TestRegistry:\')) {
         return
     }
 
@@ -59,7 +59,7 @@ function Clear-TestRegistry {
     if ($null -ne $path -and (& $SafeCommands['Test-Path'] -Path $Path)) {
         #Get-ChildItem -Exclude did not seem to work with full paths
         & $SafeCommands['Get-ChildItem'] -Recurse -Path $Path |
-            & $SafeCommands['Sort-Object'] -Descending  -Property 'PSPath' |
+            & $SafeCommands['Sort-Object'] -Descending -Property 'PSPath' |
             & $SafeCommands['Where-Object'] { $Exclude -NotContains $_.PSPath } |
             & $SafeCommands['Remove-Item'] -Force -Recurse
     }
@@ -81,11 +81,11 @@ function New-RandomTempRegistry {
             & $SafeCommands['New-Item'] -Path $Path -ErrorAction Stop
         }
         catch [System.IO.IOException] {
-                # when running in parallel this occasionally triggers
-                # IOException: No more data is available
-                # let's just retry the operation
-                & $SafeCommands['Write-Warning'] "IO exception during creating path $path"
-                & $SafeCommands['New-Item'] -Path $Path -ErrorAction Stop
+            # when running in parallel this occasionally triggers
+            # IOException: No more data is available
+            # let's just retry the operation
+            & $SafeCommands['Write-Warning'] "IO exception during creating path $path"
+            & $SafeCommands['New-Item'] -Path $Path -ErrorAction Stop
         }
     }
     catch [Exception] {
@@ -94,7 +94,7 @@ function New-RandomTempRegistry {
 }
 
 function Remove-TestRegistry ($TestRegistryPath) {
-    $DriveName = "TestRegistry"
+    $DriveName = 'TestRegistry'
     $Drive = & $SafeCommands['Get-PSDrive'] -Name $DriveName -ErrorAction Ignore
     if ($null -eq $Drive) {
         # the drive does not exist, someone must have removed it instead of us,
@@ -105,14 +105,14 @@ function Remove-TestRegistry ($TestRegistryPath) {
 
     $path = $TestRegistryPath
 
-    if ($pwd -like "$DriveName*" ) {
+    if ($pwd -like "$DriveName*") {
         #will staying in the test drive cause issues?
         #TODO: review this
         & $SafeCommands['Write-Warning'] -Message "Your current path is set to ${pwd}:. You should leave ${DriveName}:\ before leaving Describe."
     }
 
-    if ( $Drive ) {
-        $Drive | & $SafeCommands['Remove-PSDrive'] -Force #This should fail explicitly as it impacts future pester runs
+    if ($Drive) {
+        $Drive | & $SafeCommands['Remove-PSDrive'] -Force   #This should fail explicitly as it impacts future pester runs
     }
 
     if (& $SafeCommands['Test-Path'] -Path $path -PathType Container) {
@@ -193,7 +193,6 @@ function Get-TestRegistryPlugin {
             # If nested run, reattach previous TestRegistry PSDrive
             New-TestRegistry -Path $Context.GlobalPluginData.TestRegistry.ExistingTestRegistryPath
         }
-
     }
 
     New-PluginObject @p

--- a/src/functions/TestRegistry.ps1
+++ b/src/functions/TestRegistry.ps1
@@ -131,10 +131,6 @@ function Remove-TestRegistry ($TestRegistryPath) {
     if (& $SafeCommands['Test-Path'] -Path $path -PathType Container) {
         & $SafeCommands['Remove-Item'] -Path $path -Force -Recurse
     }
-
-    if (& $SafeCommands['Get-Variable'] -Name $DriveName -Scope Global -ErrorAction Ignore) {
-        & $SafeCommands['Remove-Variable'] -Scope Global -Name $DriveName -Force
-    }
 }
 
 

--- a/src/functions/TestRegistry.ps1
+++ b/src/functions/TestRegistry.ps1
@@ -139,12 +139,18 @@ function Remove-TestRegistry ($TestRegistryPath) {
 
 
 function Get-TestRegistryPlugin {
-    New-PluginObject -Name "TestRegistry" -Start {
+    $p = @{
+        Name = 'TestRegistry'
+    }
+
+    $p.Start = {
         if (& $script:SafeCommands['Test-Path'] TestRegistry:\) {
             & $SafeCommands['Remove-Item'] (& $SafeCommands['Get-PSDrive'] TestRegistry -ErrorAction Stop).Root -Force -Recurse -Confirm:$false -ErrorAction Ignore
             & $SafeCommands['Remove-PSDrive'] TestRegistry
         }
-    } -EachBlockSetupStart {
+    }
+
+    $p.EachBlockSetupStart = {
         param($Context)
 
         if ($Context.Block.IsRoot) {
@@ -164,7 +170,10 @@ function Get-TestRegistryPlugin {
                     TestRegistryPath    = $testRegistryPath
                 })
         }
-    } -EachBlockTearDownEnd {
+    }
+
+    $p.EachBlockTearDownEnd = {
+        param($Context)
 
         if ($Context.Block.IsRoot) {
             # this is top-level block remove test drive
@@ -174,4 +183,6 @@ function Get-TestRegistryPlugin {
             Clear-TestRegistry -TestRegistryPath $Context.Block.PluginData.TestRegistry.TestRegistryPath -Exclude ( $Context.Block.PluginData.TestRegistry.TestRegistryContent )
         }
     }
+
+    New-PluginObject @p
 }

--- a/tst/functions/TestDrive.Tests.ps1
+++ b/tst/functions/TestDrive.Tests.ps1
@@ -102,7 +102,7 @@ InPesterModuleScope {
     }
 }
 
-Describe 'Running Pester in Invoke-Pester' {
+Describe 'Running Pester in Pester' {
     BeforeAll {
         $tempFileName = 'testing.txt'
         $tempFilePath = Join-Path -Path $TestDrive -ChildPath $tempFileName
@@ -114,7 +114,7 @@ Describe 'Running Pester in Invoke-Pester' {
         Get-Content -Path $tempFilePath | Should -Be 'Hello'
     }
 
-    It 'Nested run' {
+    It 'Works in nested run' {
         $sb = {
             Describe 'Nested' {
                 It 'Files created in outer run are available using absolute path' {
@@ -134,7 +134,7 @@ Describe 'Running Pester in Invoke-Pester' {
         }
 
         $c = New-PesterContainer -ScriptBlock $sb -Data @{ TempFilePath = $tempFilePath }
-        $innerRun = Invoke-Pester -Container $c -PassThru
+        $innerRun = Invoke-Pester -Container $c -PassThru -Output None
         $innerRun.Result | Should -Be 'Passed'
         $innerRun.PassedCount | Should -Be 2
     }

--- a/tst/functions/TestDrive.Tests.ps1
+++ b/tst/functions/TestDrive.Tests.ps1
@@ -102,6 +102,53 @@ InPesterModuleScope {
     }
 }
 
+Describe 'Running Pester in Invoke-Pester' {
+    BeforeAll {
+        $tempFileName = 'testing.txt'
+        $tempFilePath = Join-Path -Path $TestDrive -ChildPath $tempFileName
+        'Hello' | Set-Content -Path $tempFilePath
+    }
+
+    It 'File exists before' {
+        Should -Exist -ActualValue $tempFilePath
+        Get-Content -Path $tempFilePath | Should -Be 'Hello'
+    }
+
+    It 'Nested run' {
+        $sb = {
+            Describe 'Nested' {
+                It 'Files created in outer run are available using absolute path' {
+                    Should -Exist -ActualValue $TempFilePath
+                    Get-Content -Path $TempFilePath | Should -Be 'Hello'
+                }
+
+                It 'TestDrive PSDrive and $TestDrive points to clean location' {
+                    # Variable should point to new drive
+                    $outerTestDrive = Split-Path $tempFilePath
+                    $TestDrive | Should -Not -Be $outerTestDrive
+
+                    # TestDrive should be clean in inner run
+                    Get-ChildItem -Path 'TestDrive:/' | Should -BeNullOrEmpty
+                }
+            }
+        }
+
+        $c = New-PesterContainer -ScriptBlock $sb -Data @{ TempFilePath = $tempFilePath }
+        $innerRun = Invoke-Pester -Container $c -PassThru
+        $innerRun.Result | Should -Be 'Passed'
+        $innerRun.PassedCount | Should -Be 2
+    }
+
+    It 'TestDrive PSDrive and $TestDrive point to original location' {
+        $originalTestDrive = Split-Path $tempFilePath
+        $TestDrive | Should -Be $originalTestDrive
+
+        $tempFilePath2 = Join-Path -Path 'TestDrive:/' -ChildPath $tempFileName
+        Should -Exist -ActualValue $tempFilePath2
+        Get-Content -Path $tempFilePath2 | Should -Be 'Hello'
+    }
+}
+
 # Tests problematic symlinks, but needs to run as admin
 # InPesterModuleScope {
 

--- a/tst/functions/TestRegistry.Tests.ps1
+++ b/tst/functions/TestRegistry.Tests.ps1
@@ -59,3 +59,36 @@ Describe "TestRegistry scoping" {
     }
 }
 
+Describe 'Running Pester in Invoke-Pester' {
+    BeforeAll {
+        $tempValueName = 'OuterValue'
+        $tempValue = New-ItemProperty -Path 'TestRegistry:/' -Name $tempValueName -Value 1
+    }
+
+    It 'Value exists before' {
+        (Get-ItemProperty -Path 'TestRegistry:/' -Name $tempValueName).$tempValueName | Should -Be 1
+    }
+
+    It 'Nested run' {
+        $sb = {
+            Describe 'Nested' {
+                It 'Value created in outer run are available using absolute path' {
+                    (Get-ItemProperty -Path $TempKeyPath -Name $TempValueName).$TempValueName | Should -Be 1
+                }
+
+                It 'TestRegistry PSDrive points to clean location' {
+                    (Get-Item -Path 'TestRegistry:/').Property | Should -BeNullOrEmpty
+                }
+            }
+        }
+
+        $c = New-PesterContainer -ScriptBlock $sb -Data @{ TempKeyPath = $tempValue.PSPath; TempValueName = $tempValueName }
+        $innerRun = Invoke-Pester -Container $c -PassThru
+        $innerRun.Result | Should -Be 'Passed'
+        $innerRun.PassedCount | Should -Be 2
+    }
+
+    It 'Value still exists after nested run' {
+        (Get-ItemProperty -Path 'TestRegistry:/' -Name $tempValueName).$tempValueName | Should -Be 1
+    }
+}

--- a/tst/functions/TestRegistry.Tests.ps1
+++ b/tst/functions/TestRegistry.Tests.ps1
@@ -69,7 +69,7 @@ Describe 'Running Pester in Invoke-Pester' {
         (Get-ItemProperty -Path 'TestRegistry:/' -Name $tempValueName).$tempValueName | Should -Be 1
     }
 
-    It 'Nested run' {
+    It 'Works in nested run' {
         $sb = {
             Describe 'Nested' {
                 It 'Value created in outer run are available using absolute path' {
@@ -83,7 +83,7 @@ Describe 'Running Pester in Invoke-Pester' {
         }
 
         $c = New-PesterContainer -ScriptBlock $sb -Data @{ TempKeyPath = $tempValue.PSPath; TempValueName = $tempValueName }
-        $innerRun = Invoke-Pester -Container $c -PassThru
+        $innerRun = Invoke-Pester -Container $c -PassThru -Output None
         $innerRun.Result | Should -Be 'Passed'
         $innerRun.PassedCount | Should -Be 2
     }

--- a/tst/functions/TestRegistry.Tests.ps1
+++ b/tst/functions/TestRegistry.Tests.ps1
@@ -59,6 +59,27 @@ Describe "TestRegistry scoping" {
     }
 }
 
+Describe 'Repair missing TestRegistry' {
+    BeforeAll {
+        $tempValueName = 'MyValue'
+        $tempValue = New-ItemProperty -Path 'TestRegistry:/' -Name $tempValueName -Value 1
+    }
+
+    Context 'Broken' {
+        It 'Removes TestRegistry' {
+            (Get-ItemProperty -Path 'TestRegistry:/' -Name $tempValueName).$tempValueName | Should -Be 1
+            Remove-PSDrive -Name 'TestRegistry'
+            { Get-PSDrive -Name 'TestRegistry' -ErrorAction Stop } | Should -Throw -ExpectedMessage 'Cannot find drive*'
+        }
+    }
+
+    Context 'Fixed' {
+        It 'TestRegistry exists again' {
+            (Get-ItemProperty -Path 'TestRegistry:/' -Name $tempValueName).$tempValueName | Should -Be 1
+        }
+    }
+}
+
 Describe 'Running Pester in Invoke-Pester' {
     BeforeAll {
         $tempValueName = 'OuterValue'


### PR DESCRIPTION
## PR Summary

When running Pester inside Pester, it would delete the existing/parent TestDrive/TestRegistry.
This PR detects, stores and reattaches the previous TestDrive/TestRegistry drives before returning to the parent instance.

Also remaps TestDrive/TestRegistry at end of block if missing. This can occur if user code removes it or a inner/nester Invoke-Pester failed and never got to reattach it.

Fix #2147

## PR Checklist

- [x] PR has meaningful title
- [x] Summary describes changes
- [x] PR is ready to be merged
  - If not, use the arrow next to `Create Pull Request` to mark it as a draft. PR can be marked `Ready for review` when it's ready.
- [x] Tests are added/update *(if required)*
- [ ] Documentation is updated/added *(if required)*