### PR TITLE
Hide failing output that always scares me

### DIFF
--- a/tst/functions/New-Fixture.ts.ps1
+++ b/tst/functions/New-Fixture.ts.ps1
@@ -29,7 +29,7 @@ i -PassThru:$PassThru {
             try {
                 New-Fixture -Path $tempFolder -Name $name
 
-                $r = Invoke-Pester -Path $testsPath -PassThru
+                $r = Invoke-Pester -Path $testsPath -PassThru -Output None
                 $r.Containers[0].Blocks[0].Tests[0].Result | Verify-Equal "Failed"
                 $r.Containers[0].Blocks[0].Tests[0].ErrorRecord.Exception | Verify-Type ([System.NotImplementedException])
             }


### PR DESCRIPTION
This happens really early in test.ps1, and it always scares me that tests are failing. 

![image](https://github.com/pester/Pester/assets/5735905/824ff4b9-1def-4947-bc5c-21d8544c2cbe)
