### PR TITLE
Remove Should legacy syntax error

### DIFF
--- a/publish/release.ps1
+++ b/publish/release.ps1
@@ -4,7 +4,7 @@ param (
     [String] $PsGalleryApiKey,
     [String] $NugetApiKey,
     [String] $ChocolateyApiKey,
-    [String] $CertificateThumbprint = 'c7b0582906e5205b8399d92991694a614d0c0b22',
+    [String] $CertificateThumbprint = '2FCC9148EC2C9AB951C6F9654C0D2ED16AF27738',
     [Switch] $Force
 )
 

--- a/src/functions/assertions/Should.ps1
+++ b/src/functions/assertions/Should.ps1
@@ -99,20 +99,7 @@ function Should {
     )
 
     dynamicparam {
-        # Figuring out if we are using the old syntax is 'easy'
-        # we can use $myInvocation.Line to get the surrounding context
-        $myLine = if ($null -ne $MyInvocation -and 0 -le ($MyInvocation.OffsetInLine - 1)) {
-            $MyInvocation.Line.Substring($MyInvocation.OffsetInLine - 1)
-        }
-
-        # A bit of Regex lets us know if the line used the old form
-        if ($myLine -match '^\s{0,}should\s{1,}(?<Operator>[^\-\@\s]+)') {
-            $shouldErrorMsg = "Legacy Should syntax (without dashes) is not supported in Pester 5. Please refer to migration guide at: https://pester.dev/docs/migrations/v3-to-v4"
-            throw $shouldErrorMsg
-        }
-        else {
-            Get-AssertionDynamicParams
-        }
+        Get-AssertionDynamicParams
     }
 
     begin {

--- a/tst/Pester.RSpec.ts.ps1
+++ b/tst/Pester.RSpec.ts.ps1
@@ -1990,24 +1990,6 @@ i -PassThru:$PassThru {
         }
     }
 
-    b "Should with legacy syntax will throw" {
-        t "Should with legacy syntax will throw" {
-            $sb = {
-                Describe "d" {
-                    It "i" {
-                        1 | Should Be 1
-                    }
-                }
-            }
-
-            $container = New-PesterContainer -ScriptBlock $sb
-            $r = Invoke-Pester -Container $container -PassThru
-            $test = $r.Containers[0].Blocks[0].Tests[0]
-            $test.Result | Verify-Equal "Failed"
-            $test.ErrorRecord[0] -like "*Legacy Should syntax (without dashes) is not supported in Pester 5.*"
-        }
-    }
-
     b "Running Pester in Pester" {
         t "Invoke-Pester can run in Invoke-Pester" {
             $container = New-PesterContainer -ScriptBlock {


### PR DESCRIPTION
## PR Summary
Removes the custom exception thrown when calling `Should` with legacy Pester 3 syntax. The syntax is not supported and the custom error caused too many false positives.

Before:
```powershell
> 1 | Should Be 2
Should: Cannot retrieve the dynamic parameters for the cmdlet. Legacy Should syntax (without dashes) is not supported in Pester 5. Please refer to migration guide at: https://pester.dev/docs/migrations/v3-to-v4
```

After:
```powershell
> 1 | Should Be 2                               
Should: Parameter set cannot be resolved using the specified named parameters. One or more parameters issued cannot be used together or an insufficient number of parameters were provided.
```

Fix #2437
Fix #2138

> [!NOTE]
> If rollback becomes necessary, include code in #2325 to fix #2138

## PR Checklist

- [x] PR has meaningful title
- [x] Summary describes changes
- [x] PR is ready to be merged
  - If not, use the arrow next to `Create Pull Request` to mark it as a draft. PR can be marked `Ready for review` when it's ready.
- [x] Tests are added/update *(if required)*
- [ ] Documentation is updated/added *(if required)*