### PR TITLE
Add option to disable v5 syntax

### DIFF
--- a/src/Pester.RSpec.ps1
+++ b/src/Pester.RSpec.ps1
@@ -389,6 +389,9 @@ function New-PesterConfiguration {
       ErrorAction: Controls if Should throws on error. Use 'Stop' to throw on error, or 'Continue' to fail at the end of the test.
       Default value: 'Stop'
 
+      DisableV5: Disables usage of Should -Be assertions, that are replaced by Should-Be in version 6.
+      Default value: $false
+
     Debug:
       ShowFullErrors: Show full errors including Pester internal stack. This property is deprecated, and if set to true it will override Output.StackTraceVerbosity to 'Full'.
       Default value: $false

--- a/src/csharp/Pester/ShouldConfiguration.cs
+++ b/src/csharp/Pester/ShouldConfiguration.cs
@@ -22,6 +22,7 @@ namespace Pester
     public class ShouldConfiguration : ConfigurationSection
     {
         private StringOption _errorAction;
+        private BoolOption _disableV5;
 
         public static ShouldConfiguration Default { get { return new ShouldConfiguration(); } }
 
@@ -33,11 +34,13 @@ namespace Pester
         public ShouldConfiguration() : base("Should configuration.")
         {
             ErrorAction = new StringOption("Controls if Should throws on error. Use 'Stop' to throw on error, or 'Continue' to fail at the end of the test.", "Stop");
+            DisableV5 = new BoolOption("Disables usage of Should -Be assertions, that are replaced by Should-Be in version 6.", false);
         }
 
         public ShouldConfiguration(IDictionary configuration) : this()
         {
             configuration?.AssignObjectIfNotNull<string>(nameof(ErrorAction), v => ErrorAction = v);
+            configuration?.AssignValueIfNotNull<bool>(nameof(DisableV5), v => DisableV5 = v);
         }
 
         public StringOption ErrorAction
@@ -52,6 +55,22 @@ namespace Pester
                 else
                 {
                     _errorAction = new StringOption(_errorAction, value?.Value);
+                }
+            }
+        }
+
+        public BoolOption DisableV5
+        {
+            get { return _disableV5; }
+            set
+            {
+                if (_disableV5 == null)
+                {
+                    _disableV5 = value;
+                }
+                else
+                {
+                    _disableV5 = new BoolOption(_disableV5, value.Value);
                 }
             }
         }

--- a/src/functions/assertions/Should.ps1
+++ b/src/functions/assertions/Should.ps1
@@ -129,7 +129,6 @@ function Should {
         # errors without throwing and terminating the test.
         $pesterRuntimeInvocationContext = $PSCmdlet.SessionState.PSVariable.GetValue('______parameters')
         $isInsidePesterRuntime = $null -ne $pesterRuntimeInvocationContext
-        $pesterRuntimeInvocationContext.Configuration.Should.ErrorAction.Value
 
         if ($isInsidePesterRuntime -and $pesterRuntimeInvocationContext.Configuration.Should.DisableV5.Value) {
             throw "Pester Should -Be syntax is disabled. Use Should-Be (without space), or enable it by setting: `$PesterPreference.Should.DisableV5 = `$false"

--- a/tst/Pester.RSpec.Configuration.ts.ps1
+++ b/tst/Pester.RSpec.Configuration.ts.ps1
@@ -1344,7 +1344,7 @@ i -PassThru:$PassThru {
             $r = Invoke-Pester -Configuration $c
             $err = $r.Containers.Blocks.Tests.ErrorRecord
 
-            $err.Message | Verify-Equal 'Pester Should -Be syntax is disabled. Use Should-Be (without space), or enable it by setting: $PesterPreference.Should.DisableV5 = $false'
+            $err.Exception.Message | Verify-Equal 'Pester Should -Be syntax is disabled. Use Should-Be (without space), or enable it by setting: $PesterPreference.Should.DisableV5 = $false'
         }
 
         t "Enabling V5 assertions makes Should -Be pass" {

--- a/tst/Pester.RSpec.Configuration.ts.ps1
+++ b/tst/Pester.RSpec.Configuration.ts.ps1
@@ -1339,6 +1339,9 @@ i -PassThru:$PassThru {
                 Should = @{
                     DisableV5 = $true
                 }
+                Output = @{
+                    CIFormat = 'None'
+                }
             }
 
             $r = Invoke-Pester -Configuration $c

--- a/tst/Pester.RSpec.Configuration.ts.ps1
+++ b/tst/Pester.RSpec.Configuration.ts.ps1
@@ -1344,7 +1344,7 @@ i -PassThru:$PassThru {
             $r = Invoke-Pester -Configuration $c
             $err = $r.Containers.Blocks.Tests.ErrorRecord
 
-            $err | Verify-Equal 'Pester Should -Be syntax is disabled. Use Should-Be (without space), or enable it by setting: $PesterPreference.Should.DisableV5 = $false'
+            $err.Message | Verify-Equal 'Pester Should -Be syntax is disabled. Use Should-Be (without space), or enable it by setting: $PesterPreference.Should.DisableV5 = $false'
         }
 
         t "Enabling V5 assertions makes Should -Be pass" {


### PR DESCRIPTION
Add option to disable Should -Be and other assertions shipped with Pester v5, so when you migrate you don't accidentally regress.

Fix #2495 