### PR TITLE
Use functions instead of aliases and patch warning

### DIFF
--- a/src/Module.ps1
+++ b/src/Module.ps1
@@ -8,50 +8,15 @@ $script:SafeCommands['Set-DynamicParameterVariable'] = $ExecutionContext.Session
 & $SafeCommands['Set-Alias'] 'Add-AssertionOperator'        'Add-ShouldOperator'
 & $SafeCommands['Set-Alias'] 'Get-AssertionOperator'        'Get-ShouldOperator'
 
-& $SafeCommands['Set-Alias'] 'Should-BeFalse'               'Assert-False'
-& $SafeCommands['Set-Alias'] 'Should-BeTrue'                'Assert-True'
-& $SafeCommands['Set-Alias'] 'Should-BeFalsy'               'Assert-Falsy'
-& $SafeCommands['Set-Alias'] 'Should-BeTruthy'                'Assert-Truthy'
-& $SafeCommands['Set-Alias'] 'Should-All'                   'Assert-All'
-& $SafeCommands['Set-Alias'] 'Should-Any'                   'Assert-Any'
-& $SafeCommands['Set-Alias'] 'Should-BeCollection'               'Assert-Collection'
-& $SafeCommands['Set-Alias'] 'Should-ContainCollection'               'Assert-Contain'
-& $SafeCommands['Set-Alias'] 'Should-NotContainCollection'            'Assert-NotContain'
-& $SafeCommands['Set-Alias'] 'Should-BeEquivalent'          'Assert-Equivalent'
-& $SafeCommands['Set-Alias'] 'Should-Throw'                 'Assert-Throw'
-& $SafeCommands['Set-Alias'] 'Should-Be'               'Assert-Equal'
-& $SafeCommands['Set-Alias'] 'Should-BeGreaterThan'         'Assert-GreaterThan'
-& $SafeCommands['Set-Alias'] 'Should-BeGreaterThanOrEqual'  'Assert-GreaterThanOrEqual'
-& $SafeCommands['Set-Alias'] 'Should-BeLessThan'            'Assert-LessThan'
-& $SafeCommands['Set-Alias'] 'Should-BeLessThanOrEqual'     'Assert-LessThanOrEqual'
-& $SafeCommands['Set-Alias'] 'Should-NotBe'            'Assert-NotEqual'
-& $SafeCommands['Set-Alias'] 'Should-NotBeNull'             'Assert-NotNull'
-& $SafeCommands['Set-Alias'] 'Should-NotBeSame'             'Assert-NotSame'
-& $SafeCommands['Set-Alias'] 'Should-NotHaveType'             'Assert-NotType'
-& $SafeCommands['Set-Alias'] 'Should-BeNull'                'Assert-Null'
-& $SafeCommands['Set-Alias'] 'Should-BeSame'                'Assert-Same'
-& $SafeCommands['Set-Alias'] 'Should-HaveType'                'Assert-Type'
-
-& $SafeCommands['Set-Alias'] 'Should-BeString'              'Assert-StringEqual'
-& $SafeCommands['Set-Alias'] 'Should-NotBeString'              'Assert-StringNotEqual'
-& $SafeCommands['Set-Alias'] 'Should-BeLikeString'          'Assert-Like'
-& $SafeCommands['Set-Alias'] 'Should-NotBeLikeString'       'Assert-NotLike'
-
-& $SafeCommands['Set-Alias'] 'Should-BeEmptyString'         'Assert-StringEmpty'
-& $SafeCommands['Set-Alias'] 'Should-NotBeNullOrWhiteSpaceString'         'Assert-StringNotWhiteSpace'
-& $SafeCommands['Set-Alias'] 'Should-NotBeNullOrEmptyString'         'Assert-StringNotEmpty'
-
-& $SafeCommands['Set-Alias'] 'Should-BeFasterThan'         'Assert-Faster'
-& $SafeCommands['Set-Alias'] 'Should-BeSlowerThan'         'Assert-Slower'
-& $SafeCommands['Set-Alias'] 'Should-BeBefore'         'Assert-Before'
-& $SafeCommands['Set-Alias'] 'Should-BeAfter'         'Assert-After'
 
 
 
 & $SafeCommands['Update-TypeData'] -TypeName PesterConfiguration -TypeConverter 'PesterConfigurationDeserializer' -SerializationDepth 5 -Force
 & $SafeCommands['Update-TypeData'] -TypeName 'Deserialized.PesterConfiguration' -TargetTypeForDeserialization PesterConfiguration -Force
 
