### PR TITLE
Fix ANSI sequence shown in Azure DevOps summary

### DIFF
--- a/src/functions/Output.ps1
+++ b/src/functions/Output.ps1
@@ -1037,8 +1037,14 @@ function Write-CIErrorToScreen {
 
     $errorMessage = Format-CIErrorMessage @PSBoundParameters
 
+    # Workaround for https://github.com/pester/Pester/issues/2350 until Azure DevOps trims ANSI codes in summary issues
+    $RenderMode = $PesterPreference.Output.RenderMode.Value
+    if ($RenderMode -eq 'Ansi' -and $CIFormat -eq 'AzureDevOps') {
+        $RenderMode = 'ConsoleColor'
+    }
+
     foreach ($line in $errorMessage) {
-        Write-PesterHostMessage $line
+        Write-PesterHostMessage -Object $line -RenderMode $RenderMode
     }
 }
 


### PR DESCRIPTION
## PR Summary

Fixes trailing ANSI reset sequence in pipeline run summary for errors etc. by using `ConsoleColor` RenderMode instead of `Ansi` when printing errors with AzureDevOps CI-format.

Fix #2350

## PR Checklist

- [x] PR has meaningful title
- [x] Summary describes changes
- [x] PR is ready to be merged
  - If not, use the arrow next to `Create Pull Request` to mark it as a draft. PR can be marked `Ready for review` when it's ready.
- [ ] Tests are added/update *(if required)*
- [ ] Documentation is updated/added *(if required)*