### PR TITLE
Update cert-notice readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,12 +86,12 @@ below are a list of the used certificates you can expect to be used when importi
 
 Version|Authority|Thumbprint
 ---|---|---
-5.6.0++|CN=DigiCert Trusted G4 Code Signing RSA4096 SHA384 2021 CA1, O="DigiCert, Inc.", C=US|2FCC9148EC2C9AB951C6F9654C0D2ED16AF27738
-5.2.0 - 5.5.0|CN=DigiCert SHA2 Assured ID Code Signing CA, OU=www.digicert.com, O=DigiCert Inc, C=US|C7B0582906E5205B8399D92991694A614D0C0B22
-4.10.0 - 5.1.1|CN=DigiCert SHA2 Assured ID Code Signing CA, OU=www.digicert.com, O=DigiCert Inc, C=US|7B9157664392D633EDA2C0248605C1C868EBDE43
-4.4.3 - 4.9.0|CN=DigiCert SHA2 Assured ID Code Signing CA, OU=www.digicert.com, O=DigiCert Inc, C=US|CC1168BAFCDA3B1A5E532DA87E80A4DD69BCAEB1
+5.6.0++|`CN=DigiCert Trusted G4 Code Signing RSA4096 SHA384 2021 CA1, O="DigiCert, Inc.", C=US`|`2FCC9148EC2C9AB951C6F9654C0D2ED16AF27738`
+5.2.0 - 5.5.0|`CN=DigiCert SHA2 Assured ID Code Signing CA, OU=www.digicert.com, O=DigiCert Inc, C=US`|`C7B0582906E5205B8399D92991694A614D0C0B22`
+4.10.0 - 5.1.1|`CN=DigiCert SHA2 Assured ID Code Signing CA, OU=www.digicert.com, O=DigiCert Inc, C=US`|`7B9157664392D633EDA2C0248605C1C868EBDE43`
+4.4.3 - 4.9.0|`CN=DigiCert SHA2 Assured ID Code Signing CA, OU=www.digicert.com, O=DigiCert Inc, C=US`|`CC1168BAFCDA3B1A5E532DA87E80A4DD69BCAEB1`
 3.0.3 - 4.4.2|No Certificate Found|No Certificate Found
-3.4.0|CN=Microsoft Windows Production PCA 2011, O=Microsoft Corporation, L=Redmond, S=Washington, C=US |71F53A26BB1625E466727183409A30D03D7923DF
+3.4.0|`CN=Microsoft Windows Production PCA 2011, O=Microsoft Corporation, L=Redmond, S=Washington, C=US`|`71F53A26BB1625E466727183409A30D03D7923DF`
 
 in all cases in exeption to version 3.4.0, the Authenticode issuer for certificate should be `CN=Jakub Jareš, O=Jakub Jareš, L=Praha, C=CZ`.
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 
 > 📦🔐 Pester is now signed. `-SkipPublisherCheck` should no longer be used to install from PowerShell Gallery on Windows 10.
 