-& $script:SafeCommands['Export-ModuleMember'] @(
+[Pester.VerbsPatcher]::AllowShouldVerb($PSVersionTable.PSVersion.Major)
+
+& $script:SafeCommands['Export-ModuleMember'] -Function @(
     'Invoke-Pester'
 
     # blocks
@@ -80,62 +45,6 @@ $script:SafeCommands['Set-DynamicParameterVariable'] = $ExecutionContext.Session
     'New-PesterConfiguration'
 
     # assert
-    'Assert-False'
-    'Assert-True'
-    'Assert-Falsy'
-    'Assert-Truthy'
-    'Assert-All'
-    'Assert-Any'
-    'Assert-Contain'
-    'Assert-NotContain'
-    'Assert-Collection'
-    'Assert-Equivalent'
-    'Assert-Throw'
-    'Assert-Equal'
-    'Assert-GreaterThan'
-    'Assert-GreaterThanOrEqual'
-    'Assert-LessThan'
-    'Assert-LessThanOrEqual'
-    'Assert-NotEqual'
-    'Assert-NotNull'
-    'Assert-NotSame'
-    'Assert-NotType'
-    'Assert-Null'
-    'Assert-Same'
-    'Assert-Type'
-
-    'Assert-Like'
-    'Assert-NotLike'
-    'Assert-StringEqual'
-    'Assert-StringNotEqual'
-
-    'Assert-StringEmpty'
-    'Assert-StringNotWhiteSpace'
-    'Assert-StringNotEmpty'
-
-    'Assert-Faster'
-    'Assert-Slower'
-    'Assert-Before'
-    'Assert-After'
-
-    'Get-EquivalencyOption'
-
-    # export
-    'Export-NUnitReport'
-    'ConvertTo-NUnitReport'
-    'Export-JUnitReport'
-    'ConvertTo-JUnitReport'
-    'ConvertTo-Pester4Result'
-
-    # helpers
-    'New-MockObject'
-    'New-Fixture'
-    'Set-ItResult'
-) -Alias @(
-    'Add-AssertionOperator'
-    'Get-AssertionOperator'
-
-    # assertion functions
     # bool
     'Should-BeFalse'
     'Should-BeTrue'
@@ -145,9 +54,9 @@ $script:SafeCommands['Set-DynamicParameterVariable'] = $ExecutionContext.Session
     # collection
     'Should-All'
     'Should-Any'
-    'Should-BeCollection'
     'Should-ContainCollection'
     'Should-NotContainCollection'
+    'Should-BeCollection'
     'Should-BeEquivalent'
     'Should-Throw'
     'Should-Be'
@@ -168,15 +77,32 @@ $script:SafeCommands['Set-DynamicParameterVariable'] = $ExecutionContext.Session
     'Should-NotBeString'
 
     'Should-BeEmptyString'
-    'Should-NotBeNullOrWhiteSpaceString'
-    'Should-NotBeNullOrEmptyString'
+
+    'Should-NotBeWhiteSpaceString'
+    'Should-NotBeEmptyString'
 
     'Should-BeLikeString'
     'Should-NotBeLikeString'
 
-    # time
     'Should-BeFasterThan'
     'Should-BeSlowerThan'
     'Should-BeBefore'
     'Should-BeAfter'
+
+    'Get-EquivalencyOption'
+
+    # export
+    'Export-NUnitReport'
+    'ConvertTo-NUnitReport'
+    'Export-JUnitReport'
+    'ConvertTo-JUnitReport'
+    'ConvertTo-Pester4Result'
+
+    # helpers
+    'New-MockObject'
+    'New-Fixture'
+    'Set-ItResult'
+) -Alias @(
+    'Add-AssertionOperator'
+    'Get-AssertionOperator'
 )

--- a/src/Pester.psd1
+++ b/src/Pester.psd1
@@ -67,61 +67,6 @@
         'New-PesterConfiguration'
 
         # assert
-        'Assert-False'
-        'Assert-True'
-        'Assert-Falsy'
-        'Assert-Truthy'
-        'Assert-All'
-        'Assert-Any'
-        'Assert-Contain'
-        'Assert-NotContain'
-        'Assert-Collection'
-        'Assert-Equivalent'
-        'Assert-Throw'
-        'Assert-Equal'
-        'Assert-GreaterThan'
-        'Assert-GreaterThanOrEqual'
-        'Assert-LessThan'
-        'Assert-LessThanOrEqual'
-        'Assert-NotEqual'
-        'Assert-NotNull'
-        'Assert-NotSame'
-        'Assert-NotType'
-        'Assert-Null'
-        'Assert-Same'
-        'Assert-Type'
-        'Assert-Like'
-        'Assert-NotLike'
-        'Assert-StringEqual'
-        'Assert-StringNotEqual'
-        'Assert-StringEmpty'
-        'Assert-StringNotWhiteSpace'
-        'Assert-StringNotEmpty'
-        'Assert-Faster'
-        'Assert-Slower'
-        'Assert-Before'
-        'Assert-After'
-
-        'Get-EquivalencyOption'
-
-        # helpers
-        'New-MockObject'
-        'New-Fixture'
-        'Set-ItResult'
-    )
-
-    # # Cmdlets to export from this module
-    CmdletsToExport   = ''
-
-    # Variables to export from this module
-    VariablesToExport = @()
-
-    # # Aliases to export from this module
-    AliasesToExport   = @(
-        'Add-AssertionOperator'
-        'Get-AssertionOperator'
-
-        # assertion functions
         # bool
         'Should-BeFalse'
         'Should-BeTrue'
@@ -155,8 +100,8 @@
 
         'Should-BeEmptyString'
 
-        'Should-NotBeNullOrWhiteSpaceString'
-        'Should-NotBeNullOrEmptyString'
+        'Should-NotBeWhiteSpaceString'
+        'Should-NotBeEmptyString'
 
         'Should-BeLikeString'
         'Should-NotBeLikeString'
@@ -165,6 +110,25 @@
         'Should-BeSlowerThan'
         'Should-BeBefore'
         'Should-BeAfter'
+
+        'Get-EquivalencyOption'
+
+        # helpers
+        'New-MockObject'
+        'New-Fixture'
+        'Set-ItResult'
+    )
+
+    # # Cmdlets to export from this module
+    CmdletsToExport   = ''
+
+    # Variables to export from this module
+    VariablesToExport = @()
+
+    # # Aliases to export from this module
+    AliasesToExport   = @(
+        'Add-AssertionOperator'
+        'Get-AssertionOperator'
     )
 
 

