### PR TITLE
Standardize container name and type validation

### DIFF
--- a/src/csharp/Pester/Container.cs
+++ b/src/csharp/Pester/Container.cs
@@ -48,7 +48,12 @@ namespace Pester
         }
 
         public string Name { get => ToStringConverter.ContainerItemToString(Type, Item); }
-        public string Type { get; set; }
+        private string _type = Constants.File;
+        public string Type
+        {
+            get => _type;
+            set => SetContainerType(ref _type, value);
+        }
         public object Item { get; set; }
         public object Data { get; set; }
         public List<Block> Blocks { get; set; } = new List<Block>();
@@ -76,6 +81,16 @@ namespace Pester
         public override string ToString()
         {
             return ToStringConverter.ContainerToString(this);
+        }
+
+        internal static void SetContainerType(ref string property, string value)
+        {
+            property = value.ToLower() switch
+            {
+                "file" => Constants.File,
+                "scriptblock" => Constants.ScriptBlock,
+                _ => throw new ArgumentOutOfRangeException("value", $"Type must be '{Constants.File}' or '{Constants.ScriptBlock}'"),
+            };
         }
     }
 }

--- a/src/csharp/Pester/Container.cs
+++ b/src/csharp/Pester/Container.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.IO;
 
@@ -48,6 +47,7 @@ namespace Pester
             };
         }
 
+        public string Name { get => ToStringConverter.ContainerItemToString(Type, Item); }
         public string Type { get; set; }
         public object Item { get; set; }
         public object Data { get; set; }

--- a/src/csharp/Pester/ContainerInfo.cs
+++ b/src/csharp/Pester/ContainerInfo.cs
@@ -11,7 +11,12 @@ namespace Pester
             return new ContainerInfo();
         }
 
-        public string Type { get; set; } = "File";
+        private string _type = Constants.File;
+        public string Type
+        {
+            get => _type;
+            set => Container.SetContainerType(ref _type, value);
+        }
         public object Item { get; set; }
         public object Data { get; set; }
 

--- a/src/csharp/Pester/ContainerInfo.cs
+++ b/src/csharp/Pester/ContainerInfo.cs
@@ -14,5 +14,10 @@ namespace Pester
         public string Type { get; set; } = "File";
         public object Item { get; set; }
         public object Data { get; set; }
+
+        public override string ToString()
+        {
+            return ToStringConverter.ContainerInfoToString(this);
+        }
     }
 }

--- a/src/csharp/Pester/ToStringConverter.cs
+++ b/src/csharp/Pester/ToStringConverter.cs
@@ -18,32 +18,21 @@ namespace Pester
             };
         }
 
-        internal static string ContainerItemToString(string Type, object Item)
+        internal static string ContainerItemToString(string type, object item)
         {
-            string path;
-            switch (Type)
+            return type switch
             {
-                case Constants.File:
-                    path = Item is FileInfo f ? f.FullName : Item.ToString();
-                    break;
-                case Constants.ScriptBlock:
-                    path = "<ScriptBlock>";
-                    if (Item is ScriptBlock s && !string.IsNullOrWhiteSpace(s.File))
-                    {
-                        path += $":{s.File}:{s.StartPosition.StartLine}";
-                    }
-                    break;
-                default:
-                    path = $"<{Type}>";
-                    break;
-            }
-
-            return path;
+                Constants.File => item is FileInfo f ? f.FullName : item.ToString(),
+                Constants.ScriptBlock => item is ScriptBlock s && !string.IsNullOrWhiteSpace(s.File)
+                    ? $"<ScriptBlock>:{s.File}:{s.StartPosition.StartLine}"
+                    : "<ScriptBlock>",
+                _ => $"<{type}>"
+            };
         }
 
         internal static string ContainerToString(Container container)
         {
-            return $"{ResultToString(container.Result)} {ContainerItemToString(container.Type, container.Item)}";
+            return $"{ResultToString(container.Result)} {container.Name}";
         }
 
         internal static string ContainerInfoToString(ContainerInfo containerInfo)

--- a/src/csharp/Pester/ToStringConverter.cs
+++ b/src/csharp/Pester/ToStringConverter.cs
@@ -1,4 +1,4 @@
-﻿using System;
+﻿using System.IO;
 using System.Management.Automation;
 
 namespace Pester
