### PR TITLE
Feature Request: Expected, Actual, and Because as Test Property Fields

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -22,5 +22,6 @@
       "systemId": "https://raw.githubusercontent.com/PowerShell/PowerShell/master/src/Schemas/Types.xsd",
       "pattern": "**/*.Types.ps1xml"
     }
-  ]
+  ],
+  "dotnet.defaultSolution": "src/csharp/Pester.sln"
 }

--- a/src/Pester.Runtime.ps1
+++ b/src/Pester.Runtime.ps1
@@ -693,6 +693,9 @@ function Invoke-TestItem {
                     $Test.Passed = $result.Success
                 }
 
+                $Test.ExpectedValue = $result.ErrorRecord.TargetObject.ExpectedValue
+                $Test.ActualValue = $result.ErrorRecord.TargetObject.ActualValue
+                $Test.BecauseValue = $result.ErrorRecord.TargetObject.BecauseValue
                 $Test.StandardOutput = $result.StandardOutput
                 $Test.ErrorRecord.AddRange($result.ErrorRecord)
             }

--- a/src/csharp/Pester/Factory.cs
+++ b/src/csharp/Pester/Factory.cs
@@ -34,12 +34,12 @@ namespace Pester
             return new List<object>();
         }
 
-        public static ErrorRecord CreateShouldErrorRecord(string message, string file, string line, string lineText, bool terminating)
+        public static ErrorRecord CreateShouldErrorRecord(string message, string file, string line, string lineText, bool terminating, string expectedValue = null, string actualValue = null, string becauseValue = null)
         {
-            return CreateErrorRecord("PesterAssertionFailed", message, file, line, lineText, terminating);
+            return CreateErrorRecord("PesterAssertionFailed", message, file, line, lineText, terminating, expectedValue, actualValue);
         }
 
-        public static ErrorRecord CreateErrorRecord(string errorId, string message, string file, string line, string lineText, bool terminating)
+        public static ErrorRecord CreateErrorRecord(string errorId, string message, string file, string line, string lineText, bool terminating, string expectedValue = null, string actualValue = null, string becauseValue = null)
         {
             var exception = new Exception(message);
             // we use ErrorRecord.TargetObject to pass structured information about the error to a reporting system.
@@ -50,6 +50,9 @@ namespace Pester
                 ["Line"] = line,
                 ["LineText"] = lineText,
                 ["Terminating"] = terminating,
+                ["ExpectedValue"] = expectedValue,
+                ["ActualValue"] = actualValue,
+                ["BecauseValue"] = becauseValue,
             };
             return new ErrorRecord(exception, errorId, ErrorCategory.InvalidResult, targetObject);
         }

--- a/src/csharp/Pester/Test.cs
+++ b/src/csharp/Pester/Test.cs
@@ -36,6 +36,9 @@ namespace Pester
         public string ExpandedPath { get; set; }
 
         public string Result { get; set; }
+        public string ExpectedValue { get; set; }
+        public string ActualValue { get; set; }
+        public string BecauseValue { get; set; }
         public List<object> ErrorRecord { get; set; }
         public object StandardOutput { get; set; }
         public TimeSpan Duration { get => UserDuration + FrameworkDuration; }

--- a/src/functions/Output.ps1
+++ b/src/functions/Output.ps1
@@ -287,6 +287,10 @@ function ConvertTo-PesterResult {
                 }
             }
         }