--- a/src/csharp/Pester/VerbsPatcher.cs
+++ b/src/csharp/Pester/VerbsPatcher.cs
@@ -1,0 +1,45 @@
+﻿using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Threading.Tasks;
+
+namespace Pester
+{
+    /// <summary>
+    /// Modifies that list of recommended Verbs, so we can export Should-* functions directly without
+    /// showing a warning to the user. Reverts the change after few seconds.
+    /// </summary>
+    public static class VerbsPatcher
+    {
+        // Keep the tasks we started so they finish and are not garbage collected.
+        // Concurrent bag in case we start this multiple times, and god forbid in parallel.
+        private static ConcurrentBag<Task> s_tasks = new ConcurrentBag<Task>();
+
+        public static void AllowShouldVerb(int powershellVersion)
+        {
+            var should = "Should";
+
+            var fieldName = powershellVersion == 5 ? "validVerbs" : "s_validVerbs";
+            var verbsType = typeof(System.Management.Automation.VerbsCommon).Assembly.GetType("System.Management.Automation.Verbs");
+            var verbsField = verbsType.GetField(fieldName, BindingFlags.Static | BindingFlags.NonPublic);
+
+            // private static readonly Dictionary<string, bool> s_validVerbs;
+            Dictionary<string, bool> validVerbs = (Dictionary<string, bool>)verbsField.GetValue(null);
+            // Overwrite when we call this multiple times.
+            validVerbs[should] = true; // The bool does not matter.
+
+            s_tasks.Add(Task.Run(async () =>
+            {
+                await Task.Delay(5_000);
+                try
+                {
+                    if (validVerbs.ContainsKey(should))
+                    {
+                        validVerbs.Remove(should);
+                    }
+                }
+                catch { }
+            }));
+        }
+    }
+}

