### PR TITLE
Upgrade to action/checkout v3 in PSSA workflow

### DIFF
--- a/.github/workflows/code-analysis.yml
+++ b/.github/workflows/code-analysis.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       # Checkout the repository to the GitHub Actions runner
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: PowerShell Module Cache
         uses: potatoqualitee/psmodulecache@v5.2


### PR DESCRIPTION
## PR Summary
The PSSA workflow shows a warning about node 12 being deprecated. Bumping checkout-action to v3 which runs on node 16.

## PR Checklist

- [x] PR has meaningful title
- [x] Summary describes changes
- [x] PR is ready to be merged
  - If not, use the arrow next to `Create Pull Request` to mark it as a draft. PR can be marked `Ready for review` when it's ready.
- [ ] Tests are added/update *(if required)*
- [ ] Documentation is updated/added *(if required)*