### PR TITLE
Fix a bug where the NUnit-Report fails to generate if the test output contains Virtual Terminal Sequences

### DIFF
--- a/src/functions/TestResults.NUnit3.ps1
+++ b/src/functions/TestResults.NUnit3.ps1
@@ -541,7 +541,18 @@ function Write-NUnit3OutputElement ($Output, [System.Xml.XmlWriter] $XmlWriter) 
         if ($null -eq $o) {
             [string]::Empty
         } else {
-            $o.ToString()
+            $result = ""
+            0..($o.Length-1) |% {
+                $char = $o[$_]
+                if ("`e" -eq $char) {
+                    $result += "{ESC}"
+                } elseif ("`a" -eq $char) {
+                    $result += "{BELL}"
+                } else {
+                    $result += $char
+                }
+            }
+            $result
         }
     }) -join [System.Environment]::NewLine
 

--- a/src/functions/TestResults.NUnit3.ps1
+++ b/src/functions/TestResults.NUnit3.ps1
@@ -537,19 +537,20 @@ function Write-NUnit3TestCaseAttributes {
 }
 
 function Write-NUnit3OutputElement ($Output, [System.Xml.XmlWriter] $XmlWriter) {
+    [int]$unicodeControlPictures = 0x2400
+    [int[]]$validChars = (0x9,0xA,0xD)
     $outputString = @(foreach ($o in $Output) {
         if ($null -eq $o) {
             [string]::Empty
         } else {
             $result = ""
             0..($o.Length-1) |% {
-                $char = $o[$_]
-                if (0x1B  -eq [int]$char) {
-                    $result += "`${ESC}"
-                } elseif (0x07 -eq [int]$char) {
-                    $result += "`${BELL}"
+                $s = $o[$_]
+                $char = [int]$s
+                if ((0x20 -gt $char) -and (0x00 -lt $char) -and (-not ($validChars -contains $char))) {
+                    $result += [char]($char + $unicodeControlPictures)
                 } else {
-                    $result += $char
+                    $result += $s
                 }
             }
             $result

--- a/src/functions/TestResults.NUnit3.ps1
+++ b/src/functions/TestResults.NUnit3.ps1
@@ -1,5 +1,7 @@
 ﻿# NUnit3 schema docs: https://docs.nunit.org/articles/nunit/technical-notes/usage/Test-Result-XML-Format.html
 
+[char[]] $script:invalidCDataChars = foreach ($ch in (0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x0B, 0x0C, 0x0E, 0x0F, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0x1A, 0x1B, 0x1C, 0x1D, 0x1E, 0x1F)) { [char]$ch }
+
 function Write-NUnit3Report([Pester.Run] $Result, [System.Xml.XmlWriter] $XmlWriter) {
     # Write the XML Declaration
     $XmlWriter.WriteStartDocument($false)
@@ -542,7 +544,6 @@ function Write-NUnit3OutputElement ($Output, [System.Xml.XmlWriter] $XmlWriter) 
     # We convert each of these using the unicode printable version,
     # which is obtained by adding 0x2400
     [int]$unicodeControlPictures = 0x2400
-    [char[]] $invalidChars = "`u{0001}`u{0002}`u{0003}`u{0004}`u{0005}`u{0006}`u{0007}`u{0008}`u{000B}`u{000C}`u{000E}`u{000F}`u{0010}`u{0011}`u{0012}`u{0013}`u{0014}`u{0015}`u{0016}`u{0017}`u{0018}`u{0019}`u{001A}`u{001B}`u{001C}`u{001D}`u{001E}`u{001F}"
 
     # Avoid indexing into an enumerable, such as a `string`, when there is only one item in the
     # output array.
@@ -552,7 +553,7 @@ function Write-NUnit3OutputElement ($Output, [System.Xml.XmlWriter] $XmlWriter) 
         # The input is array of objects, convert them to strings.
         $line = if ($null -eq $out[$i]) { [String]::Empty } else { $out[$i].ToString() }
 
-        if (0 -gt $line.IndexOfAny($invalidChars)) {
+        if (0 -gt $line.IndexOfAny($script:invalidCDataChars)) {
             # No special chars that need replacing.
             $line
         }
@@ -561,7 +562,7 @@ function Write-NUnit3OutputElement ($Output, [System.Xml.XmlWriter] $XmlWriter) 
             $charCount = $chars.Length
             for ($j = 0; $j -lt $charCount; $j++) {
                 $char = $chars[$j]
-                if ($char -in $invalidChars) {
+                if ($char -in $script:invalidCDataChars) {
                     $chars[$j] = [char]([int]$char + $unicodeControlPictures)
                 }
             }

--- a/src/functions/TestResults.NUnit3.ps1
+++ b/src/functions/TestResults.NUnit3.ps1
@@ -544,10 +544,13 @@ function Write-NUnit3OutputElement ($Output, [System.Xml.XmlWriter] $XmlWriter) 
     [int]$unicodeControlPictures = 0x2400
     [char[]] $invalidChars = "`u{0001}`u{0002}`u{0003}`u{0004}`u{0005}`u{0006}`u{0007}`u{0008}`u{000B}`u{000C}`u{000E}`u{000F}`u{0010}`u{0011}`u{0012}`u{0013}`u{0014}`u{0015}`u{0016}`u{0017}`u{0018}`u{0019}`u{001A}`u{001B}`u{001C}`u{001D}`u{001E}`u{001F}"
 
-    $linesCount = @($Output).Length
+    # Avoid indexing into an enumerable, such as a `string`, when there is only one item in the
+    # output array.
+    $out = @($Output)
+    $linesCount = $out.Length
     $o = for ($i = 0; $i -lt $linesCount; $i++) {
         # The input is array of objects, convert them to strings.
-        $line = if ($null -eq $Output[$i]) { [String]::Empty } else { $Output[$i].ToString() }
+        $line = if ($null -eq $out[$i]) { [String]::Empty } else { $out[$i].ToString() }
 
         if (0 -gt $line.IndexOfAny($invalidChars)) {
             # No special chars that need replacing.

--- a/src/functions/TestResults.NUnit3.ps1
+++ b/src/functions/TestResults.NUnit3.ps1
@@ -537,8 +537,12 @@ function Write-NUnit3TestCaseAttributes {
 }
 
 function Write-NUnit3OutputElement ($Output, [System.Xml.XmlWriter] $XmlWriter) {
+    # The characters in the range 0x01 to 0x19 are invalid for CData
+    # (with the exception of the characters 0x09, 0x0A and 0x0D)
+    # We convert each of these using the unicode printable version,
+    # which is obtained by adding 0x2400
     [int]$unicodeControlPictures = 0x2400
-    [int[]]$validChars = (0x9,0xA,0xD)
+    [int[]]$validChars = (0x09,0x0A,0x0D)
     $outputString = @(foreach ($o in $Output) {
         if ($null -eq $o) {
             [string]::Empty

--- a/src/functions/TestResults.NUnit3.ps1
+++ b/src/functions/TestResults.NUnit3.ps1
@@ -537,35 +537,37 @@ function Write-NUnit3TestCaseAttributes {
 }
 
 function Write-NUnit3OutputElement ($Output, [System.Xml.XmlWriter] $XmlWriter) {
-    # The characters in the range 0x01 to 0x19 are invalid for CData
+    # The characters in the range 0x01 to 0x20 are invalid for CData
     # (with the exception of the characters 0x09, 0x0A and 0x0D)
     # We convert each of these using the unicode printable version,
     # which is obtained by adding 0x2400
     [int]$unicodeControlPictures = 0x2400
-    [int[]]$validChars = (0x09,0x0A,0x0D)
-    $sb = [System.Text.StringBuilder]::new()
-    $outputLines = @($Output)
-    for ($i = 0; $i -lt $outputLines.Length; $i++) {
-        $line = $outputLines[$i]
-        if ($null -eq $line) {
-            $sb.AppendLine() | Out-null
-        } elseif ($line -is [string]) {
-            foreach($char in [char[]]$line) {
-                if ((0x20 -gt $char) -and (0x00 -lt $char) -and (-not ($validChars -contains $char))) {
-                    $sb.Append([char]([int]$char + $unicodeControlPictures)) | Out-null
-                } else {
-                    $sb.Append($char) | Out-null
+    [char[]] $invalidChars = "`u{0001}`u{0002}`u{0003}`u{0004}`u{0005}`u{0006}`u{0007}`u{0008}`u{000B}`u{000C}`u{000E}`u{000F}`u{0010}`u{0011}`u{0012}`u{0013}`u{0014}`u{0015}`u{0016}`u{0017}`u{0018}`u{0019}`u{001A}`u{001B}`u{001C}`u{001D}`u{001E}`u{001F}"
+
+    $linesCount = @($Output).Length
+    $o = for ($i = 0; $i -lt $linesCount; $i++) {
+        # The input is array of objects, convert them to strings.
+        $line = if ($null -eq $Output[$i]) { [String]::Empty } else { $Output[$i].ToString() }
+
+        if (0 -gt $line.IndexOfAny($invalidChars)) {
+            # No special chars that need replacing.
+            $line
+        }
+        else {
+            $chars = [char[]]$line;
+            $charCount = $chars.Length
+            for ($j = 0; $j -lt $charCount; $j++) {
+                $char = $chars[$j]
+                if ($char -in $invalidChars) {
+                    $chars[$j] = [char]([int]$char + $unicodeControlPictures)
                 }
             }
-            # Append a newline for all lines except the last one
-            if ($i -lt ($outputLines.Length - 1)) {
-                $sb.AppendLine() | Out-null
-            }
-        } else {
-            $sb.AppendLine($line.ToString()) | Out-null
+
+            $chars -join ''
         }
     }
-    $outputString = $sb.ToString()
+
+    $outputString = $o -join [Environment]::NewLine
     $XmlWriter.WriteStartElement('output')
     $XmlWriter.WriteCData($outputString)
     $XmlWriter.WriteEndElement()

--- a/src/functions/TestResults.NUnit3.ps1
+++ b/src/functions/TestResults.NUnit3.ps1
@@ -545,9 +545,9 @@ function Write-NUnit3OutputElement ($Output, [System.Xml.XmlWriter] $XmlWriter) 
             0..($o.Length-1) |% {
                 $char = $o[$_]
                 if (0x1B  -eq [int]$char) {
-                    $result += "{ESC}"
+                    $result += "`${ESC}"
                 } elseif (0x07 -eq [int]$char) {
-                    $result += "{BELL}"
+                    $result += "`${BELL}"
                 } else {
                     $result += $char
                 }

--- a/src/functions/TestResults.NUnit3.ps1
+++ b/src/functions/TestResults.NUnit3.ps1
@@ -544,9 +544,9 @@ function Write-NUnit3OutputElement ($Output, [System.Xml.XmlWriter] $XmlWriter) 
             $result = ""
             0..($o.Length-1) |% {
                 $char = $o[$_]
-                if ("`e" -eq $char) {
+                if (0x1B  -eq [int]$char) {
                     $result += "{ESC}"
-                } elseif ("`a" -eq $char) {
+                } elseif (0x07 -eq [int]$char) {
                     $result += "{BELL}"
                 } else {
                     $result += $char

--- a/src/functions/TestResults.ps1
+++ b/src/functions/TestResults.ps1
@@ -169,7 +169,6 @@ function Export-XmlReport {
     $settings = [Xml.XmlWriterSettings] @{
         Indent              = $true
         NewLineOnAttributes = $false
-        CheckCharacters     = $false
     }
 
     $xmlFile = $null

--- a/src/functions/TestResults.ps1
+++ b/src/functions/TestResults.ps1
@@ -169,6 +169,7 @@ function Export-XmlReport {
     $settings = [Xml.XmlWriterSettings] @{
         Indent              = $true
         NewLineOnAttributes = $false
+        CheckCharacters     = $false
     }
 
     $xmlFile = $null

--- a/tst/Pester.RSpec.TestResults.NUnit3.ts.ps1
+++ b/tst/Pester.RSpec.TestResults.NUnit3.ts.ps1
@@ -353,7 +353,12 @@ i -PassThru:$PassThru {
             $sb = {
                 Describe 'Describe VT Sequences' {
                     It "Successful" {
-                        Write-Output "`e[32mHello World`e[0m"
+                        $testCases = (
+                            "`e[32mHello World`e[0m",
+                            "Ring the bell`a")
+                        $testCases |% { 
+                            Write-Output $_ 
+                        }
                         $true | Should -Be $true
                     }
                 }

--- a/tst/Pester.RSpec.TestResults.NUnit3.ts.ps1
+++ b/tst/Pester.RSpec.TestResults.NUnit3.ts.ps1
@@ -354,7 +354,6 @@ i -PassThru:$PassThru {
                 Describe 'Describe VT Sequences' {
                     It "Successful" {
                         Write-Output "`e[32mHello World`e[0m"
-                        Write-Host "`e[32mHello World`e[0m"
                         $true | Should -Be $true
                     }
                 }

--- a/tst/Pester.RSpec.TestResults.NUnit3.ts.ps1
+++ b/tst/Pester.RSpec.TestResults.NUnit3.ts.ps1
@@ -349,7 +349,7 @@ i -PassThru:$PassThru {
             $xmlResult.Validate({ throw $args[1].Exception })
         }
 
-        dt 'replaces virtual terminal escape sequences with their printable representations' {
+        t 'replaces virtual terminal escape sequences with their printable representations' {
             $sb = {
                 Describe 'Describe VT Sequences' {
                     It "Successful" {

--- a/tst/Pester.RSpec.TestResults.NUnit3.ts.ps1
+++ b/tst/Pester.RSpec.TestResults.NUnit3.ts.ps1
@@ -356,7 +356,7 @@ i -PassThru:$PassThru {
                         $esc = [char][int]0x1B
                         $bell = [char][int]0x07
                         $testCases = (
-                            "$esc[32mHello World$esc[0m",
+                            "$esc[32mHello`tWorld$esc[0m",
                             "Ring the bell$bell")
                         $testCases |% { 
                             Write-Output $_ 
@@ -374,8 +374,8 @@ i -PassThru:$PassThru {
             $xmlDescribe = $xmlResult.'test-run'.'test-suite'.'test-suite'
             $xmlTest = $xmlDescribe.'test-case'
             $message = $xmlTest.output.'#cdata-section' -split "`n"
-            $message[0] | Verify-Equal '␛[32mHello World␛[0m'
-            $message[1] | Verify-Equal 'Ring the bell␇'
+            $message[0] | Verify-Equal "␛[32mHello`tWorld␛[0m"
+            $message[1] | Verify-Equal "Ring the bell␇"
         }
 
         t 'should use TestResult.TestSuiteName configuration value as name-attribute for run and root Assembly test-suite' {

--- a/tst/Pester.RSpec.TestResults.NUnit3.ts.ps1
+++ b/tst/Pester.RSpec.TestResults.NUnit3.ts.ps1
@@ -369,6 +369,11 @@ i -PassThru:$PassThru {
             $xmlResult.Schemas.XmlResolver = New-Object System.Xml.XmlUrlResolver
             $xmlResult.Schemas.Add($null, $schemaPath) > $null
             $xmlResult.Validate({ throw $args[1].Exception })
+            $xmlDescribe = $xmlResult.'test-run'.'test-suite'.'test-suite'
+            $xmlTest = $xmlDescribe.'test-case'
+            $message = $xmlTest.output.'#cdata-section' -split "`n"
+            $message[0] | Verify-Equal '{ESC}[32mHello World{ESC}[0m'
+            $message[1] | Verify-Equal 'Ring the bell{ESC}'
         }
 
         t 'should use TestResult.TestSuiteName configuration value as name-attribute for run and root Assembly test-suite' {

--- a/tst/Pester.RSpec.TestResults.NUnit3.ts.ps1
+++ b/tst/Pester.RSpec.TestResults.NUnit3.ts.ps1
@@ -374,8 +374,8 @@ i -PassThru:$PassThru {
             $xmlDescribe = $xmlResult.'test-run'.'test-suite'.'test-suite'
             $xmlTest = $xmlDescribe.'test-case'
             $message = $xmlTest.output.'#cdata-section' -split "`n"
-            $message[0] | Verify-Equal '{ESC}[32mHello World{ESC}[0m'
-            $message[1] | Verify-Equal 'Ring the bell{BELL}'
+            $message[0] | Verify-Equal "`${ESC}[32mHello World`${ESC}[0m"
+            $message[1] | Verify-Equal "Ring the bell`${BELL}"
         }
 
         t 'should use TestResult.TestSuiteName configuration value as name-attribute for run and root Assembly test-suite' {

--- a/tst/Pester.RSpec.TestResults.NUnit3.ts.ps1
+++ b/tst/Pester.RSpec.TestResults.NUnit3.ts.ps1
@@ -353,9 +353,11 @@ i -PassThru:$PassThru {
             $sb = {
                 Describe 'Describe VT Sequences' {
                     It "Successful" {
+                        $esc = [char][int]0x1B
+                        $bell = [char][int]0x07
                         $testCases = (
-                            "`e[32mHello World`e[0m",
-                            "Ring the bell`a")
+                            "$esc[32mHello World$esc[0m",
+                            "Ring the bell$bell")
                         $testCases |% { 
                             Write-Output $_ 
                         }
@@ -373,7 +375,7 @@ i -PassThru:$PassThru {
             $xmlTest = $xmlDescribe.'test-case'
             $message = $xmlTest.output.'#cdata-section' -split "`n"
             $message[0] | Verify-Equal '{ESC}[32mHello World{ESC}[0m'
-            $message[1] | Verify-Equal 'Ring the bell{ESC}'
+            $message[1] | Verify-Equal 'Ring the bell{BELL}'
         }
 
         t 'should use TestResult.TestSuiteName configuration value as name-attribute for run and root Assembly test-suite' {

--- a/tst/Pester.RSpec.TestResults.NUnit3.ts.ps1
+++ b/tst/Pester.RSpec.TestResults.NUnit3.ts.ps1
@@ -374,8 +374,8 @@ i -PassThru:$PassThru {
             $xmlDescribe = $xmlResult.'test-run'.'test-suite'.'test-suite'
             $xmlTest = $xmlDescribe.'test-case'
             $message = $xmlTest.output.'#cdata-section' -split "`n"
-            $message[0] | Verify-Equal "`${ESC}[32mHello World`${ESC}[0m"
-            $message[1] | Verify-Equal "Ring the bell`${BELL}"
+            $message[0] | Verify-Equal '␛[32mHello World␛[0m'
+            $message[1] | Verify-Equal 'Ring the bell␇'
         }
 
         t 'should use TestResult.TestSuiteName configuration value as name-attribute for run and root Assembly test-suite' {

--- a/tst/Pester.RSpec.TestResults.NUnit3.ts.ps1
+++ b/tst/Pester.RSpec.TestResults.NUnit3.ts.ps1
@@ -349,6 +349,24 @@ i -PassThru:$PassThru {
             $xmlResult.Validate({ throw $args[1].Exception })
         }
 
+        t "handles virtual terminal escape sequences" {
+            $sb = {
+                Describe 'Describe VT Sequences' {
+                    It "Successful" {
+                        Write-Output "`e[32mHello World`e[0m"
+                        Write-Host "`e[32mHello World`e[0m"
+                        $true | Should -Be $true
+                    }
+                }
+            }
+            $r = Invoke-Pester -Configuration ([PesterConfiguration]@{ Run = @{ ScriptBlock = $sb; PassThru = $true }; Output = @{ Verbosity = 'None' } })
+
+            $xmlResult = [xml] ($r | ConvertTo-NUnitReport -Format NUnit3)
+            $xmlResult.Schemas.XmlResolver = New-Object System.Xml.XmlUrlResolver
+            $xmlResult.Schemas.Add($null, $schemaPath) > $null
+            $xmlResult.Validate({ throw $args[1].Exception })
+        }
+
         t 'should use TestResult.TestSuiteName configuration value as name-attribute for run and root Assembly test-suite' {
             $sb = {
                 Describe 'Describe' {

--- a/tst/Pester.RSpec.TestResults.NUnit3.ts.ps1
+++ b/tst/Pester.RSpec.TestResults.NUnit3.ts.ps1
@@ -349,19 +349,16 @@ i -PassThru:$PassThru {
             $xmlResult.Validate({ throw $args[1].Exception })
         }
 
-        t "handles virtual terminal escape sequences" {
+        dt 'replaces virtual terminal escape sequences with their printable representations' {
             $sb = {
                 Describe 'Describe VT Sequences' {
                     It "Successful" {
                         $esc = [char][int]0x1B
                         $bell = [char][int]0x07
-                        $testCases = (
-                            "$esc[32mHello`tWorld$esc[0m",
-                            "Ring the bell$bell")
-                        $testCases |% { 
-                            Write-Output $_ 
-                        }
-                        $true | Should -Be $true
+
+                        # write escape sequences to output
+                        "$esc[32mHello`tWorld$esc[0m"
+                        "Ring the bell$bell"
                     }
                 }
             }
@@ -374,6 +371,8 @@ i -PassThru:$PassThru {
             $xmlDescribe = $xmlResult.'test-run'.'test-suite'.'test-suite'
             $xmlTest = $xmlDescribe.'test-case'
             $message = $xmlTest.output.'#cdata-section' -split "`n"
+
+            # message has the escape sequences replaced with their printable representations
             $message[0] | Verify-Equal "␛[32mHello`tWorld␛[0m"
             $message[1] | Verify-Equal "Ring the bell␇"
         }


### PR DESCRIPTION
<!-- Thank you for contributing to Pester! -->

## PR Summary
<!-- Please describe what your pull request fixes, or how it improves Pester.
If your pull request resolves a reported issue, please mention it by using `Fix #<issue_number>` on a new line, this will close the linked issue automatically when this PR is merged. For more info see: [Closing issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/).

If your pull request integrates Pester with another system, please tell us how the change can be tested. -->

The following test will fail to generate an NUnit report:

```
Describe 'Describe VT Sequences' {
  Write-Output "`e[32mHello World`e[0m"
  $true | Should -Be $true
}
```

This will fail because WriteCData does not support writting the ESC character, which is a valid [VT sequence](https://learn.microsoft.com/en-us/windows/console/console-virtual-terminal-sequences).
The fix is to replace the ESC and Bell characters for {ESC} and {BELL}. 
According to the [Xml CDATA spec](https://www.w3.org/TR/REC-xml/#NT-Char), there is no way to escape these characters, other than failing, but we still need to represent them in the NUnit report.
Afte this change, these characters will be represented as by its printable version in the unicode table: `␛` for the `ESC` (0x1B) and as `␇` for the `BELL` (0x07) in the resulting Xml CData for example.

## PR Checklist

- [x] PR has meaningful title
- [x] Summary describes changes
- [x] PR is ready to be merged
  - If not, use the arrow next to `Create Pull Request` to mark it as a draft. PR can be marked `Ready for review` when it's ready.
- [x] Tests are added/update *(if required)*
- [ ] Documentation is updated/added *(if required)*

<!-- Before you continue, please review [Contributing to Pester](https://pester.dev/docs/contributing/introduction).

Our continuous integration system doesn't send any notifications about failed tests. Please return to the opened pull request (after ~60 minutes) to check if everything is OK. -->
