### PR TITLE
Replace deprecated macOS 11 image with 13 in CI

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -82,11 +82,11 @@ stages:
             PS7_Ubuntu_22_04:
               vmImage: ubuntu-22.04
               pwsh: true
-            PS7_macOS_11:
-              vmImage: macOS-11
-              pwsh: true
             PS7_macOS_12:
               vmImage: macOS-12
+              pwsh: true
+            PS7_macOS_13:
+              vmImage: macOS-13
               pwsh: true
             PS7_Windows_Server2019:
               vmImage: windows-2019


### PR DESCRIPTION
## PR Summary
MacOS 11 image is deprecated in Azure Pipeline and Github will remove it in [June 2024](https://github.blog/changelog/2024-05-20-actions-upcoming-changes-to-github-hosted-macos-runners/#macos-11-deprecation-and-removal). Github manages runners for Azure Pipelines so it'll likely be removed soon after.

Bumping to MacOS 12 + 13 as a hotfix while waiting on stable macOS 14 image.

## PR Checklist

- [x] PR has meaningful title
- [x] Summary describes changes
- [x] PR is ready to be merged
  - If not, use the arrow next to `Create Pull Request` to mark it as a draft. PR can be marked `Ready for review` when it's ready.
- [ ] Tests are added/update *(if required)*
- [ ] Documentation is updated/added *(if required)*