### PR TITLE
Extract common helper-functions in P-tests

### DIFF
--- a/tst/PTestHelpers.psm1
+++ b/tst/PTestHelpers.psm1
@@ -20,3 +20,28 @@
 
     & $powershell -NoProfile -NonInteractive -ExecutionPolicy Bypass -Command $cmd
 }
+
+function Verify-PathEqual {
+    [CmdletBinding()]
+    param (
+        [Parameter(ValueFromPipeline = $true)]
+        $Actual,
+        [Parameter(Mandatory = $true, Position = 0)]
+        $Expected
+    )
+
+    if ([string]::IsNullOrEmpty($Expected)) {
+        throw 'Expected is null or empty.'
+    }
+
+    if ([string]::IsNullOrEmpty($Actual)) {
+        throw 'Actual is null or empty.'
+    }
+
+    $e = ($expected -replace '\\', '/').Trim('/')
+    $a = ($actual -replace '\\', '/').Trim('/')
+
+    if ($e -ne $a) {
+        throw "Expected path '$e' to be equal to '$a'."
+    }
+}

--- a/tst/PTestHelpers.psm1
+++ b/tst/PTestHelpers.psm1
@@ -45,3 +45,30 @@ function Verify-PathEqual {
         throw "Expected path '$e' to be equal to '$a'."
     }
 }
+
+function Verify-Property {
+    param (
+        [Parameter(ValueFromPipeline = $true)]
+        $Actual,
+        [Parameter(Mandatory = $true, Position = 0)]
+        [String] $PropertyName,
+        [Parameter(Position = 1)]
+        $Value
+    )
+
+    if ($null -eq $PropertyName) {
+        throw 'PropertyName value is $null.'
+    }
+
+    if ($null -eq $Actual) {
+        throw 'Actual value is $null.'
+    }
+
+    if (-not $Actual.PSObject.Properties.Item($PropertyName)) {
+        throw "Expected object to have property $PropertyName!"
+    }
+
+    if ($null -ne $Value -and $Value -ne $Actual.$PropertyName) {
+        throw "Expected property $PropertyName to have value '$Value', but it was '$($Actual.$PropertyName)'!"
+    }
+}

--- a/tst/PTestHelpers.psm1
+++ b/tst/PTestHelpers.psm1
@@ -72,3 +72,50 @@ function Verify-Property {
         throw "Expected property $PropertyName to have value '$Value', but it was '$($Actual.$PropertyName)'!"
     }
 }
+
+function Verify-XmlTime {
+    param (
+        [Parameter(ValueFromPipeline = $true)]
+        $Actual,
+        [Parameter(Mandatory = $true, Position = 0)]
+        [AllowNull()]
+        [Nullable[TimeSpan]]
+        $Expected,
+        [switch]$AsJUnitFormat
+    )
+
+    if ($null -eq $Expected) {
+        throw [Exception]'Expected value is $null.'
+    }
+
+    if ($null -eq $Actual) {
+        throw [Exception]'Actual value is $null.'
+    }
+
+    if ('0.0000' -eq $Actual) {
+        # it is unlikely that anything takes less than
+        # 0.0001 seconds (one tenth of a millisecond) so
+        # throw when we see 0, because that probably means
+        # we are not measuring at all
+        throw [Exception]'Actual value is zero.'
+    }
+
+    # Consider using standardized time-format for JUnit and NUnit
+    if ($AsJUnitFormat) {
+        # using this over Math.Round because it will output all the numbers for 0.1
+        $e = $Expected.TotalSeconds.ToString('0.000', [CultureInfo]::InvariantCulture)
+    }
+    else {
+        $e = [string][Math]::Round($Expected.TotalSeconds, 4)
+    }
+
+    if ($e -ne $Actual) {
+        $message = "Expected and actual values differ!`n" +
+        "Expected: '$e' seconds (raw '$($Expected.TotalSeconds)' seconds)`n" +
+        "Actual  : '$Actual' seconds"
+
+        throw [Exception]$message
+    }
+
+    $Actual
+}

--- a/tst/Pester.RSpec.BackCompat.ts.ps1
+++ b/tst/Pester.RSpec.BackCompat.ts.ps1
@@ -1,6 +1,6 @@
 ﻿param ([switch] $PassThru, [switch] $NoBuild)
 
-Get-Module Pester.Runtime, Pester.Utility, P, Pester, Axiom, Stack | Remove-Module
+Get-Module P, PTestHelpers, Pester, Axiom | Remove-Module
 
 Import-Module $PSScriptRoot\p.psm1 -DisableNameChecking
 Import-Module $PSScriptRoot\axiom\Axiom.psm1 -DisableNameChecking

