### PR TITLE
Do not output value from assertion

### DIFF
--- a/src/functions/assert/Boolean/Should-BeFalse.ps1
+++ b/src/functions/assert/Boolean/Should-BeFalse.ps1
@@ -50,6 +50,4 @@
         $Message = Get-AssertionMessage -Expected $false -Actual $Actual -Because $Because  -DefaultMessage "Expected <expectedType> <expected>,<because> but got: <actualType> <actual>."
         throw [Pester.Factory]::CreateShouldErrorRecord($Message, $MyInvocation.ScriptName, $MyInvocation.ScriptLineNumber, $MyInvocation.Line.TrimEnd([System.Environment]::NewLine), $true)
     }
-
-    $Actual
 }

--- a/src/functions/assert/Boolean/Should-BeFalsy.ps1
+++ b/src/functions/assert/Boolean/Should-BeFalsy.ps1
@@ -50,6 +50,4 @@
         $Message = Get-AssertionMessage -Expected $false -Actual $Actual -Because $Because -DefaultMessage 'Expected <expectedType> <expected> or a falsy value: 0, "", $null or @(),<because> but got: <actualType> <actual>.'
         throw [Pester.Factory]::CreateShouldErrorRecord($Message, $MyInvocation.ScriptName, $MyInvocation.ScriptLineNumber, $MyInvocation.Line.TrimEnd([System.Environment]::NewLine), $true)
     }
-
-    $Actual
 }

--- a/src/functions/assert/Boolean/Should-BeTrue.ps1
+++ b/src/functions/assert/Boolean/Should-BeTrue.ps1
@@ -50,6 +50,4 @@
         $Message = Get-AssertionMessage -Expected $true -Actual $Actual -Because $Because -DefaultMessage "Expected <expectedType> <expected>,<because> but got: <actualType> <actual>."
         throw [Pester.Factory]::CreateShouldErrorRecord($Message, $MyInvocation.ScriptName, $MyInvocation.ScriptLineNumber, $MyInvocation.Line.TrimEnd([System.Environment]::NewLine), $true)
     }
-
-    $Actual
 }

--- a/src/functions/assert/Boolean/Should-BeTruthy.ps1
+++ b/src/functions/assert/Boolean/Should-BeTruthy.ps1
@@ -51,6 +51,4 @@
         $Message = Get-AssertionMessage -Expected $true -Actual $Actual -Because $Because -DefaultMessage "Expected <expectedType> <expected> or a truthy value,<because> but got: <actualType> <actual>."
         throw [Pester.Factory]::CreateShouldErrorRecord($Message, $MyInvocation.ScriptName, $MyInvocation.ScriptLineNumber, $MyInvocation.Line.TrimEnd([System.Environment]::NewLine), $true)
     }
-
-    $Actual
 }

--- a/src/functions/assert/Collection/Should-All.ps1
+++ b/src/functions/assert/Collection/Should-All.ps1
@@ -99,6 +99,4 @@
         }
         throw [Pester.Factory]::CreateShouldErrorRecord($Message, $MyInvocation.ScriptName, $MyInvocation.ScriptLineNumber, $MyInvocation.Line.TrimEnd([System.Environment]::NewLine), $true)
     }
-
-    $Actual
 }

--- a/src/functions/assert/Collection/Should-Any.ps1
+++ b/src/functions/assert/Collection/Should-Any.ps1
@@ -88,6 +88,4 @@
         }
         throw [Pester.Factory]::CreateShouldErrorRecord($Message, $MyInvocation.ScriptName, $MyInvocation.ScriptLineNumber, $MyInvocation.Line.TrimEnd([System.Environment]::NewLine), $true)
     }
-
-    $Actual
 }

