### PR TITLE
Fix WildcardPatternException when using dt in P

### DIFF
--- a/tst/p.psm1
+++ b/tst/p.psm1
@@ -104,7 +104,7 @@ function t {
     )
 
     if (-not $script:discovery) {
-        if (-not $script:filter -or $script:filter -like "*$name") {
+        if (-not $script:filter -or $script:filter -like "*$([System.Management.Automation.WildcardPattern]::Escape($name))") {
             try {
                 $script:total++
                 $null = & $ScriptBlock


### PR DESCRIPTION
## PR Summary
Tests with special characters in name would fail during filter-evaluation.

Example pre-PR:
```powershell
. '/workspaces/Pester/tst/Pester.RSpec.TestResults.NUnit3.ts.ps1'
                                                                                                                        
| - Write NUnit3 test results 
WildcardPatternException: The specified wildcard character pattern is not valid: *handles special characters well -!@#$%^&*()_+1234567890[];',./"-
```

## PR Checklist

- [x] PR has meaningful title
- [x] Summary describes changes
- [x] PR is ready to be merged
  - If not, use the arrow next to `Create Pull Request` to mark it as a draft. PR can be marked `Ready for review` when it's ready.
- [ ] Tests are added/update *(if required)*
- [ ] Documentation is updated/added *(if required)*