### PR TITLE
Fix collection assertions with Should

### DIFF
--- a/src/functions/assert/Collection/Should-All.ps1
+++ b/src/functions/assert/Collection/Should-All.ps1
@@ -76,9 +76,16 @@
                 $appendMore = $true
             }
 
-            $pass = $false
+            $pass = @($false)
         }
-        if (-not $pass) { $item }
+
+        # The API returns a collection and user can return anything from their script
+        # or there can be no output when assertion is used, so we are checking if the first item
+        # in the output is a boolean $false. The scriptblock should not fail in $null for example,
+        # hence the explicit type check
+        if (($pass.Count -ge 1) -and ($pass[0] -is [bool]) -and ($false -eq $pass[0])) {
+            $item
+        }
     }
 
     # Make sure are checking the count of the filtered items, not just truthiness of a single item.

--- a/src/functions/assert/Collection/Should-Any.ps1
+++ b/src/functions/assert/Collection/Should-Any.ps1
@@ -55,7 +55,6 @@
 
     $failReasons = $null
     $appendMore = $false
-    $pass = $false
     foreach ($item in $Actual) {
         $underscore = [PSVariable]::new('_', $item)
         try {
@@ -72,9 +71,18 @@
                 $appendMore = $true
             }
 
-            $pass = $false
+            # InvokeWithContext returns collection. This makes it easier to check the value if we throw and don't assign the value.
+            $pass = @($false)
         }
-        if ($pass) { break }
+
+        # The API returns a collection and user can return anything from their script
+        # or there can be no output when assertion is used, so we are checking if the first item
+        # in the output is a boolean $false. The scriptblock should not fail in $null for example,
+        # hence the explicit type check
+        if (-not (($pass.Count -ge 1) -and ($pass[0] -is [bool]) -and ($false -eq $pass[0]))) {
+            $pass = $true
+            break
+        }
     }
 
     if (-not $pass) {

--- a/tst/functions/assert/Collection/Should-Any.Tests.ps1
+++ b/tst/functions/assert/Collection/Should-Any.Tests.ps1
@@ -9,6 +9,12 @@ Describe "Should-Any" {
         $Actual | Should-Any -FilterScript { $_ -eq 1 }
     }
 
+    It "Passes when at least one item in the given collection passes the predicate with assertion" -TestCases @(
+        @{ Actual = @(1, 2, 3) }
+    ) {
+        $Actual | Should-Any -FilterScript { $_ | Should-Be 1 }
+    }
+
     It "Fails when none of the items passes the predicate" -TestCases @(
         @{ Actual = @(1, 2, 3) }
         @{ Actual = @(1) }


### PR DESCRIPTION
Should-Any was not passing when at least one item was passing the predicate, because output is $null when you run with Should-* assertion in the predicate, and it does not fail. But that was converted to $false, and so the item did not pass.