--- a/src/functions/assert/Collection/Should-BeCollection.ps1
+++ b/src/functions/assert/Collection/Should-BeCollection.ps1
@@ -111,7 +111,5 @@
             $Message = Get-AssertionMessage -Expected $Expected -Actual $Actual -Because $Because -Data @{ expectedDifference = $expectedDifference; actualDifference = $actualDifference } -DefaultMessage "Expected <expectedType> <expected> to be present in <actualType> <actual> in any order, but some values were not.`nMissing in actual: <expectedDifference>`nExtra in actual: <actualDifference>"
             throw [Pester.Factory]::CreateShouldErrorRecord($Message, $MyInvocation.ScriptName, $MyInvocation.ScriptLineNumber, $MyInvocation.Line.TrimEnd([System.Environment]::NewLine), $true)
         }
-
-        $Actual
     }
 }

--- a/src/functions/assert/Collection/Should-ContainCollection.ps1
+++ b/src/functions/assert/Collection/Should-ContainCollection.ps1
@@ -51,6 +51,4 @@
         $Message = Get-AssertionMessage -Expected $Expected -Actual $Actual -Because $Because -DefaultMessage "Expected <expectedType> <expected> to be present in <actualType> <actual>, but it was not there."
         throw [Pester.Factory]::CreateShouldErrorRecord($Message, $MyInvocation.ScriptName, $MyInvocation.ScriptLineNumber, $MyInvocation.Line.TrimEnd([System.Environment]::NewLine), $true)
     }
-
-    $Actual
 }

--- a/src/functions/assert/Collection/Should-NotContainCollection.ps1
+++ b/src/functions/assert/Collection/Should-NotContainCollection.ps1
@@ -51,6 +51,4 @@
         $Message = Get-AssertionMessage -Expected $Expected -Actual $Actual -Because $Because -DefaultMessage "Expected <expectedType> <expected> to not be present in collection <actual>, but it was there."
         throw [Pester.Factory]::CreateShouldErrorRecord($Message, $MyInvocation.ScriptName, $MyInvocation.ScriptLineNumber, $MyInvocation.Line.TrimEnd([System.Environment]::NewLine), $true)
     }
-
-    $Actual
 }

--- a/src/functions/assert/General/Should-Be.ps1
+++ b/src/functions/assert/General/Should-Be.ps1
@@ -44,6 +44,4 @@
         $Message = Get-AssertionMessage -Expected $Expected -Actual $Actual -Because $Because -DefaultMessage "Expected <expectedType> <expected>,<because> but got <actualType> <actual>."
         throw [Pester.Factory]::CreateShouldErrorRecord($Message, $MyInvocation.ScriptName, $MyInvocation.ScriptLineNumber, $MyInvocation.Line.TrimEnd([System.Environment]::NewLine), $true)
     }
-
-    $Actual
 }

--- a/src/functions/assert/General/Should-BeGreaterThan.ps1
+++ b/src/functions/assert/General/Should-BeGreaterThan.ps1
@@ -42,6 +42,4 @@
         $Message = Get-AssertionMessage -Expected $Expected -Actual $Actual -Because $Because -DefaultMessage "Expected the actual value to be greater than <expectedType> <expected>,<because> but it was not. Actual: <actualType> <actual>"
         throw [Pester.Factory]::CreateShouldErrorRecord($Message, $MyInvocation.ScriptName, $MyInvocation.ScriptLineNumber, $MyInvocation.Line.TrimEnd([System.Environment]::NewLine), $true)
     }
-
-    $Actual
 }

--- a/src/functions/assert/General/Should-BeGreaterThanOrEqual.ps1
+++ b/src/functions/assert/General/Should-BeGreaterThanOrEqual.ps1
@@ -42,6 +42,4 @@
         $Message = Get-AssertionMessage -Expected $Expected -Actual $Actual -Because $Because -DefaultMessage "Expected the actual value to be greater than or equal to <expectedType> <expected>,<because> but it was not. Actual: <actualType> <actual>"
         throw [Pester.Factory]::CreateShouldErrorRecord($Message, $MyInvocation.ScriptName, $MyInvocation.ScriptLineNumber, $MyInvocation.Line.TrimEnd([System.Environment]::NewLine), $true)
     }
-
-    $Actual
 }

