### PR TITLE
Implement CodeCoverage.ExcludeTests

### DIFF
--- a/src/functions/Coverage.ps1
+++ b/src/functions/Coverage.ps1
@@ -167,6 +167,10 @@ function Get-CoverageInfoFromDictionary {
     $includeTests = Get-DictionaryValueFromFirstKeyFound -Dictionary $Dictionary -Key 'IncludeTests'
     $recursePaths = Get-DictionaryValueFromFirstKeyFound -Dictionary $Dictionary -Key 'RecursePaths'
 
+    # TODO: Implement or remove the IDictionary config logic from CodeCoverage
+    # Jank fix for https://github.com/pester/Pester/issues/2514 until CodeCoverage config logic is updated
+    if ($null -eq $includeTests) { $includeTests = $PesterPreference.CodeCoverage.ExcludeTests.Value -ne $true }
+
     $startLine = Convert-UnknownValueToInt -Value $startLine -DefaultValue 0
     $endLine = Convert-UnknownValueToInt -Value $endLine -DefaultValue 0
     [bool] $includeTests = Convert-UnknownValueToInt -Value $includeTests -DefaultValue 0

--- a/src/functions/Coverage.ps1
+++ b/src/functions/Coverage.ps1
@@ -168,7 +168,7 @@ function Get-CoverageInfoFromDictionary {
     $recursePaths = Get-DictionaryValueFromFirstKeyFound -Dictionary $Dictionary -Key 'RecursePaths'
 
     # TODO: Implement or remove the IDictionary config logic from CodeCoverage
-    # Jank fix for https://github.com/pester/Pester/issues/2514 until CodeCoverage config logic is updated
+    # Quick fix for https://github.com/pester/Pester/issues/2514 until CodeCoverage config logic is updated
     if ($null -eq $includeTests) { $includeTests = $PesterPreference.CodeCoverage.ExcludeTests.Value -ne $true }
 
     $startLine = Convert-UnknownValueToInt -Value $startLine -DefaultValue 0

--- a/tst/Pester.RSpec.Coverage.ts.ps1
+++ b/tst/Pester.RSpec.Coverage.ts.ps1
@@ -289,4 +289,38 @@ i -PassThru:$PassThru {
             $r.Result | Verify-Equal 'Passed'
         }
     }
+
+    b 'Coverage path resolution' {
+        t 'Excludes test files when ExcludeTests is true' {
+            # https://github.com/pester/Pester/issues/2514
+            $c = New-PesterConfiguration
+            $c.Run.Path = "$PSScriptRoot/testProjects/CoverageTestFile.Tests.ps1"
+            $c.Run.PassThru = $true
+            $c.CodeCoverage.Enabled = $true
+            $c.CodeCoverage.ExcludeTests = $true # default
+            $c.CodeCoverage.Path = "$PSScriptRoot/CoverageTestFile.ps1", "$PSScriptRoot/testProjects"
+
+            $r = Invoke-Pester -Configuration $c
+
+            $r.Result | Verify-Equal 'Passed'
+            $r.CodeCoverage.FilesAnalyzedCount | Verify-Equal 1
+            @($r.CodeCoverage.FilesAnalyzed) -match '\.Tests.ps1$' | Verify-Null
+        }
+
+        t 'Includes test files when ExcludeTests is false' {
+            # https://github.com/pester/Pester/issues/2514
+            $c = New-PesterConfiguration
+            $c.Run.Path = "$PSScriptRoot/testProjects/CoverageTestFile.Tests.ps1"
+            $c.Run.PassThru = $true
+            $c.CodeCoverage.Enabled = $true
+            $c.CodeCoverage.ExcludeTests = $false
+            $c.CodeCoverage.Path = "$PSScriptRoot/CoverageTestFile.ps1", "$PSScriptRoot/testProjects"
+
+            $r = Invoke-Pester -Configuration $c
+
+            $r.Result | Verify-Equal 'Passed'
+            $r.CodeCoverage.FilesAnalyzedCount | Verify-Equal 4
+            @($r.CodeCoverage.FilesAnalyzed) -match '\.Tests.ps1$' | Verify-NotNull
+        }
+    }
 }


### PR DESCRIPTION
## PR Summary
Temporary fix to implement `CodeCoverage.ExcludeTests` until CodeCoverage configuration parsing either implements old advanced interface or removes the old code and updates tests.

Fix #2514

## PR Checklist

- [x] PR has meaningful title
- [x] Summary describes changes
- [x] PR is ready to be merged
  - If not, use the arrow next to `Create Pull Request` to mark it as a draft. PR can be marked `Ready for review` when it's ready.
- [x] Tests are added/update *(if required)*
- [ ] Documentation is updated/added *(if required)*