### PR TITLE
Use the actual object instead of 'the other'

### DIFF
--- a/src/functions/assert/Equivalence/Should-BeEquivalent.ps1
+++ b/src/functions/assert/Equivalence/Should-BeEquivalent.ps1
@@ -278,7 +278,7 @@ function Compare-HashtableEquivalent ($Actual, $Expected, $Property, $Options) {
         $actualHasKey = $actualKeys -contains $k
         if (-not $actualHasKey) {
             Write-EquivalenceResult -Difference "`$Actual is missing key '$k'."
-            $result += "Expected has key '$k' that the other object does not have."
+            $result += "Expected has key '$k' that the actual object does not have."
             continue
         }
 
@@ -303,7 +303,7 @@ function Compare-HashtableEquivalent ($Actual, $Expected, $Property, $Options) {
         }
 
         foreach ($k in $filteredKeysNotInExpected | & $SafeCommands['Where-Object'] { $_ }) {
-            $result += "Expected is missing key '$k' that the other object has."
+            $result += "Expected is missing key '$k' that the actual object has."
         }
     }
 
@@ -344,7 +344,7 @@ function Compare-DictionaryEquivalent ($Actual, $Expected, $Property, $Options) 
         $actualHasKey = $actualKeys -contains $k
         if (-not $actualHasKey) {
             Write-EquivalenceResult -Difference "`$Actual is missing key '$k'."
-            $result += "Expected has key '$k' that the other object does not have."
+            $result += "Expected has key '$k' that the actual object does not have."
             continue
         }
 
@@ -367,7 +367,7 @@ function Compare-DictionaryEquivalent ($Actual, $Expected, $Property, $Options) 
         }
 
         foreach ($k in $filteredKeysNotInExpected | & $SafeCommands['Where-Object'] { $_ }) {
-            $result += "Expected is missing key '$k' that the other object has."
+            $result += "Expected is missing key '$k' that the actual object has."
         }
     }
 
@@ -406,7 +406,7 @@ function Compare-ObjectEquivalent ($Actual, $Expected, $Property, $Options) {
         $actualProperty = $actualProperties | & $SafeCommands['Where-Object'] { $_.Name -eq $propertyName }
         if (-not $actualProperty) {
             Write-EquivalenceResult -Difference "Property '$propertyName' was not found on `$Actual."
-            "Expected has property '$PropertyName' that the other object does not have."
+            "Expected has property '$PropertyName' that the actual object does not have."
             continue
         }
         Write-EquivalenceResult "Property '$propertyName` was found on `$Actual, comparing them for equivalence."
@@ -439,7 +439,7 @@ function Compare-ObjectEquivalent ($Actual, $Expected, $Property, $Options) {
 
         # fix for powershell v2 where foreach goes once over null
         foreach ($p in $filteredPropertiesNotInExpected | & $SafeCommands['Where-Object'] { $_ }) {
-            "Expected is missing property '$($p.Name)' that the other object has."
+            "Expected is missing property '$($p.Name)' that the actual object has."
         }
     }
 }
