### PR TITLE
Remove blank output in PesterThrow.Tests.ps1

### DIFF
--- a/tst/functions/assertions/PesterThrow.Tests.ps1
+++ b/tst/functions/assertions/PesterThrow.Tests.ps1
@@ -287,7 +287,6 @@ InPesterModuleScope {
         Context 'Assertion messages' {
             It 'returns the correct assertion message when an exception is thrown' {
                 $err = { { throw } | Should -Not -Throw -Because 'reason' } | Verify-AssertionFailed
-                write-host ($err.Exception.Message -replace "(.*)", '')
                 $err.Exception.Message -replace "(`r|`n)" -replace '\s+', ' ' -replace ' "ScriptHalted"', '' -replace " from.*" | Verify-Equal "Expected no exception to be thrown, because reason, but an exception was thrown"
             }
         }


### PR DESCRIPTION
## PR Summary
This has been bugging me for a while 😄 
![image](https://github.com/pester/Pester/assets/3436158/6eb54ccb-a5da-4e4f-885d-90145fe7fb60)

## PR Checklist

- [x] PR has meaningful title
- [x] Summary describes changes
- [x] PR is ready to be merged
  - If not, use the arrow next to `Create Pull Request` to mark it as a draft. PR can be marked `Ready for review` when it's ready.
- [x] Tests are added/update *(if required)*
- [ ] Documentation is updated/added *(if required)*