### PR TITLE
Throw when providing null or empty array to -ForEach

### DIFF
--- a/src/csharp/Pester/RunConfiguration.cs
+++ b/src/csharp/Pester/RunConfiguration.cs
@@ -70,7 +70,7 @@ namespace Pester
             PassThru = new BoolOption("Return result object to the pipeline after finishing the test run.", false);
             SkipRun = new BoolOption("Runs the discovery phase but skips run. Use it with PassThru to get object populated with all tests.", false);
             SkipRemainingOnFailure = new StringOption("Skips remaining tests after failure for selected scope, options are None, Run, Container and Block.", "None");
-            FailOnNullOrEmptyForEach  = new BoolOption("Fails the block or test when -ForEach is provided `$null or @(). Can be overriden using -AllowNullOrEmptyForEach on a specific block or test.", true);
+            FailOnNullOrEmptyForEach  = new BoolOption("Fails discovery when -ForEach is provided $null or @() in a block or test. Can be overriden for a specific Describe/Context/It using -AllowNullOrEmptyForEach.", true);
         }
 
         public StringArrayOption Path

--- a/src/csharp/Pester/RunConfiguration.cs
+++ b/src/csharp/Pester/RunConfiguration.cs
@@ -32,6 +32,7 @@ namespace Pester
         private BoolOption _passThru;
         private BoolOption _skipRun;
         private StringOption _skipRemainingOnFailure;
+        private BoolOption _failOnNullOrEmptyForEach;
 
         public static RunConfiguration Default { get { return new RunConfiguration(); } }
         public static RunConfiguration ShallowClone(RunConfiguration configuration)
@@ -53,6 +54,7 @@ namespace Pester
                 configuration.AssignValueIfNotNull<bool>(nameof(PassThru), v => PassThru = v);
                 configuration.AssignValueIfNotNull<bool>(nameof(SkipRun), v => SkipRun = v);
                 configuration.AssignObjectIfNotNull<string>(nameof(SkipRemainingOnFailure), v => SkipRemainingOnFailure = v);
+                configuration.AssignValueIfNotNull<bool>(nameof(FailOnNullOrEmptyForEach ), v => FailOnNullOrEmptyForEach  = v);
             }
         }
 
@@ -68,6 +70,7 @@ namespace Pester
             PassThru = new BoolOption("Return result object to the pipeline after finishing the test run.", false);
             SkipRun = new BoolOption("Runs the discovery phase but skips run. Use it with PassThru to get object populated with all tests.", false);
             SkipRemainingOnFailure = new StringOption("Skips remaining tests after failure for selected scope, options are None, Run, Container and Block.", "None");
+            FailOnNullOrEmptyForEach  = new BoolOption("Fails the block or test when -ForEach is provided `$null or @(). Can be overriden using -AllowNullOrEmptyForEach on a specific block or test.", true);
         }
 
         public StringArrayOption Path
@@ -226,6 +229,22 @@ namespace Pester
                 else
                 {
                     _skipRemainingOnFailure = new StringOption(_skipRemainingOnFailure, value?.Value);
+                }
+            }
+        }
+
+        public BoolOption FailOnNullOrEmptyForEach
+        {
+            get { return _failOnNullOrEmptyForEach; }
+            set
+            {
+                if (_failOnNullOrEmptyForEach == null)
+                {
+                    _failOnNullOrEmptyForEach = value;
+                }
+                else
+                {
+                    _failOnNullOrEmptyForEach = new BoolOption(_failOnNullOrEmptyForEach, value.Value);
                 }
             }
         }

--- a/src/en-US/about_PesterConfiguration.help.txt
+++ b/src/en-US/about_PesterConfiguration.help.txt
@@ -69,6 +69,10 @@ SECTIONS AND OPTIONS
         Type: string
         Default value: 'None'
 