--- a/src/functions/assert/Boolean/Should-BeFalse.ps1
+++ b/src/functions/assert/Boolean/Should-BeFalse.ps1
@@ -1,4 +1,4 @@
-﻿function Assert-False {
+﻿function Should-BeFalse {
     <#
     .SYNOPSIS
     Compares the actual value to a boolean $false. It does not convert input values to boolean, and will fail for any value that is not $false.

--- a/src/functions/assert/Boolean/Should-BeFalsy.ps1
+++ b/src/functions/assert/Boolean/Should-BeFalsy.ps1
@@ -1,4 +1,4 @@
-﻿function Assert-Falsy {
+﻿function Should-BeFalsy {
     <#
     .SYNOPSIS
     Compares the actual value to a boolean $false or a falsy value: 0, "", $null or @(). It converts the input value to a boolean.

--- a/src/functions/assert/Boolean/Should-BeTrue.ps1
+++ b/src/functions/assert/Boolean/Should-BeTrue.ps1
@@ -1,4 +1,4 @@
-﻿function Assert-True {
+﻿function Should-BeTrue {
     <#
     .SYNOPSIS
     Compares the actual value to a boolean $true. It does not convert input values to boolean, and will fail for any value is not $true.

--- a/src/functions/assert/Boolean/Should-BeTruthy.ps1
+++ b/src/functions/assert/Boolean/Should-BeTruthy.ps1
@@ -1,4 +1,4 @@
-﻿function Assert-Truthy {
+﻿function Should-BeTruthy {
     <#
     .SYNOPSIS
     Compares the actual value to a boolean $true. It converts input values to boolean, and will fail for any value is not $true, or truthy.

--- a/src/functions/assert/Collection/Should-All.ps1
+++ b/src/functions/assert/Collection/Should-All.ps1
@@ -1,4 +1,4 @@
-﻿function Assert-All {
+﻿function Should-All {
     <#
     .SYNOPSIS
     Compares all items in a collection to a filter script. If the filter returns true, or does not throw for all the items in the collection, the assertion passes.

--- a/src/functions/assert/Collection/Should-Any.ps1
+++ b/src/functions/assert/Collection/Should-Any.ps1
@@ -1,4 +1,4 @@
-﻿function Assert-Any {
+﻿function Should-Any {
     <#
     .SYNOPSIS
     Compares all items in a collection to a filter script. If the filter returns true, or does not throw for any of the items in the collection, the assertion passes.

--- a/src/functions/assert/Collection/Should-BeCollection.ps1
+++ b/src/functions/assert/Collection/Should-BeCollection.ps1
@@ -1,4 +1,4 @@
-﻿function Assert-Collection {
+﻿function Should-BeCollection {
     <#
     .SYNOPSIS
     Compares collections for equality, by comparing their sizes and each item in them. It does not compare the types of the input collections.

--- a/src/functions/assert/Collection/Should-ContainCollection.ps1
+++ b/src/functions/assert/Collection/Should-ContainCollection.ps1
@@ -1,4 +1,4 @@
-﻿function Assert-Contain {
+﻿function Should-ContainCollection {
     <#
     .SYNOPSIS
     Compares collections to see if the expected collection is present in the provided collection. It does not compare the types of the input collections.

--- a/src/functions/assert/Collection/Should-NotContainCollection.ps1
+++ b/src/functions/assert/Collection/Should-NotContainCollection.ps1
@@ -1,4 +1,4 @@
-﻿function Assert-NotContain {
+﻿function Should-NotContainCollection {
     <#
     .SYNOPSIS
     Compares collections to ensure that the expected collection is not present in the provided collection. It does not compare the types of the input collections.

--- a/src/functions/assert/Equivalence/Should-BeEquivalent.ps1
+++ b/src/functions/assert/Equivalence/Should-BeEquivalent.ps1
@@ -613,7 +613,7 @@ function Compare-Equivalent {
     Compare-ObjectEquivalent -Expected $Expected -Actual $Actual -Property $Path -Options $Options
 }
 
-function Assert-Equivalent {
+function Should-BeEquivalent {
     <#
     .SYNOPSIS
     Compares two objects for equivalency, by recursively comparing their properties for equivalency.

--- a/src/functions/assert/Exception/Should-Throw.ps1
+++ b/src/functions/assert/Exception/Should-Throw.ps1
@@ -1,4 +1,4 @@
-function Assert-Throw {
+function Should-Throw {
     <#
     .SYNOPSIS
     Asserts that a script block throws an exception.

--- a/src/functions/assert/General/Should-Be.ps1
+++ b/src/functions/assert/General/Should-Be.ps1
@@ -1,4 +1,4 @@
-﻿function Assert-Equal {
+﻿function Should-Be {
     <#
     .SYNOPSIS
     Compares the expected value to actual value, to see if they are equal.

--- a/src/functions/assert/General/Should-BeGreaterThan.ps1
+++ b/src/functions/assert/General/Should-BeGreaterThan.ps1
@@ -1,4 +1,4 @@
-﻿function Assert-GreaterThan {
+﻿function Should-BeGreaterThan {
     <#
     .SYNOPSIS
     Compares the expected value to actual value, to see if the actual value is greater than the expected value.

--- a/src/functions/assert/General/Should-BeGreaterThanOrEqual.ps1
+++ b/src/functions/assert/General/Should-BeGreaterThanOrEqual.ps1
@@ -1,4 +1,4 @@
-﻿function Assert-GreaterThanOrEqual {
+﻿function Should-BeGreaterThanOrEqual {
     <#
     .SYNOPSIS
     Compares the expected value to actual value, to see if the actual value is greater than or equal to the expected value.

--- a/src/functions/assert/General/Should-BeLessThan.ps1
+++ b/src/functions/assert/General/Should-BeLessThan.ps1
@@ -1,4 +1,4 @@
-﻿function Assert-LessThan {
+﻿function Should-BeLessThan {
     <#
     .SYNOPSIS
     Compares the expected value to actual value, to see if the actual value is less than the expected value.

--- a/src/functions/assert/General/Should-BeLessThanOrEqual.ps1
+++ b/src/functions/assert/General/Should-BeLessThanOrEqual.ps1
@@ -1,4 +1,4 @@
-﻿function Assert-LessThanOrEqual {
+﻿function Should-BeLessThanOrEqual {
     <#
     .SYNOPSIS
     Compares the expected value to actual value, to see if the actual value is less than or equal to the expected value.

--- a/src/functions/assert/General/Should-BeNull.ps1
+++ b/src/functions/assert/General/Should-BeNull.ps1
@@ -1,4 +1,4 @@
-﻿function Assert-Null {
+﻿function Should-BeNull {
     <#
     .SYNOPSIS
     Asserts that the input is `$null`.

--- a/src/functions/assert/General/Should-BeSame.ps1
+++ b/src/functions/assert/General/Should-BeSame.ps1
@@ -1,4 +1,4 @@
-﻿function Assert-Same {
+﻿function Should-BeSame {
     <#
     .SYNOPSIS
     Compares the expected value to actual value, to see if they are the same instance.

--- a/src/functions/assert/General/Should-HaveType.ps1
+++ b/src/functions/assert/General/Should-HaveType.ps1
@@ -1,4 +1,4 @@
-﻿function Assert-Type {
+﻿function Should-HaveType {
     <#
     .SYNOPSIS
     Asserts that the input is of the expected type.

--- a/src/functions/assert/General/Should-NotBe.ps1
+++ b/src/functions/assert/General/Should-NotBe.ps1
@@ -1,4 +1,4 @@
-﻿function Assert-NotEqual {
+﻿function Should-NotBe {
     <#
     .SYNOPSIS
     Compares the expected value to actual value, to see if they are not equal.

--- a/src/functions/assert/General/Should-NotBeNull.ps1
+++ b/src/functions/assert/General/Should-NotBeNull.ps1
@@ -1,4 +1,4 @@
-﻿function Assert-NotNull {
+﻿function Should-NotBeNull {
     <#
     .SYNOPSIS
     Asserts that the input is not `$null`.

--- a/src/functions/assert/General/Should-NotBeSame.ps1
+++ b/src/functions/assert/General/Should-NotBeSame.ps1
@@ -1,4 +1,4 @@
-﻿function Assert-NotSame {
+﻿function Should-NotBeSame {
     <#
     .SYNOPSIS
     Compares the expected value to actual value, to see if the actual value is not the same instance as the expected value.

--- a/src/functions/assert/General/Should-NotHaveType.ps1
+++ b/src/functions/assert/General/Should-NotHaveType.ps1
@@ -1,4 +1,4 @@
-﻿function Assert-NotType {
+﻿function Should-NotHaveType {
     <#
     .SYNOPSIS
     Asserts that the input is not of the expected type.

--- a/src/functions/assert/String/Should-BeEmptyString.ps1
+++ b/src/functions/assert/String/Should-BeEmptyString.ps1
@@ -1,4 +1,4 @@
-﻿function Assert-StringEmpty {
+﻿function Should-BeEmptyString {
     <#
     .SYNOPSIS
     Ensures that input is an empty string.

--- a/src/functions/assert/String/Should-BeLikeString.ps1
+++ b/src/functions/assert/String/Should-BeLikeString.ps1
@@ -13,7 +13,7 @@
     }
 }
 
-function Assert-Like {
+function Should-BeLikeString {
     <#
     .SYNOPSIS
     Asserts that the actual value is like the expected value.

--- a/src/functions/assert/String/Should-BeString.ps1
+++ b/src/functions/assert/String/Should-BeString.ps1
@@ -23,7 +23,7 @@
     }
 }
 
-function Assert-StringEqual {
+function Should-BeString {
     <#
     .SYNOPSIS
     Asserts that the actual value is equal to the expected value.

--- a/src/functions/assert/String/Should-NotBeEmptyString.ps1
+++ b/src/functions/assert/String/Should-NotBeEmptyString.ps1
@@ -1,4 +1,4 @@
-﻿function Assert-StringNotEmpty {
+﻿function Should-NotBeEmptyString {
     <#
     .SYNOPSIS
     Ensures that the input is a string, and that the input is not $null or empty string.
@@ -12,7 +12,7 @@
     .EXAMPLE
     ```powershell
     $actual = "hello"
-    $actual | Should-NotBeNullOrEmptyString
+    $actual | Should-NotBeEmptyString
     ```
 
     This test will pass.
@@ -20,23 +20,23 @@
     .EXAMPLE
     ```powershell
     $actual = ""
-    $actual | Should-NotBeNullOrEmptyString
+    $actual | Should-NotBeEmptyString
     ```
 
     This test will fail, the input is an empty string.
 
     .EXAMPLE
     ```
-    $null | Should-NotBeNullOrEmptyString
-    $() | Should-NotBeNullOrEmptyString
-    $false | Should-NotBeNullOrEmptyString
-    1 | Should-NotBeNullOrEmptyString
+    $null | Should-NotBeEmptyString
+    $() | Should-NotBeEmptyString
+    $false | Should-NotBeEmptyString
+    1 | Should-NotBeEmptyString
     ```
 
     All the tests above will fail, the input is not a string.
 
     .LINK
-    https://pester.dev/docs/commands/Should-NotBeNullOrEmptyString
+    https://pester.dev/docs/commands/Should-NotBeEmptyString
 
     .LINK
     https://pester.dev/docs/assertions

--- a/src/functions/assert/String/Should-NotBeLikeString.ps1
+++ b/src/functions/assert/String/Should-NotBeLikeString.ps1
@@ -21,7 +21,7 @@ function Get-NotLikeDefaultFailureMessage ([String]$Expected, $Actual, [switch]$
     "Expected the string '$Actual' to$caseSensitiveMessage not match '$Expected' but it matched it."
 }
 
-function Assert-NotLike {
+function Should-NotBeLikeString {
     <#
     .SYNOPSIS
     Asserts that the actual value is not like the expected value.

--- a/src/functions/assert/String/Should-NotBeString.ps1
+++ b/src/functions/assert/String/Should-NotBeString.ps1
@@ -2,7 +2,7 @@
     "Expected the strings to be different but they were the same '$Expected'."
 }
 
-function Assert-StringNotEqual {
+function Should-NotBeString {
     <#
     .SYNOPSIS
     Asserts that the actual value is not equal to the expected value.

--- a/src/functions/assert/String/Should-NotBeWhiteSpaceString.ps1
+++ b/src/functions/assert/String/Should-NotBeWhiteSpaceString.ps1
@@ -1,4 +1,4 @@
-﻿function Assert-StringNotWhiteSpace {
+﻿function Should-NotBeWhiteSpaceString {
     <#
     .SYNOPSIS
     Ensures that the input is a string, and that the input is not $null, empty, or whitespace only string.
@@ -12,7 +12,7 @@
     .EXAMPLE
     ```powershell
     $actual = "hello"
-    $actual | Should-NotBeNullOrWhiteSpaceString
+    $actual | Should-NotBeWhiteSpaceString
     ```
 
     This test will pass.
@@ -20,24 +20,24 @@
     .EXAMPLE
     ```powershell
     $actual = "  "
-    $actual | Should-NotBeNullOrWhiteSpaceString
+    $actual | Should-NotBeWhiteSpaceString
     ```
 
     This test will fail, the input is a whitespace only string.
 
     .EXAMPLE
     ```
-    $null | Should-NotBeNullOrWhiteSpaceString
-    "" | Should-NotBeNullOrWhiteSpaceString
-    $() | Should-NotBeNullOrWhiteSpaceString
-    $false | Should-NotBeNullOrWhiteSpaceString
-    1 | Should-NotBeNullOrWhiteSpaceString
+    $null | Should-NotBeWhiteSpaceString
+    "" | Should-NotBeWhiteSpaceString
+    $() | Should-NotBeWhiteSpaceString
+    $false | Should-NotBeWhiteSpaceString
+    1 | Should-NotBeWhiteSpaceString
     ```
 
     All the tests above will fail, the input is not a string.
 
     .LINK
-    https://pester.dev/docs/commands/Should-NotBeNullOrWhiteSpaceString
+    https://pester.dev/docs/commands/Should-NotBeWhiteSpaceString
 
     .LINK
     https://pester.dev/docs/assertions

--- a/src/functions/assert/Time/Should-BeAfter.ps1
+++ b/src/functions/assert/Time/Should-BeAfter.ps1
@@ -1,4 +1,4 @@
-﻿function Assert-After {
+﻿function Should-BeAfter {
     <#
     .SYNOPSIS
     Asserts that the provided [datetime] is after the expected [datetime].

--- a/src/functions/assert/Time/Should-BeBefore.ps1
+++ b/src/functions/assert/Time/Should-BeBefore.ps1
@@ -1,4 +1,4 @@
-﻿function Assert-Before {
+﻿function Should-BeBefore {
     <#
     .SYNOPSIS
     Asserts that the provided [datetime] is before the expected [datetime].

--- a/src/functions/assert/Time/Should-BeFasterThan.ps1
+++ b/src/functions/assert/Time/Should-BeFasterThan.ps1
@@ -1,4 +1,4 @@
-﻿function Assert-Faster {
+﻿function Should-BeFasterThan {
     <#
     .SYNOPSIS
     Asserts that the provided [timespan] or [scriptblock] is faster than the expected [timespan].

--- a/src/functions/assert/Time/Should-BeSlowerThan.ps1
+++ b/src/functions/assert/Time/Should-BeSlowerThan.ps1
@@ -1,4 +1,4 @@
-﻿function Assert-Slower {
+﻿function Should-BeSlowerThan {
     <#
     .SYNOPSIS
     Asserts that the provided [timespan] is slower than the expected [timespan].

--- a/tst/Help.Tests.ps1
+++ b/tst/Help.Tests.ps1
@@ -23,8 +23,8 @@ Describe "Testing module help" -Tag 'Help' -ForEach @{ exportedFunctions = $expo
             $help.Synopsis | Should -Not -Match "^\s*$($_.Name)((\s+\[+?-\w+)|$)"
         }
 
-        # TODO: Missing on new Assert-* assertions
-        It 'Description is defined' -Skip:($_.Name -match '^Assert-') {
+        # TODO: Missing on new Should-* assertions
+        It 'Description is defined' -Skip:($_.Name -match '^Should-') {
             # Property is missing if undefined
             $help.description | Should -Not -BeNullOrEmpty
         }

--- a/tst/functions/assert/String/Should-NotBeNullOrEmptyString.Tests.ps1
+++ b/tst/functions/assert/String/Should-NotBeNullOrEmptyString.Tests.ps1
@@ -1,20 +1,20 @@
 ﻿Set-StrictMode -Version Latest
 
-Describe "Should-NotBeNullOrEmptyString" {
+Describe "Should-NotBeEmptyString" {
     It "Does not throw when string has value" -ForEach @(
         @{ Actual = "1" }
         @{ Actual = " " }
         @{ Actual = "`t" }
         @{ Actual = "`n" }
     ) {
-        $Actual | Should-NotBeNullOrEmptyString
+        $Actual | Should-NotBeEmptyString
     }
 
     It "Throws when string is `$null or empty" -ForEach @(
         @{ Actual = "" }
         @{ Actual = $null }
     ) {
-        { $Actual | Should-NotBeNullOrEmptyString } | Verify-AssertionFailed
+        { $Actual | Should-NotBeEmptyString } | Verify-AssertionFailed
     }
 
     It "Throws when value is not string" -ForEach @(
@@ -22,24 +22,24 @@ Describe "Should-NotBeNullOrEmptyString" {
         @{ Actual = @() }
         @{ Actual = $true }
     ) {
-        { $Actual | Should-NotBeNullOrEmptyString } | Verify-AssertionFailed
+        { $Actual | Should-NotBeEmptyString } | Verify-AssertionFailed
     }
 
 
     It "Allows actual to be passed from pipeline" {
-        "abc" | Should-NotBeNullOrEmptyString
+        "abc" | Should-NotBeEmptyString
     }
 
     It "Allows actual to be passed by position" {
-        Should-NotBeNullOrEmptyString "abc"
+        Should-NotBeEmptyString "abc"
     }
 
     It "Fails when empty collection is passed in by pipeline" {
-        { @() | Should-NotBeNullOrEmptyString } | Verify-AssertionFailed
+        { @() | Should-NotBeEmptyString } | Verify-AssertionFailed
     }
 
     It "Fails when `$null collection is passed in by pipeline" {
-        { $null | Should-NotBeNullOrEmptyString } | Verify-AssertionFailed
+        { $null | Should-NotBeEmptyString } | Verify-AssertionFailed
     }
 
     It "Fails with the expected message" -ForEach @(
@@ -49,7 +49,7 @@ Describe "Should-NotBeNullOrEmptyString" {
     ) {
         $actual = $Actual
         $expectedMessage = $ExpectedMessage
-        $err = { Should-NotBeNullOrEmptyString -Actual $actual -Because $Because } | Verify-AssertionFailed
+        $err = { Should-NotBeEmptyString -Actual $actual -Because $Because } | Verify-AssertionFailed
         $err.Exception.Message | Verify-Equal $ExpectedMessage
     }
 }

--- a/tst/functions/assert/String/Should-NotBeNullOrWhiteSpaceString.Tests.ps1
+++ b/tst/functions/assert/String/Should-NotBeNullOrWhiteSpaceString.Tests.ps1
@@ -1,8 +1,8 @@
 ﻿Set-StrictMode -Version Latest
 
-Describe "Should-NotBeNullOrWhiteSpaceString" {
+Describe "Should-NotBeWhiteSpaceString" {
     It "Does not throw when string has value" {
-        "bde" | Should-NotBeNullOrWhiteSpaceString
+        "bde" | Should-NotBeWhiteSpaceString
     }
 
     It "Throws when string is emptyish" -ForEach @(
@@ -12,7 +12,7 @@ Describe "Should-NotBeNullOrWhiteSpaceString" {
         @{ Actual = "`n" }
         @{ Actual = "`r" }
     ) {
-        { $Actual | Should-NotBeNullOrWhiteSpaceString } | Verify-AssertionFailed
+        { $Actual | Should-NotBeWhiteSpaceString } | Verify-AssertionFailed
     }
 
     It "Throws when value is not string" -ForEach @(
@@ -21,24 +21,24 @@ Describe "Should-NotBeNullOrWhiteSpaceString" {
         @{ Actual = $true }
         @{ Actual = $null }
     ) {
-        { $Actual | Should-NotBeNullOrWhiteSpaceString } | Verify-AssertionFailed
+        { $Actual | Should-NotBeWhiteSpaceString } | Verify-AssertionFailed
     }
 
 
     It "Allows actual to be passed from pipeline" {
-        "abc" | Should-NotBeNullOrWhiteSpaceString
+        "abc" | Should-NotBeWhiteSpaceString
     }
 
     It "Allows actual to be passed by position" {
-        Should-NotBeNullOrWhiteSpaceString "abc"
+        Should-NotBeWhiteSpaceString "abc"
     }
 
     It "Fails when empty collection is passed in by pipeline" {
-        { @() | Should-NotBeNullOrWhiteSpaceString } | Verify-AssertionFailed
+        { @() | Should-NotBeWhiteSpaceString } | Verify-AssertionFailed
     }
 
     It "Fails when `$null collection is passed in by pipeline" {
-        { $null | Should-NotBeNullOrWhiteSpaceString } | Verify-AssertionFailed
+        { $null | Should-NotBeWhiteSpaceString } | Verify-AssertionFailed
     }
 
     It "Fails with the expected message" -ForEach @(
@@ -48,7 +48,7 @@ Describe "Should-NotBeNullOrWhiteSpaceString" {
     ) {
         $actual = $Actual
         $expectedMessage = $ExpectedMessage
-        $err = { Should-NotBeNullOrWhiteSpaceString -Actual $actual -Because $Because } | Verify-AssertionFailed
+        $err = { Should-NotBeWhiteSpaceString -Actual $actual -Because $Because } | Verify-AssertionFailed
         $err.Exception.Message | Verify-Equal $ExpectedMessage
     }
 }

--- a/tst/functions/assert/Time/Should-BeSlowerThan.Tests.ps1
+++ b/tst/functions/assert/Time/Should-BeSlowerThan.Tests.ps1
@@ -2,7 +2,7 @@
 
 Describe "Should-BeSlowerThan" {
     It "Does not throw when actual is slower than expected" -ForEach @(
-        @{ Actual = { Start-Sleep -Milliseconds 10 }; Expected = "1ms" }
+        @{ Actual = { Start-Sleep -Milliseconds 100 }; Expected = "1ms" }
     ) {
         $Actual | Should-BeSlowerThan -Expected $Expected
     }


### PR DESCRIPTION
Use function exports instead of exporting Assert-* functions and Should-* aliases. We have to hack the recommended verbs list, but import is faster, and usage less confusing.