### PR TITLE
Revert "Avoid nested array when using Should -ActualValue (#2315)"

### DIFF
--- a/src/Pester.Utility.ps1
+++ b/src/Pester.Utility.ps1
@@ -385,13 +385,6 @@ function Fold-Run {
     }
 }
 
-function IsPSEnumerable($Object) {
-    # https://github.com/pester/Pester/issues/1200#issuecomment-493043683
-    # PowerShell doesn't consider all IEnumerable an enumerable, ex. string is excluded.
-    $enumerator = [System.Management.Automation.LanguagePrimitives]::GetEnumerator($Object)
-    return $null -ne $enumerator
-}
-
 function Get-StringOptionErrorMessage {
     param (
         [Parameter(Mandatory)]

--- a/src/functions/assertions/Should.ps1
+++ b/src/functions/assertions/Should.ps1
@@ -120,14 +120,7 @@ function Should {
     }
 
     process {
-        # If array was provided using -ActualValue @(1,2,3), unroll like pipeline for consistent behaviour
-        if (-not $PSCmdlet.MyInvocation.ExpectingInput -and (IsPSEnumerable -Object $ActualValue)) {
-            foreach ($object in $ActualValue) {
-                $inputArray.Add($object)
-            }
-        } else {
-            $inputArray.Add($ActualValue)
-        }
+        $inputArray.Add($ActualValue)
     }
 
     end {

--- a/tst/functions/assertions/Should.Tests.ps1
+++ b/tst/functions/assertions/Should.Tests.ps1
@@ -28,12 +28,6 @@ InPesterModuleScope {
             @($item1, $item2) | Should -Not -BeNullOrEmpty
         }
 
-        It 'works consistenly with array-input using pipeline or -ActualValue' {
-            # https://github.com/pester/Pester/issues/2314
-            @(1, 2, 3) | Should -Be -ExpectedValue @(1, 2, 3)
-            Should -Be -ActualValue @(1, 2, 3) -ExpectedValue @(1, 2, 3)
-        }
-
         It "can handle exception thrown assertions" {
             { foo } | Should -Throw
         }


### PR DESCRIPTION
This reverts commit bd7bfe718bac5cec0bca1384cb02fd9863a17732.


Regression https://github.com/pester/Pester/issues/2371