+
+        $testResult.ExpectedValue = $details.ExpectedValue
+        $testResult.ActualValue = $details.ActualValue
+        $testResult.BecauseValue = $details.BecauseValue
     }
     else {
         $failureMessage = $ErrorRecord.ToString()

--- a/src/functions/assertions/Be.ps1
+++ b/src/functions/assertions/Be.ps1
@@ -38,6 +38,8 @@ function Should-Be ($ActualValue, $ExpectedValue, [switch] $Negate, [string] $Be
     return [PSCustomObject] @{
         Succeeded      = $succeeded
         FailureMessage = $failureMessage
+        ActualValue    = Format-Nicely $ActualValue
+        ExpectedValue  = Format-Nicely $ExpectedValue
     }
 }
 
@@ -111,6 +113,8 @@ function Should-BeExactly($ActualValue, $ExpectedValue, $Because) {
     return [PSCustomObject] @{
         Succeeded      = $succeeded
         FailureMessage = $failureMessage
+        ActualValue    = Format-Nicely $ActualValue
+        ExpectedValue  = Format-Nicely $ExpectedValue
     }
 }
 

--- a/src/functions/assertions/BeGreaterThan.ps1
+++ b/src/functions/assertions/BeGreaterThan.ps1
@@ -17,6 +17,9 @@
         return [PSCustomObject] @{
             Succeeded      = $false
             FailureMessage = "Expected the actual value to be greater than $(Format-Nicely $ExpectedValue),$(Format-Because $Because) but got $(Format-Nicely $ActualValue)."
+            ActualValue    = Format-Nicely $ActualValue
+            ExpectedValue  = Format-Nicely $ExpectedValue
+            BecauseValue  = $Because
         }
     }
 
@@ -50,6 +53,9 @@ function Should-BeLessOrEqual($ActualValue, $ExpectedValue, [switch] $Negate, [s
         return [PSCustomObject] @{
             Succeeded      = $false
             FailureMessage = "Expected the actual value to be less than or equal to $(Format-Nicely $ExpectedValue),$(Format-Because $Because) but got $(Format-Nicely $ActualValue)."
+            ActualValue          = Format-Nicely $ActualValue
+            ExpectedValue        = Format-Nicely $ExpectedValue
+            BecauseValue         = $Because
         }
     }
 

--- a/src/functions/assertions/BeIn.ps1
+++ b/src/functions/assertions/BeIn.ps1
@@ -19,12 +19,18 @@
             return [PSCustomObject] @{
                 Succeeded      = $false
                 FailureMessage = "Expected collection $(Format-Nicely $ExpectedValue) to not contain $(Format-Nicely $ActualValue),$(Format-Because $Because) but it was found."
+                ActualValue    = Format-Nicely $ActualValue
+                ExpectedValue  = Format-Nicely $ExpectedValue
+                BecauseValue   = $Because
             }
         }
         else {
             return [PSCustomObject] @{
                 Succeeded      = $false
                 FailureMessage = "Expected collection $(Format-Nicely $ExpectedValue) to contain $(Format-Nicely $ActualValue),$(Format-Because $Because) but it was not found."
+                ActualValue    = Format-Nicely $ActualValue
+                ExpectedValue  = Format-Nicely $ExpectedValue
+                BecauseValue   = $Because
             }
         }
     }

--- a/src/functions/assertions/BeLessThan.ps1
+++ b/src/functions/assertions/BeLessThan.ps1
@@ -17,7 +17,10 @@
         return [PSCustomObject] @{
             Succeeded      = $false
             FailureMessage = "Expected the actual value to be less than $(Format-Nicely $ExpectedValue),$(Format-Because $Because) but got $(Format-Nicely $ActualValue)."
-        }
+            ActualValue    = Format-Nicely $ActualValue
+            ExpectedValue  = Format-Nicely $ExpectedValue
+            BecauseValue   = $Because
+          }
     }
 
     return [PSCustomObject] @{
@@ -50,6 +53,9 @@ function Should-BeGreaterOrEqual($ActualValue, $ExpectedValue, [switch] $Negate,
         return [PSCustomObject] @{
             Succeeded      = $false
             FailureMessage = "Expected the actual value to be greater than or equal to $(Format-Nicely $ExpectedValue),$(Format-Because $Because) but got $(Format-Nicely $ActualValue)."
+            ActualValue    = Format-Nicely $ActualValue
+            ExpectedValue  = Format-Nicely $ExpectedValue
+            BecauseValue   = $Because
         }
     }
 

--- a/src/functions/assertions/BeLike.ps1
+++ b/src/functions/assertions/BeLike.ps1
@@ -27,13 +27,19 @@
             return [PSCustomObject] @{
                 Succeeded      = $false
                 FailureMessage = "Expected like wildcard $(Format-Nicely $ExpectedValue) to not match $(Format-Nicely $ActualValue),$(Format-Because $Because) but it did match."
-            }
+                ActualValue    = Format-Nicely $ActualValue
+                ExpectedValue  = Format-Nicely $ExpectedValue
+                BecauseValue   = $Because
+              }
         }
         else {
             return [PSCustomObject] @{
                 Succeeded      = $false
                 FailureMessage = "Expected like wildcard $(Format-Nicely $ExpectedValue) to match $(Format-Nicely $ActualValue),$(Format-Because $Because) but it did not match."
-            }
+                ActualValue    = Format-Nicely $ActualValue
+                ExpectedValue  = Format-Nicely $ExpectedValue
+                BecauseValue   = $Because
+              }
         }
     }
 

