### PR TITLE
Remove Assert-MockCalled and Assert-VerifiableMock

### DIFF
--- a/src/Module.ps1
+++ b/src/Module.ps1
@@ -127,13 +127,10 @@ $script:SafeCommands['Set-DynamicParameterVariable'] = $ExecutionContext.Session
     'ConvertTo-JUnitReport'
     'ConvertTo-Pester4Result'
 
-    # legacy
-    'Assert-VerifiableMock'
-    'Assert-MockCalled'
-    'Set-ItResult'
+    # helpers
     'New-MockObject'
-
     'New-Fixture'
+    'Set-ItResult'
 ) -Alias @(
     'Add-AssertionOperator'
     'Get-AssertionOperator'

--- a/src/Pester.psd1
+++ b/src/Pester.psd1
@@ -104,13 +104,10 @@
 
         'Get-EquivalencyOption'
 
-        # legacy
-        'Assert-VerifiableMock'
-        'Assert-MockCalled'
-        'Set-ItResult'
+        # helpers
         'New-MockObject'
-
         'New-Fixture'
+        'Set-ItResult'
     )
 
     # # Cmdlets to export from this module

--- a/src/en-US/about_Mocking.help.txt
+++ b/src/en-US/about_Mocking.help.txt
@@ -22,11 +22,11 @@ LONG DESCRIPTION
     Mocks the behavior of an existing command with an alternate
     implementation.
 
-  Assert-VerifiableMock
+  Should -InvokeVerifiable
     Checks if any Verifiable Mock has not been invoked. If so, this will
     throw an exception.
 
-  Assert-MockCalled
+  Should -Invoke
     Checks if a Mocked command has been called a certain number of times
     and throws an exception if it has not.
 
@@ -55,7 +55,7 @@ LONG DESCRIPTION
         $result = BuildIfChanged
 
         It "Builds the next version" {
-          Assert-VerifiableMock
+          Should -InvokeVerifiable
         }
         It "returns the next version number" {
           $result | Should -Be 1.2
@@ -69,7 +69,7 @@ LONG DESCRIPTION
         $result = BuildIfChanged
 
         It "Should not build the next version" {
-          Assert-MockCalled Build -Times 0 -ParameterFilter {$version -eq 1.1}
+          Should -Invoke Build -Times 0 -ParameterFilter {$version -eq 1.1}
         }
       }
     }
