### PR TITLE
Set profiler based CodeCoverage as default

### DIFF
--- a/src/Pester.RSpec.ps1
+++ b/src/Pester.RSpec.ps1
@@ -363,10 +363,10 @@ function New-PesterConfiguration {
       CoveragePercentTarget: Target percent of code coverage that you want to achieve, default 75%.
       Default value: 75
 
-      UseBreakpoints: EXPERIMENTAL: When false, use Profiler based tracer to do CodeCoverage instead of using breakpoints.
-      Default value: $true
+      UseBreakpoints: When false, use Profiler based tracer to do CodeCoverage instead of using breakpoints.
+      Default value: $false
 
-      SingleHitBreakpoints: Remove breakpoint when it is hit.
+      SingleHitBreakpoints: Remove breakpoint when it is hit. This increases performance of breakpoint based CodeCoverage.
       Default value: $true
 
     TestResult:

--- a/src/csharp/Pester/CodeCoverageConfiguration.cs
+++ b/src/csharp/Pester/CodeCoverageConfiguration.cs
@@ -47,9 +47,9 @@ namespace Pester
             Path = new StringArrayOption("Directories or files to be used for code coverage, by default the Path(s) from general settings are used, unless overridden here.", new string[0]);
             ExcludeTests = new BoolOption("Exclude tests from code coverage. This uses the TestFilter from general configuration.", true);
             RecursePaths = new BoolOption("Will recurse through directories in the Path option.", true);
-            UseBreakpoints = new BoolOption("EXPERIMENTAL: When false, use Profiler based tracer to do CodeCoverage instead of using breakpoints.", true);
+            UseBreakpoints = new BoolOption("When false, use Profiler based tracer to do CodeCoverage instead of using breakpoints.", false);
             CoveragePercentTarget = new DecimalOption("Target percent of code coverage that you want to achieve, default 75%.", 75m);
-            SingleHitBreakpoints = new BoolOption("Remove breakpoint when it is hit.", true);
+            SingleHitBreakpoints = new BoolOption("Remove breakpoint when it is hit. This increases performance of breakpoint based CodeCoverage.", true);
         }
 
         public CodeCoverageConfiguration(IDictionary configuration) : this()

--- a/src/functions/Coverage.ps1
+++ b/src/functions/Coverage.ps1
@@ -4,7 +4,7 @@
         [object[]] $CodeCoverage,
         [ScriptBlock] $Logger,
         [bool] $UseSingleHitBreakpoints = $true,