--- a/src/functions/assertions/BeLikeExactly.ps1
+++ b/src/functions/assertions/BeLikeExactly.ps1
@@ -26,13 +26,19 @@
             return [PSCustomObject] @{
                 Succeeded      = $false
                 FailureMessage = "Expected case sensitive like wildcard $(Format-Nicely $ExpectedValue) to not match $(Format-Nicely $ActualValue),$(Format-Because $Because) but it did match."
+                ActualValue    = Format-Nicely $ActualValue
+                ExpectedValue  = Format-Nicely $ExpectedValue
+                BecauseValue   = $Because
             }
         }
         else {
             return [PSCustomObject] @{
                 Succeeded      = $false
                 FailureMessage = "Expected case sensitive like wildcard $(Format-Nicely $ExpectedValue) to match $(Format-Nicely $ActualValue),$(Format-Because $Because) but it did not match."
-            }
+                ActualValue    = Format-Nicely $ActualValue
+                ExpectedValue  = Format-Nicely $ExpectedValue
+                BecauseValue   = $Because
+              }
         }
     }
 

--- a/src/functions/assertions/BeNullOrEmpty.ps1
+++ b/src/functions/assertions/BeNullOrEmpty.ps1
@@ -61,6 +61,9 @@ function Should-BeNullOrEmpty($ActualValue, [switch] $Negate, [string] $Because)
     return [PSCustomObject] @{
         Succeeded      = $succeeded
         FailureMessage = $failureMessage
+        ActualValue    = Format-Nicely $ActualValue
+        ExpectedValue  = if ($Negate) { '$null or empty' } else { 'a value' }
+        BecauseValue   = $Because
     }
 }
 

--- a/src/functions/assertions/BeOfType.ps1
+++ b/src/functions/assertions/BeOfType.ps1
@@ -63,6 +63,9 @@ function Should-BeOfType($ActualValue, $ExpectedType, [switch] $Negate, [string]
     return [PSCustomObject] @{
         Succeeded      = $succeded
         FailureMessage = $failureMessage
+        ActualValue    = Format-Nicely $ActualValue
+        ExpectedValue  = if ($Negate) { "not $(Format-Nicely $ExpectedType) or any of its subtypes" } else { "a $(Format-Nicely $ExpectedType) or any of its subtypes" }
+        BecauseValue   = $Because
     }
 }
 

--- a/src/functions/assertions/BeTrueOrFalse.ps1
+++ b/src/functions/assertions/BeTrueOrFalse.ps1
@@ -28,6 +28,9 @@
         return [PSCustomObject] @{
             Succeeded      = $false
             FailureMessage = $failureMessage
+            ActualValue    = Format-Nicely $ActualValue
+            ExpectedValue  = $true
+            BecauseValue   = $Because
         }
     }
 
@@ -66,6 +69,8 @@ function Should-BeFalse($ActualValue, [switch] $Negate, $Because) {
         return [PSCustomObject] @{
             Succeeded      = $false
             FailureMessage = $failureMessage
+            ActualValue    = Format-Nicely $ActualValue
+            ExpectedValue  = $false
         }
     }
 

