### PR TITLE
Add null check for $host.UI and its properties to avoid race condition (#2383)

### DIFF
--- a/src/functions/Output.ps1
+++ b/src/functions/Output.ps1
@@ -1127,7 +1127,8 @@ function Resolve-OutputConfiguration ([PesterConfiguration]$PesterPreference) {
             # https://no-color.org/)
             $PesterPreference.Output.RenderMode = 'Plaintext'
         }
-        elseif (($supportsVT = $host.UI.psobject.Properties['SupportsVirtualTerminal']) -and $supportsVT.Value) {
+        # Null check $host.UI and its properties to avoid race condition when accessing them from multiple threads. https://github.com/pester/Pester/issues/2383
+        elseif ($null -ne $host.UI -and ($hostProperties = $host.UI.psobject.Properties) -and ($supportsVT = $hostProperties['SupportsVirtualTerminal']) -and $supportsVT.Value) {
             $PesterPreference.Output.RenderMode = 'Ansi'
         }
         else {


### PR DESCRIPTION
<!-- Thank you for contributing to Pester! -->

## PR Summary
<!-- Please describe what your pull request fixes, or how it improves Pester.

If your pull request resolves a reported issue, please mention it by using `Fix #<issue_number>` on a new line, this will close the linked issue automatically when this PR is merged. For more info see: [Closing issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/).

If your pull request integrates Pester with another system, please tell us how the change can be tested. -->

Added null check for `$host.UI` and `$host.UI.properties` to avoid race condition in PowerShell when accessing the properties from multiple threads.

Fixes #2383.

## PR Checklist

- [x] PR has meaningful title
- [x] Summary describes changes
- [x] PR is ready to be merged
  - If not, use the arrow next to `Create Pull Request` to mark it as a draft. PR can be marked `Ready for review` when it's ready.
- [ ] Tests are added/update *(if required)*
- [ ] Documentation is updated/added *(if required)*

<!-- Before you continue, please review [Contributing to Pester](https://pester.dev/docs/contributing/introduction).

Our continuous integration system doesn't send any notifications about failed tests. Please return to the opened pull request (after ~60 minutes) to check if everything is OK. -->
