### PR TITLE
Fix false errors and broken CI-logs from P-tests

### DIFF
--- a/tst/PTestHelpers.psm1
+++ b/tst/PTestHelpers.psm1
@@ -1,0 +1,22 @@
+﻿function Invoke-InNewProcess ([ScriptBlock] $ScriptBlock) {
+    # get the path of the currently loaded Pester to re-import it in the child process
+    $pesterPath = Get-Module Pester | Select-Object -ExpandProperty Path
+    $powershell = Get-Process -Id $pid | Select-Object -ExpandProperty Path
+    # run any scriptblock in a separate process to be able to grab all the output
+    # doesn't enforce Invoke-Pester usage so we can test other public functions directly
+    $command = {
+        param ($PesterPath, [ScriptBlock] $ScriptBlock)
+        Import-Module $PesterPath
+
+        . $ScriptBlock
+    }.ToString()
+
+    if ($PSVersionTable.PSVersion -ge '7.3' -and $PSNativeCommandArgumentPassing -ne 'Legacy') {
+        $cmd = "& { $command } -PesterPath ""$PesterPath"" -ScriptBlock { $ScriptBlock }"
+    }
+    else {
+        $cmd = "& { $command } -PesterPath ""$PesterPath"" -ScriptBlock { $($ScriptBlock -replace '"','\"') }"
+    }
+
+    & $powershell -NoProfile -NonInteractive -ExecutionPolicy Bypass -Command $cmd
+}

