### PR TITLE
Add OutputType to improve tab-completion/intellisense

### DIFF
--- a/src/Main.ps1
+++ b/src/Main.ps1
@@ -570,6 +570,7 @@ function Invoke-Pester {
     # Currently doesn't work. $IgnoreUnsafeCommands filter used in rule as workaround
     # [Diagnostics.CodeAnalysis.SuppressMessageAttribute('Pester.BuildAnalyzerRules\Measure-SafeCommands', 'Remove-Variable', Justification = 'Remove-Variable can't remove "optimized variables" when using "alias" for Remove-Variable.')]
     [CmdletBinding(DefaultParameterSetName = 'Simple')]
+    [OutputType([Pester.Run])]
     param(
         [Parameter(Position = 0, Mandatory = 0, ParameterSetName = "Simple")]
         [Parameter(Position = 0, Mandatory = 0, ParameterSetName = "Legacy")]  # Legacy set for v4 compatibility during migration - deprecated

--- a/src/Pester.RSpec.ps1
+++ b/src/Pester.RSpec.ps1
@@ -481,6 +481,7 @@ function New-PesterConfiguration {
     https://pester.dev/docs/commands/Invoke-Pester
     #>
     [CmdletBinding()]
+    [OutputType([PesterConfiguration])]
     param(
         [System.Collections.IDictionary] $Hashtable
     )
@@ -683,6 +684,7 @@ function New-PesterContainer {
     https://pester.dev/docs/usage/data-driven-tests
     #>
     [CmdletBinding(DefaultParameterSetName = "Path")]
+    [OutputType([Pester.ContainerInfo])]
     param(
         [Parameter(Mandatory, ParameterSetName = "Path")]
         [String[]] $Path,

--- a/src/Pester.Runtime.ps1
+++ b/src/Pester.Runtime.ps1
@@ -110,6 +110,7 @@ function Reset-PerContainerState {
 }
 
 function Find-Test {
+    [OutputType([Pester.Container])]
     [CmdletBinding()]
     param (
         [Parameter(Mandatory = $true)]
@@ -138,6 +139,7 @@ function Find-Test {
 }
 
 function ConvertTo-DiscoveredBlockContainer {
+    [OutputType([Pester.Container])]
     param (
         [Parameter(Mandatory = $true)]
         $Block
@@ -148,6 +150,7 @@ function ConvertTo-DiscoveredBlockContainer {
 }
 
 function ConvertTo-ExecutedBlockContainer {
+    [OutputType([Pester.Container])]
     param (
         [Parameter(Mandatory = $true)]
         $Block
@@ -156,8 +159,6 @@ function ConvertTo-ExecutedBlockContainer {
     foreach ($b in $Block) {
         [Pester.Container]::CreateFromBlock($b)
     }
-
-
 }
 
 function New-ParametrizedBlock {
@@ -2479,6 +2480,7 @@ function Invoke-BlockContainer {
 }
 
 function New-BlockContainerObject {
+    [OutputType([Pester.ContainerInfo])]
     [CmdletBinding()]
     param (
         [Parameter(Mandatory, ParameterSetName = 'ScriptBlock')]

--- a/src/functions/New-Fixture.ps1
+++ b/src/functions/New-Fixture.ps1
@@ -69,6 +69,7 @@
     .LINK
     https://pester.dev/docs/commands/Should
     #>
+    [OutputType([System.IO.FileInfo])]
     param (
         [Parameter(Mandatory = $true)]
         [String]$Name,
@@ -78,7 +79,7 @@
     $Name = $Name -replace '.ps(m?)1', ''
 
     if ($Name -notmatch '^\S+$') {
-        throw "Name is not valid. Whitespace are not allowed in a function name."
+        throw 'Name is not valid. Whitespace are not allowed in a function name.'
     }
 
     #keep this formatted as is. the format is output to the file as is, including indentation
@@ -94,7 +95,7 @@ Describe "#name#" {
     It "Returns expected output" {
         #name# | Should -Be "YOUR_EXPECTED_VALUE"
     }
-}' -replace "#name#", $Name
+}' -replace '#name#', $Name
 
     $Path = $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($Path)
 
@@ -104,6 +105,7 @@ Describe "#name#" {
 
 function Create-File {
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('Pester.BuildAnalyzerRules\Measure-SafeCommands', 'Write-Warning', Justification = 'Mocked in unit test for New-Fixture.')]
+    [OutputType([System.IO.FileInfo])]
     param($Path, $Name, $Content)
     if (-not (& $SafeCommands['Test-Path'] -Path $Path)) {
         & $SafeCommands['New-Item'] -ItemType Directory -Path $Path | & $SafeCommands['Out-Null']

--- a/src/functions/TestResults.ps1
+++ b/src/functions/TestResults.ps1
@@ -270,8 +270,9 @@ function ConvertTo-NUnitReport {
     .LINK
     https://pester.dev/docs/commands/Invoke-Pester
     #>
+    [OutputType([xml], [string])]
     param (
-        [parameter(Mandatory = $true, ValueFromPipeline = $true)]
+        [Parameter(Mandatory = $true, ValueFromPipeline = $true)]
         [Pester.Run] $Result,
         [Switch] $AsString,
 
@@ -360,8 +361,9 @@ function ConvertTo-JUnitReport {
     .LINK
     https://pester.dev/docs/commands/Invoke-Pester
     #>
+    [OutputType([xml], [string])]
     param (
-        [parameter(Mandatory = $true, ValueFromPipeline = $true)]
+        [Parameter(Mandatory = $true, ValueFromPipeline = $true)]
         [Pester.Run] $Result,
         [Switch] $AsString
     )


### PR DESCRIPTION
## PR Summary
Defines OutputType for functions returning typed objects to enable tab-completion/intellisense while writing code without executing it. Especially useful for `New-PesterConfiguration` when writing quick demos.

**Note:** Tab-completion currently ignores ParameterSet defined in `[OutputType]`, so no need to split them in e.g. `ConvertTo-*UnitReport`

## PR Checklist

- [x] PR has meaningful title
- [x] Summary describes changes
- [x] PR is ready to be merged
  - If not, use the arrow next to `Create Pull Request` to mark it as a draft. PR can be marked `Ready for review` when it's ready.
- [ ] Tests are added/update *(if required)*
- [ ] Documentation is updated/added *(if required)*