--- a/src/functions/assert/General/Should-BeLessThan.ps1
+++ b/src/functions/assert/General/Should-BeLessThan.ps1
@@ -42,6 +42,4 @@
         $Message = Get-AssertionMessage -Expected $Expected -Actual $Actual -Because $Because -DefaultMessage "Expected the actual value to be less than <expectedType> <expected>,<because> but it was not. Actual: <actualType> <actual>"
         throw [Pester.Factory]::CreateShouldErrorRecord($Message, $MyInvocation.ScriptName, $MyInvocation.ScriptLineNumber, $MyInvocation.Line.TrimEnd([System.Environment]::NewLine), $true)
     }
-
-    $Actual
 }

--- a/src/functions/assert/General/Should-BeLessThanOrEqual.ps1
+++ b/src/functions/assert/General/Should-BeLessThanOrEqual.ps1
@@ -51,6 +51,4 @@
         $Message = Get-AssertionMessage -Expected $Expected -Actual $Actual -Because $Because -DefaultMessage "Expected the actual value to be less than or equal to <expectedType> <expected>,<because> but it was not. Actual: <actualType> <actual>"
         throw [Pester.Factory]::CreateShouldErrorRecord($Message, $MyInvocation.ScriptName, $MyInvocation.ScriptLineNumber, $MyInvocation.Line.TrimEnd([System.Environment]::NewLine), $true)
     }
-
-    $Actual
 }

--- a/src/functions/assert/General/Should-BeNull.ps1
+++ b/src/functions/assert/General/Should-BeNull.ps1
@@ -36,6 +36,4 @@
         $Message = Get-AssertionMessage -Expected $null -Actual $Actual -Because $Because -DefaultMessage "Expected `$null,<because> but got <actualType> '<actual>'."
         throw [Pester.Factory]::CreateShouldErrorRecord($Message, $MyInvocation.ScriptName, $MyInvocation.ScriptLineNumber, $MyInvocation.Line.TrimEnd([System.Environment]::NewLine), $true)
     }
-
-    $Actual
 }

--- a/src/functions/assert/General/Should-BeSame.ps1
+++ b/src/functions/assert/General/Should-BeSame.ps1
@@ -57,6 +57,4 @@
         $Message = Get-AssertionMessage -Expected $Expected -Actual $Actual -Because $Because -DefaultMessage "Expected <expectedType> <expected>,<because> to be the same instance but it was not. Actual: <actualType> <actual>"
         throw [Pester.Factory]::CreateShouldErrorRecord($Message, $MyInvocation.ScriptName, $MyInvocation.ScriptLineNumber, $MyInvocation.Line.TrimEnd([System.Environment]::NewLine), $true)
     }
-
-    $Actual
 }

--- a/src/functions/assert/General/Should-HaveType.ps1
+++ b/src/functions/assert/General/Should-HaveType.ps1
@@ -42,6 +42,4 @@
         $Message = Get-AssertionMessage -Expected $Expected -Actual $Actual -Because $Because -DefaultMessage "Expected value to have type <expected>,<because> but got <actualType> <actual>."
         throw [Pester.Factory]::CreateShouldErrorRecord($Message, $MyInvocation.ScriptName, $MyInvocation.ScriptLineNumber, $MyInvocation.Line.TrimEnd([System.Environment]::NewLine), $true)
     }
-
-    $Actual
 }

--- a/src/functions/assert/General/Should-NotBe.ps1
+++ b/src/functions/assert/General/Should-NotBe.ps1
@@ -43,6 +43,4 @@
         $Message = Get-AssertionMessage -Expected $Expected -Actual $Actual -Because $Because -DefaultMessage "Expected <expectedType> <expected>, to be different than the actual value,<because> but they were equal."
         throw [Pester.Factory]::CreateShouldErrorRecord($Message, $MyInvocation.ScriptName, $MyInvocation.ScriptLineNumber, $MyInvocation.Line.TrimEnd([System.Environment]::NewLine), $true)
     }
-
-    $Actual
 }