--- a/tst/Pester.RSpec.InNewProcess.ts.ps1
+++ b/tst/Pester.RSpec.InNewProcess.ts.ps1
@@ -30,8 +30,8 @@ function Invoke-InNewProcess ([ScriptBlock] $ScriptBlock) {
 
     # using base64 because we need to escape quotes in $ScriptBlock and previous method using \" stopped working in PS7.3
     $cmd = "& { $command } -PesterPath ""$PesterPath"" -ScriptBlock { $ScriptBlock }"
-    $encodedcommand = [Convert]::ToBase64String([System.Text.Encoding]::Unicode.GetBytes($cmd))
-    & $powershell -NoProfile -ExecutionPolicy Bypass  -OutputFormat Text -encodedCommand $encodedcommand
+    $encodedCommand = [Convert]::ToBase64String([System.Text.Encoding]::Unicode.GetBytes($cmd))
+    & $powershell -NoProfile -NonInteractive -ExecutionPolicy Bypass -OutputFormat Text -EncodedCommand $encodedCommand
 }
 
 i -PassThru:$PassThru {

--- a/tst/Pester.RSpec.InNewProcess.ts.ps1
+++ b/tst/Pester.RSpec.InNewProcess.ts.ps1
@@ -31,7 +31,7 @@ function Invoke-InNewProcess ([ScriptBlock] $ScriptBlock) {
     # using base64 because we need to escape quotes in $ScriptBlock and previous method using \" stopped working in PS7.3
     $cmd = "& { $command } -PesterPath ""$PesterPath"" -ScriptBlock { $ScriptBlock }"
     $encodedcommand = [Convert]::ToBase64String([System.Text.Encoding]::Unicode.GetBytes($cmd))
-    & $powershell -NoProfile -ExecutionPolicy Bypass -encodedCommand $encodedcommand
+    & $powershell -NoProfile -ExecutionPolicy Bypass  -OutputFormat Text -encodedCommand $encodedcommand
 }
 
 i -PassThru:$PassThru {

--- a/tst/Pester.RSpec.InNewProcess.ts.ps1
+++ b/tst/Pester.RSpec.InNewProcess.ts.ps1
@@ -1,9 +1,10 @@
 ﻿param ([switch] $PassThru, [switch] $NoBuild)
 
-Get-Module Pester.Runtime, Pester.Utility, P, Pester, Axiom, Stack | Remove-Module
+Get-Module P, PTestHelpers, Pester, Axiom | Remove-Module
 
 Import-Module $PSScriptRoot\p.psm1 -DisableNameChecking
 Import-Module $PSScriptRoot\axiom\Axiom.psm1 -DisableNameChecking
+Import-Module $PSScriptRoot\PTestHelpers.psm1 -DisableNameChecking
 
 if (-not $NoBuild) { & "$PSScriptRoot\..\build.ps1" }
 Import-Module $PSScriptRoot\..\bin\Pester.psd1
@@ -14,32 +15,6 @@ $global:PesterPreference = @{
     }
 }
 $PSDefaultParameterValues = @{}
-
-function Invoke-InNewProcess ([ScriptBlock] $ScriptBlock) {
-    # get the path of the currently loaded Pester to re-import it in the child process
-    $pesterPath = Get-Module Pester | Select-Object -ExpandProperty Path
-    $powershell = Get-Process -Id $pid | Select-Object -ExpandProperty Path
-    # run any scriptblock in a separate process to be able to grab all the output
-    # doesn't enforce Invoke-Pester usage so we can test other public functions directly
-    $command = {
-        param ($PesterPath, [ScriptBlock] $ScriptBlock)
-        Import-Module $PesterPath
-
-        . $ScriptBlock
-    }.ToString()
-
-    if ($PSVersionTable.PSVersion -ge '6.2') {
-        # Using base64 because we need to escape quotes in $ScriptBlock and previous method using \" stopped working in PS7.3
-        $cmd = "& { $command } -PesterPath ""$PesterPath"" -ScriptBlock { $ScriptBlock }"
-        $encodedCommand = [Convert]::ToBase64String([System.Text.Encoding]::Unicode.GetBytes($cmd))
-        & $powershell -NoProfile -NonInteractive -ExecutionPolicy Bypass -OutputFormat Text -EncodedCommand $encodedCommand
-    }
-    else {
-        # Using -Command because -encodedCommand causes CliXML output in Azure DevOps pipeline etc.
-        $cmd = "& { $command } -PesterPath ""$PesterPath"" -ScriptBlock { $($ScriptBlock -replace '"','\"') }"
-        & $powershell -NoProfile -NonInteractive -ExecutionPolicy Bypass -Command $cmd
-    }
-}
 
 i -PassThru:$PassThru {
     b "Interactive execution" {

--- a/tst/Pester.RSpec.InNewProcess.ts.ps1
+++ b/tst/Pester.RSpec.InNewProcess.ts.ps1
@@ -28,10 +28,17 @@ function Invoke-InNewProcess ([ScriptBlock] $ScriptBlock) {
         . $ScriptBlock
     }.ToString()
 
-    # using base64 because we need to escape quotes in $ScriptBlock and previous method using \" stopped working in PS7.3
-    $cmd = "& { $command } -PesterPath ""$PesterPath"" -ScriptBlock { $ScriptBlock }"
-    $encodedCommand = [Convert]::ToBase64String([System.Text.Encoding]::Unicode.GetBytes($cmd))
-    & $powershell -NoProfile -NonInteractive -ExecutionPolicy Bypass -OutputFormat Text -EncodedCommand $encodedCommand
+    if ($PSVersionTable.PSVersion -ge '6.2') {
+        # Using base64 because we need to escape quotes in $ScriptBlock and previous method using \" stopped working in PS7.3
+        $cmd = "& { $command } -PesterPath ""$PesterPath"" -ScriptBlock { $ScriptBlock }"
+        $encodedCommand = [Convert]::ToBase64String([System.Text.Encoding]::Unicode.GetBytes($cmd))
+        & $powershell -NoProfile -NonInteractive -ExecutionPolicy Bypass -OutputFormat Text -EncodedCommand $encodedCommand
+    }
+    else {
+        # Using -Command because -encodedCommand causes CliXML output in Azure DevOps pipeline etc.
+        $cmd = "& { $command } -PesterPath ""$PesterPath"" -ScriptBlock { $($ScriptBlock -replace '"','\"') }"
+        & $powershell -NoProfile -NonInteractive -ExecutionPolicy Bypass -Command $cmd
+    }
 }
 
 i -PassThru:$PassThru {

--- a/tst/Pester.RSpec.Output.ts.ps1
+++ b/tst/Pester.RSpec.Output.ts.ps1
@@ -36,8 +36,8 @@ function Invoke-InNewProcess ([ScriptBlock] $ScriptBlock) {
 
     # using base64 because we need to escape quotes in $ScriptBlock and previous method using \" stopped working in PS7.3
     $cmd = "& { $command } -PesterPath ""$PesterPath"" -ScriptBlock { $ScriptBlock }"
-    $encodedcommand = [Convert]::ToBase64String([System.Text.Encoding]::Unicode.GetBytes($cmd))
-    & $powershell -NoProfile -ExecutionPolicy Bypass -OutputFormat Text -encodedCommand $encodedcommand
+    $encodedCommand = [Convert]::ToBase64String([System.Text.Encoding]::Unicode.GetBytes($cmd))
+    & $powershell -NoProfile -NonInteractive -ExecutionPolicy Bypass -OutputFormat Text -EncodedCommand $encodedCommand
 }
 
 i -PassThru:$PassThru {

--- a/tst/Pester.RSpec.Output.ts.ps1
+++ b/tst/Pester.RSpec.Output.ts.ps1
@@ -1,9 +1,10 @@
 ﻿param ([switch] $PassThru, [switch] $NoBuild)
 
-Get-Module Pester.Runtime, Pester.Utility, P, Pester, Axiom, Stack | Remove-Module
+Get-Module P, PTestHelpers, Pester, Axiom | Remove-Module
 
 Import-Module $PSScriptRoot\p.psm1 -DisableNameChecking
 Import-Module $PSScriptRoot\axiom\Axiom.psm1 -DisableNameChecking
+Import-Module $PSScriptRoot\PTestHelpers.psm1 -DisableNameChecking
 
 if (-not $NoBuild) { & "$PSScriptRoot\..\build.ps1" }
 Import-Module $PSScriptRoot\..\bin\Pester.psd1
@@ -20,32 +21,6 @@ $global:PesterPreference = @{
     }
 }
 $PSDefaultParameterValues = @{}
-
-function Invoke-InNewProcess ([ScriptBlock] $ScriptBlock) {
-    # get the path of the currently loaded Pester to re-import it in the child process
-    $pesterPath = Get-Module Pester | Select-Object -ExpandProperty Path
-    $powershell = Get-Process -Id $pid | Select-Object -ExpandProperty Path
-    # run any scriptblock in a separate process to be able to grab all the output
-    # doesn't enforce Invoke-Pester usage so we can test other public functions directly
-    $command = {
-        param ($PesterPath, [ScriptBlock] $ScriptBlock)
-        Import-Module $PesterPath
-
-        . $ScriptBlock
-    }.ToString()
-
-    if ($PSVersionTable.PSVersion -ge '6.2') {
-        # Using base64 because we need to escape quotes in $ScriptBlock and previous method using \" stopped working in PS7.3
-        $cmd = "& { $command } -PesterPath ""$PesterPath"" -ScriptBlock { $ScriptBlock }"
-        $encodedCommand = [Convert]::ToBase64String([System.Text.Encoding]::Unicode.GetBytes($cmd))
-        & $powershell -NoProfile -NonInteractive -ExecutionPolicy Bypass -OutputFormat Text -EncodedCommand $encodedCommand
-    }
-    else {
-        # Using -Command because -encodedCommand causes CliXML output in Azure DevOps pipeline etc.
-        $cmd = "& { $command } -PesterPath ""$PesterPath"" -ScriptBlock { $($ScriptBlock -replace '"','\"') }"
-        & $powershell -NoProfile -NonInteractive -ExecutionPolicy Bypass -Command $cmd
-    }
-}
 
 i -PassThru:$PassThru {
     b 'Output in VSCode mode' {

--- a/tst/Pester.RSpec.Output.ts.ps1
+++ b/tst/Pester.RSpec.Output.ts.ps1
@@ -37,7 +37,7 @@ function Invoke-InNewProcess ([ScriptBlock] $ScriptBlock) {
     # using base64 because we need to escape quotes in $ScriptBlock and previous method using \" stopped working in PS7.3
     $cmd = "& { $command } -PesterPath ""$PesterPath"" -ScriptBlock { $ScriptBlock }"
     $encodedcommand = [Convert]::ToBase64String([System.Text.Encoding]::Unicode.GetBytes($cmd))
-    & $powershell -NoProfile -ExecutionPolicy Bypass -encodedCommand $encodedcommand
+    & $powershell -NoProfile -ExecutionPolicy Bypass -OutputFormat Text -encodedCommand $encodedcommand
 }
 
 i -PassThru:$PassThru {


### PR DESCRIPTION
## PR Summary
After switching to `-EncodedCommand` for child `powershell/pwsh` processes in P-tests (#2267) we get CliXML-output in CI logs and false errors in CI-report.

Using `-EncodedCommand` changes default output to XML in non-interactive environments with redirected output like our AzDO Pipelines CI. The normal workaround of explicitly setting `-OutputFormat Text` is not honored prior to PS 6.2 (incl. 5.1). 

This PR reverts to using `-Command` with different commands to handle the changed argument-behavior in PS 7.3+. It also extracts the helper to a `PTestHelpers` module to reduce duplicated code.

Fix #2340 

## PR Checklist

- [x] PR has meaningful title
- [x] Summary describes changes
- [x] PR is ready to be merged
  - If not, use the arrow next to `Create Pull Request` to mark it as a draft. PR can be marked `Ready for review` when it's ready.
- [x] Tests are added/update *(if required)*
- [ ] Documentation is updated/added *(if required)*