### PR TITLE
Ignore excluded/skipped tests and unnecessary setup/teardown using SkipRemainingOnFailure

### DIFF
--- a/src/Pester.RSpec.ps1
+++ b/src/Pester.RSpec.ps1
@@ -206,7 +206,7 @@ function PostProcess-RspecTestRun ($TestRun) {
         ## decorate
 
         # here we add result
-        $b.result = if ($b.Skipped) {
+        $b.result = if ($b.Skip) {
             "Skipped"
         }
         elseif ($b.Passed) {

--- a/src/Pester.Utility.ps1
+++ b/src/Pester.Utility.ps1
@@ -334,7 +334,7 @@ function Fold-Block {
         foreach ($b in $Block) {
             $Accumulator = & $OnBlock $Block $Accumulator
             foreach ($test in $Block.Tests) {
-                $Accumulator = &$OnTest $test $Accumulator
+                $Accumulator = & $OnTest $test $Accumulator
             }
 
             foreach ($b in $Block.Blocks) {

--- a/src/functions/Get-SkipRemainingOnFailurePlugin.ps1
+++ b/src/functions/Get-SkipRemainingOnFailurePlugin.ps1
@@ -53,6 +53,7 @@ function Get-SkipRemainingOnFailurePlugin {
 
     $p.Start = {
         param ($Context)
+
         # TODO: Use $Context.GlobalPluginData.SkipRemainingOnFailure.SkippedCount when exposed in $Context
         $Context.Configuration.SkipRemainingOnFailureCount = 0
     }
@@ -61,7 +62,7 @@ function Get-SkipRemainingOnFailurePlugin {
         $p.EachTestTeardownEnd = {
             param($Context)
 
-            # If test is not marked skipped and failed
+            # If test was not skipped and failed
             if (-not $Context.Test.Skipped -and -not $Context.Test.Passed) {
                 # Skip all remaining tests in the block recursively
                 Set-RemainingAsSkipped -FailedTest $Context.Test -Block $Context.Block
@@ -73,7 +74,7 @@ function Get-SkipRemainingOnFailurePlugin {
         $p.EachTestTeardownEnd = {
             param($Context)
 
-            # If test is not marked skipped and failed
+            # If test was not skipped and failed
             if (-not $Context.Test.Skipped -and -not $Context.Test.Passed) {
                 # Skip all remaining tests in the container recursively
                 Set-RemainingAsSkipped -FailedTest $Context.Test -Block $Context.Block.Root
@@ -97,14 +98,12 @@ function Get-SkipRemainingOnFailurePlugin {
         $p.EachTestTeardownEnd = {
             param($Context)
 
-            # If test is not marked skipped and failed
+            # If test was not skipped but failed
             if (-not $Context.Test.Skipped -and -not $Context.Test.Passed) {
                 # Skip all remaining tests in current container
                 Set-RemainingAsSkipped -FailedTest $Context.Test -Block $Context.Block.Root
-            }
 
-            if (-not $Context.Test.Skipped -and -not $Context.Test.Passed) {
-                # Store hint to be used in ContainerRunStart-step to skip future containers
+                # Store failed test so we can skip remaining containers in ContainerRunStart-step
                 # TODO: Use $Context.GlobalPluginData.SkipRemainingOnFailure.FailedTest when exposed in $Context
                 $Context.Configuration.SkipRemainingFailedTest = $Context.Test
             }

--- a/src/functions/Get-SkipRemainingOnFailurePlugin.ps1
+++ b/src/functions/Get-SkipRemainingOnFailurePlugin.ps1
@@ -87,6 +87,8 @@ function Get-SkipRemainingOnFailurePlugin {
 
             # If a test failed in a previous container, skip all tests
             if ($Context.Configuration.SkipRemainingFailedTest) {
+                # Skip container root block to avoid root-level BeforeAll/AfterAll from running. Only applicable in this mode
+                $Context.Block.Root.Skip = $true
                 # Skip all remaining tests in current container
                 Set-RemainingAsSkipped -FailedTest $Context.Configuration.SkipRemainingFailedTest -Block $Context.Block
             }

--- a/tst/Pester.RSpec.ts.ps1
+++ b/tst/Pester.RSpec.ts.ps1
@@ -2657,7 +2657,7 @@ i -PassThru:$PassThru {
                 # Should not modify explicitly skipped tests
                 $r.Tests[3].Skipped | Verify-True
                 $r.Tests[3].Result | Verify-Equal 'Skipped'
-                $r.Tests[3].ErrorRecord.TargetObject.Message | Verify-Null
+                $r.Tests[3].ErrorRecord | Verify-Null
 
                 switch ($mode) {
                     'Block' { $r.PluginConfiguration.SkipRemainingOnFailureCount | Verify-Equal 1 }

--- a/tst/Pester.RSpec.ts.ps1
+++ b/tst/Pester.RSpec.ts.ps1
@@ -2668,7 +2668,7 @@ i -PassThru:$PassThru {
         }
 
         foreach ($mode in 'Block', 'Container', 'Run') {
-            t "Remaining blocks are skipped and setup/teardowns are not executed in mode '$mode'" {
+            t "Remaining blocks are skipped in mode '$mode'" {
                 $container = [ordered]@{
                     RootBeforeAll  = 0
                     RootAfterAll   = 0
@@ -2724,14 +2724,15 @@ i -PassThru:$PassThru {
                 }
 
                 $r = Invoke-Pester -Configuration $c
+                $r.Containers[0].Result | Verify-Equal 'Failed'
+                $r.Containers[0].Blocks[0].Result | Verify-Equal 'Failed'
+                $r.Containers[0].Blocks[0].Blocks[0].Result | Verify-Equal 'Skipped'
 
+                # AfterAll should always execute for current and parent blocks of the failure
+                # BeforeAll and AfterAll should not be executed for remaining children or siblings
                 switch ($mode) {
                     'Block' {
-                        $r.Containers[0].Result | Verify-Equal 'Failed'
-                        $r.Containers[0].Blocks[0].Result | Verify-Equal 'Failed'
-                        $r.Containers[0].Blocks[0].Blocks[0].Result | Verify-Equal 'Skipped'
                         $r.Containers[0].Blocks[1].Result | Verify-Equal 'Passed'
-
                         $r.Containers[1].Result | Verify-Equal 'Passed'
                         $r.Containers[1].Blocks[0].Result | Verify-Equal 'Passed'
 
@@ -2741,11 +2742,7 @@ i -PassThru:$PassThru {
                         $container.BlockAfterAll | Verify-Equal 3
                     }
                     'Container' {
-                        $r.Containers[0].Result | Verify-Equal 'Failed'
-                        $r.Containers[0].Blocks[0].Result | Verify-Equal 'Failed'
-                        $r.Containers[0].Blocks[0].Blocks[0].Result | Verify-Equal 'Skipped'
                         $r.Containers[0].Blocks[1].Result | Verify-Equal 'Skipped'
-
                         $r.Containers[1].Result | Verify-Equal 'Passed'
                         $r.Containers[1].Blocks[0].Result | Verify-Equal 'Passed'
 
@@ -2755,11 +2752,7 @@ i -PassThru:$PassThru {
                         $container.BlockAfterAll | Verify-Equal 2
                     }
                     'Run' {
-                        $r.Containers[0].Result | Verify-Equal 'Failed'
-                        $r.Containers[0].Blocks[0].Result | Verify-Equal 'Failed'
-                        $r.Containers[0].Blocks[0].Blocks[0].Result | Verify-Equal 'Skipped'
                         $r.Containers[0].Blocks[1].Result | Verify-Equal 'Skipped'
-
                         $r.Containers[1].Result | Verify-Equal 'Skipped'
                         $r.Containers[1].Blocks[0].Result | Verify-Equal 'Skipped'
 


### PR DESCRIPTION
## PR Summary

- Refactors plugin to reduce code duplication.
- Ignores tests excluded by filters or explicitly skipped using `-Skip` from being marked as skipped by `Run.SkipRemainingOnFailure` option.
- Marks relevant blocks as skipped to avoid running `BeforeAll/AfterAll`

Fix #2440
Fix #2424

## PR Checklist

- [x] PR has meaningful title
- [x] Summary describes changes
- [x] PR is ready to be merged
  - If not, use the arrow next to `Create Pull Request` to mark it as a draft. PR can be marked `Ready for review` when it's ready.
- [x] Tests are added/update *(if required)*
- [ ] Documentation is updated/added *(if required)*