### PR TITLE
Support v5 positional syntax in Should-Throw

### DIFF
--- a/src/functions/assert/Exception/Should-Throw.ps1
+++ b/src/functions/assert/Exception/Should-Throw.ps1
@@ -52,11 +52,15 @@ function Should-Throw {
     param (
         [Parameter(ValueFromPipeline = $true, Mandatory = $true)]
         [ScriptBlock]$ScriptBlock,
-        [Type]$ExceptionType,
+        [Parameter(Position = 0)]
         [String]$ExceptionMessage,
+        [Parameter(Position = 1)]
         [String]$FullyQualifiedErrorId,
-        [Switch]$AllowNonTerminatingError,
-        [String]$Because
+        [Parameter(Position = 2)]
+        [Type]$ExceptionType,
+        [Parameter(Position = 3)]
+        [String]$Because,
+        [Switch]$AllowNonTerminatingError
     )
 
     $collectedInput = Collect-Input -ParameterInput $ScriptBlock -PipelineInput $local:Input -IsPipelineInput $MyInvocation.ExpectingInput -UnrollInput

--- a/tst/functions/assert/Exception/Should-Throw.Tests.ps1
+++ b/tst/functions/assert/Exception/Should-Throw.Tests.ps1
@@ -18,6 +18,11 @@ Describe "Should-Throw" {
         { { Write-Error "fail!" } | Should-Throw -AllowNonTerminatingError } | Verify-AssertionFailed
     }
 
+    It 'Supports same positional parameters as Should -Throw' {
+        { Write-Error -Message 'MockErrorMessage' -ErrorId 'MockErrorId' -Category 'InvalidOperation' -TargetObject 'MockTargetObject' -ErrorAction 'Stop' } |
+            Should-Throw 'MockErrorMessage' 'MockErrorId' ([Microsoft.PowerShell.Commands.WriteErrorException]) 'MockBecauseString'
+    }
+
     Context "Filtering with exception type" {
         It "Passes when exception has the expected type" {
             { throw [ArgumentException]"A is null!" } | Should-Throw -ExceptionType ([ArgumentException])


### PR DESCRIPTION
## PR Summary
Support same positional arguments in `Should-Throw` as `Should -Throw` in v5.

Fix #2527

## PR Checklist

- [x] PR has meaningful title
- [x] Summary describes changes
- [x] PR is ready to be merged
  - If not, use the arrow next to `Create Pull Request` to mark it as a draft. PR can be marked `Ready for review` when it's ready.
- [x] Tests are added/update *(if required)*
- [ ] Documentation is updated/added *(if required)*