--- a/src/functions/assert/General/Should-NotBeNull.ps1
+++ b/src/functions/assert/General/Should-NotBeNull.ps1
@@ -36,6 +36,4 @@
         $Message = Get-AssertionMessage -Expected $null -Actual $Actual -Because $Because -DefaultMessage "Expected not `$null,<because> but got `$null."
         throw [Pester.Factory]::CreateShouldErrorRecord($Message, $MyInvocation.ScriptName, $MyInvocation.ScriptLineNumber, $MyInvocation.Line.TrimEnd([System.Environment]::NewLine), $true)
     }
-
-    $Actual
 }

--- a/src/functions/assert/General/Should-NotBeSame.ps1
+++ b/src/functions/assert/General/Should-NotBeSame.ps1
@@ -51,6 +51,4 @@
         $Message = Get-AssertionMessage -Expected $Expected -Actual $Actual -Because $Because -DefaultMessage "Expected <expectedType> <expected>, to not be the same instance,<because> but they were the same instance."
         throw [Pester.Factory]::CreateShouldErrorRecord($Message, $MyInvocation.ScriptName, $MyInvocation.ScriptLineNumber, $MyInvocation.Line.TrimEnd([System.Environment]::NewLine), $true)
     }
-
-    $Actual
 }

--- a/src/functions/assert/General/Should-NotHaveType.ps1
+++ b/src/functions/assert/General/Should-NotHaveType.ps1
@@ -44,6 +44,4 @@
         $Message = Get-AssertionMessage -Expected $Expected -Actual $Actual -Because $Because -DefaultMessage "Expected value to be of different type than <expected>,<because> but got <actualType> <actual>."
         throw [Pester.Factory]::CreateShouldErrorRecord($Message, $MyInvocation.ScriptName, $MyInvocation.ScriptLineNumber, $MyInvocation.Line.TrimEnd([System.Environment]::NewLine), $true)
     }
-
-    $Actual
 }

--- a/tst/functions/assert/Boolean/Should-BeFalse.Tests.ps1
+++ b/tst/functions/assert/Boolean/Should-BeFalse.Tests.ps1
@@ -28,11 +28,6 @@ Describe "Should-BeFalse" {
         }
     }
 
-    It "Returns the value on output" {
-        $expected = $false
-        $expected | Should-BeFalse | Verify-Equal $expected
-    }
-
     It "Can be called with positional parameters" {
         { Should-BeFalse $true } | Verify-AssertionFailed
     }

--- a/tst/functions/assert/Boolean/Should-BeFalsy.Tests.ps1
+++ b/tst/functions/assert/Boolean/Should-BeFalsy.Tests.ps1
@@ -29,11 +29,6 @@ Describe "Should-BeFalsy" {
         }
     }
 
-    It "Returns the value on output" {
-        $expected = $false
-        $expected | Should-BeFalsy | Verify-Equal $expected
-    }
-
     It "Can be called with positional parameters" {
         { Should-BeFalsy $true } | Verify-AssertionFailed
     }

--- a/tst/functions/assert/Boolean/Should-BeTrue.Tests.ps1
+++ b/tst/functions/assert/Boolean/Should-BeTrue.Tests.ps1
@@ -25,11 +25,6 @@ Describe "Should-BeTrue" {
         }
     }
 
-    It "Returns the value on output" {
-        $expected = $true
-        $expected | Should-BeTrue | Verify-Equal $expected
-    }
-
     It "Can be called with positional parameters" {
         { Should-BeTrue $false } | Verify-AssertionFailed
     }

--- a/tst/functions/assert/Boolean/Should-BeTruthy.Tests.ps1
+++ b/tst/functions/assert/Boolean/Should-BeTruthy.Tests.ps1
@@ -24,11 +24,6 @@ Describe "Should-BeTruthy" {
         }
     }
 
-    It "Returns the value on output" {
-        $expected = $true
-        $expected | Should-BeTruthy | Verify-Equal $expected
-    }
-
     It "Can be called with positional parameters" {
         { Should-BeTruthy $false } | Verify-AssertionFailed
     }