@@ -18,29 +18,37 @@ namespace Pester
             };
         }
 
-        internal static string ContainerToString(Container container)
+        internal static string ContainerItemToString(string Type, object Item)
         {
             string path;
-            switch (container.Type)
+            switch (Type)
             {
                 case Constants.File:
-                    path = container.Item.ToString();
+                    path = Item is FileInfo f ? f.FullName : Item.ToString();
                     break;
                 case Constants.ScriptBlock:
                     path = "<ScriptBlock>";
-                    if (container.Item is ScriptBlock s) {
-                        if (!string.IsNullOrWhiteSpace(s.File))
-                        {
-                            path += $":{s.File}:{s.StartPosition.StartLine}";
-                        }
+                    if (Item is ScriptBlock s && !string.IsNullOrWhiteSpace(s.File))
+                    {
+                        path += $":{s.File}:{s.StartPosition.StartLine}";
                     }
                     break;
                 default:
-                    path = $"<{container.Type}>";
+                    path = $"<{Type}>";
                     break;
             }
 
-            return $"{ResultToString(container.Result)} {path}";
+            return path;
+        }
+
+        internal static string ContainerToString(Container container)
+        {
+            return $"{ResultToString(container.Result)} {ContainerItemToString(container.Type, container.Item)}";
+        }
+
+        internal static string ContainerInfoToString(ContainerInfo containerInfo)
+        {
+            return ContainerItemToString(containerInfo.Type, containerInfo.Item);
         }
 
         internal static string TestToString(Test test)

--- a/src/functions/Output.ps1
+++ b/src/functions/Output.ps1
@@ -200,35 +200,12 @@ function Write-PesterStart {
         $Context
     )
     process {
-        # if (-not ( $Context.Show | Has-Flag 'All, Fails, Header')) {
-        #     return
-        # }
-
-        $OFS = $ReportStrings.MessageOfs
-
-        $hash = @{
-            Files        = [System.Collections.Generic.List[object]]@()
-            ScriptBlocks = 0
-        }
-
         $moduleInfo = $MyInvocation.MyCommand.ScriptBlock.Module
         $moduleVersion = $moduleInfo.Version.ToString()
         if ($moduleInfo.PrivateData.PSData.Prerelease) {
             $moduleVersion += "-$($moduleInfo.PrivateData.PSData.Prerelease)"
         }
         $message = $ReportStrings.VersionMessage -f $moduleVersion
-
-        # todo write out filters that are applied
-        # if ($PesterState.TestNameFilter) {
-        #     $message += $ReportStrings.FilterMessage -f "$($PesterState.TestNameFilter)"
-        # }
-        # if ($PesterState.ScriptBlockFilter) {
-        #     $m = $(foreach ($m in $PesterState.ScriptBlockFilter) { "$($m.Path):$($m.Line)" }) -join ", "
-        #     $message += $ReportStrings.FilterMessage -f $m
-        # }
-        # if ($PesterState.TagFilter) {
-        #     $message += $ReportStrings.TagMessage -f "$($PesterState.TagFilter)"
-        # }
 
         Write-PesterHostMessage -ForegroundColor $ReportTheme.Discovery $message
     }
@@ -245,15 +222,15 @@ function ConvertTo-PesterResult {
     $testResult = @{
         Name           = $Name
         Time           = $time
-        FailureMessage = ""
-        StackTrace     = ""
+        FailureMessage = ''
+        StackTrace     = ''
         ErrorRecord    = $null
         Success        = $false
-        Result         = "Failed"
+        Result         = 'Failed'
     }
 
     if (-not $ErrorRecord) {
-        $testResult.Result = "Passed"
+        $testResult.Result = 'Passed'
         $testResult.Success = $true
         return $testResult
     }
@@ -270,13 +247,13 @@ function ConvertTo-PesterResult {
         if (-not $Pester.Strict) {
             switch ($ErrorRecord.FullyQualifiedErrorID) {
                 PesterTestInconclusive {
-                    $testResult.Result = "Inconclusive"; break;
+                    $testResult.Result = 'Inconclusive'; break;
                 }
                 PesterTestPending {
-                    $testResult.Result = "Pending"; break;
+                    $testResult.Result = 'Pending'; break;
                 }
                 PesterTestSkipped {
-                    $testResult.Result = "Skipped"; break;
+                    $testResult.Result = 'Skipped'; break;
                 }
             }
         }
@@ -372,7 +349,7 @@ function Write-PesterReport {
     Write-PesterHostMessage ($ReportStrings.TestsNotRun -f $RunResult.NotRunCount) -Foreground $NotRun
 
     if (0 -lt $RunResult.FailedBlocksCount) {
-        Write-PesterHostMessage ("BeforeAll \ AfterAll failed: {0}" -f $RunResult.FailedBlocksCount) -Foreground $ReportTheme.Fail
+        Write-PesterHostMessage ('BeforeAll \ AfterAll failed: {0}' -f $RunResult.FailedBlocksCount) -Foreground $ReportTheme.Fail
         Write-PesterHostMessage ($(foreach ($b in $RunResult.FailedBlocks) { "  - $($b.Path -join '.')" }) -join [Environment]::NewLine) -Foreground $ReportTheme.Fail
     }
 

--- a/src/functions/Output.ps1
+++ b/src/functions/Output.ps1
@@ -211,14 +211,6 @@ function Write-PesterStart {
             ScriptBlocks = 0
         }
 
-        foreach ($c in $Context.Containers) {
-            switch ($c.Type) {
-                "File" { $null = $hash.Files.Add($c.Item.FullName) }
-                "ScriptBlock" { $null = $hash.ScriptBlocks++ }
-                Default { throw "$($c.Type) is not supported." }
-            }
-        }
-
         $moduleInfo = $MyInvocation.MyCommand.ScriptBlock.Module
         $moduleVersion = $moduleInfo.Version.ToString()
         if ($moduleInfo.PrivateData.PSData.Prerelease) {
@@ -306,7 +298,7 @@ function ConvertTo-PesterResult {
 function Write-PesterReport {
     param (
         [Parameter(mandatory = $true, valueFromPipeline = $true)]
-        $RunResult
+        [Pester.Run] $RunResult
     )
     # if(-not ($PesterState.Show | Has-Flag Summary)) { return }
 
@@ -386,10 +378,6 @@ function Write-PesterReport {
 
     if (0 -lt $RunResult.FailedContainersCount) {
         $cs = foreach ($container in $RunResult.FailedContainers) {
-            if ($container.Type -notin 'File', 'ScriptBlock') {
-                throw "Container type '$($container.Type)' is not supported."
-            }
-
             "  - $($container.Name)"
         }
         Write-PesterHostMessage ('Container failed: {0}' -f $RunResult.FailedContainersCount) -Foreground $ReportTheme.Fail
@@ -614,10 +602,6 @@ function Get-WriteScreenPlugin ($Verbosity) {
         param ($Context)
 
         if ('Failed' -eq $Context.Block.Result) {
-            if ($Context.BlockContainer.Type -notin 'File', 'ScriptBlock') {
-                throw "Context.BlockContainer type '$($Context.BlockContainer.Type)' is not supported."
-            }
-
             $errorHeader = "[-] Discovery in $($Context.BlockContainer) failed with:"
 
             $formatErrorParams = @{

--- a/src/functions/TestResults.JUnit4.ps1
+++ b/src/functions/TestResults.JUnit4.ps1
@@ -42,23 +42,16 @@ function Write-JUnitTestSuiteElements {
 
     $XmlWriter.WriteStartElement('testsuite')
 
-    if ('File' -eq $Container.Type) {
-        $path = $Container.Item.FullName
-    }
-    elseif ('ScriptBlock' -eq $Container.Type) {
-        $path = "<ScriptBlock>$($Container.Item.File):$($Container.Item.StartPosition.StartLine)"
-    }
-    else {
-        throw "Container type '$($Container.Type)' is not supported."
+    if ($container.Type -notin 'File', 'ScriptBlock') {
+        throw "Container type '$($container.Type)' is not supported."
     }
 
-    Write-JUnitTestSuiteAttributes -Action $Container -XmlWriter $XmlWriter -Package $path -Id $Id
-
+    Write-JUnitTestSuiteAttributes -Action $Container -XmlWriter $XmlWriter -Package $container.Name -Id $Id
 
     $testResults = [Pester.Factory]::CreateCollection()
     Fold-Container -Container $Container -OnTest { param ($t) if ($t.ShouldRun) { $testResults.Add($t) } }
     foreach ($t in $testResults) {
-        Write-JUnitTestCaseElements -TestResult $t -XmlWriter $XmlWriter -Package $path
+        Write-JUnitTestCaseElements -TestResult $t -XmlWriter $XmlWriter -Package $container.Name
     }
 
     $XmlWriter.WriteEndElement()

--- a/src/functions/TestResults.JUnit4.ps1
+++ b/src/functions/TestResults.JUnit4.ps1
@@ -1,5 +1,5 @@
 ﻿function Write-JUnitReport {
-    param($Result, [System.Xml.XmlWriter] $XmlWriter)
+    param([Pester.Run] $Result, [System.Xml.XmlWriter] $XmlWriter)
     # Write the XML Declaration
     $XmlWriter.WriteStartDocument($false)
 
@@ -24,7 +24,7 @@
 
 function Write-JUnitTestResultAttributes {
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns','')]
-    param($Result, [System.Xml.XmlWriter] $XmlWriter)
+    param([Pester.Run] $Result, [System.Xml.XmlWriter] $XmlWriter)
 
     $XmlWriter.WriteAttributeString('xmlns', 'xsi', $null, 'http://www.w3.org/2001/XMLSchema-instance')
     $XmlWriter.WriteAttributeString('xsi', 'noNamespaceSchemaLocation', [Xml.Schema.XmlSchema]::InstanceNamespace , 'junit_schema_4.xsd')
@@ -38,13 +38,9 @@ function Write-JUnitTestResultAttributes {
 
 function Write-JUnitTestSuiteElements {
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns','')]
-    param($Container, [System.Xml.XmlWriter] $XmlWriter, [uint16] $Id)
+    param([Pester.Container] $Container, [System.Xml.XmlWriter] $XmlWriter, [uint16] $Id)
 
     $XmlWriter.WriteStartElement('testsuite')
-
-    if ($container.Type -notin 'File', 'ScriptBlock') {
-        throw "Container type '$($container.Type)' is not supported."
-    }
 
     Write-JUnitTestSuiteAttributes -Action $Container -XmlWriter $XmlWriter -Package $container.Name -Id $Id
 

--- a/src/functions/TestResults.NUnit25.ps1
+++ b/src/functions/TestResults.NUnit25.ps1
@@ -53,16 +53,10 @@ function Write-NUnitTestResultChildNodes {
             continue
         }
 
-        if ('File' -eq $container.Type) {
-            $path = $container.Item.FullName
-        }
-        elseif ('ScriptBlock' -eq $container.Type) {
-            $path = "<ScriptBlock>$($container.Item.File):$($container.Item.StartPosition.StartLine)"
-        }
-        else {
+        if ($container.Type -notin 'File', 'ScriptBlock') {
             throw "Container type '$($container.Type)' is not supported."
         }
-        Write-NUnitTestSuiteElements -XmlWriter $XmlWriter -Node $container -Path $path
+        Write-NUnitTestSuiteElements -XmlWriter $XmlWriter -Node $container -Path $container.Name
     }
 
     $XmlWriter.WriteEndElement()

--- a/src/functions/TestResults.NUnit25.ps1
+++ b/src/functions/TestResults.NUnit25.ps1
@@ -1,5 +1,5 @@
 ﻿function Write-NUnitReport {
-    param($Result, [System.Xml.XmlWriter] $XmlWriter)
+    param([Pester.Run] $Result, [System.Xml.XmlWriter] $XmlWriter)
     # Write the XML Declaration
     $XmlWriter.WriteStartDocument($false)
 
@@ -14,7 +14,7 @@
 
 function Write-NUnitTestResultAttributes {
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '')]
-    param($Result, [System.Xml.XmlWriter] $XmlWriter)
+    param([Pester.Run] $Result, [System.Xml.XmlWriter] $XmlWriter)
 
     $XmlWriter.WriteAttributeString('xmlns', 'xsi', $null, 'http://www.w3.org/2001/XMLSchema-instance')
     $XmlWriter.WriteAttributeString('xsi', 'noNamespaceSchemaLocation', [Xml.Schema.XmlSchema]::InstanceNamespace , 'nunit_schema_2.5.xsd')
@@ -33,7 +33,7 @@ function Write-NUnitTestResultAttributes {
 
 function Write-NUnitTestResultChildNodes {
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '')]
-    param($Result, [System.Xml.XmlWriter] $XmlWriter)
+    param([Pester.Run] $Result, [System.Xml.XmlWriter] $XmlWriter)
 
     Write-NUnitEnvironmentInformation -Result $Result -XmlWriter $XmlWriter
     Write-NUnitCultureInformation -Result $Result -XmlWriter $XmlWriter
@@ -53,9 +53,6 @@ function Write-NUnitTestResultChildNodes {
             continue
         }
 
-        if ($container.Type -notin 'File', 'ScriptBlock') {
-            throw "Container type '$($container.Type)' is not supported."
-        }
         Write-NUnitTestSuiteElements -XmlWriter $XmlWriter -Node $container -Path $container.Name
     }
 

--- a/src/functions/TestResults.NUnit3.ps1
+++ b/src/functions/TestResults.NUnit3.ps1
@@ -230,21 +230,12 @@ function Get-NUnit3TestSuiteInfo {
     }
 
     if ($TestSuite -is [Pester.Container]) {
-        switch ($TestSuite.Type) {
-            'File' {
-                $name = $TestSuite.Item.Name
-                $fullname = $TestSuite.Item.FullName
-                break
-            }
-            'ScriptBlock' {
-                $name = $TestSuite.Item.Id.Guid
-                $fullname = "<ScriptBlock>$($TestSuite.Item.File):$($TestSuite.Item.StartPosition.StartLine)"
-                break
-            }
-            default {
-                throw "Container type '$($TestSuite.Type)' is not supported."
-            }
+        $name = switch ($TestSuite.Type) {
+            'File' { $TestSuite.Item.Name; break }
+            'ScriptBlock' { $TestSuite.Item.Id.Guid; break }
+            default { throw "Container type '$($TestSuite.Type)' is not supported." }
         }
+        $fullname = $TestSuite.Name
         $classname = ''
     }
     else {

--- a/src/functions/TestResults.NUnit3.ps1
+++ b/src/functions/TestResults.NUnit3.ps1
@@ -19,13 +19,8 @@ function Write-NUnit3Report([Pester.Run] $Result, [System.Xml.XmlWriter] $XmlWri
 }
 
 function Write-NUnit3TestRunAttributes {
-<<<<<<< Updated upstream
-    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '')]
-    param($Result, [System.Xml.XmlWriter] $XmlWriter)
-=======
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns','')]
     param([Pester.Run] $Result, [System.Xml.XmlWriter] $XmlWriter)
->>>>>>> Stashed changes
 
     $XmlWriter.WriteAttributeString('id', '0')
     $XmlWriter.WriteAttributeString('name', $Result.Configuration.TestResult.TestSuiteName.Value) # required attr. in schema, but not in docs or nunit-console output...

--- a/src/functions/TestResults.NUnit3.ps1
+++ b/src/functions/TestResults.NUnit3.ps1
@@ -1,6 +1,6 @@
 ﻿# NUnit3 schema docs: https://docs.nunit.org/articles/nunit/technical-notes/usage/Test-Result-XML-Format.html
 
-function Write-NUnit3Report($Result, [System.Xml.XmlWriter] $XmlWriter) {
+function Write-NUnit3Report([Pester.Run] $Result, [System.Xml.XmlWriter] $XmlWriter) {
     # Write the XML Declaration
     $XmlWriter.WriteStartDocument($false)
 
@@ -19,8 +19,13 @@ function Write-NUnit3Report($Result, [System.Xml.XmlWriter] $XmlWriter) {
 }
 
 function Write-NUnit3TestRunAttributes {
+<<<<<<< Updated upstream
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '')]
     param($Result, [System.Xml.XmlWriter] $XmlWriter)
+=======
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns','')]
+    param([Pester.Run] $Result, [System.Xml.XmlWriter] $XmlWriter)
+>>>>>>> Stashed changes
 
     $XmlWriter.WriteAttributeString('id', '0')
     $XmlWriter.WriteAttributeString('name', $Result.Configuration.TestResult.TestSuiteName.Value) # required attr. in schema, but not in docs or nunit-console output...
@@ -42,7 +47,7 @@ function Write-NUnit3TestRunAttributes {
 
 function Write-NUnit3TestRunChildNode {
     param(
-        $Result,
+        [Pester.Run] $Result,
         [System.Xml.XmlWriter] $XmlWriter
     )
 

--- a/src/functions/TestResults.NUnit3.ps1
+++ b/src/functions/TestResults.NUnit3.ps1
@@ -19,7 +19,7 @@ function Write-NUnit3Report([Pester.Run] $Result, [System.Xml.XmlWriter] $XmlWri
 }
 
 function Write-NUnit3TestRunAttributes {
-    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns','')]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '')]
     param([Pester.Run] $Result, [System.Xml.XmlWriter] $XmlWriter)
 
     $XmlWriter.WriteAttributeString('id', '0')

--- a/src/functions/TestResults.ps1
+++ b/src/functions/TestResults.ps1
@@ -20,7 +20,7 @@
 
 function Export-PesterResult {
     param (
-        $Result,
+        [Pester.Run] $Result,
         [string] $Path,
         [string] $Format
     )
@@ -85,7 +85,7 @@ function Export-NUnitReport {
     #>
     param (
         [parameter(Mandatory = $true, ValueFromPipeline = $true)]
-        $Result,
+        [Pester.Run] $Result,
 
         [parameter(Mandatory = $true)]
         [String] $Path,
@@ -135,7 +135,7 @@ function Export-JUnitReport {
     #>
     param (
         [parameter(Mandatory = $true, ValueFromPipeline = $true)]
-        $Result,
+        [Pester.Run] $Result,
 
         [parameter(Mandatory = $true)]
         [String] $Path
@@ -147,7 +147,7 @@ function Export-JUnitReport {
 function Export-XmlReport {
     param (
         [parameter(Mandatory = $true, ValueFromPipeline = $true)]
-        $Result,
+        [Pester.Run] $Result,
 
         [parameter(Mandatory = $true)]
         [String] $Path,
@@ -272,7 +272,7 @@ function ConvertTo-NUnitReport {
     #>
     param (
         [parameter(Mandatory = $true, ValueFromPipeline = $true)]
-        $Result,
+        [Pester.Run] $Result,
         [Switch] $AsString,
 
         [ValidateSet('NUnit2.5', 'NUnit3')]
@@ -362,7 +362,7 @@ function ConvertTo-JUnitReport {
     #>
     param (
         [parameter(Mandatory = $true, ValueFromPipeline = $true)]
-        $Result,
+        [Pester.Run] $Result,
         [Switch] $AsString
     )
 

--- a/tst/Pester.RSpec.TestResults.JUnit4.ts.ps1
+++ b/tst/Pester.RSpec.TestResults.JUnit4.ts.ps1
@@ -16,7 +16,7 @@ $global:PesterPreference = @{
 }
 
 function Get-ScriptBlockName ($ScriptBlock) {
-    "<ScriptBlock>$($ScriptBlock.File):$($ScriptBlock.StartPosition.StartLine)"
+    "<ScriptBlock>:$($ScriptBlock.File):$($ScriptBlock.StartPosition.StartLine)"
 }
 
 $schemaPath = (Get-Module -Name Pester).Path | Split-Path | Join-Path -ChildPath 'schemas/JUnit4/junit_schema_4.xsd'


### PR DESCRIPTION
## PR Summary
This PR adds a `Name`-property to Container-objects to standardize naming currently set in multiple places.

There was two variations in the codebase when container type was `File`:
- `$Item.ToString()` which is FullName in PS7, but Name in Windows PowerShell
- `$Item.FullName`

**After PR:** Prefer `FullName` if `FileInfo`-object for consistency, else `ToString()`.

There was two variations in the codebase when the scriptblock was linked to a file:
- `<ScriptBlock>file:line`
- `<ScriptBlock>:file:line`

**After PR:** `<ScriptBlock>:file:line`

PR also moves container type validation to property setter to avoid checking in multiple places.

## PR Checklist

- [x] PR has meaningful title
- [x] Summary describes changes
- [x] PR is ready to be merged
  - If not, use the arrow next to `Create Pull Request` to mark it as a draft. PR can be marked `Ready for review` when it's ready.
- [x] Tests are added/update *(if required)*
- [ ] Documentation is updated/added *(if required)*