### PR TITLE
Update code-analysis workflow to node20 actions

### DIFF
--- a/.github/workflows/code-analysis.yml
+++ b/.github/workflows/code-analysis.yml
@@ -18,10 +18,10 @@ jobs:
     steps:
       # Checkout the repository to the GitHub Actions runner
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: PowerShell Module Cache
-        uses: potatoqualitee/psmodulecache@v5.2
+        uses: potatoqualitee/psmodulecache@v6.2
         with:
           modules-to-cache: PSScriptAnalyzer, ConvertToSARIF:1.0.0
 
@@ -37,7 +37,7 @@ jobs:
 
       # Upload the SARIF file generated in the previous step
       - name: Upload SARIF results file
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: results.sarif
   # codeql:


### PR DESCRIPTION
## PR Summary
Code analysis workflow running PSScriptAnalyzer reports warnings due to node16 being deprecated. PR updates actions used in workflow to version running node20.

https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/

## PR Checklist

- [x] PR has meaningful title
- [x] Summary describes changes
- [x] PR is ready to be merged
  - If not, use the arrow next to `Create Pull Request` to mark it as a draft. PR can be marked `Ready for review` when it's ready.
- [ ] Tests are added/update *(if required)*
- [ ] Documentation is updated/added *(if required)*