### PR TITLE
Skip blocks without runnable tests

### DIFF
--- a/publish/release.ps1
+++ b/publish/release.ps1
@@ -4,7 +4,7 @@ param (
     [String] $PsGalleryApiKey,
     [String] $NugetApiKey,
     [String] $ChocolateyApiKey,
-    [String] $CertificateThumbprint = 'c7b0582906e5205b8399d92991694a614d0c0b22',
+    [String] $CertificateThumbprint = '2FCC9148EC2C9AB951C6F9654C0D2ED16AF27738',
     [Switch] $Force
 )
 

--- a/src/Pester.Runtime.ps1
+++ b/src/Pester.Runtime.ps1
@@ -2188,20 +2188,22 @@ function PostProcess-DiscoveredBlock {
 
         $b.ShouldRun = $shouldRunBasedOnChildren
 
-        if (-not $b.Skip -and $shouldSkipBasedOnChildren) {
-            if ($PesterPreference.Debug.WriteDebugMessages.Value) {
-                if ($b.IsRoot) {
-                    Write-PesterDebugMessage -Scope Skip "($($b.BlockContainer)) Container will be skipped because all children are excluded or skipped."
-                } else {
-                    Write-PesterDebugMessage -Scope Skip "($($b.Path -join '.')) Block will be skipped because all children are excluded or skipped."
+        if ($b.ShouldRun) {
+            if (-not $b.Skip -and $shouldSkipBasedOnChildren) {
+                if ($PesterPreference.Debug.WriteDebugMessages.Value) {
+                    if ($b.IsRoot) {
+                        Write-PesterDebugMessage -Scope Skip "($($b.BlockContainer)) Container will be skipped because all children are excluded or skipped."
+                    } else {
+                        Write-PesterDebugMessage -Scope Skip "($($b.Path -join '.')) Block will be skipped because all children are excluded or skipped."
+                    }
                 }
+                $b.Skip = $true
+            } elseif ($b.Skip -and -not $shouldSkipBasedOnChildren) {
+                if ($PesterPreference.Debug.WriteDebugMessages.Value) {
+                    Write-PesterDebugMessage -Scope Skip "($($b.Path -join '.')) Block was marked as Skip, but one or more children should run and is not skipped, so the block will not be skipped."
+                }
+                $b.Skip = $false
             }
-            $b.Skip = $true
-        } elseif ($b.Skip -and -not $shouldSkipBasedOnChildren) {
-            if ($PesterPreference.Debug.WriteDebugMessages.Value) {
-                Write-PesterDebugMessage -Scope Skip "($($b.Path -join '.')) Block was marked as Skip, but one or more children should run and is not skipped, so the block will not be skipped."
-            }
-            $b.Skip = $false
         }
     }
 }

--- a/src/Pester.Runtime.ps1
+++ b/src/Pester.Runtime.ps1
@@ -2192,16 +2192,18 @@ function PostProcess-DiscoveredBlock {
             if (-not $b.Skip -and $shouldSkipBasedOnChildren) {
                 if ($PesterPreference.Debug.WriteDebugMessages.Value) {
                     if ($b.IsRoot) {
-                        Write-PesterDebugMessage -Scope Skip "($($b.BlockContainer)) Container will be skipped because all children are excluded or skipped."
+                        Write-PesterDebugMessage -Scope Skip "($($b.BlockContainer)) Container will be skipped because all included children are marked as skipped."
                     } else {
-                        Write-PesterDebugMessage -Scope Skip "($($b.Path -join '.')) Block will be skipped because all children are excluded or skipped."
+                        Write-PesterDebugMessage -Scope Skip "($($b.Path -join '.')) Block will be skipped because all included children are marked as skipped."
                     }
                 }
                 $b.Skip = $true
             } elseif ($b.Skip -and -not $shouldSkipBasedOnChildren) {
                 if ($PesterPreference.Debug.WriteDebugMessages.Value) {
-                    Write-PesterDebugMessage -Scope Skip "($($b.Path -join '.')) Block was marked as Skip, but one or more children should run and is not skipped, so the block will not be skipped."
+                    Write-PesterDebugMessage -Scope Skip "($($b.Path -join '.')) Block was marked as skipped, but one or more children are explicitly requested to be run, so the block itself will not be skipped."
                 }
+                # This is done to execute setup and teardown before explicitly included tests, e.g. using line filter
+                # Remaining children have already inherited block-level Skip earlier in this function as expected
                 $b.Skip = $false
             }
         }

--- a/tst/Pester.Runtime.ts.ps1
+++ b/tst/Pester.Runtime.ts.ps1
@@ -1243,7 +1243,6 @@ i -PassThru:$PassThru {
                 New-OneTimeTestTeardown -ScriptBlock { $container.OneTimeTestTeardown++ }
 
                 New-Block 'parent block' {
-                        # putting this in child block because each test setup is not supported in root block
                         New-OneTimeTestSetup -ScriptBlock { $container.OneTimeTestSetup++ }
                         New-OneTimeTestTeardown -ScriptBlock { $container.OneTimeTestTeardown++ }
 
@@ -1255,9 +1254,11 @@ i -PassThru:$PassThru {
                             'a'
                         }
 
-                        New-Test 'test2' -Skip {
-                            $container.TestRun++
-                            'a'
+                        New-Block 'inner block' -Skip {
+                            New-Test 'test2' {
+                                $container.TestRun++
+                                'a'
+                            }
                         }
                     }
                 })

--- a/tst/Pester.Runtime.ts.ps1
+++ b/tst/Pester.Runtime.ts.ps1
@@ -1229,52 +1229,48 @@ i -PassThru:$PassThru {
             $container.EachTestTeardown | Verify-Equal 0
         }
 
-        t "skipping all items in a block will skip the parent block" {
-            # this is not implemented, but is a possible feature
-            # which could be implemented together with "if any test is explicitly unskipped in child
-            # then the block should run, this will be needed for running tests explicitly by path I think
-            # it also should be taken into consideration whether or not adding a lazySkip is a good idea and how it would
-            # affect implementation of this. Right now skipping the block goes from parent down, and skipping all items in a block
-            # will not prevent the parent block setups from running
+        t 'skipping all items in a block will skip the parent block' {
+            $container = @{
+                OneTimeTestSetup    = 0
+                OneTimeTestTeardown = 0
+                EachTestSetup       = 0
+                EachTestTeardown    = 0
+                TestRun             = 0
+            }
 
-            #     $container = @{
-            #         OneTimeTestSetup = 0
-            #         OneTimeTestTeardown = 0
-            #         EachTestSetup = 0
-            #         EachTestTeardown = 0
-            #         TestRun = 0
-            #     }
+            $actual = Invoke-Test -SessionState $ExecutionContext.SessionState -BlockContainer (New-BlockContainerObject -ScriptBlock {
+                New-OneTimeTestSetup -ScriptBlock { $container.OneTimeTestSetup++ }
+                New-OneTimeTestTeardown -ScriptBlock { $container.OneTimeTestTeardown++ }
 
-            #     $actual = Invoke-Test -SessionState $ExecutionContext.SessionState -BlockContainer (New-BlockContainerObject -ScriptBlock {
-            #         New-Block "parent block" {
-            #             New-Block "parent block" {
-            #                 # putting this in child block because each test setup is not supported in root block
-            #                 New-OneTimeTestSetup -ScriptBlock { $container.OneTimeTestSetup++ }
-            #                 New-OneTimeTestTeardown -ScriptBlock { $container.OneTimeTestTeardown++ }
+                New-Block 'parent block' {
+                        # putting this in child block because each test setup is not supported in root block
+                        New-OneTimeTestSetup -ScriptBlock { $container.OneTimeTestSetup++ }
+                        New-OneTimeTestTeardown -ScriptBlock { $container.OneTimeTestTeardown++ }
 
-            #                 New-EachTestSetup -ScriptBlock { $container.EachTestSetup++ }
-            #                 New-EachTestTeardown -ScriptBlock { $container.EachTestTeardown++ }
+                        New-EachTestSetup -ScriptBlock { $container.EachTestSetup++ }
+                        New-EachTestTeardown -ScriptBlock { $container.EachTestTeardown++ }
 
-            #                 New-Test "test1" -Skip {
-            #                     $container.TestRun++
-            #                     "a"
-            #                 }
+                        New-Test 'test1' -Skip {
+                            $container.TestRun++
+                            'a'
+                        }
 
-            #                 New-Test "test2" -Skip {
-            #                     $container.TestRun++
-            #                     "a"
-            #                 }
-            #             }
-            #         }
-            #     })
+                        New-Test 'test2' -Skip {
+                            $container.TestRun++
+                            'a'
+                        }
+                    }
+                })
 
-            #     # $actual.Blocks[0].Skip | Verify-True
-            #     $actual.Blocks[0].ErrorRecord.Count | Verify-Equal 0
-            #     $container.TestRun | Verify-Equal 0
-            #     $container.OneTimeTestSetup | Verify-Equal 0
-            #     $container.OneTimeTestTeardown | Verify-Equal 0
-            #     $container.EachTestSetup | Verify-Equal 0
-            #     $container.EachTestTeardown | Verify-Equal 0
+            # Should be marked as Skip by runtime
+            $actual.Blocks[0].Skip | Verify-True
+            $actual.Blocks[0].ErrorRecord.Count | Verify-Equal 0
+
+            $container.TestRun | Verify-Equal 0
+            $container.OneTimeTestSetup | Verify-Equal 0
+            $container.OneTimeTestTeardown | Verify-Equal 0
+            $container.EachTestSetup | Verify-Equal 0
+            $container.EachTestTeardown | Verify-Equal 0
         }
     }
 


### PR DESCRIPTION
## PR Summary
Mark blocks (incl. container root) as Skip when no child tests will run. This is done to avoid running `BeforeAll/AfterAll` when it's not needed.

Fix #2439
Fix #2449

## PR Checklist

- [x] PR has meaningful title
- [x] Summary describes changes
- [x] PR is ready to be merged
  - If not, use the arrow next to `Create Pull Request` to mark it as a draft. PR can be marked `Ready for review` when it's ready.
- [x] Tests are added/update *(if required)*
- [ ] Documentation is updated/added *(if required)*