--- a/src/functions/assertions/Contain.ps1
+++ b/src/functions/assertions/Contain.ps1
@@ -19,12 +19,18 @@
             return [PSCustomObject] @{
                 Succeeded      = $false
                 FailureMessage = "Expected $(Format-Nicely $ExpectedValue) to not be found in collection $(Format-Nicely $ActualValue),$(Format-Because $Because) but it was found."
+                ActualValue    = Format-Nicely $ActualValue
+                ExpectedValue  = Format-Nicely $ExpectedValue
+                BecauseValue   = $Because
             }
         }
         else {
             return [PSCustomObject] @{
                 Succeeded      = $false
                 FailureMessage = "Expected $(Format-Nicely $ExpectedValue) to be found in collection $(Format-Nicely $ActualValue),$(Format-Because $Because) but it was not found."
+                ActualValue    = Format-Nicely $ActualValue
+                ExpectedValue  = Format-Nicely $ExpectedValue
+                BecauseValue   = $Because
             }
         }
     }

--- a/src/functions/assertions/Exist.ps1
+++ b/src/functions/assertions/Exist.ps1
@@ -32,6 +32,9 @@
     return [PSCustomObject] @{
         Succeeded      = $succeeded
         FailureMessage = $failureMessage
+        ActualValue    = Format-Nicely $ActualValue
+        ExpectedValue  = if ($Negate) { 'not exist' } else { 'exist' }
+        BecauseValue   = $Because
     }
 }
 

--- a/src/functions/assertions/FileContentMatch.ps1
+++ b/src/functions/assertions/FileContentMatch.ps1
@@ -54,6 +54,9 @@
     return [PSCustomObject] @{
         Succeeded      = $succeeded
         FailureMessage = $failureMessage
+        ActualValue    = Format-Nicely $ActualValue
+        ExpectedValue  = Format-Nicely $ExpectedContent
+        BecauseValue   = $Because
     }
 }
 

--- a/src/functions/assertions/FileContentMatchExactly.ps1
+++ b/src/functions/assertions/FileContentMatchExactly.ps1
@@ -37,6 +37,9 @@
     return [PSCustomObject] @{
         Succeeded      = $succeeded
         FailureMessage = $failureMessage
+        ActualValue    = Format-Nicely $ActualValue
+        ExpectedValue  = Format-Nicely $ExpectedContent
+        BecauseValue   = $Because
     }
 }
 

--- a/src/functions/assertions/FileContentMatchMultiline.ps1
+++ b/src/functions/assertions/FileContentMatchMultiline.ps1
@@ -46,6 +46,9 @@
     return [PSCustomObject] @{
         Succeeded      = $succeeded
         FailureMessage = $failureMessage
+        ActualValue    = Format-Nicely $ActualValue
+        ExpectedValue  = Format-Nicely $ExpectedContent
+        BecauseValue   = $Because
     }
 }
 

--- a/src/functions/assertions/FileContentMatchMultilineExactly.ps1
+++ b/src/functions/assertions/FileContentMatchMultilineExactly.ps1
@@ -63,6 +63,9 @@
     return [PSCustomObject] @{
         Succeeded      = $succeeded
         FailureMessage = $failureMessage
+        ActualValue    = Format-Nicely $ActualValue
+        ExpectedValue  = Format-Nicely $ExpectedContent
+        BecauseValue   = $Because
     }
 }
 

--- a/src/functions/assertions/HaveCount.ps1
+++ b/src/functions/assertions/HaveCount.ps1
@@ -43,6 +43,9 @@
             return [PSCustomObject] @{
                 Succeeded      = $false
                 FailureMessage = "$expect,$(Format-Because $Because) $but"
+                ActualValue    = Format-Nicely $ActualValue
+                ExpectedValue  = if ($expectingEmpty) { "a non-empty collection" } else { "a collection with size different from $(Format-Nicely $ExpectedValue)" }
+                BecauseValue   = $Because
             }
         }
         else {
@@ -61,6 +64,9 @@
             return [PSCustomObject] @{
                 Succeeded      = $false
                 FailureMessage = "$expect,$(Format-Because $Because) $but"
+                ActualValue    = Format-Nicely $ActualValue
+                ExpectedValue  = if ($expectingEmpty) { "an empty collection" } else { "a collection with size $(Format-Nicely $ExpectedValue)" }
+                BecauseValue   = $Because
             }
         }
     }