+> 📦🔐 If you upgrade to 5.6.0 you will get a "certificate changed" error if you dont skip publisher check. This is related to a new module certificate. [more info here](#regarding-certificate-for-different-versions).
+
 > 👩👨 We are looking for contributors! All issues labeled [help wanted](https://github.com/pester/Pester/labels/help%20wanted) are up for grabs. They further split up into [good first issue](https://github.com/pester/Pester/labels/good%20first%20issue) that are issues I hope are easy to solve. [Bad first issue](https://github.com/pester/Pester/labels/bad%20first%20issue) where I expect the implementation to be problematic or needs to be proposed and discussed beforehand. And the rest which is somewhere in the middle. If you decide to pick up an issue please comment in the issue thread so others don't waste their time working on the same issue as you.
 > There is also [contributor's guide](https://pester.dev/docs/contributing/introduction) that will hopefully help you.
 
@@ -76,6 +78,26 @@ Install-Module -Name Pester -Force
 ```
 
 Not running Windows 10 or facing problems? See the [full installation and update guide](https://pester.dev/docs/introduction/installation).
+
+## Regarding Certificate for different versions
+
+with 5.6.0 the certificate used for deplyment has changed. this will give you a error when updating.
+below are a list of the used certificates you can expect to be used when importing the module (going back to 2016)
+
+Version|Authority|Thumbprint
+---|---|---
+5.6.0++|CN=DigiCert Trusted G4 Code Signing RSA4096 SHA384 2021 CA1, O="DigiCert, Inc.", C=US|2FCC9148EC2C9AB951C6F9654C0D2ED16AF27738
+5.2.0 - 5.5.0|CN=DigiCert SHA2 Assured ID Code Signing CA, OU=www.digicert.com, O=DigiCert Inc, C=US|C7B0582906E5205B8399D92991694A614D0C0B22
+4.10.0 - 5.1.1|CN=DigiCert SHA2 Assured ID Code Signing CA, OU=www.digicert.com, O=DigiCert Inc, C=US|7B9157664392D633EDA2C0248605C1C868EBDE43
+4.4.3 - 4.9.0|CN=DigiCert SHA2 Assured ID Code Signing CA, OU=www.digicert.com, O=DigiCert Inc, C=US|CC1168BAFCDA3B1A5E532DA87E80A4DD69BCAEB1
+3.0.3 - 4.4.2|No Certificate Found|No Certificate Found
+3.4.0|CN=Microsoft Windows Production PCA 2011, O=Microsoft Corporation, L=Redmond, S=Washington, C=US |71F53A26BB1625E466727183409A30D03D7923DF
+
+in all cases in exeption to version 3.4.0, the Authenticode issuer for certificate should be `CN=Jakub Jareš, O=Jakub Jareš, L=Praha, C=CZ`.
+
+3.4.0 is a special case as this is the version signed my microsoft and deployed to w10.
+
+to fix any issue when using a module that have changed certificate is to append `-SkipPublisherCheck` to the install command.
 
 ## Features
 
@@ -173,7 +195,6 @@ Pester is sponsored by [Octopus Deploy](https://octopus.com).
 <a href="https://octopus.com"><img src="https://octopus.com/images/company/OctopusDeploy-logo-RGB.svg" alt="Octopus deploy"  height="150"></a>
 
 As well as all the great folks on [OpenCollective](https://opencollective.com/pester) and [GitHub](https://github.com/users/nohwnd/sponsorship#sponsors).
-
 
 ## Contributors
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 > 📦🔐 Pester is now signed. `-SkipPublisherCheck` should no longer be used to install from PowerShell Gallery on Windows 10.
 
-> 📦🔐 If you upgrade to 5.6.0 you will get a "certificate changed" error if you dont skip publisher check. This is related to a new module certificate. [more info here](#regarding-certificate-for-different-versions).
+> 📦🔐 Upgrading to 5.6.0 will show a "certificate changed" error, this is because a change in Root Certificate, and you have to specify `-SkipPublisherCheck` to update. [More info below.](#560-certificate-error).
 
 > 👩👨 We are looking for contributors! All issues labeled [help wanted](https://github.com/pester/Pester/labels/help%20wanted) are up for grabs. They further split up into [good first issue](https://github.com/pester/Pester/labels/good%20first%20issue) that are issues I hope are easy to solve. [Bad first issue](https://github.com/pester/Pester/labels/bad%20first%20issue) where I expect the implementation to be problematic or needs to be proposed and discussed beforehand. And the rest which is somewhere in the middle. If you decide to pick up an issue please comment in the issue thread so others don't waste their time working on the same issue as you.
 > There is also [contributor's guide](https://pester.dev/docs/contributing/introduction) that will hopefully help you.
@@ -81,8 +81,8 @@ Not running Windows 10 or facing problems? See the [full installation and update
 
 ## Regarding Certificate for different versions
 
-with 5.6.0 the certificate used for deplyment has changed. this will give you a error when updating.
-below are a list of the used certificates you can expect to be used when importing the module (going back to 2016)
+The certificate used for signing the code has changed in 5.6.0. Error is shown when updating the module.
+Below is the list of the certificates you can expect to be used when importing the module (going back to 2016)
 
 Version|Authority|Thumbprint
 ---|---|---
@@ -93,11 +93,9 @@ Version|Authority|Thumbprint
 3.0.3 - 4.4.2|No Certificate Found|No Certificate Found
 3.4.0|`CN=Microsoft Windows Production PCA 2011, O=Microsoft Corporation, L=Redmond, S=Washington, C=US`|`71F53A26BB1625E466727183409A30D03D7923DF`
 
-in all cases in exeption to version 3.4.0, the Authenticode issuer for certificate should be `CN=Jakub Jareš, O=Jakub Jareš, L=Praha, C=CZ`.
+In all cases, except for version 3.4.0 that was signed directly by Microsoft, the Authenticode issuer for certificate is `CN=Jakub Jareš, O=Jakub Jareš, L=Praha, C=CZ`.
 
-3.4.0 is a special case as this is the version signed my microsoft and deployed to w10.
-
-to fix any issue when using a module that have changed certificate is to append `-SkipPublisherCheck` to the install command.
+To successfully update the module when certificate changed, you need to provide `-SkipPublisherCheck` to the `Install-Module` command.
 
 ## Features
 


### PR DESCRIPTION
<!-- Thank you for contributing to Pester! -->

## PR Summary
<!-- Please describe what your pull request fixes, or how it improves Pester.

If your pull request resolves a reported issue, please mention it by using `Fix #<issue_number>` on a new line, this will close the linked issue automatically when this PR is merged. For more info see: [Closing issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/).

If your pull request integrates Pester with another system, please tell us how the change can be tested. -->

Fix #2438

Updated so that there is a notice at top of readme and a list futher down of all certificate issuers, and thumbprint going back to 3.0.3

after installing all available versions from ps module store i ran the following command to list all the different module certificates
``` powershell
 get-module pester -ListAvailable|%{$sign = Get-AuthenticodeSignature -FilePath $_.Path;[pscustomobject]@{version=$_.version;issuer=$sign.SignerCertificate.Issuer;thumbprint=$sign.SignerCertificate.Thumbprint;subject=$sign.SignerCertificate.Subject}}|ft -a
```
after that i just manually found the different certificate thumbprint and figured out the certificate for the different certificate ranges.

I noted that 3.4.0 had a different certificate subject due to it being released as a w10 module, but this might be wrong.
3.0.3 -> 4.4.2 did not have any certificate (except for 3.4.0 )

## PR Checklist

- [x ] PR has meaningful title
- [ x] Summary describes changes
- [ x] PR is ready to be merged
  - If not, use the arrow next to `Create Pull Request` to mark it as a draft. PR can be marked `Ready for review` when it's ready.
- [ x] Tests are added/update *(if required)*
- [ x] Documentation is updated/added *(if required)*

<!-- Before you continue, please review [Contributing to Pester](https://pester.dev/docs/contributing/introduction).

Our continuous integration system doesn't send any notifications about failed tests. Please return to the opened pull request (after ~60 minutes) to check if everything is OK. -->