--- a/tst/Pester.RSpec.Configuration.ts.ps1
+++ b/tst/Pester.RSpec.Configuration.ts.ps1
@@ -1,6 +1,6 @@
 ﻿param ([switch] $PassThru, [switch] $NoBuild)
 
-Get-Module Pester.Runtime, Pester.Utility, P, Pester, Axiom, Stack | Remove-Module
+Get-Module P, PTestHelpers, Pester, Axiom | Remove-Module
 
 Import-Module $PSScriptRoot\p.psm1 -DisableNameChecking
 Import-Module $PSScriptRoot\axiom\Axiom.psm1 -DisableNameChecking

--- a/tst/Pester.RSpec.Configuration.ts.ps1
+++ b/tst/Pester.RSpec.Configuration.ts.ps1
@@ -4,6 +4,7 @@ Get-Module P, PTestHelpers, Pester, Axiom | Remove-Module
 
 Import-Module $PSScriptRoot\p.psm1 -DisableNameChecking
 Import-Module $PSScriptRoot\axiom\Axiom.psm1 -DisableNameChecking
+Import-Module $PSScriptRoot\PTestHelpers.psm1 -DisableNameChecking
 
 if (-not $NoBuild) { & "$PSScriptRoot\..\build.ps1" }
 Import-Module $PSScriptRoot\..\bin\Pester.psd1
@@ -12,33 +13,8 @@ $global:PesterPreference = @{
     Debug = @{
         ShowFullErrors         = $true
         WriteDebugMessages     = $false
-        WriteDebugMessagesFrom = "Mock"
+        WriteDebugMessagesFrom = 'Mock'
         ReturnRawResultObject  = $true
-    }
-}
-
-function Verify-PathEqual {
-    [CmdletBinding()]
-    param (
-        [Parameter(ValueFromPipeline = $true)]
-        $Actual,
-        [Parameter(Mandatory = $true, Position = 0)]
-        $Expected
-    )
-
-    if ([string]::IsNullOrEmpty($Expected)) {
-        throw "Expected is null or empty."
-    }
-
-    if ([string]::IsNullOrEmpty($Actual)) {
-        throw "Actual is null or empty."
-    }
-
-    $e = ($expected -replace "\\", '/').Trim('/')
-    $a = ($actual -replace "\\", '/').Trim('/')
-
-    if ($e -ne $a) {
-        throw "Expected path '$e' to be equal to '$a'."
     }
 }
 

--- a/tst/Pester.RSpec.Coverage.ts.ps1
+++ b/tst/Pester.RSpec.Coverage.ts.ps1
@@ -1,6 +1,6 @@
 param ([switch] $PassThru, [switch] $NoBuild)
 
-Get-Module Pester.Runtime, Pester.Utility, P, Pester, Axiom, Stack | Remove-Module
+Get-Module P, PTestHelpers, Pester, Axiom | Remove-Module
 
 Import-Module $PSScriptRoot\p.psm1 -DisableNameChecking
 Import-Module $PSScriptRoot\axiom\Axiom.psm1 -DisableNameChecking

--- a/tst/Pester.RSpec.Demo.ts.ps1
+++ b/tst/Pester.RSpec.Demo.ts.ps1
@@ -1,6 +1,6 @@
 ﻿param ([switch] $PassThru, [switch] $NoBuild)
 
-Get-Module Pester.Runtime, Pester.Utility, P, Pester, Axiom, Stack | Remove-Module
+Get-Module P, PTestHelpers, Pester, Axiom | Remove-Module
 
 Import-Module $PSScriptRoot\p.psm1 -DisableNameChecking
 Import-Module $PSScriptRoot\axiom\Axiom.psm1 -DisableNameChecking

--- a/tst/Pester.RSpec.Pester4ResultObject.ts.ps1
+++ b/tst/Pester.RSpec.Pester4ResultObject.ts.ps1
@@ -6,10 +6,10 @@ Get-Module P, PTestHelpers, Pester, Axiom | Remove-Module
 
 Import-Module $PSScriptRoot\p.psm1 -DisableNameChecking
 Import-Module $PSScriptRoot\axiom\Axiom.psm1 -DisableNameChecking
+Import-Module $PSScriptRoot\PTestHelpers.psm1 -DisableNameChecking
 
 if (-not $NoBuild) { & "$PSScriptRoot\..\build.ps1" }
 Import-Module $PSScriptRoot\..\bin\Pester.psd1
