### PR TITLE
Fix possible NRE in NUnit3 export

### DIFF
--- a/src/functions/TestResults.NUnit3.ps1
+++ b/src/functions/TestResults.NUnit3.ps1
@@ -539,7 +539,13 @@ function Write-NUnit3TestCaseAttributes {
 }
 
 function Write-NUnit3OutputElement ($Output, [System.Xml.XmlWriter] $XmlWriter) {
-    $outputString = @(foreach ($o in $Output) { $o.ToString() }) -join [System.Environment]::NewLine
+    $outputString = @(foreach ($o in $Output) {
+        if ($null -eq $o) {
+            [string]::Empty
+        } else {
+            $o.ToString()
+        }
+    }) -join [System.Environment]::NewLine
 
     $XmlWriter.WriteStartElement('output')
     $XmlWriter.WriteCData($outputString)

--- a/tst/Pester.RSpec.TestResults.NUnit3.ts.ps1
+++ b/tst/Pester.RSpec.TestResults.NUnit3.ts.ps1
@@ -425,7 +425,10 @@ i -PassThru:$PassThru {
 
             $xmlTest = $xmlDescribe.'test-case'
             $xmlTest.name | Verify-Equal 'Describe.Test'
-            $xmlTest.output.'#cdata-section' | Verify-Equal "test output$([System.Environment]::NewLine)$([System.Environment]::NewLine)123"
+            $message = $xmlTest.output.'#cdata-section' -split "`n"
+            $message[0] | Verify-Equal 'test output'
+            $message[1] | Verify-Equal ''
+            $message[2] | Verify-Equal '123'
         }
 
         t 'should add site-attribute to identity failure location' {

--- a/tst/Pester.RSpec.TestResults.NUnit3.ts.ps1
+++ b/tst/Pester.RSpec.TestResults.NUnit3.ts.ps1
@@ -409,6 +409,8 @@ i -PassThru:$PassThru {
                     }
                     It 'Test' {
                         'test output'
+                        $null # Should not throw but leave blank line
+                        123
                         $true | Should -Be $true
                     }
                 }
@@ -423,7 +425,7 @@ i -PassThru:$PassThru {
 
             $xmlTest = $xmlDescribe.'test-case'
             $xmlTest.name | Verify-Equal 'Describe.Test'
-            $xmlTest.output.'#cdata-section' | Verify-Equal 'test output'
+            $xmlTest.output.'#cdata-section' | Verify-Equal "test output$([System.Environment]::NewLine)$([System.Environment]::NewLine)123"
         }
 
         t 'should add site-attribute to identity failure location' {


### PR DESCRIPTION
## PR Summary
Handles null-objects when exporting `StandardOutput` to NUnit3 output-element.

Fix #2421

## PR Checklist

- [x] PR has meaningful title
- [x] Summary describes changes
- [x] PR is ready to be merged
  - If not, use the arrow next to `Create Pull Request` to mark it as a draft. PR can be marked `Ready for review` when it's ready.
- [x] Tests are added/update *(if required)*
- [ ] Documentation is updated/added *(if required)*