### PR TITLE
Fix docs for FileContentMatchMultiline* operators

### DIFF
--- a/src/functions/assertions/FileContentMatchMultiline.ps1
+++ b/src/functions/assertions/FileContentMatchMultiline.ps1
@@ -62,4 +62,4 @@ function NotShouldFileContentMatchMultilineFailureMessage($ActualValue, $Expecte
     -Test         ${function:Should-FileContentMatchMultiline}
 
 Set-ShouldOperatorHelpMessage -OperatorName FileContentMatchMultiline `
-    -HelpMessage 'As opposed to FileContentMatch and FileContentMatchExactly operators, FileContentMatchMultiline presents content of the file being tested as one string object, so that the expression you are comparing it to can consist of several lines.'
+    -HelpMessage "As opposed to FileContentMatch and FileContentMatchExactly operators, FileContentMatchMultiline presents content of the file being tested as one string object, so that the expression you are comparing it to can consist of several lines.`n`nWhen using FileContentMatchMultiline operator, '^' and '$' represent the beginning and end of the whole file, instead of the beginning and end of a line"

--- a/src/functions/assertions/FileContentMatchMultilineExactly.ps1
+++ b/src/functions/assertions/FileContentMatchMultilineExactly.ps1
@@ -79,4 +79,4 @@ function NotShouldFileContentMatchMultilineExactlyFailureMessage($ActualValue, $
     -Test         ${function:Should-FileContentMatchMultilineExactly}
 
 Set-ShouldOperatorHelpMessage -OperatorName FileContentMatchMultilineExactly `
-    -HelpMessage 'As opposed to FileContentMatch and FileContentMatchExactly operators, FileContentMatchMultilineExactly presents content of the file being tested as one string object, so that the case sensitive expression you are comparing it to can consist of several lines.'
+    -HelpMessage "As opposed to FileContentMatch and FileContentMatchExactly operators, FileContentMatchMultilineExactly presents content of the file being tested as one string object, so that the case sensitive expression you are comparing it to can consist of several lines.`n`nWhen using FileContentMatchMultilineExactly operator, '^' and '$' represent the beginning and end of the whole file, instead of the beginning and end of a line."


### PR DESCRIPTION
## PR Summary
Adds missing section to operator help message used for https://pester.dev .
Got lost in #2336

## PR Checklist

- [x] PR has meaningful title
- [x] Summary describes changes
- [x] PR is ready to be merged
  - If not, use the arrow next to `Create Pull Request` to mark it as a draft. PR can be marked `Ready for review` when it's ready.
- [ ] Tests are added/update *(if required)*
- [x] Documentation is updated/added *(if required)*