### PR TITLE
Add Description section to new Should-* functions

### DIFF
--- a/src/functions/assert/Boolean/Should-BeFalse.ps1
+++ b/src/functions/assert/Boolean/Should-BeFalse.ps1
@@ -3,6 +3,9 @@
     .SYNOPSIS
     Compares the actual value to a boolean $false. It does not convert input values to boolean, and will fail for any value that is not $false.
 
+    .DESCRIPTION
+    This assertion checks if the actual value is exactly $false without converting it to a boolean. It is useful when you need to ensure that the value is strictly $false and not just a falsy value.
+
     .PARAMETER Actual
     The actual value to compare to $false.
 

--- a/src/functions/assert/Boolean/Should-BeFalsy.ps1
+++ b/src/functions/assert/Boolean/Should-BeFalsy.ps1
@@ -3,6 +3,9 @@
     .SYNOPSIS
     Compares the actual value to a boolean $false or a falsy value: 0, "", $null or @(). It converts the input value to a boolean.
 
+    .DESCRIPTION
+    This assertion checks if the actual value is $false or a falsy value (0, "", $null, or @()). It is useful when you need to ensure that the value is falsy and not just not $true.
+
     .PARAMETER Actual
     The actual value to compare to $false.
 

--- a/src/functions/assert/Boolean/Should-BeTrue.ps1
+++ b/src/functions/assert/Boolean/Should-BeTrue.ps1
@@ -3,6 +3,9 @@
     .SYNOPSIS
     Compares the actual value to a boolean $true. It does not convert input values to boolean, and will fail for any value is not $true.
 
+    .DESCRIPTION
+    This assertion checks if the actual value is exactly $true without converting it to a boolean. It is useful when you need to ensure that the value is strictly $true and not just a truthy value.
+
     .PARAMETER Actual
     The actual value to compare to $true.
 

--- a/src/functions/assert/Boolean/Should-BeTruthy.ps1
+++ b/src/functions/assert/Boolean/Should-BeTruthy.ps1
@@ -3,6 +3,9 @@
     .SYNOPSIS
     Compares the actual value to a boolean $true. It converts input values to boolean, and will fail for any value is not $true, or truthy.
 
+    .DESCRIPTION
+    This assertion checks if the actual value is $true or a truthy value (1, non-empty string, non-empty array, etc.). It is useful when you need to ensure that the value is truthy and not just not $false.
+
     .PARAMETER Actual
     The actual value to compare to $true.
 

--- a/src/functions/assert/Collection/Should-All.ps1
+++ b/src/functions/assert/Collection/Should-All.ps1
@@ -3,6 +3,9 @@
     .SYNOPSIS
     Compares all items in a collection to a filter script. If the filter returns true, or does not throw for all the items in the collection, the assertion passes.
 
+    .DESCRIPTION
+    This assertion checks if all items in a collection pass a filter script. It is useful when you need to ensure that every item in the collection meets a specific condition.
+
     .PARAMETER FilterScript
     A script block that filters the input collection. The script block can use Should-* assertions or throw exceptions to indicate failure.
 

--- a/src/functions/assert/Collection/Should-Any.ps1
+++ b/src/functions/assert/Collection/Should-Any.ps1
@@ -3,6 +3,9 @@
     .SYNOPSIS
     Compares all items in a collection to a filter script. If the filter returns true, or does not throw for any of the items in the collection, the assertion passes.
 
+    .DESCRIPTION
+    This assertion checks if any item in a collection passes a filter script. It is useful when you need to ensure that at least one item in the collection meets a specific condition.
+
     .PARAMETER FilterScript
     A script block that filters the input collection. The script block can use Should-* assertions or throw exceptions to indicate failure.
 

--- a/src/functions/assert/Collection/Should-BeCollection.ps1
+++ b/src/functions/assert/Collection/Should-BeCollection.ps1
@@ -3,6 +3,9 @@
     .SYNOPSIS
     Compares collections for equality, by comparing their sizes and each item in them. It does not compare the types of the input collections.
 