-        [bool] $UseBreakpoints = $true
+        [bool] $UseBreakpoints = $false
     )
 
     if ($null -ne $logger) {

--- a/tst/functions/Coverage.Tests.ps1
+++ b/tst/functions/Coverage.Tests.ps1
@@ -495,7 +495,7 @@ InPesterModuleScope {
             @{ UseBreakpoints = $false; Description = "Profiler based cc" }
         ) {
             BeforeAll {
-                $breakpoints = Enter-CoverageAnalysis -CodeCoverage @{Path = $testScriptPath; Function = 'FunctionTwo' }
+                $breakpoints = Enter-CoverageAnalysis -CodeCoverage @{Path = $testScriptPath; Function = 'FunctionTwo' } -UseBreakpoints $UseBreakpoints
                 @($breakpoints).Count | Should -Be 1 -Because "it has the proper number of breakpoints defined"
 
                 if ($UseBreakpoints) {
@@ -543,7 +543,7 @@ InPesterModuleScope {
         ) {
             BeforeAll {
 
-                $breakpoints = Enter-CoverageAnalysis -CodeCoverage @{Path = $testScriptPath; Function = 'FunctionOne' }
+                $breakpoints = Enter-CoverageAnalysis -CodeCoverage @{Path = $testScriptPath; Function = 'FunctionOne' } -UseBreakpoints $UseBreakpoints
 
                 @($breakpoints).Count | Should -Be 9 -Because "it has the proper number of breakpoints defined"
 
@@ -592,7 +592,7 @@ InPesterModuleScope {
         ) {
             BeforeAll {
 
-                $breakpoints = Enter-CoverageAnalysis -CodeCoverage @{Path = $testScriptPath; StartLine = 11; EndLine = 12 }
+                $breakpoints = Enter-CoverageAnalysis -CodeCoverage @{Path = $testScriptPath; StartLine = 11; EndLine = 12 } -UseBreakpoints $UseBreakpoints
 
                 @($breakpoints).Count | Should -Be 2 -Because 'it has the proper number of breakpoints defined'
 
@@ -640,7 +640,7 @@ InPesterModuleScope {
             @{ UseBreakpoints = $false; Description = "Profiler based cc" }
         ) {
             BeforeAll {
-                $breakpoints = Enter-CoverageAnalysis -CodeCoverage @{Path = "$(Join-Path -Path $root -ChildPath *.ps1)"; Function = '*' }
+                $breakpoints = Enter-CoverageAnalysis -CodeCoverage @{Path = "$(Join-Path -Path $root -ChildPath *.ps1)"; Function = '*' } -UseBreakpoints $UseBreakpoints
 
                 @($breakpoints).Count | Should -Be 13 -Because 'it has the proper number of breakpoints defined'
 
@@ -700,7 +700,7 @@ InPesterModuleScope {
             ) {
                 BeforeAll {
 
-                    $breakpoints = Enter-CoverageAnalysis -CodeCoverage @{Path = $testScriptPath; Class = 'MyClass' }
+                    $breakpoints = Enter-CoverageAnalysis -CodeCoverage @{Path = $testScriptPath; Class = 'MyClass' } -UseBreakpoints $UseBreakpoints
 
                     @($breakpoints).Count | Should -Be 3 -Because 'it has the proper number of breakpoints defined'
 
@@ -745,7 +745,7 @@ InPesterModuleScope {
             ) {
                 BeforeAll {
 
-                    $breakpoints = Enter-CoverageAnalysis -CodeCoverage @{Path = $testScriptPath; Class = '*' }
+                    $breakpoints = Enter-CoverageAnalysis -CodeCoverage @{Path = $testScriptPath; Class = '*' } -UseBreakpoints $UseBreakpoints
 
                     @($breakpoints).Count | Should -Be 3 -Because 'it has the proper number of breakpoints defined'
 
@@ -790,12 +790,20 @@ InPesterModuleScope {
             ) {
                 BeforeAll {
 
-                    $breakpoints = Enter-CoverageAnalysis -CodeCoverage @{Path = $testScriptPath; Class = 'MyClass'; Function = 'MethodTwo' }
+                    $breakpoints = Enter-CoverageAnalysis -CodeCoverage @{Path = $testScriptPath; Class = 'MyClass'; Function = 'MethodTwo' } -UseBreakpoints $UseBreakpoints
 
                     @($breakpoints).Count | Should -Be 1 -Because 'it has the proper number of breakpoints defined'
 
-                    $null = & $testScriptPath
-                    $coverageReport = Get-CoverageReport -CommandCoverage $breakpoints
+                    if ($UseBreakpoints) {
+                        & $testScriptPath
+                    }
+                    else {
+                        $patched, $tracer = Start-TraceScript $breakpoints
+                        try { & $testScriptPath } finally { Stop-TraceScript -Patched $patched }
+                        $measure = $tracer.Hits
+                    }
+
+                    $coverageReport = Get-CoverageReport -CommandCoverage $breakpoints -Measure $measure
                 }
 
                 It 'Reports the proper number of executed commands' {
@@ -828,7 +836,7 @@ InPesterModuleScope {
             ) {
                 BeforeAll {
 
-                    $breakpoints = Enter-CoverageAnalysis -CodeCoverage @{ Path = $testScriptPath; Class = 'MyClass' }
+                    $breakpoints = Enter-CoverageAnalysis -CodeCoverage @{ Path = $testScriptPath; Class = 'MyClass' } -UseBreakpoints $UseBreakpoints
 
                     @($breakpoints).Count | Should -Be 0 -Because 'it has the proper number of breakpoints defined'
 


### PR DESCRIPTION
Remove experimental flag from Profiler based Code Coverage and use it by default because it is way more performant.
 
Fix https://github.com/pester/Pester/issues/2441