@@ -123,7 +123,7 @@ LONG DESCRIPTION
         $result = BuildIfChanged
 
         It "Builds the next version and calls Write-Host" {
-          Assert-VerifiableMock
+          Should -InvokeVerifiable
         }
 
         It "returns the next version number" {
@@ -139,7 +139,7 @@ LONG DESCRIPTION
         $result = BuildIfChanged
 
         It "Should not build the next version" {
-          Assert-MockCalled Build -ModuleName MyModule -Times 0 -ParameterFilter {
+          Should -Invoke Build -ModuleName MyModule -Times 0 -ParameterFilter {
             $version -eq 1.1
           }
         }
@@ -147,7 +147,7 @@ LONG DESCRIPTION
     }
 
 
-  In this sample test script, all calls to Mock and Assert-MockCalled have the
+  In this sample test script, all calls to Mock and Should -Invoke have the
   -ModuleName MyModule parameter added. This tells Pester to inject the mock into the module scope,
   which causes any calls to those commands from inside the module to execute the mock instead.
 
@@ -168,7 +168,7 @@ LONG DESCRIPTION
         Build $testVersion
 
         It 'Outputs the correct message' {
-          Assert-MockCalled Write-Host -ParameterFilter {
+          Should -Invoke Write-Host -ParameterFilter {
             $Object -eq "a build was run for version: $testVersion"
           }
         }
@@ -176,13 +176,12 @@ LONG DESCRIPTION
     }
 
   When using InModuleScope, you no longer need to specify a ModuleName parameter when calling
-  Mock or Assert-MockCalled for commands in the module. You can also directly call the Build
+  Mock or Should -Invoke for commands in the module. You can also directly call the Build
   function that the module does not export.
 
 SEE ALSO
   Mock
-  Assert-VerifiableMock
-  Assert-MockCalled
+  Should
   InModuleScope
   Describe
   Context

--- a/src/functions/Pester.SessionState.Mock.ps1
+++ b/src/functions/Pester.SessionState.Mock.ps1
@@ -606,30 +606,6 @@ function Get-MockDataForCurrentScope {
     $location.PluginData.Mock
 }
 
-function Assert-VerifiableMock {
-    <#
-    .SYNOPSIS
-    Checks if all verifiable Mocks has been called at least once.
-
-    THIS COMMAND IS OBSOLETE AND WILL BE REMOVED SOMEWHERE DURING v5 LIFETIME,
-    USE Should -InvokeVerifiable INSTEAD.
-
-    .LINK
-    https://pester.dev/docs/commands/Assert-VerifiableMock
-    #>
-
-    # Should does not accept a session state, so invoking it directly would
-    # make the assertion run from inside of Pester module, we move it to the
-    # user scope instead an run it from there to keep the scoping correct
-    # for this compatibility adapter
-    [CmdletBinding()]param()
-    $sb = {
-        Should -InvokeVerifiable
-    }
-
-    Set-ScriptBlockScope -ScriptBlock $sb -SessionState $PSCmdlet.SessionState
-    & $sb
-}
 function Should-InvokeVerifiable ([switch] $Negate, [string] $Because) {
     <#
     .SYNOPSIS
@@ -671,51 +647,6 @@ function Should-InvokeVerifiable ([switch] $Negate, [string] $Because) {
 
 Set-ShouldOperatorHelpMessage -OperatorName InvokeVerifiable `
     -HelpMessage 'Checks if any Verifiable Mock has not been invoked. If so, this will throw an exception.'
-
-function Assert-MockCalled {
-    <#
-    .SYNOPSIS
-    Checks if a Mocked command has been called a certain number of times
-    and throws an exception if it has not.
-
-    THIS COMMAND IS OBSOLETE AND WILL BE REMOVED SOMEWHERE DURING v5 LIFETIME,
-    USE Should -Invoke INSTEAD.
-
-    .LINK
-    https://pester.dev/docs/commands/Assert-MockCalled
-    #>
-    [CmdletBinding(DefaultParameterSetName = 'ParameterFilter')]
-    param(
-        [Parameter(Mandatory = $true, Position = 0)]
-        [string]$CommandName,
-
-        [Parameter(Position = 1)]
-        [int]$Times = 1,
-
-        [ScriptBlock]$ParameterFilter = { $True },
-
-        [Parameter(ParameterSetName = 'ExclusiveFilter', Mandatory = $true)]
-        [scriptblock] $ExclusiveFilter,
-
-        [string] $ModuleName,
-
-        [string] $Scope = 0,
-        [switch] $Exactly
-    )
-
-    # Should does not accept a session state, so invoking it directly would
-    # make the assertion run from inside of Pester module, we move it to the
-    # user scope instead an run it from there to keep the scoping correct
-    # for this compatibility adapter
-
-    $sb = {
-        param ($__params__p)
-        Should -Invoke @__params__p
-    }
-
-    Set-ScriptBlockScope -ScriptBlock $sb -SessionState $PSCmdlet.SessionState
-    & $sb $PSBoundParameters
-}
 
 function Should-Invoke {
     <#

--- a/tst/Help.Tests.ps1
+++ b/tst/Help.Tests.ps1
@@ -23,7 +23,8 @@ Describe "Testing module help" -Tag 'Help' -ForEach @{ exportedFunctions = $expo
             $help.Synopsis | Should -Not -Match "^\s*$($_.Name)((\s+\[+?-\w+)|$)"
         }
 
-        It 'Description is defined' {
+        # TODO: Missing on new Assert-* assertions
+        It 'Description is defined' -Skip:($_.Name -match '^Assert-') {
             # Property is missing if undefined
             $help.description | Should -Not -BeNullOrEmpty
         }

--- a/tst/Help.Tests.ps1
+++ b/tst/Help.Tests.ps1
@@ -23,8 +23,7 @@ Describe "Testing module help" -Tag 'Help' -ForEach @{ exportedFunctions = $expo
             $help.Synopsis | Should -Not -Match "^\s*$($_.Name)((\s+\[+?-\w+)|$)"
         }
 
-        # Skipping Assert-MockCalled and Assert-VerifiableMock which are deprecated and missing docs
-        It 'Description is defined' -Skip:($_.Name -match '^Assert-') {
+        It 'Description is defined' {
             # Property is missing if undefined
             $help.description | Should -Not -BeNullOrEmpty
         }
@@ -40,14 +39,12 @@ Describe "Testing module help" -Tag 'Help' -ForEach @{ exportedFunctions = $expo
             $firstUri | Should -Be "https://pester.dev/docs/commands/$helpName" -Because 'first uri-link should be to online version of this help topic'
         }
 
-        # Skipping Assert-MockCalled and Assert-VerifiableMock which are deprecated and missing docs
-        It 'Has at least one example' -Skip:($_.Name -match '^Assert-') {
+        It 'Has at least one example' {
             $help.Examples | Should -Not -BeNullOrEmpty
             $help.Examples.example | Where-Object { -not $_.Code.Trim() } | Foreach-Object { $_.title.Trim("- ") } | Should -Be @() -Because 'no examples should be empty'
         }
 
-        # Skipping Assert-MockCalled which are deprecated and missing docs
-        It 'All static parameters have description' -Skip:($_.Name -match '^Assert-MockCalled') {
+        It 'All static parameters have description' {
             $RiskMitigationParameters = 'Whatif', 'Confirm'
 
             if ($help.parameters) {
@@ -65,7 +62,7 @@ Describe "Testing module help" -Tag 'Help' -ForEach @{ exportedFunctions = $expo
     }
 
     Context 'Should operators' {
-        # Parameter help for Should -OperatorName.. Set using Set-ShouldOperatorHelpMessage
+        # Parameter help for Should -OperatorName .. . This is set using Set-ShouldOperatorHelpMessage
         It 'All built-in operators have parameter help' {
             $operatorParams = InPesterModuleScope {
                 $operators = $script:AssertionOperators.Keys

--- a/tst/Pester.Mock.ClassMetadata.ps1
+++ b/tst/Pester.Mock.ClassMetadata.ps1
@@ -21,7 +21,7 @@ Describe 'Use class with custom attribute' {
         # ValidateClassAttribute would be missing
         Mock Test-Foo
         Test-Foo
-        Assert-MockCalled Test-Foo
+        Should -Invoke Test-Foo
     }
 
     It 'should be able to run Test-Foo' {

--- a/tst/functions/Mock.Tests.ps1
+++ b/tst/functions/Mock.Tests.ps1
@@ -2997,26 +2997,6 @@ Describe "Mocks can be defined outside of BeforeAll" {
     }
 }
 
-Describe "Assert-MockCalled is available as a wrapper over Should -Invoke for backwards compatibility" {
-
-    It  "Count calls" {
-        function f () { "real" }
-        Mock f { "mock" }
-        f
-        Assert-MockCalled -CommandName f -Exactly 1
-    }
-}
-
-Describe "Assert-VerifiableMock is available as a wrapper over Should -InvokeVerifiable for backwards compatibility" {
-
-    It  "Verify calls" {
-        function f () { "real" }
-        Mock f { "mock" } -Verifiable
-        f
-        Assert-VerifiableMock
-    }
-}
-
 Describe "Debugging mocks" {
     It "Hits breakpoints in mock related scriptblocks" {
         try {


### PR DESCRIPTION
## PR Summary
Removes Assert-MockCalled and Assert-VerifiableMock legacy wrapper functions. They were deprecated and planned removed in 5.x.

## PR Checklist

- [x] PR has meaningful title
- [x] Summary describes changes
- [x] PR is ready to be merged
  - If not, use the arrow next to `Create Pull Request` to mark it as a draft. PR can be marked `Ready for review` when it's ready.
- [x] Tests are added/update *(if required)*
- [x] Documentation is updated/added *(if required)*