### PR TITLE
Support Should -HaveParameter -DefaultValue for AliasInfo and scripts

### DIFF
--- a/src/functions/assertions/HaveParameter.ps1
+++ b/src/functions/assertions/HaveParameter.ps1
@@ -196,7 +196,7 @@
         $buts += "the parameter is missing"
     }
     elseif ($Negate -and -not $hasKey) {
-        return & $SafeCommands['New-Object'] PSObject -Property @{ Succeeded = $true }
+        return [PSCustomObject] @{ Succeeded = $true }
     }
     elseif ($Negate -and $hasKey -and -not ($InParameterSet -or $Mandatory -or $Type -or $DefaultValue -or $HasArgumentCompleter)) {
         $buts += "the parameter exists"
@@ -314,13 +314,13 @@
         $but = Join-And $buts
         $failureMessage = "Expected command $($ActualValue.Name)$filter,$(Format-Because $Because) but $but."
 
-        return & $SafeCommands['New-Object'] PSObject -Property @{
+        return [PSCustomObject] @{
             Succeeded      = $false
             FailureMessage = $failureMessage
         }
     }
     else {
-        return & $SafeCommands['New-Object'] PSObject -Property @{ Succeeded = $true }
+        return [PSCustomObject] @{ Succeeded = $true }
     }
 }
 

--- a/src/functions/assertions/HaveParameter.ps1
+++ b/src/functions/assertions/HaveParameter.ps1
@@ -51,14 +51,20 @@
 
         if ($null -eq $ast) {
             # Ast is unavailable, ex. for a binary cmdlet
-            throw [ArgumentException]'Using -DefaultValue is only supported for scripts and functions.'
+            throw [ArgumentException]'Using -DefaultValue is only supported for functions and scripts.'
         }
 
         if ($null -ne $ast.Parameters) {
+            # Functions without paramblock
             $parameters = $ast.Parameters
         }
         elseif ($null -ne $ast.Body.ParamBlock) {
+            # Functions with paramblock
             $parameters = $ast.Body.ParamBlock.Parameters
+        }
+        elseif ($null -ne $ast.ParamBlock) {
+            # Script paramblock
+            $parameters = $ast.ParamBlock.Parameters
         }
         else {
             return

--- a/src/functions/assertions/HaveParameter.ps1
+++ b/src/functions/assertions/HaveParameter.ps1
@@ -1,4 +1,4 @@
-﻿function Should-HaveParameter (
+function Should-HaveParameter (
     $ActualValue,
     [String] $ParameterName,
     $Type,
@@ -24,11 +24,15 @@
         if the attribute does not exist.
     #>
     if ($null -eq $ActualValue -or $ActualValue -isnot [Management.Automation.CommandInfo]) {
-        throw "Input value must be non-null CommandInfo object. You can get one by calling Get-Command."
+        throw [ArgumentException]"Input value must be non-null CommandInfo object. You can get one by calling Get-Command."
+    }
+
+    if ($ActualValue -is [Management.Automation.ApplicationInfo]) {
+        throw [ArgumentException]"Input value can not be an ApplicationInfo object."
     }
 
     if ($null -eq $ParameterName) {
-        throw "The ParameterName can't be empty"
+        throw [ArgumentException]"The ParameterName can't be empty"
     }
 
     #region HelperFunctions

--- a/tst/functions/assertions/HaveParameter.Tests.ps1
+++ b/tst/functions/assertions/HaveParameter.Tests.ps1
@@ -156,6 +156,16 @@ InPesterModuleScope {
             Get-Command "Invoke-DummyFunction" | Should -HaveParameter $ParameterName -DefaultValue $ExpectedValue
         }
 
+        It 'supports validating parameters and default values in functions without param block' {
+            function simple ($param1, $param2 = '123') { }
+            Get-Command simple | Should -HaveParameter 'param2' -DefaultValue '123'
+        }
+
+        It 'supports validating parameters and default values in scripts' {
+            Set-Content -Path 'TestDrive:\ShouldHaveParameterTestFile.ps1' -Value 'param([int]$RetryCount = 3)'
+            Get-Command 'TestDrive:\ShouldHaveParameterTestFile.ps1' | Should -HaveParameter RetryCount -DefaultValue 3 -Type [int]
+        }
+
         It "passes if the paramblock has opening parenthesis on new line and parameter has a default value" {
             function Test-Paramblock {
                 param
@@ -277,7 +287,7 @@ InPesterModuleScope {
 
         It 'fails if the parameter DefaultValue is used with a binary cmdlet' {
             $err = { Get-Command 'Get-Content' | Should -HaveParameter Force -DefaultValue $False } | Verify-Throw
-            $err.Exception.Message | Verify-Equal 'Using -DefaultValue is only supported for scripts and functions.'
+            $err.Exception.Message | Verify-Equal 'Using -DefaultValue is only supported for functions and scripts.'
         }
 
         It "fails if the parameter MandatoryParam has no alias 'Second'" {


### PR DESCRIPTION
## PR Summary

This PR enhances `Should -HaveParameter` assertion with:
- Throws exception when `-DefaultValue` is used with unsupported command types like binary cmdlet
- Throws exception when `ApplicationInfo`-object is used as input value to `Should -HaveParameter`
- Adds support for using `-DefaultValue` when provided resolvable `AliasInfo`.
- Adds support for using `-DefaultValue` with script parameters (https://github.com/pester/Pester/pull/2288#discussion_r1111312637)

Fix #2286
Fix #2290

## PR Checklist

- [x] PR has meaningful title
- [x] Summary describes changes
- [x] PR is ready to be merged
  - If not, use the arrow next to `Create Pull Request` to mark it as a draft. PR can be marked `Ready for review` when it's ready.
- [x] Tests are added/update *(if required)*
- [ ] Documentation is updated/added *(if required)*