--- a/tst/functions/assert/Collection/Should-All.Tests.ps1
+++ b/tst/functions/assert/Collection/Should-All.Tests.ps1
@@ -45,13 +45,6 @@ Expected [int] 2, but got [int] 1." -replace "`r`n", "`n")
         $err.Exception.Message | Verify-Equal $Message
     }
 
-    It "Returns the value on output" {
-        $expected = "a", "b"
-        $v = $expected | Should-All { $true }
-        $v[0] | Verify-Equal $expected[0]
-        $v[1] | Verify-Equal $expected[1]
-    }
-
     It "Can filter using variables from the sorrounding context" {
         $f = 1
         2, 4 | Should-All { $_ / $f }

--- a/tst/functions/assert/Collection/Should-Any.Tests.ps1
+++ b/tst/functions/assert/Collection/Should-Any.Tests.ps1
@@ -52,13 +52,6 @@ Expected [int] 2, but got [int] 1." -replace "`r`n", "`n")
         $err.Exception.Message | Verify-Equal $Message
     }
 
-    It "Returns the value on output" {
-        $expected = "a", "b"
-        $v = $expected | Should-Any { $true }
-        $v[0] | Verify-Equal $expected[0]
-        $v[1] | Verify-Equal $expected[1]
-    }
-
     It "Accepts FilterScript and Actual by position" {
         Should-Any { $true } 1, 2
     }

--- a/tst/functions/assert/General/Should-Be.Tests.ps1
+++ b/tst/functions/assert/General/Should-Be.Tests.ps1
@@ -69,11 +69,6 @@ Describe "Should-Be" {
         }
     }
 
-    It "Returns the value on output" {
-        $expected = 1
-        $expected | Should-Be 1 | Verify-Equal $expected
-    }
-
     It "Can be called with positional parameters" {
         { Should-Be 1 2 } | Verify-AssertionFailed
     }

--- a/tst/functions/assert/General/Should-BeGreaterThan.Tests.ps1
+++ b/tst/functions/assert/General/Should-BeGreaterThan.Tests.ps1
@@ -87,11 +87,6 @@ Describe "Should-BeGreaterThan" {
         }
     }
 
-    It "Returns the value on output" {
-        $expected = 1
-        $expected | Should-BeGreaterThan 0 | Verify-Equal $expected
-    }
-
     It "Can be called with positional parameters" {
         { Should-BeGreaterThan 2 1 } | Verify-AssertionFailed
     }

--- a/tst/functions/assert/General/Should-BeGreaterThanOrEqual.Tests.ps1
+++ b/tst/functions/assert/General/Should-BeGreaterThanOrEqual.Tests.ps1
@@ -87,11 +87,6 @@ Describe "Should-BeGreaterThanOrEqual" {
         }
     }
 
-    It "Returns the value on output" {
-        $expected = 1
-        $expected | Should-BeGreaterThanOrEqual 0 | Verify-Equal $expected
-    }
-
     It "Can be called with positional parameters" {
         { Should-BeGreaterThanOrEqual 2 1 } | Verify-AssertionFailed
     }

--- a/tst/functions/assert/General/Should-BeLessThan.Tests.ps1
+++ b/tst/functions/assert/General/Should-BeLessThan.Tests.ps1
@@ -87,15 +87,6 @@ Describe "Should-BeLessThan" {
         }
     }
 
-    It "Returns the value on output" {
-        $expected = 0
-        $expected | Should-BeLessThan 1 | Verify-Equal $expected
-    }
-
-    It "Can be called with positional parameters" {
-        { Should-BeLessThan 1 2 } | Verify-AssertionFailed
-    }
-
     It "Given collection to Expected it throws" {
         $err = { "dummy" | Should-BeLessThan @() } | Verify-Throw
         $err.Exception | Verify-Type ([ArgumentException])

--- a/tst/functions/assert/General/Should-BeLessThanOrEqual.Tests.ps1
+++ b/tst/functions/assert/General/Should-BeLessThanOrEqual.Tests.ps1
@@ -87,11 +87,6 @@ Describe "Should-BeLessThanOrEqual" {
         }
     }
 