+    .DESCRIPTION
+    This assertion checks if two collections are equal by comparing their sizes and each item in them. It is useful when you need to ensure that the collections have the same size and the items are equal, regardless of their types.
+
     .PARAMETER Expected
     A collection of items.
 

--- a/src/functions/assert/Collection/Should-ContainCollection.ps1
+++ b/src/functions/assert/Collection/Should-ContainCollection.ps1
@@ -3,6 +3,9 @@
     .SYNOPSIS
     Compares collections to see if the expected collection is present in the provided collection. It does not compare the types of the input collections.
 
+    .DESCRIPTION
+    This assertion checks if the expected collection is present in the provided collection. It is useful when you need to ensure that all items in the expected collection are present in the actual collection, in the right order.
+
     .PARAMETER Expected
     A collection of items.
 

--- a/src/functions/assert/Collection/Should-NotContainCollection.ps1
+++ b/src/functions/assert/Collection/Should-NotContainCollection.ps1
@@ -3,6 +3,9 @@
     .SYNOPSIS
     Compares collections to ensure that the expected collection is not present in the provided collection. It does not compare the types of the input collections.
 
+    .DESCRIPTION
+    This assertion checks if the expected collection is not present in the provided collection. It is useful when you need to ensure that none of the items in the expected collection are present in the actual collection.
+
     .PARAMETER Expected
     A collection of items.
 

