### PR TITLE
Add missing container-parameters to Data before BeforeDiscovery

### DIFF
--- a/src/Main.ps1
+++ b/src/Main.ps1
@@ -1712,6 +1712,11 @@ function BeforeDiscovery {
     )
 
     if ($ExecutionContext.SessionState.PSVariable.Get('invokedViaInvokePester')) {
+        if ($state.CurrentBlock.IsRoot -and -not $state.CurrentBlock.FrameworkData.MissingParametersProcessed) {
+            # For undefined parameters in container, add parameter's default value to Data
+            Add-MissingContainerParameters -RootBlock $state.CurrentBlock -Container $container -CallingFunction $PSCmdlet
+        }
+
         . $ScriptBlock
     }
     else {

--- a/src/Pester.Runtime.ps1
+++ b/src/Pester.Runtime.ps1
@@ -2702,4 +2702,6 @@ function Add-MissingContainerParameters ($RootBlock, $Container, $CallingFunctio
             }
         }
     }
+
+    $RootBlock.FrameworkData.MissingParametersProcessed = $true
 }

--- a/src/functions/Context.ps1
+++ b/src/functions/Context.ps1
@@ -96,7 +96,7 @@
     }
 
     if ($ExecutionContext.SessionState.PSVariable.Get('invokedViaInvokePester')) {
-        if ($state.CurrentBlock.IsRoot -and $state.CurrentBlock.Blocks.Count -eq 0) {
+        if ($state.CurrentBlock.IsRoot -and -not $state.CurrentBlock.FrameworkData.MissingParametersProcessed) {
             # For undefined parameters in container, add parameter's default value to Data
             Add-MissingContainerParameters -RootBlock $state.CurrentBlock -Container $container -CallingFunction $PSCmdlet
         }

--- a/src/functions/Describe.ps1
+++ b/src/functions/Describe.ps1
@@ -104,7 +104,7 @@
     }
 
     if ($ExecutionContext.SessionState.PSVariable.Get('invokedViaInvokePester')) {
-        if ($state.CurrentBlock.IsRoot -and $state.CurrentBlock.Blocks.Count -eq 0) {
+        if ($state.CurrentBlock.IsRoot -and -not $state.CurrentBlock.FrameworkData.MissingParametersProcessed) {
             # For undefined parameters in container, add parameter's default value to Data
             Add-MissingContainerParameters -RootBlock $state.CurrentBlock -Container $container -CallingFunction $PSCmdlet
         }


### PR DESCRIPTION
## PR Summary

Add default values for unused script parameters to container's Data before executing `BeforeDiscovery`. Avoids changes to the variables in `BeforeDiscover` from being captured and sent to Run-phase.

**Known limitation:** Changing the variable outside `BeforeDiscovery/Describe/Context` would still modify it in Data. Can't fix as we don't have a hook to execute code before it. Root-level code is also discouraged in Pester v5.

Fix #2359

## PR Checklist

- [x] PR has meaningful title
- [x] Summary describes changes
- [x] PR is ready to be merged
  - If not, use the arrow next to `Create Pull Request` to mark it as a draft. PR can be marked `Ready for review` when it's ready.
- [x] Tests are added/update *(if required)*
- [ ] Documentation is updated/added *(if required)*