-    It "Returns the value on output" {
-        $expected = 0
-        $expected | Should-BeLessThanOrEqual 1 | Verify-Equal $expected
-    }
-
     It "Can be called with positional parameters" {
         { Should-BeLessThanOrEqual 1 2 } | Verify-AssertionFailed
     }

--- a/tst/functions/assert/General/Should-BeSame.Tests.ps1
+++ b/tst/functions/assert/General/Should-BeSame.Tests.ps1
@@ -24,11 +24,6 @@ Describe "Should-BeSame" {
         $err.Exception.Message | Verify-Equal $Message
     }
 
-    It "Returns the value on output" {
-        $expected = New-Object Diagnostics.Process
-        $expected | Should-BeSame $expected | Verify-Equal $expected
-    }
-
     Context "Throws when `$expected is a value type or string to warn user about unexpected behavior" {
         It "throws for value <value>" -TestCases @(
             @{ Value = 1 }

--- a/tst/functions/assert/General/Should-HaveType.Tests.ps1
+++ b/tst/functions/assert/General/Should-HaveType.Tests.ps1
@@ -9,10 +9,6 @@ Describe "Should-HaveType" {
         { 1 | Should-HaveType ([string]) } | Verify-AssertionFailed
     }
 
-    It "Returns the given value" {
-        'b' | Should-HaveType ([string]) | Verify-Equal 'b'
-    }
-
     It "Can be called with positional parameters" {
         { Should-HaveType ([string]) 1 } | Verify-AssertionFailed
     }

--- a/tst/functions/assert/General/Should-NotBe.Tests.ps1
+++ b/tst/functions/assert/General/Should-NotBe.Tests.ps1
@@ -68,11 +68,6 @@ Describe "Should-NotBe" {
         }
     }
 
-    It "Returns the value on output" {
-        $expected = 1
-        $expected | Should-NotBe 9 | Verify-Equal $expected
-    }
-
     It "Can be called with positional parameters" {
         { Should-NotBe 1 1 } | Verify-AssertionFailed
     }

--- a/tst/functions/assert/General/Should-NotBeNull.Tests.ps1
+++ b/tst/functions/assert/General/Should-NotBeNull.Tests.ps1
@@ -10,10 +10,6 @@ InPesterModuleScope {
             { $null | Should-NotBeNull } | Verify-AssertionFailed
         }
 
-        It "Returns the given value" {
-            1 | Should-NotBeNull | Verify-NotNull
-        }
-
         It "Can be called with positional parameters" {
             { Should-NotBeNull $null } | Verify-AssertionFailed
         }

--- a/tst/functions/assert/General/Should-NotBeSame.Tests.ps1
+++ b/tst/functions/assert/General/Should-NotBeSame.Tests.ps1
@@ -24,11 +24,6 @@ Describe "Should-NotBeSame" {
         $err.Exception.Message | Verify-Equal $Message
     }
 
-    It "Returns the value on output" {
-        $expected = 1
-        $expected | Should-NotBeSame 7 | Verify-Equal $expected
-    }
-
     It "Can be called with positional parameters" {
         {
             $obj = New-Object -TypeName PSObject

--- a/tst/functions/assert/General/Should-NotHaveType.Tests.ps1
+++ b/tst/functions/assert/General/Should-NotHaveType.Tests.ps1
@@ -9,10 +9,6 @@ Describe "Should-NotHaveType" {
         1 | Should-NotHaveType ([string])
     }
 
-    It "Returns the given value" {
-        'b' | Should-NotHaveType ([int]) | Verify-Equal 'b'
-    }
-
     It "Can be called with positional parameters" {
         { Should-NotHaveType ([int]) 1 } | Verify-AssertionFailed
     }


### PR DESCRIPTION
Fix #2508

Seems that this functionality is not very helpful, you can check more values on actual value by saving the original value to a variable, and it is easier to debug.