+        FailOnNullOrEmptyForEach: Fails the block or test when -ForEach is provided `$null or @(). Can be overriden using -AllowNullOrEmptyForEach on a specific block or test.
+        Type: bool
+        Default value: $true
+
     Filter:
         Tag: Tags of Describe, Context or It to be run.
         Type: string[]

--- a/src/en-US/about_PesterConfiguration.help.txt
+++ b/src/en-US/about_PesterConfiguration.help.txt
@@ -69,7 +69,7 @@ SECTIONS AND OPTIONS
         Type: string
         Default value: 'None'
 
-        FailOnNullOrEmptyForEach: Fails the block or test when -ForEach is provided `$null or @(). Can be overriden using -AllowNullOrEmptyForEach on a specific block or test.
+        FailOnNullOrEmptyForEach: Fails discovery when -ForEach is provided $null or @() in a block or test. Can be overriden for a specific Describe/Context/It using -AllowNullOrEmptyForEach.
         Type: bool
         Default value: $true
 

--- a/src/functions/Context.ps1
+++ b/src/functions/Context.ps1
@@ -1,4 +1,4 @@
-function Context {
+﻿function Context {
     <#
     .SYNOPSIS
     Provides logical grouping of It blocks within a single Describe block.
@@ -112,13 +112,15 @@ function Context {
         }
 
         if ($PSBoundParameters.ContainsKey('ForEach')) {
-            if ($null -ne $ForEach -and 0 -lt @($ForEach).Count) {
-                New-ParametrizedBlock -Name $Name -ScriptBlock $Fixture -StartLine $MyInvocation.ScriptLineNumber -StartColumn $MyInvocation.OffsetInLine -Tag $Tag -FrameworkData @{ CommandUsed = 'Context'; WrittenToScreen = $false } -Focus:$Focus -Skip:$Skip -Data $ForEach
+            if ($null -eq $ForEach -or 0 -eq @($ForEach).Count) {
+                if ($PesterPreference.Run.FailOnNullOrEmptyForEach.Value -and -not $AllowNullOrEmptyForEach) {
+                    throw [System.ArgumentException]::new('Value can not be null or empty array. If this is expected, use -AllowNullOrEmptyForEach', 'ForEach')
+                }
+                # @() or $null is provided and allowed, do nothing
+                return
             }
-            else {
-                # @() or $null is provided do nothing
 
-            }
+            New-ParametrizedBlock -Name $Name -ScriptBlock $Fixture -StartLine $MyInvocation.ScriptLineNumber -StartColumn $MyInvocation.OffsetInLine -Tag $Tag -FrameworkData @{ CommandUsed = 'Context'; WrittenToScreen = $false } -Focus:$Focus -Skip:$Skip -Data $ForEach
         }
         else {
             New-Block -Name $Name -ScriptBlock $Fixture -StartLine $MyInvocation.ScriptLineNumber -Tag $Tag -FrameworkData @{ CommandUsed = 'Context'; WrittenToScreen = $false } -Focus:$Focus -Skip:$Skip

--- a/src/functions/Context.ps1
+++ b/src/functions/Context.ps1
@@ -1,4 +1,4 @@
-﻿function Context {
+function Context {
     <#
     .SYNOPSIS
     Provides logical grouping of It blocks within a single Describe block.
@@ -25,6 +25,10 @@
     .PARAMETER Skip
     Use this parameter to explicitly mark the block to be skipped. This is preferable to temporarily
     commenting out a block, because it remains listed in the output.
+
+    .PARAMETER AllowNullOrEmptyForEach
+    Allows empty or null values for -ForEach when Run.FailOnNullOrEmptyForEach is enabled.
+    This might be excepted in certain scenarios like using external data.
 
     .PARAMETER ForEach
     Allows data driven tests to be written.
@@ -85,6 +89,7 @@
 
         # [Switch] $Focus,
         [Switch] $Skip,
+        [Switch] $AllowNullOrEmptyForEach,
 
         [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidAssignmentToAutomaticVariable', '', Justification = 'ForEach is not used in Foreach-Object loop')]
         $ForEach

--- a/src/functions/Describe.ps1
+++ b/src/functions/Describe.ps1
@@ -1,4 +1,4 @@
-function Describe {
+﻿function Describe {
     <#
     .SYNOPSIS
     Creates a logical group of tests.
@@ -120,12 +120,15 @@ function Describe {
         }
 
         if ($PSBoundParameters.ContainsKey('ForEach')) {
-            if ($null -ne $ForEach -and 0 -lt @($ForEach).Count) {
-                New-ParametrizedBlock -Name $Name -ScriptBlock $Fixture -StartLine $MyInvocation.ScriptLineNumber -StartColumn $MyInvocation.OffsetInLine -Tag $Tag -FrameworkData @{ CommandUsed = 'Describe'; WrittenToScreen = $false } -Focus:$Focus -Skip:$Skip -Data $ForEach
+            if ($null -eq $ForEach -or 0 -eq @($ForEach).Count) {
+                if ($PesterPreference.Run.FailOnNullOrEmptyForEach.Value -and -not $AllowNullOrEmptyForEach) {
+                    throw [System.ArgumentException]::new('Value can not be null or empty array. If this is expected, use -AllowNullOrEmptyForEach', 'ForEach')
+                }
+                # @() or $null is provided and allowed, do nothing
+                return
             }
-            else {
-                # @() or $null is provided do nothing
-            }
+
+            New-ParametrizedBlock -Name $Name -ScriptBlock $Fixture -StartLine $MyInvocation.ScriptLineNumber -StartColumn $MyInvocation.OffsetInLine -Tag $Tag -FrameworkData @{ CommandUsed = 'Describe'; WrittenToScreen = $false } -Focus:$Focus -Skip:$Skip -Data $ForEach
         }
         else {
             New-Block -Name $Name -ScriptBlock $Fixture -StartLine $MyInvocation.ScriptLineNumber -Tag $Tag -FrameworkData @{ CommandUsed = 'Describe'; WrittenToScreen = $false } -Focus:$Focus -Skip:$Skip

--- a/src/functions/Describe.ps1
+++ b/src/functions/Describe.ps1
@@ -1,4 +1,4 @@
-﻿function Describe {
+function Describe {
     <#
     .SYNOPSIS
     Creates a logical group of tests.
@@ -27,6 +27,10 @@
     .PARAMETER Skip
     Use this parameter to explicitly mark the block to be skipped. This is preferable to temporarily
     commenting out a block, because it remains listed in the output.
+
+    .PARAMETER AllowNullOrEmptyForEach
+    Allows empty or null values for -ForEach when Run.FailOnNullOrEmptyForEach is enabled.
+    This might be excepted in certain scenarios like using external data.
 
     .PARAMETER ForEach
     Allows data driven tests to be written.
@@ -93,6 +97,7 @@
 
         # [Switch] $Focus,
         [Switch] $Skip,
+        [Switch] $AllowNullOrEmptyForEach,
 
         [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidAssignmentToAutomaticVariable', '', Justification = 'ForEach is not used in Foreach-Object loop')]
         $ForEach

--- a/src/functions/It.ps1
+++ b/src/functions/It.ps1
@@ -1,4 +1,4 @@
-function It {
+﻿function It {
     <#
     .SYNOPSIS
     Validates the results of a test inside of a Describe block.
@@ -153,12 +153,15 @@ function It {
     }
 
     if ($PSBoundParameters.ContainsKey('ForEach')) {
-        if ($null -ne $ForEach -and 0 -lt @($ForEach).Count) {
-            New-ParametrizedTest -Name $Name -ScriptBlock $Test -StartLine $MyInvocation.ScriptLineNumber -StartColumn $MyInvocation.OffsetInLine -Data $ForEach -Tag $Tag -Focus:$Focus -Skip:$Skip
+        if ($null -eq $ForEach -or 0 -eq @($ForEach).Count) {
+            if ($PesterPreference.Run.FailOnNullOrEmptyForEach.Value -and -not $AllowNullOrEmptyForEach) {
+                throw [System.ArgumentException]::new('Value can not be null or empty array. If this is expected, use -AllowNullOrEmptyForEach', 'ForEach')
+            }
+            # @() or $null is provided and allowed, do nothing
+            return
         }
-        else {
-            # @() or $null is provided do nothing
-        }
+
+        New-ParametrizedTest -Name $Name -ScriptBlock $Test -StartLine $MyInvocation.ScriptLineNumber -StartColumn $MyInvocation.OffsetInLine -Data $ForEach -Tag $Tag -Focus:$Focus -Skip:$Skip
     }
     else {
         New-Test -Name $Name -ScriptBlock $Test -StartLine $MyInvocation.ScriptLineNumber -Tag $Tag -Focus:$Focus -Skip:$Skip

--- a/src/functions/It.ps1
+++ b/src/functions/It.ps1
@@ -1,4 +1,4 @@
-﻿function It {
+function It {
     <#
     .SYNOPSIS
     Validates the results of a test inside of a Describe block.
@@ -30,6 +30,10 @@
     .PARAMETER Skip
     Use this parameter to explicitly mark the test to be skipped. This is preferable to temporarily
     commenting out a test, because the test remains listed in the output.
+
+    .PARAMETER AllowNullOrEmptyForEach
+    Allows empty or null values for -ForEach when Run.FailOnNullOrEmptyForEach is enabled.
+    This might be excepted in certain scenarios like using external data.
 
     .PARAMETER ForEach
     (Formerly called TestCases.) Optional array of hashtable (or any IDictionary) objects.
@@ -128,7 +132,8 @@
         [String[]] $Tag,
 
         [Parameter(ParameterSetName = 'Skip')]
-        [Switch] $Skip
+        [Switch] $Skip,
+        [Switch] $AllowNullOrEmptyForEach
 
         # [Parameter(ParameterSetName = 'Skip')]
         # [String] $SkipBecause,

--- a/tst/Format2.Tests.ps1
+++ b/tst/Format2.Tests.ps1
@@ -17,8 +17,7 @@ InPesterModuleScope {
 
 
     Describe "Format-Collection2" {
-        It "Formats empty collection to @()" -TestCases @(
-        ) {
+        It "Formats empty collection to @()" {
             Format-Collection2 -Value @() | Verify-Equal "@()"
         }
 

--- a/tst/Pester.RSpec.Configuration.ts.ps1
+++ b/tst/Pester.RSpec.Configuration.ts.ps1
@@ -55,6 +55,10 @@ i -PassThru:$PassThru {
             [PesterConfiguration]::Default.Run.SkipRemainingOnFailure.Value | Verify-Equal "None"
         }
 
+        t 'Run.FailOnNullOrEmptyForEach is $true' {
+            [PesterConfiguration]::Default.Run.FailOnNullOrEmptyForEach.Value | Verify-Equal $true
+        }
+
         # Output configuration
         t "Output.Verbosity is Normal" {
             [PesterConfiguration]::Default.Output.Verbosity.Value | Verify-Equal "Normal"

--- a/tst/functions/assert/Time/Should-BeAfter.Tests.ps1
+++ b/tst/functions/assert/Time/Should-BeAfter.Tests.ps1
@@ -45,8 +45,7 @@ Describe "Should-BeAfter" {
         { [DateTime]::Now.Add([timespan]::FromMinutes(-1)) | Should-BeAfter } | Verify-AssertionFailed
     }
 
-    It "Throws when both -Ago and -FromNow are used" -ForEach @(
-    ) {
+    It "Throws when both -Ago and -FromNow are used" {
         { $Actual | Should-BeAfter 10minutes -Ago -FromNow } | Verify-Throw
     }
 

--- a/tst/functions/assert/Time/Should-BeBefore.Tests.ps1
+++ b/tst/functions/assert/Time/Should-BeBefore.Tests.ps1
@@ -45,8 +45,7 @@ Describe "Should-BeBefore" {
         { [DateTime]::Now.Add([timespan]::FromMinutes(20)) | Should-BeBefore } | Verify-AssertionFailed
     }
 
-    It "Throws when both -Ago and -FromNow are used" -ForEach @(
-    ) {
+    It "Throws when both -Ago and -FromNow are used" {
         { $Actual | Should-BeBefore 10minutes -Ago -FromNow } | Verify-Throw
     }
 


### PR DESCRIPTION
## PR Summary
Throw during Discovery when `Describe/Context/It` is provided `$null` or `@()` to `-ForEach/TestCases` to avoid silent failure. 

The previous behavior, ignoring the test/block, can be achieved by setting the configuration option `Run.FailOnNullOrEmptyForEach` to `$false`.

When enabled, individual blocks or tests can be overriden to allow empty array or null by adding a new `-AllowNullOrEmptyForEach` parameter to `Describe/Context/It`, e.g. if a test is generated using external data which might be empty.

Fix #2151 

## PR Checklist

- [x] PR has meaningful title
- [x] Summary describes changes
- [x] PR is ready to be merged
  - If not, use the arrow next to `Create Pull Request` to mark it as a draft. PR can be marked `Ready for review` when it's ready.
- [x] Tests are added/update *(if required)*
- [x] Documentation is updated/added *(if required)*