@@ -463,7 +463,7 @@ function Compare-DataRowEquivalent ($Actual, $Expected, $Property, $Options) {
         $propertyName = $p.Name
         $actualProperty = $actualProperties | & $SafeCommands['Where-Object'] { $_.Name -eq $propertyName }
         if (-not $actualProperty) {
-            "Expected has property '$PropertyName' that the other object does not have."
+            "Expected has property '$PropertyName' that the actual object does not have."
             continue
         }
 
@@ -477,7 +477,7 @@ function Compare-DataRowEquivalent ($Actual, $Expected, $Property, $Options) {
 
     # fix for powershell v2 where foreach goes once over null
     foreach ($p in $propertiesNotInExpected | & $SafeCommands['Where-Object'] { $_ }) {
-        "Expected is missing property '$($p.Name)' that the other object has."
+        "Expected is missing property '$($p.Name)' that the actual object has."
     }
 }
 

--- a/tst/functions/assert/Equivalence/Should-BeEquivalent.Tests.ps1
+++ b/tst/functions/assert/Equivalence/Should-BeEquivalent.Tests.ps1
@@ -261,9 +261,9 @@ InPesterModuleScope {
 
         It "Given values '<expected>' and '<actual>' that are not equivalent it returns message '<message>'." -TestCases @(
             @{ Actual = 'a'; Expected = @{ Name = 'Jakub' }; Message = "Expected hashtable @{Name='Jakub'}, but got 'a'." }
-            @{ Actual = @{ }; Expected = @{ Name = 'Jakub' }; Message = "Expected hashtable @{Name='Jakub'}, but got @{}.`nExpected has key 'Name' that the other object does not have." }
+            @{ Actual = @{ }; Expected = @{ Name = 'Jakub' }; Message = "Expected hashtable @{Name='Jakub'}, but got @{}.`nExpected has key 'Name' that the actual object does not have." }
             @{ Actual = @{ Name = 'Tomas' }; Expected = @{ Name = 'Jakub' }; Message = "Expected hashtable @{Name='Jakub'}, but got @{Name='Tomas'}.`nExpected property .Name with value 'Jakub' to be equivalent to the actual value, but got 'Tomas'." }
-            @{ Actual = @{ Name = 'Tomas'; Value = 10 }; Expected = @{ Name = 'Jakub' }; Message = "Expected hashtable @{Name='Jakub'}, but got @{Name='Tomas'; Value=10}.`nExpected property .Name with value 'Jakub' to be equivalent to the actual value, but got 'Tomas'.`nExpected is missing key 'Value' that the other object has." }
+            @{ Actual = @{ Name = 'Tomas'; Value = 10 }; Expected = @{ Name = 'Jakub' }; Message = "Expected hashtable @{Name='Jakub'}, but got @{Name='Tomas'; Value=10}.`nExpected property .Name with value 'Jakub' to be equivalent to the actual value, but got 'Tomas'.`nExpected is missing key 'Value' that the actual object has." }
         ) {
             param ($Actual, $Expected, $Message)
 
@@ -282,9 +282,9 @@ InPesterModuleScope {
 
         It "Given values '<expected>' and '<actual>' that are not equivalent it returns message '<message>'." -TestCases @(
             @{ Actual = 'a'; Expected = New-Dictionary @{ Name = 'Jakub' }; Message = "Expected dictionary Dictionary{Name='Jakub'}, but got 'a'." }
-            @{ Actual = New-Dictionary @{ }; Expected = New-Dictionary @{ Name = 'Jakub' }; Message = "Expected dictionary Dictionary{Name='Jakub'}, but got Dictionary{}.`nExpected has key 'Name' that the other object does not have." }
+            @{ Actual = New-Dictionary @{ }; Expected = New-Dictionary @{ Name = 'Jakub' }; Message = "Expected dictionary Dictionary{Name='Jakub'}, but got Dictionary{}.`nExpected has key 'Name' that the actual object does not have." }
             @{ Actual = New-Dictionary @{ Name = 'Tomas' }; Expected = New-Dictionary @{ Name = 'Jakub' }; Message = "Expected dictionary Dictionary{Name='Jakub'}, but got Dictionary{Name='Tomas'}.`nExpected property .Name with value 'Jakub' to be equivalent to the actual value, but got 'Tomas'." }
-            @{ Actual = New-Dictionary @{ Name = 'Tomas'; Value = 10 }; Expected = New-Dictionary @{ Name = 'Jakub' }; Message = "Expected dictionary Dictionary{Name='Jakub'}, but got Dictionary{Name='Tomas'; Value=10}.`nExpected property .Name with value 'Jakub' to be equivalent to the actual value, but got 'Tomas'.`nExpected is missing key 'Value' that the other object has." }
+            @{ Actual = New-Dictionary @{ Name = 'Tomas'; Value = 10 }; Expected = New-Dictionary @{ Name = 'Jakub' }; Message = "Expected dictionary Dictionary{Name='Jakub'}, but got Dictionary{Name='Tomas'; Value=10}.`nExpected property .Name with value 'Jakub' to be equivalent to the actual value, but got 'Tomas'.`nExpected is missing key 'Value' that the actual object has." }
         ) {
             param ($Actual, $Expected, $Message)
 
@@ -374,12 +374,12 @@ InPesterModuleScope {
             @{
                 Expected = [PSCustomObject]@{ Name = 'Jakub'; Age = 28 }
                 Actual   = [PSCustomObject]@{ Name = 'Jakub' }
-                Message  = "Expected has property 'Age' that the other object does not have."
+                Message  = "Expected has property 'Age' that the actual object does not have."
             },
             @{
                 Expected = [PSCustomObject]@{ Name = 'Jakub' }
                 Actual   = [PSCustomObject]@{ Name = 'Jakub'; Age = 28 }
-                Message  = "Expected is missing property 'Age' that the other object has."
+                Message  = "Expected is missing property 'Age' that the actual object has."
             }
         ) {
             param ($Expected, $Actual, $Message)


### PR DESCRIPTION
Better wording in Should-BeEquivalent

![image](https://github.com/pester/Pester/assets/5735905/8caea22c-0995-4eaa-a3a8-add5ff6754a3)

co-authored with: @powershellpr0mpt