### PR TITLE
Allow using 'RootModule/NestedModule' as ModuleName

### DIFF
--- a/src/functions/InModuleScope.ps1
+++ b/src/functions/InModuleScope.ps1
@@ -176,7 +176,12 @@ function Get-CompatibleModule {
         if ($PesterPreference.Debug.WriteDebugMessages.Value) {
             Write-PesterDebugMessage -Scope Runtime "Searching for a module $ModuleName."
         }
-        $modules = @(& $SafeCommands['Get-Module'] -Name $ModuleName -All -ErrorAction Stop)
+        if ($ModuleName -match '(?<RootModule>\w+)[/\\](?<NestedModule>\w+)') {
+            $modules = @(& $SafeCommands['Get-Module'] -Name $Matches['RootModule'] -All -ErrorAction Stop | & $SafeCommands['Select-Object'] -ExpandProperty NestedModules | & $SafeCommands['Where-Object'] { $_.Name -eq $Matches['NestedModule'] })
+        }
+        else {
+            $modules = @(& $SafeCommands['Get-Module'] -Name $ModuleName -All -ErrorAction Stop)
+        }
     }
     catch {
         throw "No modules named '$ModuleName' are currently loaded."


### PR DESCRIPTION
<!-- Thank you for contributing to Pester! -->

## PR Summary

Updated function `Get-CompatibleModule` to allow specifying a module name as `RootModule/NestedModule`. This change solves an issue where multiple modules with a similarly named nested module cause an exception `Multiple script or manifest modules named...` to be thrown when attempting to create a mock in a nested module.

## PR Checklist

- [X] PR has meaningful title
- [X] Summary describes changes
- [X] PR is ready to be merged
  - If not, use the arrow next to `Create Pull Request` to mark it as a draft. PR can be marked `Ready for review` when it's ready.
- [X] Tests are added/update *(if required)*
- [ ] Documentation is updated/added *(if required)*

<!-- Before you continue, please review [Contributing to Pester](https://pester.dev/docs/contributing/introduction).

Our continuous integration system doesn't send any notifications about failed tests. Please return to the opened pull request (after ~60 minutes) to check if everything is OK. -->
