### PR TITLE
Fix parameter default values leaking to Data in user-provided Container

### DIFF
--- a/src/Main.ps1
+++ b/src/Main.ps1
@@ -1106,9 +1106,9 @@ function Invoke-Pester {
                 $containers += @( $PesterPreference.Run.ScriptBlock.Value | & $SafeCommands['ForEach-Object'] { New-BlockContainerObject -ScriptBlock $_ })
             }
 
-            if (any $PesterPreference.Run.Container.Value) {
+            foreach ($c in $PesterPreference.Run.Container.Value) {
                 # Running through New-BlockContainerObject again to avoid modifying original container and it's Data during runtime
-                $containers += @($PesterPreference.Run.Container.Value | & $SafeCommands['ForEach-Object'] { New-BlockContainerObject -Container $_ -Data $_.Data })
+                $containers += (New-BlockContainerObject -Container $c -Data $c.Data)
             }
 
             if ((any $PesterPreference.Run.Path.Value)) {

--- a/src/Main.ps1
+++ b/src/Main.ps1
@@ -1108,7 +1108,7 @@ function Invoke-Pester {
 
             if (any $PesterPreference.Run.Container.Value) {
                 # Running through New-BlockContainerObject again to avoid modifying original container and it's Data during runtime
-                $containers += @($PesterPreference.Run.Container.Value | & $SafeCommands['ForEach-Object'] { New-BlockContainerObject -Container $_ })
+                $containers += @($PesterPreference.Run.Container.Value | & $SafeCommands['ForEach-Object'] { New-BlockContainerObject -Container $_ -Data $_.Data })
             }
 
             if ((any $PesterPreference.Run.Path.Value)) {

--- a/src/Main.ps1
+++ b/src/Main.ps1
@@ -1106,8 +1106,9 @@ function Invoke-Pester {
                 $containers += @( $PesterPreference.Run.ScriptBlock.Value | & $SafeCommands['ForEach-Object'] { New-BlockContainerObject -ScriptBlock $_ })
             }
 
-            foreach ($c in $PesterPreference.Run.Container.Value) {
-                $containers += $c
+            if (any $PesterPreference.Run.Container.Value) {
+                # Running through New-BlockContainerObject again to avoid modifying original container and it's Data during runtime
+                $containers += @($PesterPreference.Run.Container.Value | & $SafeCommands['ForEach-Object'] { New-BlockContainerObject -Container $_ })
             }
 
             if ((any $PesterPreference.Run.Path.Value)) {

--- a/src/Pester.Runtime.ps1
+++ b/src/Pester.Runtime.ps1
@@ -2440,25 +2440,16 @@ function New-BlockContainerObject {
         [Parameter(Mandatory, ParameterSetName = 'Container')]
         [Pester.ContainerInfo] $Container,
 
-        [Parameter(ParameterSetName = 'ScriptBlock')]
-        [Parameter(ParameterSetName = 'Path')]
-        [Parameter(ParameterSetName = 'File')]
         $Data
     )
 
-    if ($PSCmdlet.ParameterSetName -eq 'Container') {
-        # A ContainerInfo-object has already executed this code, so we can safely clone hashtable
-        $ContainerData = $Container.Data.Clone()
-    }
-    else {
-        # Data is null or IDictionary, but all IDictionary does not work with ContainsKey()
-        # Contains() requires interface-casting for some types, ex. generic dictionary.
-        # Instead we're merging to a controlled data structure to have consistent API internally
-        # Also works as a shallow clone to avoid leaking default parameter values between containers with same Data
-        $ContainerData = @{ }
-        if ($Data -is [System.Collections.IDictionary]) {
-            Merge-Hashtable -Destination $ContainerData -Source $Data
-        }
+    # Data is null or IDictionary, but all IDictionary does not work with ContainsKey()
+    # Contains() requires interface-casting for some types, ex. generic dictionary.
+    # Instead we're merging to a controlled data structure to have consistent API internally
+    # Also works as a shallow clone to avoid leaking default parameter values between containers with same Data
+    $ContainerData = @{ }
+    if ($Data -is [System.Collections.IDictionary]) {
+        Merge-Hashtable -Destination $ContainerData -Source $Data
     }
 
     $type, $item = switch ($PSCmdlet.ParameterSetName) {


### PR DESCRIPTION
## PR Summary

Always create new Container-objects during runtime to avoid mutating reusable input/configuration.

Fix #2357

## PR Checklist

- [x] PR has meaningful title
- [x] Summary describes changes
- [x] PR is ready to be merged
  - If not, use the arrow next to `Create Pull Request` to mark it as a draft. PR can be marked `Ready for review` when it's ready.
- [x] Tests are added/update *(if required)*
- [ ] Documentation is updated/added *(if required)*