--- a/src/functions/assert/Equivalence/Should-BeEquivalent.ps1
+++ b/src/functions/assert/Equivalence/Should-BeEquivalent.ps1
@@ -619,6 +619,9 @@ function Should-BeEquivalent {
     .SYNOPSIS
     Compares two objects for equivalency, by recursively comparing their properties for equivalency.
 
+    .DESCRIPTION
+    This assertion checks if two objects are equivalent by recursively comparing their properties. It is useful when you need to ensure that the objects have the same structure and values, even if they are not the same instance.
+
     .PARAMETER Actual
     The actual object to compare.
 
@@ -644,7 +647,7 @@ function Should-BeEquivalent {
     This example generates an equivalency option object that excludes the 'Id' and 'Timestamp' properties from the comparison and uses a simple equality comparison strategy.
 
     .EXAMPLE
-    ```powereshell
+    ```powershell
         Should-BeEquivalent ... -ExcludePathsNotOnExpected
     ```
     This example generates an equivalency option object that excludes any paths not present on the expected object from the comparison, using the default deep comparison strategy.

--- a/src/functions/assert/Exception/Should-Throw.ps1
+++ b/src/functions/assert/Exception/Should-Throw.ps1
@@ -3,6 +3,9 @@ function Should-Throw {
     .SYNOPSIS
     Asserts that a script block throws an exception.
 
+    .DESCRIPTION
+    This assertion checks if a script block throws an exception. It is useful when you need to ensure that a specific exception is thrown during the execution of a script block.
+
     .PARAMETER ScriptBlock
     The script block that should throw an exception.
 

--- a/src/functions/assert/General/Should-Be.ps1
+++ b/src/functions/assert/General/Should-Be.ps1
@@ -3,6 +3,9 @@
     .SYNOPSIS
     Compares the expected value to actual value, to see if they are equal.
 
+    .DESCRIPTION
+    This assertion compares the expected value to the actual value to determine if they are equal. It is useful for validating that the actual value matches the expected value in tests.
+
     .PARAMETER Expected
     The expected value.
 

--- a/src/functions/assert/General/Should-BeGreaterThan.ps1
+++ b/src/functions/assert/General/Should-BeGreaterThan.ps1
@@ -3,6 +3,9 @@
     .SYNOPSIS
     Compares the expected value to actual value, to see if the actual value is greater than the expected value.
 
+    .DESCRIPTION
+    This assertion checks if the actual value is greater than the expected value. It is useful when you need to ensure that the actual value exceeds the expected value in tests.
+
     .PARAMETER Expected
     The expected value.
 

--- a/src/functions/assert/General/Should-BeGreaterThanOrEqual.ps1
+++ b/src/functions/assert/General/Should-BeGreaterThanOrEqual.ps1
@@ -3,6 +3,9 @@
     .SYNOPSIS
     Compares the expected value to actual value, to see if the actual value is greater than or equal to the expected value.
 
+    .DESCRIPTION
+    This assertion checks if the actual value is greater than or equal to the expected value. It is useful when you need to ensure that the actual value meets or exceeds the expected value in tests.
+
     .PARAMETER Expected
     The expected value.
 

--- a/src/functions/assert/General/Should-BeLessThan.ps1
+++ b/src/functions/assert/General/Should-BeLessThan.ps1
@@ -3,6 +3,9 @@
     .SYNOPSIS
     Compares the expected value to actual value, to see if the actual value is less than the expected value.
 
+    .DESCRIPTION
+    This assertion checks if the actual value is less than the expected value. It is useful when you need to ensure that the actual value is less than the expected value in tests.
+
     .PARAMETER Expected
     The expected value.
 

--- a/src/functions/assert/General/Should-BeLessThanOrEqual.ps1
+++ b/src/functions/assert/General/Should-BeLessThanOrEqual.ps1
@@ -3,6 +3,9 @@
     .SYNOPSIS
     Compares the expected value to actual value, to see if the actual value is less than or equal to the expected value.
 
+    .DESCRIPTION
+    This assertion checks if the actual value is less than or equal to the expected value. It is useful when you need to ensure that the actual value does not exceed the expected value in tests.
+
     .PARAMETER Expected
     The expected value.
 

--- a/src/functions/assert/General/Should-BeNull.ps1
+++ b/src/functions/assert/General/Should-BeNull.ps1
@@ -3,6 +3,9 @@
     .SYNOPSIS
     Asserts that the input is `$null`.
 
+    .DESCRIPTION
+    This assertion checks if the actual value is `$null`. It is useful when you need to ensure that the value is `$null` in tests.
+
     .PARAMETER Actual
     The actual value.
 

--- a/src/functions/assert/General/Should-BeSame.ps1
+++ b/src/functions/assert/General/Should-BeSame.ps1
@@ -3,6 +3,9 @@
     .SYNOPSIS
     Compares the expected value to actual value, to see if they are the same instance.
 
+    .DESCRIPTION
+    This assertion checks if the actual value is the same instance as the expected value. It is useful when you need to ensure that two variables reference the same object in memory.
+
     .PARAMETER Expected
     The expected value.
 

--- a/src/functions/assert/General/Should-HaveType.ps1
+++ b/src/functions/assert/General/Should-HaveType.ps1
@@ -3,6 +3,9 @@
     .SYNOPSIS
     Asserts that the input is of the expected type.
 
+    .DESCRIPTION
+    This assertion checks if the actual value is of the expected type. It is useful when you need to ensure that the value is of a specific type in tests.
+
     .PARAMETER Expected
     The expected type.
 

--- a/src/functions/assert/General/Should-NotBe.ps1
+++ b/src/functions/assert/General/Should-NotBe.ps1
@@ -3,6 +3,9 @@
     .SYNOPSIS
     Compares the expected value to actual value, to see if they are not equal.
 
+    .DESCRIPTION
+    This assertion checks if the actual value is not equal to the expected value. It is useful when you need to ensure that the actual value is different from the expected value in tests.
+
     .PARAMETER Expected
     The expected value.
 

--- a/src/functions/assert/General/Should-NotBeNull.ps1
+++ b/src/functions/assert/General/Should-NotBeNull.ps1
@@ -3,6 +3,9 @@
     .SYNOPSIS
     Asserts that the input is not `$null`.
 
+    .DESCRIPTION
+    This assertion checks if the actual value is not `$null`. It is useful when you need to ensure that the value is not `$null` in tests.
+
     .PARAMETER Actual
     The actual value.
 

--- a/src/functions/assert/General/Should-NotBeSame.ps1
+++ b/src/functions/assert/General/Should-NotBeSame.ps1
@@ -3,6 +3,9 @@
     .SYNOPSIS
     Compares the expected value to actual value, to see if the actual value is not the same instance as the expected value.
 
+    .DESCRIPTION
+    This assertion checks if the actual value is not the same instance as the expected value. It is useful when you need to ensure that two variables do not reference the same object in memory.
+
     .PARAMETER Expected
     The expected value.
 

--- a/src/functions/assert/General/Should-NotHaveType.ps1
+++ b/src/functions/assert/General/Should-NotHaveType.ps1
@@ -3,6 +3,9 @@
     .SYNOPSIS
     Asserts that the input is not of the expected type.
 
+    .DESCRIPTION
+    This assertion checks if the actual value is not of the expected type. It is useful when you need to ensure that the value is not of a specific type in tests.
+
     .PARAMETER Expected
     The expected type.
 

--- a/src/functions/assert/String/Should-BeEmptyString.ps1
+++ b/src/functions/assert/String/Should-BeEmptyString.ps1
@@ -3,6 +3,9 @@
     .SYNOPSIS
     Ensures that input is an empty string.
 
+    .DESCRIPTION
+    This assertion checks if the actual value is an empty string. It is useful when you need to ensure that the value is an empty string in tests.
+
     .PARAMETER Actual
     The actual value that will be compared to an empty string.
 

--- a/src/functions/assert/String/Should-BeLikeString.ps1
+++ b/src/functions/assert/String/Should-BeLikeString.ps1
@@ -19,7 +19,7 @@ function Should-BeLikeString {
     Asserts that the actual value is like the expected value.
 
     .DESCRIPTION
-    The `Should-BeLikeString` assertion compares the actual value to the expected value using the `-like` operator. The `-like` operator is case-insensitive by default, but you can make it case-sensitive by using the `-CaseSensitive` switch.
+    This assertion checks if the actual value matches the expected value using the `-like` operator. It is useful when you need to ensure that the actual value matches a specific pattern, with optional case sensitivity.
 
     .PARAMETER Expected
     The expected value.

--- a/src/functions/assert/String/Should-BeString.ps1
+++ b/src/functions/assert/String/Should-BeString.ps1
@@ -35,7 +35,7 @@ function Should-BeString {
     Asserts that the actual value is equal to the expected value.
 
     .DESCRIPTION
-    The `Should-BeString` assertion compares the actual value to the expected value using the `-eq` operator. The `-eq` operator is case-insensitive by default, but you can make it case-sensitive by using the `-CaseSensitive` switch.
+    This assertion checks if the actual value is equal to the expected value. It is useful when you need to ensure that the actual value matches the expected value in tests.
 
     .PARAMETER Expected
     The expected value.

--- a/src/functions/assert/String/Should-NotBeEmptyString.ps1
+++ b/src/functions/assert/String/Should-NotBeEmptyString.ps1
@@ -3,6 +3,9 @@
     .SYNOPSIS
     Ensures that the input is a string, and that the input is not $null or empty string.
 
+    .DESCRIPTION
+    This assertion checks if the actual value is not $null or an empty string. It is useful when you need to ensure that the value is a non-empty string in tests.
+
     .PARAMETER Actual
     The actual value that will be compared.
 

--- a/src/functions/assert/String/Should-NotBeLikeString.ps1
+++ b/src/functions/assert/String/Should-NotBeLikeString.ps1
@@ -27,7 +27,7 @@ function Should-NotBeLikeString {
     Asserts that the actual value is not like the expected value.
 
     .DESCRIPTION
-    The `Should-NotBeLikeString` assertion compares the actual value to the expected value using the `-notlike` operator. The `-notlike` operator is case-insensitive by default, but you can make it case-sensitive by using the `-CaseSensitive` switch.
+    This assertion checks if the actual value does not match the expected value using the `-notlike` operator. It is useful when you need to ensure that the actual value does not match a specific pattern, with optional case sensitivity.
 
     .PARAMETER Expected
     The expected value.
@@ -50,6 +50,7 @@ function Should-NotBeLikeString {
 
     .EXAMPLE
     ```powershell
+
     "hello" | Should-NotBeLikeString "h*" -CaseSensitive
     ```
 

--- a/src/functions/assert/String/Should-NotBeWhiteSpaceString.ps1
+++ b/src/functions/assert/String/Should-NotBeWhiteSpaceString.ps1
@@ -3,6 +3,9 @@
     .SYNOPSIS
     Ensures that the input is a string, and that the input is not $null, empty, or whitespace only string.
 
+    .DESCRIPTION
+    This assertion checks if the actual value is not $null, empty, or a whitespace-only string. It is useful when you need to ensure that the value is a non-empty string that contains non-whitespace characters in tests.
+
     .PARAMETER Actual
     The actual value that will be compared.
 

--- a/src/functions/assert/Time/Should-BeAfter.ps1
+++ b/src/functions/assert/Time/Should-BeAfter.ps1
@@ -3,6 +3,9 @@
     .SYNOPSIS
     Asserts that the provided [datetime] is after the expected [datetime].
 
+    .DESCRIPTION
+    This assertion checks if the actual value is after the expected value. It is useful when you need to ensure that the actual value is later than the expected value in tests.
+
     .PARAMETER Actual
     The actual [datetime] value.
 
@@ -28,7 +31,6 @@
     ```powershell
     (Get-Date).AddDays(1) | Should-BeAfter (Get-Date)
     ```
-
 
     This assertion will pass, because the actual value is after the expected value.
 

--- a/src/functions/assert/Time/Should-BeBefore.ps1
+++ b/src/functions/assert/Time/Should-BeBefore.ps1
@@ -3,6 +3,9 @@
     .SYNOPSIS
     Asserts that the provided [datetime] is before the expected [datetime].
 
+    .DESCRIPTION
+    This assertion checks if the actual value is before the expected value. It is useful when you need to ensure that the actual value is earlier than the expected value in tests.
+
     .PARAMETER Actual
     The actual [datetime] value.
 

--- a/src/functions/assert/Time/Should-BeFasterThan.ps1
+++ b/src/functions/assert/Time/Should-BeFasterThan.ps1
@@ -3,6 +3,9 @@
     .SYNOPSIS
     Asserts that the provided [timespan] or [scriptblock] is faster than the expected [timespan].
 
+    .DESCRIPTION
+    This assertion checks if the actual value is faster than the expected value. It is useful when you need to ensure that the actual value is faster than the expected value in tests.
+
     .PARAMETER Actual
     The actual [timespan] or [scriptblock] value.
 

--- a/src/functions/assert/Time/Should-BeSlowerThan.ps1
+++ b/src/functions/assert/Time/Should-BeSlowerThan.ps1
@@ -3,6 +3,9 @@
     .SYNOPSIS
     Asserts that the provided [timespan] is slower than the expected [timespan].
 
+    .DESCRIPTION
+    This assertion checks if the actual value is slower than the expected value. It is useful when you need to ensure that the actual value is slower than the expected value in tests.
+
     .PARAMETER Actual
     The actual [timespan] or [scriptblock] value.
 


### PR DESCRIPTION
Related to #2490

Add missing Description sections to new `Should-*` functions.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/pester/Pester/issues/2490?shareId=ba3621fe-3370-498a-9a9a-d1c4cea782c0).