### PR TITLE
Add missing help for -Skip in Context and Describe

### DIFF
--- a/src/functions/Context.ps1
+++ b/src/functions/Context.ps1
@@ -22,6 +22,10 @@
     Script that is executed. This may include setup specific to the context
     and one or more It blocks that validate the expected outcomes.
 
+    .PARAMETER Skip
+    Use this parameter to explicitly mark the block to be skipped. This is preferable to temporarily
+    commenting out a block, because it remains listed in the output.
+
     .PARAMETER ForEach
     Allows data driven tests to be written.
     Takes an array of data and generates one block for each item in the array, and makes the item

--- a/src/functions/Describe.ps1
+++ b/src/functions/Describe.ps1
@@ -24,6 +24,10 @@
     it is possible to specify a -Tag parameter which will only execute Describe blocks
     containing the same Tag.
 
+    .PARAMETER Skip
+    Use this parameter to explicitly mark the block to be skipped. This is preferable to temporarily
+    commenting out a block, because it remains listed in the output.
+
     .PARAMETER ForEach
     Allows data driven tests to be written.
     Takes an array of data and generates one block for each item in the array, and makes the item

--- a/src/functions/It.ps1
+++ b/src/functions/It.ps1
@@ -35,8 +35,7 @@
 
     .PARAMETER Skip
     Use this parameter to explicitly mark the test to be skipped. This is preferable to temporarily
-    commenting out a test, because the test remains listed in the output. Use the Strict parameter
-    of Invoke-Pester to force all skipped tests to fail.
+    commenting out a test, because the test remains listed in the output.
 
     .PARAMETER ForEach
     (Formerly called TestCases.) Optional array of hashtable (or any IDictionary) objects.


### PR DESCRIPTION
## PR Summary
`-Skip` was missing help in `Context` and `Describe` functions. False positive due to commented `-Focus` switch in the parameter-block.

## PR Checklist

- [x] PR has meaningful title
- [x] Summary describes changes
- [x] PR is ready to be merged
  - If not, use the arrow next to `Create Pull Request` to mark it as a draft. PR can be marked `Ready for review` when it's ready.
- [ ] Tests are added/update *(if required)*
- [x] Documentation is updated/added *(if required)*