### PR TITLE
WIP - Block original command by default when parameterized mocks exist

### DIFF
--- a/src/functions/Mock.ps1
+++ b/src/functions/Mock.ps1
@@ -984,10 +984,8 @@ function FindMatchingBehavior {
 
     $foundDefaultBehavior = $false
     $defaultBehavior = $null
-    # A mock exists so we do not allow original command to be called. Either:
-    # - A parameterized mock explicitly allows it below
-    # - Or a default mock exists which takes precedence either way
-    $fallbackAllowed = $false
+    # Allow fallback unless parameterized behaviors exist. Required to support nested runs where mock exists but no behaviors.
+    $blockOriginalCommand = @($Behaviors).IsDefault -contains $false
     foreach ($b in $Behaviors) {
 
         if ($b.IsDefault -and -not $foundDefaultBehavior) {
@@ -1012,7 +1010,7 @@ function FindMatchingBehavior {
                 return $b
             }
 
-            if ($b.AllowFallback) { $fallbackAllowed = $true }
+            if ($b.AllowFallback) { $blockOriginalCommand = $false }
         }
     }
 
@@ -1027,7 +1025,7 @@ function FindMatchingBehavior {
         Write-PesterDebugMessage -Scope Mock "No parametrized or default behaviors were found filter."
     }
 
-    if (-not $fallbackAllowed) {
+    if ($blockOriginalCommand) {
         throw 'Not implemented. None of the parameterized mocks match the call or accept fallback to original command.'
     }
 

--- a/src/functions/Pester.SessionState.Mock.ps1
+++ b/src/functions/Pester.SessionState.Mock.ps1
@@ -1056,7 +1056,7 @@ function Invoke-Mock {
             param ($b)
             "     Target module: $(if ($b.ModuleName) { $b.ModuleName } else { '$null' })`n"
             "    Body: { $($b.ScriptBlock.ToString().Trim()) }`n"
-            "    Filter$(if ($b.AllowFallback) { ' (with fallback)' }): $(if (-not $b.IsDefault) { "{ $($b.Filter.ToString().Trim()) }" }) else { '$null' })`n"
+            "    Filter$(if ($b.AllowFallback) { ' (with fallback)' }): $(if (-not $b.IsDefault) { "{ $($b.Filter.ToString().Trim()) }" } else { '$null' })`n"
             "    Default: $(if ($b.IsDefault) { '$true' } else { '$false' })`n"
             "    Verifiable: $(if ($b.Verifiable) { '$true' } else { '$false' })"
         }

--- a/tst/functions/Mock.Tests.ps1
+++ b/tst/functions/Mock.Tests.ps1
@@ -374,7 +374,7 @@ Describe 'When calling Mock, StrictMode is enabled, and variables are used in th
 
 Describe "When calling Mock on existing function without matching bound params" {
     It "Should redirect to real function" {
-        Mock FunctionUnderTest { return "fake results" } -parameterFilter { $param1 -eq "test" }
+        Mock FunctionUnderTest { return "fake results" } -parameterFilter { $param1 -eq "test" } -AllowFallback
         $result = FunctionUnderTest "badTest"
         $result | Should -Be "I am a real world test"
     }
@@ -390,7 +390,7 @@ Describe "When calling Mock on existing function with matching bound params" {
 
 Describe  "When calling Mock on existing function without matching unbound arguments" {
     It "Should redirect to real function" {
-        Mock FunctionUnderTestWithoutParams { return "fake results" } -parameterFilter { $param1 -eq "test" -and $args[0] -eq 'notArg0' }
+        Mock FunctionUnderTestWithoutParams { return "fake results" } -parameterFilter { $param1 -eq "test" -and $args[0] -eq 'notArg0' } -AllowFallback
         $result = FunctionUnderTestWithoutParams -param1 "test" "arg0"
         $result | Should -Be "I am a real world test with no params"
     }
@@ -518,7 +518,7 @@ Describe 'When calling Mock on a module-internal function.' {
         BeforeAll {
             Mock -ModuleName TestModule InternalFunction { 'I am the mock test' }
             Mock -ModuleName TestModule Start-Sleep { }
-            Mock -ModuleName TestModule2 InternalFunction -ParameterFilter { $args[0] -eq 'Test' } {
+            Mock -ModuleName TestModule2 InternalFunction -ParameterFilter { $args[0] -eq 'Test' } -AllowFallback {
                 "I'm the mock who's been passed parameter Test"
             }
             # Mock -ModuleName TestModule2 InternalFunction2 {
@@ -526,7 +526,7 @@ Describe 'When calling Mock on a module-internal function.' {
             #     # so this module internal function is not accessible to the mock body
             #     InternalFunction 'Test'
             # }
-            Mock -ModuleName TestModule2 Get-CallerModuleName -ParameterFilter { $false }
+            Mock -ModuleName TestModule2 Get-CallerModuleName -ParameterFilter { $false } -AllowFallback
             Mock -ModuleName TestModule2 Get-Content { }
         }
 
@@ -632,7 +632,7 @@ Describe "When Applying multiple Mocks on a single command where one has no filt
 Describe "When Creating Verifiable Mock that is not called" {
     Context "In the test script's scope" {
         It "Should throw" {
-            Mock FunctionUnderTest { return "I am a verifiable test" } -Verifiable -parameterFilter { $param1 -eq "one" }
+            Mock FunctionUnderTest { return "I am a verifiable test" } -Verifiable -parameterFilter { $param1 -eq "one" } -AllowFallback
             FunctionUnderTest "three" | Out-Null
             $result = $null
             try {
@@ -1952,9 +1952,9 @@ Describe 'Mocking a function taking input from pipeline' {
         $noMockResultByProperty = $psobj | PipelineInputFunction -PipeStr 'val'
         $noMockArrayResultByProperty = $psArrayobj | PipelineInputFunction -PipeStr 'val'
 
-        Mock PipelineInputFunction { write-output 'mocked' } -ParameterFilter { $PipeStr -eq 'blah' }
+        Mock PipelineInputFunction { write-output 'mocked' } -ParameterFilter { $PipeStr -eq 'blah' } -AllowFallback
     }
-    context 'when calling original function with an array' {
+    Context 'when calling original function with an array' {
         BeforeAll {
             $result = @(1, 2) | PipelineInputFunction
         }
@@ -1967,7 +1967,7 @@ Describe 'Mocking a function taking input from pipeline' {
         }
     }
 
-    context 'when calling original function with an int' {
+    Context 'when calling original function with an int' {
         BeforeAll {
             $result = 1 | PipelineInputFunction
         }
@@ -1978,7 +1978,7 @@ Describe 'Mocking a function taking input from pipeline' {
         }
     }
 
-    context 'when calling original function with a string' {
+    Context 'when calling original function with a string' {
         BeforeAll {
             $result = '1' | PipelineInputFunction
         }
@@ -1989,7 +1989,7 @@ Describe 'Mocking a function taking input from pipeline' {
         }
     }
 
-    context 'when calling original function and pipeline is bound by property name' {
+    Context 'when calling original function and pipeline is bound by property name' {
         BeforeAll {
             $result = $psobj | PipelineInputFunction -PipeStr 'val'
         }
@@ -2001,7 +2001,7 @@ Describe 'Mocking a function taking input from pipeline' {
         }
     }
 
-    context 'when calling original function and forcing a parameter binding exception' {
+    Context 'when calling original function and forcing a parameter binding exception' {
         BeforeAll {
             Mock PipelineInputFunction {
                 if ($MyInvocation.ExpectingInput) {
@@ -2017,7 +2017,7 @@ Describe 'Mocking a function taking input from pipeline' {
         }
     }
 
-    context 'when calling original function and pipeline is bound by property name with array values' {
+    Context 'when calling original function and pipeline is bound by property name with array values' {
         BeforeAll {
             $result = $psArrayobj | PipelineInputFunction -PipeStr 'val'
         }
@@ -2029,7 +2029,7 @@ Describe 'Mocking a function taking input from pipeline' {
         }
     }
 
-    context 'when calling the mocked function' {
+    Context 'when calling the mocked function' {
         BeforeAll {
             $result = 'blah' | PipelineInputFunction
         }
@@ -2289,7 +2289,7 @@ Describe 'Nested Mock calls' {
     BeforeAll {
         $testDate = New-Object DateTime(2012, 6, 13)
 
-        Mock Get-Date -ParameterFilter { $null -eq $Date } {
+        Mock Get-Date -ParameterFilter { $null -eq $Date } -AllowFallback {
             Get-Date -Date $testDate -Format o
         }
     }
@@ -2452,7 +2452,7 @@ Describe "Mocking Set-Variable" {
         # we mock the command but the mock will never be triggered because
         # the filter will never pass, so this mock will always call through
         # to the real Set-Variable
-        Mock Set-Variable -ParameterFilter { $false }
+        Mock Set-Variable -ParameterFilter { $false } -AllowFallback
 
         Set-Variable -Name v2 -Value 10
 
@@ -2467,7 +2467,7 @@ Describe "Mocking Set-Variable" {
         Set-Variable -Name v1 -Value 1
         $v1 | Should -Be 1 -Because "we defined it without mocking Set-Variable"
 
-        Mock Set-Variable -ParameterFilter { $false }
+        Mock Set-Variable -ParameterFilter { $false } -AllowFallback
 
         Set-Variable -Name v2 -Value 11 -Scope 0
         $v2 | Should -Be 11
@@ -2478,7 +2478,7 @@ Describe "Mocking Set-Variable" {
         Set-Variable -Name v1 -Value 1
         $v1 | Should -Be 1 -Because "we defined it without mocking Set-Variable"
 
-        Mock Set-Variable -ParameterFilter { $false }
+        Mock Set-Variable -ParameterFilter { $false } -AllowFallback
 
         Set-Variable -Name v2 -Value 12 -Scope Local
 
@@ -2509,7 +2509,7 @@ Describe "Mocking Set-Variable" {
                 & {
                     # scope 1
                     & {
-                        Mock Set-Variable -ParameterFilter { $false }
+                        Mock Set-Variable -ParameterFilter { $false } -AllowFallback
                         Set-Variable -Name v2 -Value 11 -Scope 3
                     }
                 }
@@ -2536,7 +2536,7 @@ Describe "Mocking functions with conflicting parameters" {
                     $ParamToAvoid
                 }
 
-                Mock Get-ExampleTest { "World" } -ParameterFilter { $_ParamToAvoid -eq "Hello" }
+                Mock Get-ExampleTest { "World" } -ParameterFilter { $_ParamToAvoid -eq "Hello" } -AllowFallback
             }
 
             It 'executes the mock' {

--- a/tst/functions/Mock.Tests.ps1
+++ b/tst/functions/Mock.Tests.ps1
@@ -2823,6 +2823,7 @@ Describe 'Calls not matching ParameterFilter' {
         }
 
         It 'Calls real function when at least one parameterized mock has -AllowFallback' {
+            # TODO: Is this expected? Or should all parameterized mocks allow fallback?
             Mock demo -ParameterFilter { $name -eq 'world' } -MockWith { 'mocked' } -AllowFallback
             Mock demo -ParameterFilter { $name -eq 'Wisconsin' } -MockWith { 'mocked2' }
             demo -name 'you' | Should -Be 'hello you'
@@ -2862,7 +2863,8 @@ Describe 'Calls not matching ParameterFilter' {
             demo -name 'you' | Should -Be 'hello you'
         }
 
-        It 'Throws when a more local parameterized mock does not allow fallback' {
+        It 'Throws when a more local parameterized mock does not allow fallback' -Skip {
+            # TODO:Do we expect this? If so, we need to expose mock scope depth from Get-AllMockBehaviors
             Mock demo -ParameterFilter { $name -eq 'world' } -MockWith { 'mocked' }
             { demo -name 'you' } | Should -Throw
         }

--- a/tst/functions/Mock.Tests.ps1
+++ b/tst/functions/Mock.Tests.ps1
@@ -2821,6 +2821,12 @@ Describe 'Calls not matching ParameterFilter' {
             Mock demo -ParameterFilter { $name -eq 'world' } -MockWith { 'mocked' } -AllowFallback
             demo -name 'you' | Should -Be 'hello you'
         }
+
+        It 'Calls real function when at least one parameterized mock has -AllowFallback' {
+            Mock demo -ParameterFilter { $name -eq 'world' } -MockWith { 'mocked' } -AllowFallback
+            Mock demo -ParameterFilter { $name -eq 'Wisconsin' } -MockWith { 'mocked2' }
+            demo -name 'you' | Should -Be 'hello you'
+        }
     }
 
     Context 'When default mock exists in parent scope' {
@@ -2854,6 +2860,11 @@ Describe 'Calls not matching ParameterFilter' {
         }
         It 'Calls real function' {
             demo -name 'you' | Should -Be 'hello you'
+        }
+
+        It 'Throws when a more local parameterized mock does not allow fallback' {
+            Mock demo -ParameterFilter { $name -eq 'world' } -MockWith { 'mocked' }
+            { demo -name 'you' } | Should -Throw
         }
     }
 }


### PR DESCRIPTION
## PR Summary
**WIP**

When a command is mocked by only parameterized mocks, throw for calls not matching any filters unless `-AllowFallback` is specified.

Fix #2166
Fix #2178

TODO
- [ ] Discuss desired behavior for precedence and multiple parameterized mocks etc. See review comments
- [ ] Discuss API
  - [ ] Do we need a global setting to disable for v5 backwards compatibility?
  - [ ] Change parameter and property name? `-AllowFallback` could reference fallback to default mock in module or script-scope
  - [ ] Is this the right approach? Having to add `-AllowFallback` is weird with multiple parameterized mocks in scope. Better to introduce `Mock -Throw` shortcut which can be used for both default mock and special parameterized tests?
- [x] Troubleshoot seemingly unaffected but failing test `Mocking with nested Pester runs.Mocking works in nested run`
- [ ] Update error thrown when original command is blocked. Currently a placeholder.

## PR Checklist

- [ ] PR has meaningful title
- [ ] Summary describes changes
- [ ] PR is ready to be merged
  - If not, use the arrow next to `Create Pull Request` to mark it as a draft. PR can be marked `Ready for review` when it's ready.
- [x] Tests are added/update *(if required)*
- [x] Documentation is updated/added *(if required)*