--- a/src/functions/assertions/HaveParameter.ps1
+++ b/src/functions/assertions/HaveParameter.ps1
@@ -317,6 +317,9 @@
         return [PSCustomObject] @{
             Succeeded      = $false
             FailureMessage = $failureMessage
+            ActualValue    = Format-Nicely $ActualValue
+            ExpectedValue  = "Parameter $($ActualValue.Name)$filter"
+            BecauseValue   = $Because
         }
     }
     else {

--- a/src/functions/assertions/Match.ps1
+++ b/src/functions/assertions/Match.ps1
@@ -43,6 +43,9 @@
     return [PSCustomObject] @{
         Succeeded      = $succeeded
         FailureMessage = $failureMessage
+        ActualValue    = Format-Nicely $ActualValue
+        ExpectedValue  = Format-Nicely $RegularExpression
+        BecauseValue   = $Because
     }
 }
 

--- a/src/functions/assertions/MatchExactly.ps1
+++ b/src/functions/assertions/MatchExactly.ps1
@@ -36,6 +36,9 @@
     return [PSCustomObject] @{
         Succeeded      = $succeeded
         FailureMessage = $failureMessage
+        ActualValue    = Format-Nicely $ActualValue
+        ExpectedValue  = Format-Nicely $RegularExpression
+        BecauseValue   = $Because
     }
 }
 

--- a/src/functions/assertions/PesterThrow.ps1
+++ b/src/functions/assertions/PesterThrow.ps1
@@ -127,6 +127,9 @@
         return [PSCustomObject] @{
             Succeeded      = $false
             FailureMessage = $failureMessage
+            ActualValue    = Format-Nicely $actualExceptionMessage
+            ExpectedValue  = if ($filterOnExceptionType) { "type $(Format-Nicely $ExceptionType)" } else { "any exception" }
+            BecauseValue   = $Because
         }
     }
 

--- a/src/functions/assertions/Should.ps1
+++ b/src/functions/assertions/Should.ps1
@@ -258,8 +258,7 @@ function Invoke-Assertion {
     $testResult = & $AssertionEntry.Test -ActualValue $ValueToTest -Negate:$Negate -CallerSessionState $CallerSessionState @BoundParameters
 
     if (-not $testResult.Succeeded) {
-        $errorRecord = [Pester.Factory]::CreateShouldErrorRecord($testResult.FailureMessage, $file, $lineNumber, $lineText, $shouldThrow)
-
+        $errorRecord = [Pester.Factory]::CreateShouldErrorRecord($testResult.FailureMessage, $file, $lineNumber, $lineText, $shouldThrow, $testResult.ExpectedValue, $testResult.ActualValue, $testResult.BecauseValue)
 
         if ($null -eq $AddErrorCallback -or $ShouldThrow) {
             # throw this error to fail the test immediately


### PR DESCRIPTION
Fixes #1993

<!-- Thank you for contributing to Pester! -->

## PR Summary
<!-- Please describe what your pull request fixes, or how it improves Pester.

If your pull request resolves a reported issue, please mention it by using `Fix #<issue_number>` on a new line, this will close the linked issue automatically when this PR is merged. For more info see: [Closing issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/).

If your pull request integrates Pester with another system, please tell us how the change can be tested. -->


## PR Checklist

- [ ] PR has meaningful title
- [ ] Summary describes changes
- [ ] PR is ready to be merged
  - If not, use the arrow next to `Create Pull Request` to mark it as a draft. PR can be marked `Ready for review` when it's ready.
- [ ] Tests are added/update *(if required)*
- [ ] Documentation is updated/added *(if required)*

<!-- Before you continue, please review [Contributing to Pester](https://pester.dev/docs/contributing/introduction).

Our continuous integration system doesn't send any notifications about failed tests. Please return to the opened pull request (after ~60 minutes) to check if everything is OK. -->
