### PR TITLE
Set-ItResult: Return distinctive ErrorId depending on switch used

### DIFF
--- a/src/Pester.Runtime.ps1
+++ b/src/Pester.Runtime.ps1
@@ -680,7 +680,7 @@ function Invoke-TestItem {
 
                 $Test.FrameworkData.Runtime.ExecutionStep = 'Finished'
 
-                if ($Result.ErrorRecord.FullyQualifiedErrorId -eq 'PesterTestSkipped') {
+                if (@('PesterTestSkipped', 'PesterTestInconclusive', 'PesterTestPending') -contains $Result.ErrorRecord.FullyQualifiedErrorId) {
                     #Same logic as when setting a test block to skip
                     if ($PesterPreference.Debug.WriteDebugMessages.Value) {
                         $path = $Test.Path -join '.'

--- a/src/functions/Output.ps1
+++ b/src/functions/Output.ps1
@@ -753,7 +753,7 @@ function Get-WriteScreenPlugin ($Verbosity) {
             $margin = $ReportStrings.Margin * ($level)
             $error_margin = $margin + $ReportStrings.Margin
             $out = $_test.ExpandedName
-            if (-not $_test.Skip -and $_test.ErrorRecord.FullyQualifiedErrorId -eq 'PesterTestSkipped') {
+            if (-not $_test.Skip -and @('PesterTestSkipped', 'PesterTestInconclusive', 'PesterTestPending') -contains $Result.ErrorRecord.FullyQualifiedErrorId) {
                 $skippedMessage = [String]$_Test.ErrorRecord
                 [String]$out += " $skippedMessage"
             }

--- a/src/functions/Set-ItResult.ps1
+++ b/src/functions/Set-ItResult.ps1
@@ -78,8 +78,20 @@
         }
     }
 
+    switch ($result) {
+        'Inconclusive' {
+            [String]$errorId = 'PesterTestInconclusive'
+        }
+        'Pending' {
+            [String]$errorId = 'PesterTestPending'
+        }
+        'Skipped' {
+            [String]$errorId = 'PesterTestSkipped'
+        }
+    }
+
     throw [Pester.Factory]::CreateErrorRecord(
-        'PesterTestSkipped', #string errorId
+        $errorId, #string errorId
         $Message, #string message
         $File, #string file
         $Line, #string line

--- a/tst/functions/Set-ItResult.Tests.ps1
+++ b/tst/functions/Set-ItResult.Tests.ps1
@@ -1,10 +1,5 @@
 ﻿Set-StrictMode -Version Latest
 
-#TODO: skipped pending and inconclusive test results are not implemented yet
-return
-
-
-
 Describe "Testing Set-ItResult" {
     It "This test should be inconclusive" {
         try {


### PR DESCRIPTION
<!-- Thank you for contributing to Pester! -->

## PR Summary
<!-- Please describe what your pull request fixes, or how it improves Pester.

If your pull request resolves a reported issue, please mention it by using `Fix #<issue_number>` on a new line, this will close the linked issue automatically when this PR is merged. For more info see: [Closing issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/).

If your pull request integrates Pester with another system, please tell us how the change can be tested. -->

- Set-ItResult updated to return distinctive ErrorId depending on switch used (previously always returned `PesterTestSkipped`).
  - `-Inconclusive` now returns `PesterTestInconclusive`
  - `-Pending` now returns `PesterTestPending`
  - `Skipped` still returns `PesterTestSkipped`
- Invoke-TestItem in Pester.Runtime updated to handle additional ErrorId´s.
- Existing Set-ItResult Pester tests re-enabled.

I am not sure if these changes require additional tests and/or documentation updates - let me know if they do.

Related to issue #2400.

## PR Checklist

- [x] PR has meaningful title
- [x] Summary describes changes
- [x] PR is ready to be merged
  - If not, use the arrow next to `Create Pull Request` to mark it as a draft. PR can be marked `Ready for review` when it's ready.
- [ ] Tests are added/update *(if required)*
- [ ] Documentation is updated/added *(if required)*

<!-- Before you continue, please review [Contributing to Pester](https://pester.dev/docs/contributing/introduction).

Our continuous integration system doesn't send any notifications about failed tests. Please return to the opened pull request (after ~60 minutes) to check if everything is OK. -->
