### PR TITLE
Fix console warnings in Should-BeEquivalent.Tests.ps1

### DIFF
--- a/src/functions/assert/Equivalence/Should-BeEquivalent.ps1
+++ b/src/functions/assert/Equivalence/Should-BeEquivalent.ps1
@@ -1,4 +1,4 @@
-﻿function Test-Same ($Expected, $Actual) {
+function Test-Same ($Expected, $Actual) {
     [object]::ReferenceEquals($Expected, $Actual)
 }
 
@@ -527,11 +527,12 @@ function Compare-Equivalent {
         $Actual,
         $Expected,
         $Path,
-        $Options = (& {
-                & $SafeCommands['Write-Warning'] "Getting default equivalency options, this should never be seen. If you see this and you are not developing Pester, please file issue at https://github.com/pester/Pester/issues"
-                Get-EquivalencyOption
-            })
+        $Options
     )
+
+    if ($null -eq $Options) {
+        throw [System.ArgumentNullException]::new('Options', 'Options must be defined and not null. If you see this and you are not developing Pester, please file issue at https://github.com/pester/Pester/issues')
+    }
 
     if ($null -ne $Options.ExludedPaths -and $Options.ExcludedPaths -contains $Path) {
         Write-EquivalenceResult -Skip "Current path '$Path' is excluded from the comparison."

--- a/src/functions/assert/Equivalence/Should-BeEquivalent.ps1
+++ b/src/functions/assert/Equivalence/Should-BeEquivalent.ps1
@@ -1,4 +1,4 @@
-function Test-Same ($Expected, $Actual) {
+﻿function Test-Same ($Expected, $Actual) {
     [object]::ReferenceEquals($Expected, $Actual)
 }
 
@@ -534,7 +534,7 @@ function Compare-Equivalent {
         throw [System.ArgumentNullException]::new('Options', 'Options must be defined and not null. If you see this and you are not developing Pester, please file issue at https://github.com/pester/Pester/issues')
     }
 
-    if ($null -ne $Options.ExludedPaths -and $Options.ExcludedPaths -contains $Path) {
+    if ($null -ne $Options.ExcludedPaths -and $Options.ExcludedPaths -contains $Path) {
         Write-EquivalenceResult -Skip "Current path '$Path' is excluded from the comparison."
         return
     }

--- a/src/functions/assert/Equivalence/Should-BeEquivalent.ps1
+++ b/src/functions/assert/Equivalence/Should-BeEquivalent.ps1
@@ -530,8 +530,8 @@ function Compare-Equivalent {
         $Options
     )
 
-    if ($null -eq $Options) {
-        throw [System.ArgumentNullException]::new('Options', 'Options must be defined and not null. If you see this and you are not developing Pester, please file issue at https://github.com/pester/Pester/issues')
+    if (-not $PSBoundParameters.ContainsKey('Options')) {
+        throw [System.ArgumentException]::new('-Options must be provided. If you see this and you are not developing Pester, please file issue at https://github.com/pester/Pester/issues','Options')
     }
 
     if ($null -ne $Options.ExcludedPaths -and $Options.ExcludedPaths -contains $Path) {

--- a/tst/functions/assert/Equivalence/Should-BeEquivalent.Tests.ps1
+++ b/tst/functions/assert/Equivalence/Should-BeEquivalent.Tests.ps1
@@ -1,4 +1,4 @@
-﻿Set-StrictMode -Version Latest
+Set-StrictMode -Version Latest
 
 InPesterModuleScope {
     BeforeDiscovery {
@@ -30,6 +30,15 @@ InPesterModuleScope {
                 }
             }
         }
+
+        # Using this to avoid warning when not providing -Options in Compare-Equivalent tests. Cleared in AfterAll
+        $defaultOptions = Get-EquivalencyOption
+        $PSDefaultParameterValues['Compare-Equivalent:Options'] = $defaultOptions
+    }
+
+    AfterAll {
+        # Remove default set in BeforeAll
+        $PSDefaultParameterValues.Remove('Compare-Equivalent:Options')
     }
 
     Describe "Test-Same" {

--- a/tst/functions/assert/Equivalence/Should-BeEquivalent.Tests.ps1
+++ b/tst/functions/assert/Equivalence/Should-BeEquivalent.Tests.ps1
@@ -1,4 +1,4 @@
-Set-StrictMode -Version Latest
+﻿Set-StrictMode -Version Latest
 
 InPesterModuleScope {
     BeforeDiscovery {
@@ -46,7 +46,7 @@ InPesterModuleScope {
             @{ Value = $null },
             @{ Value = @() },
             @{ Value = [Type] },
-            @{ Value = (New-Object -TypeName Diagnostics.Process) }
+            @{ Value = ([System.Diagnostics.Process]::new()) }
         ) {
             param($Value)
             Test-Same -Expected $Value -Actual $Value | Verify-True
@@ -54,7 +54,7 @@ InPesterModuleScope {
 
         It "Given different instances of a reference type it returns `$false" -TestCases @(
             @{ Actual = @(); Expected = @() },
-            @{ Actual = (New-Object -TypeName Diagnostics.Process) ; Expected = (New-Object -TypeName Diagnostics.Process) }
+            @{ Actual = ([System.Diagnostics.Process]::new()) ; Expected = ([System.Diagnostics.Process]::new()) }
         ) {
             param($Expected, $Actual)
             Test-Same -Expected $Expected -Actual $Actual | Verify-False
@@ -390,7 +390,7 @@ InPesterModuleScope {
 
         It "Given PSObject '<expected>' and object '<actual> that have the same values it returns `$null" -TestCases @(
             @{
-                Expected = New-Object -TypeName Assertions.TestType.Person2 -Property @{ Name = 'Jakub'; Age = 28 }
+                Expected = [Assertions.TestType.Person2]@{ Name = 'Jakub'; Age = 28 }
                 Actual   = [PSCustomObject]@{ Name = 'Jakub'; Age = 28 }
             }
         ) {
@@ -432,7 +432,7 @@ InPesterModuleScope {
 
         It "Comparing DataTable" {
             # todo: move this to it's own describe, split the tests to smaller parts, and make them use Verify-* axioms
-            $Expected = New-Object Data.DataTable 'Test'
+            $Expected = [System.Data.DataTable]::new('Test')
             $null = $Expected.Columns.Add('IDD', [System.Int32])
             $null = $Expected.Columns.Add('Name')
             $null = $Expected.Columns.Add('Junk')
@@ -440,7 +440,7 @@ InPesterModuleScope {
             $null = $Expected.Rows.Add(1, 'A', 'AAA', 5)
             $null = $Expected.Rows.Add(3, 'C', $null, $null)
 
-            $Actual = New-Object Data.DataTable 'Test'
+            $Actual = [System.Data.DataTable]::new('Test')
             $null = $Actual.Columns.Add('IDD', [System.Int32])
             $null = $Actual.Columns.Add('Name')
             $null = $Actual.Columns.Add('Junk')


### PR DESCRIPTION
## PR Summary
Removes "Getting default equivalency options" warning spam in `tests.ps1` ouptut. Fixed by providing default options by... well, default in `Should-BeEquivalent.Tests.ps1`.

_Also replaces some calls to `New-Object`_

## PR Checklist

- [x] PR has meaningful title
- [x] Summary describes changes
- [x] PR is ready to be merged
  - If not, use the arrow next to `Create Pull Request` to mark it as a draft. PR can be marked `Ready for review` when it's ready.
- [x] Tests are added/update *(if required)*
- [ ] Documentation is updated/added *(if required)*