-
 
 function Invoke-Pester4 ($Arguments) {
     $sb = {
@@ -21,34 +21,6 @@ function Invoke-Pester4 ($Arguments) {
 
     Start-Job -ScriptBlock $sb -ArgumentList $Arguments | Wait-Job | Receive-Job
 }
-
-function Verify-Property {
-    param (
-        [Parameter(ValueFromPipeline = $true)]
-        $Actual,
-        [Parameter(Mandatory = $true, Position = 0)]
-        [String] $PropertyName,
-        [Parameter(Position = 1)]
-        $Value
-    )
-
-    if ($null -eq $PropertyName) {
-        throw 'PropertyName value is $null.'
-    }
-
-    if ($null -eq $Actual) {
-        throw 'Actual value is $null.'
-    }
-
-    if (-not $Actual.PSObject.Properties.Item($PropertyName)) {
-        throw "Expected object to have property $PropertyName!"
-    }
-
-    if ($null -ne $Value -and $Value -ne $Actual.$PropertyName) {
-        throw "Expected property $PropertyName to have value '$Value', but it was '$($Actual.$PropertyName)'!"
-    }
-}
-
 
 i -PassThru:$PassThru {
 

--- a/tst/Pester.RSpec.Pester4ResultObject.ts.ps1
+++ b/tst/Pester.RSpec.Pester4ResultObject.ts.ps1
@@ -2,7 +2,7 @@
 # excluding this, as it produces errors because errors are processed differently between v4 and v5, but it is still useful to have around to confirm the overall shape of the result object is correct
 return (i -PassThru:$PassThru { })
 
-Get-Module Pester.Runtime, Pester.Utility, P, Pester, Axiom, Stack | Remove-Module
+Get-Module P, PTestHelpers, Pester, Axiom | Remove-Module
 
 Import-Module $PSScriptRoot\p.psm1 -DisableNameChecking
 Import-Module $PSScriptRoot\axiom\Axiom.psm1 -DisableNameChecking

--- a/tst/Pester.RSpec.ResultObject.ts.ps1
+++ b/tst/Pester.RSpec.ResultObject.ts.ps1
@@ -4,43 +4,16 @@ Get-Module P, PTestHelpers, Pester, Axiom | Remove-Module
 
 Import-Module $PSScriptRoot\p.psm1 -DisableNameChecking
 Import-Module $PSScriptRoot\axiom\Axiom.psm1 -DisableNameChecking
+Import-Module $PSScriptRoot\PTestHelpers.psm1 -DisableNameChecking
 
 Import-Module $PSScriptRoot/../bin/Pester.psd1
-
 
 $global:PesterPreference = @{
     Debug = @{
         ShowFullErrors         = $false
         WriteDebugMessages     = $false
-        WriteDebugMessagesFrom = "Mock"
+        WriteDebugMessagesFrom = 'Mock'
         ReturnRawResultObject  = $true
-    }
-}
-
-function Verify-Property {
-    param (
-        [Parameter(ValueFromPipeline = $true)]
-        $Actual,
-        [Parameter(Mandatory = $true, Position = 0)]
-        [String] $PropertyName,
-        [Parameter(Position = 1)]
-        $Value
-    )
-
-    if ($null -eq $PropertyName) {
-        throw 'PropertyName value is $null.'
-    }
-
-    if ($null -eq $Actual) {
-        throw 'Actual value is $null.'
-    }
-
-    if (-not $Actual.PSObject.Properties.Item($PropertyName)) {
-        throw "Expected object to have property $PropertyName!"
-    }
-
-    if ($null -ne $Value -and $Value -ne $Actual.$PropertyName) {
-        throw "Expected property $PropertyName to have value '$Value', but it was '$($Actual.$PropertyName)'!"
     }
 }
 

--- a/tst/Pester.RSpec.ResultObject.ts.ps1
+++ b/tst/Pester.RSpec.ResultObject.ts.ps1
@@ -1,6 +1,6 @@
 ﻿param ([switch] $PassThru)
 
-Get-Module Pester.Runtime, Pester.Utility, P, Pester, Axiom, Stack | Remove-Module
+Get-Module P, PTestHelpers, Pester, Axiom | Remove-Module
 
 Import-Module $PSScriptRoot\p.psm1 -DisableNameChecking
 Import-Module $PSScriptRoot\axiom\Axiom.psm1 -DisableNameChecking

--- a/tst/Pester.RSpec.TestResults.JUnit4.ts.ps1
+++ b/tst/Pester.RSpec.TestResults.JUnit4.ts.ps1
@@ -1,6 +1,6 @@
 ﻿param ([switch] $PassThru, [switch] $NoBuild)
 
-Get-Module Pester.Runtime, Pester.Utility, P, Pester, Axiom, Stack | Remove-Module
+Get-Module P, PTestHelpers, Pester, Axiom | Remove-Module
 
 Import-Module $PSScriptRoot\p.psm1 -DisableNameChecking
 Import-Module $PSScriptRoot\axiom\Axiom.psm1 -DisableNameChecking

--- a/tst/Pester.RSpec.TestResults.JUnit4.ts.ps1
+++ b/tst/Pester.RSpec.TestResults.JUnit4.ts.ps1
@@ -4,6 +4,7 @@ Get-Module P, PTestHelpers, Pester, Axiom | Remove-Module
 
 Import-Module $PSScriptRoot\p.psm1 -DisableNameChecking
 Import-Module $PSScriptRoot\axiom\Axiom.psm1 -DisableNameChecking
+Import-Module $PSScriptRoot\PTestHelpers.psm1 -DisableNameChecking
 
 if (-not $NoBuild) { & "$PSScriptRoot\..\build.ps1" }
 Import-Module $PSScriptRoot\..\bin\Pester.psd1
@@ -12,45 +13,6 @@ $global:PesterPreference = @{
     Debug = @{
         ShowFullErrors = $false
     }
-}
-
-function Verify-XmlTime {
-    param (
-        [Parameter(ValueFromPipeline = $true)]
-        $Actual,
-        [Parameter(Mandatory = $true, Position = 0)]
-        [AllowNull()]
-        [Nullable[TimeSpan]]
-        $Expected
-    )
-
-    if ($null -eq $Expected) {
-        throw [Exception]'Expected value is $null.'
-    }
-
-    if ($null -eq $Actual) {
-        throw [Exception]'Actual value is $null.'
-    }
-
-    if ('0.0000' -eq $Actual) {
-        # it is unlikely that anything takes less than
-        # 0.0001 seconds (one tenth of a millisecond) so
-        # throw when we see 0, because that probably means
-        # we are not measuring at all
-        throw [Exception]'Actual value is zero.'
-    }
-
-    # using this over Math.Round because it will output all the numbers for 0.1
-    $e = $Expected.TotalSeconds.ToString('0.000', [CultureInfo]::InvariantCulture)
-    if ($e -ne $Actual) {
-        $message = "Expected and actual values differ!`n" +
-        "Expected: '$e' seconds (raw '$($Expected.TotalSeconds)' seconds)`n" +
-        "Actual  : '$Actual' seconds"
-
-        throw [Exception]$message
-    }
-
-    $Actual
 }
 
 function Get-ScriptBlockName ($ScriptBlock) {
@@ -77,7 +39,7 @@ i -PassThru:$PassThru {
             $xmlTestCase = $xmlResult.'testsuites'.'testsuite'.'testcase'
             $xmlTestCase.name | Verify-Equal "Mocked Describe.Successful testcase"
             $xmlTestCase.status | Verify-Equal "Passed"
-            $xmlTestCase.time | Verify-XmlTime -Expected $r.Containers[0].Blocks[0].Tests[0].Duration
+            $xmlTestCase.time | Verify-XmlTime -AsJUnitFormat -Expected $r.Containers[0].Blocks[0].Tests[0].Duration
         }
 
         t "should write a failed test result" {
@@ -94,7 +56,7 @@ i -PassThru:$PassThru {
             $xmlTestCase = $xmlResult.'testsuites'.'testsuite'.'testcase'
             $xmlTestCase.name | Verify-Equal "Mocked Describe.Failed testcase"
             $xmlTestCase.status | Verify-Equal "Failed"
-            $xmlTestCase.time | Verify-XmlTime $r.Containers[0].Blocks[0].Tests[0].Duration
+            $xmlTestCase.time | Verify-XmlTime -AsJUnitFormat -Expected $r.Containers[0].Blocks[0].Tests[0].Duration
 
             $message = $xmlTestCase.failure.message -split "`n" -replace "`r"
             $message[0] | Verify-Equal "Expected strings to be the same, but they were different."
@@ -160,7 +122,7 @@ i -PassThru:$PassThru {
             $xmlTestCase = $xmlResult.'testsuites'.'testsuite'.'testcase'
             $xmlTestCase.name | Verify-Equal "Mocked Describe.Failed testcase"
             $xmlTestCase.status | Verify-Equal "Failed"
-            $xmlTestCase.time | Verify-XmlTime $r.Containers[0].Blocks[0].Tests[0].Duration
+            $xmlTestCase.time | Verify-XmlTime -AsJUnitFormat -Expected $r.Containers[0].Blocks[0].Tests[0].Duration
 
             $message = $xmlTestCase.failure.message -split "`n" -replace "`r"
             $message[0] | Verify-Equal "[0] Expected strings to be the same, but they were different."
@@ -210,7 +172,7 @@ i -PassThru:$PassThru {
             $xmlTestResult = $xmlResult.'testsuites'
             $xmlTestResult.tests | Verify-Equal 1
             $xmlTestResult.failures | Verify-Equal 0
-            $xmlTestResult.time | Verify-XmlTime $r.Containers[0].Duration
+            $xmlTestResult.time | Verify-XmlTime -AsJUnitFormat -Expected $r.Containers[0].Duration
         }
 
         t "should write two test-suite elements for two containers" {
@@ -235,11 +197,11 @@ i -PassThru:$PassThru {
             $xmlResult = $r | ConvertTo-JUnitReport
             $xmlTestSuite1 = $xmlResult.'testsuites'.'testsuite'[0]
             $xmlTestSuite1.name | Verify-Equal (Get-ScriptBlockName $sb1)
-            $xmlTestSuite1.time | Verify-XmlTime $r.Containers[0].Duration
+            $xmlTestSuite1.time | Verify-XmlTime -AsJUnitFormat -Expected $r.Containers[0].Duration
 
             $xmlTestSuite2 = $xmlResult.'testsuites'.'testsuite'[1]
             $xmlTestSuite2.name | Verify-Equal (Get-ScriptBlockName $sb2)
-            $xmlTestSuite2.time | Verify-XmlTime $r.Containers[1].Duration
+            $xmlTestSuite2.time | Verify-XmlTime -AsJUnitFormat -Expected $r.Containers[1].Duration
         }
 
         t "should write the environment information in properties" {
@@ -335,7 +297,7 @@ i -PassThru:$PassThru {
                 $xmlTestCase = $xmlResult.'testsuites'.'testsuite'.'testcase'
                 $xmlTestCase.name | Verify-Equal "Mocked Describe.Successful testcase"
                 $xmlTestCase.status | Verify-Equal "Passed"
-                $xmlTestCase.time | Verify-XmlTime -Expected $r.Containers[0].Blocks[0].Tests[0].Duration
+                $xmlTestCase.time | Verify-XmlTime -AsJUnitFormat -Expected $r.Containers[0].Blocks[0].Tests[0].Duration
             }
             finally {
                 if (Test-Path $temp) {
@@ -376,7 +338,7 @@ i -PassThru:$PassThru {
                 $xmlTestCase = $xmlResult.'testsuites'.'testsuite'.'testcase'
                 $xmlTestCase.name | Verify-Equal "Mocked Describe.Successful testcase"
                 $xmlTestCase.status | Verify-Equal "Passed"
-                $xmlTestCase.time | Verify-XmlTime -Expected $r.Containers[0].Blocks[0].Tests[0].Duration
+                $xmlTestCase.time | Verify-XmlTime -AsJUnitFormat -Expected $r.Containers[0].Blocks[0].Tests[0].Duration
             }
             finally {
                 if (Test-Path $temp) {
@@ -411,7 +373,7 @@ i -PassThru:$PassThru {
                 $xmlTestCase = $xmlResult.'testsuites'.'testsuite'.'testcase'
                 $xmlTestCase.name | Verify-Equal "Mocked Describe.Successful testcase"
                 $xmlTestCase.status | Verify-Equal "Passed"
-                $xmlTestCase.time | Verify-XmlTime -Expected $r.Containers[0].Blocks[0].Tests[0].Duration
+                $xmlTestCase.time | Verify-XmlTime -AsJUnitFormat -Expected $r.Containers[0].Blocks[0].Tests[0].Duration
             }
             finally {
                 if (Test-Path $temp) {
@@ -442,7 +404,7 @@ i -PassThru:$PassThru {
                 $xmlTestCase = $xmlResult.'testsuites'.'testsuite'.'testcase'
                 $xmlTestCase.name | Verify-Equal "Mocked Describe.Successful testcase"
                 $xmlTestCase.status | Verify-Equal "Passed"
-                $xmlTestCase.time | Verify-XmlTime -Expected $r.Containers[0].Blocks[0].Tests[0].Duration
+                $xmlTestCase.time | Verify-XmlTime -AsJUnitFormat -Expected $r.Containers[0].Blocks[0].Tests[0].Duration
             }
             finally {
                 if (Test-Path $script) {

--- a/tst/Pester.RSpec.TestResults.NUnit25.ts.ps1
+++ b/tst/Pester.RSpec.TestResults.NUnit25.ts.ps1
@@ -1,6 +1,6 @@
 ﻿param ([switch] $PassThru, [switch] $NoBuild)
 
-Get-Module Pester.Runtime, Pester.Utility, P, Pester, Axiom, Stack | Remove-Module
+Get-Module P, PTestHelpers, Pester, Axiom | Remove-Module
 
 Import-Module $PSScriptRoot\p.psm1 -DisableNameChecking
 Import-Module $PSScriptRoot\axiom\Axiom.psm1 -DisableNameChecking

--- a/tst/Pester.RSpec.TestResults.NUnit25.ts.ps1
+++ b/tst/Pester.RSpec.TestResults.NUnit25.ts.ps1
@@ -4,6 +4,7 @@ Get-Module P, PTestHelpers, Pester, Axiom | Remove-Module
 
 Import-Module $PSScriptRoot\p.psm1 -DisableNameChecking
 Import-Module $PSScriptRoot\axiom\Axiom.psm1 -DisableNameChecking
+Import-Module $PSScriptRoot\PTestHelpers.psm1 -DisableNameChecking
 
 if (-not $NoBuild) { & "$PSScriptRoot\..\build.ps1" }
 Import-Module $PSScriptRoot\..\bin\Pester.psd1
@@ -12,44 +13,6 @@ $global:PesterPreference = @{
     Debug = @{
         ShowFullErrors = $false
     }
-}
-
-function Verify-XmlTime {
-    param (
-        [Parameter(ValueFromPipeline = $true)]
-        $Actual,
-        [Parameter(Mandatory = $true, Position = 0)]
-        [AllowNull()]
-        [Nullable[TimeSpan]]
-        $Expected
-    )
-
-    if ($null -eq $Expected) {
-        throw [Exception]'Expected value is $null.'
-    }
-
-    if ($null -eq $Actual) {
-        throw [Exception]'Actual value is $null.'
-    }
-
-    if ('0.0000' -eq $Actual) {
-        # it is unlikely that anything takes less than
-        # 0.0001 seconds (one tenth of a millisecond) so
-        # throw when we see 0, because that probably means
-        # we are not measuring at all
-        throw [Exception]'Actual value is zero.'
-    }
-
-    $e = [string][Math]::Round($Expected.TotalSeconds, 4)
-    if ($e -ne $Actual) {
-        $message = "Expected and actual values differ!`n" +
-        "Expected: '$e' seconds (raw '$($Expected.TotalSeconds)' seconds)`n" +
-        "Actual  : '$Actual' seconds"
-
-        throw [Exception]$message
-    }
-
-    $Actual
 }
 
 $schemaPath = (Get-Module -Name Pester).Path | Split-Path | Join-Path -ChildPath 'schemas/NUnit25/nunit_schema_2.5.xsd'

--- a/tst/Pester.RSpec.TestResults.NUnit3.ts.ps1
+++ b/tst/Pester.RSpec.TestResults.NUnit3.ts.ps1
@@ -611,7 +611,7 @@ i -PassThru:$PassThru {
             $xmlResult.Validate({ throw $args[1].Exception })
         }
 
-        dt 'should add properties for Data when Data is dictionary' {
+        t 'should add properties for Data when Data is dictionary' {
             $sb = {
                 # not supported
                 Describe 'Describe Array' -ForEach @(123) {

--- a/tst/Pester.RSpec.TestResults.NUnit3.ts.ps1
+++ b/tst/Pester.RSpec.TestResults.NUnit3.ts.ps1
@@ -1,6 +1,6 @@
 ﻿param ([switch] $PassThru, [switch] $NoBuild)
 
-Get-Module Pester.Runtime, Pester.Utility, P, Pester, Axiom, Stack | Remove-Module
+Get-Module P, PTestHelpers, Pester, Axiom | Remove-Module
 
 Import-Module $PSScriptRoot\p.psm1 -DisableNameChecking
 Import-Module $PSScriptRoot\axiom\Axiom.psm1 -DisableNameChecking
@@ -648,7 +648,7 @@ i -PassThru:$PassThru {
             $xmlResult.Validate({ throw $args[1].Exception })
         }
 
-        t 'should add properties for Data when Data is dictionary' {
+        dt 'should add properties for Data when Data is dictionary' {
             $sb = {
                 # not supported
                 Describe 'Describe Array' -ForEach @(123) {

--- a/tst/Pester.RSpec.TestResults.NUnit3.ts.ps1
+++ b/tst/Pester.RSpec.TestResults.NUnit3.ts.ps1
@@ -4,6 +4,7 @@ Get-Module P, PTestHelpers, Pester, Axiom | Remove-Module
 
 Import-Module $PSScriptRoot\p.psm1 -DisableNameChecking
 Import-Module $PSScriptRoot\axiom\Axiom.psm1 -DisableNameChecking
+Import-Module $PSScriptRoot\PTestHelpers.psm1 -DisableNameChecking
 
 if (-not $NoBuild) { & "$PSScriptRoot\..\build.ps1" }
 Import-Module $PSScriptRoot\..\bin\Pester.psd1
@@ -12,44 +13,6 @@ $global:PesterPreference = @{
     Debug = @{
         ShowFullErrors = $false
     }
-}
-
-function Verify-XmlTime {
-    param (
-        [Parameter(ValueFromPipeline = $true)]
-        $Actual,
-        [Parameter(Mandatory = $true, Position = 0)]
-        [AllowNull()]
-        [Nullable[TimeSpan]]
-        $Expected
-    )
-
-    if ($null -eq $Expected) {
-        throw [Exception]'Expected value is $null.'
-    }
-
-    if ($null -eq $Actual) {
-        throw [Exception]'Actual value is $null.'
-    }
-
-    if ('0.0000' -eq $Actual) {
-        # it is unlikely that anything takes less than
-        # 0.0001 seconds (one tenth of a millisecond) so
-        # throw when we see 0, because that probably means
-        # we are not measuring at all
-        throw [Exception]'Actual value is zero.'
-    }
-
-    $e = [string][Math]::Round($Expected.TotalSeconds, 4)
-    if ($e -ne $Actual) {
-        $message = "Expected and actual values differ!`n" +
-        "Expected: '$e' seconds (raw '$($Expected.TotalSeconds)' seconds)`n" +
-        "Actual  : '$Actual' seconds"
-
-        throw [Exception]$message
-    }
-
-    $Actual
 }
 
 $schemaPath = (Get-Module -Name Pester).Path | Split-Path | Join-Path -ChildPath 'schemas/NUnit3/TestResult.xsd'

--- a/tst/Pester.RSpec.ts.ps1
+++ b/tst/Pester.RSpec.ts.ps1
@@ -1,6 +1,6 @@
 ﻿param ([switch] $PassThru, [switch] $NoBuild)
 
-Get-Module Pester.Runtime, Pester.Utility, P, Pester, Axiom, Stack | Remove-Module
+Get-Module P, PTestHelpers, Pester, Axiom | Remove-Module
 
 Import-Module $PSScriptRoot\p.psm1 -DisableNameChecking
 Import-Module $PSScriptRoot\axiom\Axiom.psm1 -DisableNameChecking

--- a/tst/Pester.Rspec.Filtering.ts.ps1
+++ b/tst/Pester.Rspec.Filtering.ts.ps1
@@ -1,6 +1,6 @@
 ﻿param ([switch] $PassThru, [switch] $NoBuild)
 
-Get-Module Pester.Runtime, Pester.Utility, P, Pester, Axiom, Stack | Remove-Module
+Get-Module P, PTestHelpers, Pester, Axiom | Remove-Module
 
 Import-Module $PSScriptRoot\p.psm1 -DisableNameChecking
 Import-Module $PSScriptRoot\axiom\Axiom.psm1 -DisableNameChecking

--- a/tst/Pester.Runtime.ResultObject.ts.ps1
+++ b/tst/Pester.Runtime.ResultObject.ts.ps1
@@ -1,9 +1,6 @@
 ﻿param ([switch] $PassThru)
 
-Get-Item function:wrapper -ErrorAction SilentlyContinue | remove-item
-
-
-Get-Module Pester.Runtime.Wrapper, Pester.Utility, P, Pester, Axiom | Remove-Module
+Get-Module Pester.Runtime.Wrapper, P, PTestHelpers, Pester, Axiom | Remove-Module
 
 . $PSScriptRoot\..\src\Pester.Utility.ps1
 New-Module -Name Pester.Runtime.Wrapper -ScriptBlock {
@@ -22,10 +19,9 @@ $global:PesterPreference = @{
     Debug = @{
         ShowFullErrors         = $true
         WriteDebugMessages     = $false
-        WriteDebugMessagesFrom = "Timing*"
+        WriteDebugMessagesFrom = 'Timing*'
     }
 }
-
 
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'

--- a/tst/Pester.Runtime.ts.ps1
+++ b/tst/Pester.Runtime.ts.ps1
@@ -1,9 +1,6 @@
 ﻿param ([switch] $PassThru)
 
-Get-Item function:wrapper -ErrorAction SilentlyContinue | remove-item
-
-
-Get-Module Pester.Runtime.Wrapper, Pester.Utility, P, Pester, Axiom | Remove-Module
+Get-Module Pester.Runtime.Wrapper, P, PTestHelpers, Pester, Axiom | Remove-Module
 
 . $PSScriptRoot\..\src\Pester.Utility.ps1
 New-Module -Name Pester.Runtime.Wrapper -ScriptBlock {

--- a/tst/Pester.Utility.ts.ps1
+++ b/tst/Pester.Utility.ts.ps1
@@ -1,6 +1,6 @@
 ﻿param ([switch] $PassThru)
 
-Get-Module Pester.Utility, P, Axiom | Remove-Module
+Get-Module P, PTestHelpers, Pester, Axiom | Remove-Module
 
 Import-Module $PSScriptRoot\p.psm1 -DisableNameChecking
 Import-Module $PSScriptRoot\axiom\Axiom.psm1 -DisableNameChecking

--- a/tst/functions/Add-ShouldOperator.ts.ps1
+++ b/tst/functions/Add-ShouldOperator.ts.ps1
@@ -1,6 +1,6 @@
 ﻿param ([switch] $PassThru, [switch] $NoBuild)
 
-Get-Module Pester.Runtime, Pester.Utility, P, Pester, Axiom, Stack | Remove-Module
+Get-Module P, PTestHelpers, Pester, Axiom | Remove-Module
 
 Import-Module $PSScriptRoot\..\p.psm1 -DisableNameChecking
 Import-Module $PSScriptRoot\..\axiom\Axiom.psm1 -DisableNameChecking

--- a/tst/functions/New-Fixture.ts.ps1
+++ b/tst/functions/New-Fixture.ts.ps1
@@ -1,6 +1,6 @@
 ﻿param ([switch] $PassThru, [switch] $NoBuild)
 
-Get-Module Pester.Runtime, Pester.Utility, P, Pester, Axiom, Stack | Remove-Module
+Get-Module P, PTestHelpers, Pester, Axiom | Remove-Module
 
 Import-Module $PSScriptRoot\..\p.psm1 -DisableNameChecking
 Import-Module $PSScriptRoot\..\axiom\Axiom.psm1 -DisableNameChecking

--- a/tst/functions/Pester.TestDrive.ts.ps1
+++ b/tst/functions/Pester.TestDrive.ts.ps1
@@ -1,6 +1,6 @@
 ﻿param ([switch] $PassThru, [switch] $NoBuild)
 
-Get-Module Pester.Runtime, Pester.Utility, P, Pester, Axiom, Stack | Remove-Module
+Get-Module P, PTestHelpers, Pester, Axiom | Remove-Module
 
 Import-Module $PSScriptRoot\..\p.psm1 -DisableNameChecking
 Import-Module $PSScriptRoot\..\axiom\Axiom.psm1 -DisableNameChecking

--- a/tst/functions/Pester.TestRegistry.ts.ps1
+++ b/tst/functions/Pester.TestRegistry.ts.ps1
@@ -1,7 +1,6 @@
 ﻿param ([switch] $PassThru, [switch] $NoBuild)
 
-
-Get-Module Pester.Runtime, Pester.Utility, P, Pester, Axiom, Stack | Remove-Module
+Get-Module P, PTestHelpers, Pester, Axiom | Remove-Module
 
 Import-Module $PSScriptRoot\..\p.psm1 -DisableNameChecking
 Import-Module $PSScriptRoot\..\axiom\Axiom.psm1 -DisableNameChecking


### PR DESCRIPTION
## PR Summary
Extracts shared helper-functions in P-tests to `PTestHelper`-module, as mentioned in https://github.com/pester/Pester/pull/2345#discussion_r1192973682

## PR Checklist

- [x] PR has meaningful title
- [x] Summary describes changes
- [x] PR is ready to be merged
  - If not, use the arrow next to `Create Pull Request` to mark it as a draft. PR can be marked `Ready for review` when it's ready.
- [x] Tests are added/update *(if required)*
- [ ] Documentation is updated/added *(if required)*