### PR TITLE
Fix NRE in mock debug log for native commands

### DIFF
--- a/src/functions/Mock.ps1
+++ b/src/functions/Mock.ps1
@@ -412,7 +412,9 @@ function Should-InvokeInternal {
 
     # Check for variables in ParameterFilter that already exists in session. Risk of conflict
     # Excluding native applications as they don't have parameters or metadata. Will always use $args
-    if ($PesterPreference.Debug.WriteDebugMessages.Value -and $null -ne $ContextInfo.Hook.Metadata) {
+    if ($PesterPreference.Debug.WriteDebugMessages.Value -and
+        $null -ne $ContextInfo.Hook.Metadata -and
+        $ContextInfo.Hook.Metadata.Parameters.Count -gt 0) {
         $preExistingFilterVariables = @{}
         foreach ($v in $filter.Ast.FindAll( { $args[0] -is [System.Management.Automation.Language.VariableExpressionAst] }, $true)) {
             if (-not $preExistingFilterVariables.ContainsKey($v.VariablePath.UserPath)) {
@@ -423,7 +425,7 @@ function Should-InvokeInternal {
         }
 
         # Check against parameters and aliases in mocked command as it may cause false positives
-        if ($preExistingFilterVariables.Count -gt 0 -and $null -ne $ContextInfo.Hook.Metadata.Parameters) {
+        if ($preExistingFilterVariables.Count -gt 0) {
             foreach ($p in $ContextInfo.Hook.Metadata.Parameters.GetEnumerator()) {
                 if ($preExistingFilterVariables.ContainsKey($p.Key)) {
                     Write-PesterDebugMessage -Scope Mock -Message "! Variable `$$($p.Key) with value '$($preExistingFilterVariables[$p.Key])' exists in current scope and matches a parameter in $CommandName which may cause false matches in ParameterFilter. Consider renaming the existing variable or use `$PesterBoundParameters.$($p.Key) in ParameterFilter."


### PR DESCRIPTION
## PR Summary
Fixes NRE using mock debug logging when `Should-Invoke` with `-ParameterFilter` is used for a mocked native application. Caused by variable conflict-logging looking for CommandMetaData which doesn't exist for external commands = N/A logging.

Fix #2479 

Backport to 5.6.0

## PR Checklist

- [x] PR has meaningful title
- [x] Summary describes changes
- [x] PR is ready to be merged
  - If not, use the arrow next to `Create Pull Request` to mark it as a draft. PR can be marked `Ready for review` when it's ready.
- [ ] Tests are added/update *(if required)*
- [ ] Documentation is updated/added *(if required)*