### PR TITLE
Throw on unbound user-provided scriptblocks

### DIFF
--- a/src/Main.ps1
+++ b/src/Main.ps1
@@ -80,6 +80,8 @@ function Add-ShouldOperator {
         [switch] $SupportsArrayInput
     )
 
+    Assert-BoundScriptBlockInput -ScriptBlock $Test
+
     $entry = [PSCustomObject]@{
         Test               = $Test
         SupportsArrayInput = [bool]$SupportsArrayInput
@@ -1259,6 +1261,8 @@ function BeforeDiscovery {
         [Parameter(Mandatory)]
         [ScriptBlock]$ScriptBlock
     )
+
+    Assert-BoundScriptBlockInput -ScriptBlock $ScriptBlock
 
     if ($ExecutionContext.SessionState.PSVariable.Get('invokedViaInvokePester')) {
         if ($state.CurrentBlock.IsRoot -and -not $state.CurrentBlock.FrameworkData.MissingParametersProcessed) {

--- a/src/Pester.Runtime.ps1
+++ b/src/Pester.Runtime.ps1
@@ -2619,9 +2619,9 @@ function Assert-BoundScriptBlockInput {
         $maxLength = 250
         $prettySb = (Format-Nicely2 $ScriptBlock) -replace '\s{2,}', ' '
         if ($prettySb.Length -gt $maxLength) {
-            $prettySb = $prettySb.Remove($maxLength) + "..."
+            $prettySb = "$($prettySb.Remove($maxLength))..."
         }
 
-        throw [System.ArgumentException]::new("Unbound scriptblock '$prettySb' is not allowed. See https://github.com/pester/Pester/issues/2411.")
+        throw [System.ArgumentException]::new("Unbound scriptblock is not allowed, because it would run inside of Pester session state and produce unexpected results. See https://github.com/pester/Pester/issues/2411 for more details and workarounds. ScriptBlock: '$prettySb'")
     }
 }

--- a/src/functions/Context.ps1
+++ b/src/functions/Context.ps1
@@ -105,6 +105,8 @@
         }
     }
 
+    Assert-BoundScriptBlockInput -ScriptBlock $Fixture
+
     if ($ExecutionContext.SessionState.PSVariable.Get('invokedViaInvokePester')) {
         if ($state.CurrentBlock.IsRoot -and -not $state.CurrentBlock.FrameworkData.MissingParametersProcessed) {
             # For undefined parameters in container, add parameter's default value to Data

--- a/src/functions/Describe.ps1
+++ b/src/functions/Describe.ps1
@@ -113,6 +113,8 @@
         }
     }
 
+    Assert-BoundScriptBlockInput -ScriptBlock $Fixture
+
     if ($ExecutionContext.SessionState.PSVariable.Get('invokedViaInvokePester')) {
         if ($state.CurrentBlock.IsRoot -and -not $state.CurrentBlock.FrameworkData.MissingParametersProcessed) {
             # For undefined parameters in container, add parameter's default value to Data

--- a/src/functions/It.ps1
+++ b/src/functions/It.ps1
@@ -152,6 +152,8 @@
         }
     }
 
+    Assert-BoundScriptBlockInput -ScriptBlock $Test
+
     if ($PSBoundParameters.ContainsKey('ForEach')) {
         if ($null -eq $ForEach -or 0 -eq @($ForEach).Count) {
             if ($PesterPreference.Run.FailOnNullOrEmptyForEach.Value -and -not $AllowNullOrEmptyForEach) {

--- a/src/functions/SetupTeardown.ps1
+++ b/src/functions/SetupTeardown.ps1
@@ -57,6 +57,7 @@
         $Scriptblock
     )
     Assert-DescribeInProgress -CommandName BeforeEach
+    Assert-BoundScriptBlockInput -ScriptBlock $Scriptblock
 
     New-EachTestSetup -ScriptBlock $Scriptblock
 }
@@ -123,6 +124,7 @@ function AfterEach {
         $Scriptblock
     )
     Assert-DescribeInProgress -CommandName AfterEach
+    Assert-BoundScriptBlockInput -ScriptBlock $Scriptblock
 
     New-EachTestTeardown -ScriptBlock $Scriptblock
 }
@@ -198,6 +200,7 @@ function BeforeAll {
         [Scriptblock]
         $Scriptblock
     )
+    Assert-BoundScriptBlockInput -ScriptBlock $Scriptblock
 
     New-OneTimeTestSetup -ScriptBlock $Scriptblock
 }
@@ -265,6 +268,7 @@ function AfterAll {
         $Scriptblock
     )
     Assert-DescribeInProgress -CommandName AfterAll
+    Assert-BoundScriptBlockInput -ScriptBlock $Scriptblock
 
     New-OneTimeTestTeardown -ScriptBlock $Scriptblock
 }

--- a/src/functions/assert/Collection/Should-All.ps1
+++ b/src/functions/assert/Collection/Should-All.ps1
@@ -45,6 +45,7 @@
         [String]$Because
     )
 
+    Assert-BoundScriptBlockInput -ScriptBlock $FilterScript
 
     $Expected = $FilterScript
     $collectedInput = Collect-Input -ParameterInput $Actual -PipelineInput $local:Input -IsPipelineInput $MyInvocation.ExpectingInput

--- a/src/functions/assert/Collection/Should-Any.ps1
+++ b/src/functions/assert/Collection/Should-Any.ps1
@@ -44,6 +44,8 @@
         [String]$Because
     )
 
+    Assert-BoundScriptBlockInput -ScriptBlock $FilterScript
+
     $Expected = $FilterScript
     $collectedInput = Collect-Input -ParameterInput $Actual -PipelineInput $local:Input -IsPipelineInput $MyInvocation.ExpectingInput
     $Actual = $collectedInput.Actual

--- a/src/functions/assert/Exception/Should-Throw.ps1
+++ b/src/functions/assert/Exception/Should-Throw.ps1
@@ -67,6 +67,8 @@ function Should-Throw {
     $collectedInput = Collect-Input -ParameterInput $ScriptBlock -PipelineInput $local:Input -IsPipelineInput $MyInvocation.ExpectingInput -UnrollInput
     $ScriptBlock = $collectedInput.Actual
 
+    Assert-BoundScriptBlockInput -ScriptBlock $ScriptBlock
+
     $errorThrown = $false
     $err = $null
     try {

--- a/tst/functions/Add-ShouldOperator.ts.ps1
+++ b/tst/functions/Add-ShouldOperator.ts.ps1
@@ -70,6 +70,17 @@ i -PassThru:$PassThru {
         }
     }
 
+    b 'Add-ShouldOperator input validation' {
+        Get-Module Pester | Remove-Module
+        Import-Module "$PSScriptRoot\..\..\bin\Pester.psd1"
+
+        t 'Does not allow unbound scriptblocks' {
+            # Would execute in Pester's internal module state
+            $ex = { Add-ShouldOperator -Name DenyUnbound -Test ([ScriptBlock]::Create('$true')) } | Verify-Throw
+            $ex.Exception.Message | Verify-Like 'Unbound scriptblock*'
+        }
+    }
+
     b 'Executing custom Should assertions' {
         # Testing paramter and output syntax described in docs (https://pester.dev/docs/assertions/custom-assertions)
         Get-Module Pester | Remove-Module

--- a/tst/functions/Context.Tests.ps1
+++ b/tst/functions/Context.Tests.ps1
@@ -7,7 +7,7 @@ Describe 'Testing Context' {
 
                 }
             }
-        } | should -Throw  'Test fixture name has multiple lines and no test fixture is provided. (Have you provided a name for the test group?)'
+        } | Should -Throw  'Test fixture name has multiple lines and no test fixture is provided. (Have you provided a name for the test group?)'
     }
 
     It "Has a name that looks like a script block" {
@@ -17,6 +17,11 @@ Describe 'Testing Context' {
 
                 }
             }
-        } | should -Throw  'No test fixture is provided. (Have you put the open curly brace on the next line?)'
+        } | Should -Throw  'No test fixture is provided. (Have you put the open curly brace on the next line?)'
+    }
+
+    It 'Throws when provided unbound scriptblock' {
+        # Unbound scriptblocks would execute in Pester's internal module state
+        { Context 'c' -Fixture ([scriptblock]::Create('')) } | Should -Throw -ExpectedMessage 'Unbound scriptblock*'
     }
 }

--- a/tst/functions/Describe.Tests.ps1
+++ b/tst/functions/Describe.Tests.ps1
@@ -36,6 +36,11 @@ Describe 'Testing Describe' {
             }
         } | Should -Throw 'Test fixture name has multiple lines and no test fixture is provided. (Have you provided a name for the test group?)'
     }
+
+    It 'Throws when provided unbound scriptblock' {
+        # Unbound scriptblocks would execute in Pester's internal module state
+        { Describe 'd' -Fixture ([scriptblock]::Create('')) } | Should -Throw -ExpectedMessage 'Unbound scriptblock*'
+    }
 }
 
 

--- a/tst/functions/It.Tests.ps1
+++ b/tst/functions/It.Tests.ps1
@@ -1,0 +1,24 @@
+﻿Set-StrictMode -Version Latest
+
+Describe 'Testing It' {
+    It 'Throws when missing name' {
+        { It {
+
+            'something'
+            }
+        } | Should -Throw -ExpectedMessage 'Test name has multiple lines and no test scriptblock is provided*'
+    }
+
+    It 'Throws when missing scriptblock' {
+        { It 'runs a test'
+            {
+                # This scriptblock is a new statement as scriptblock didn't start on It-line nor used a backtick
+            }
+        } | Should -Throw -ExpectedMessage 'No test scriptblock is provided*'
+    }
+
+    It 'Throws when provided unbound scriptblock' {
+        # Unbound scriptblocks would execute in Pester's internal module state
+        { It 'i' -Test ([scriptblock]::Create('')) } | Should -Throw -ExpectedMessage 'Unbound scriptblock*'
+    }
+}

--- a/tst/functions/SetupTeardown.Tests.ps1
+++ b/tst/functions/SetupTeardown.Tests.ps1
@@ -190,6 +190,25 @@ Describe 'Finishing TestGroup Setup and Teardown tests' {
     }
 }
 
+Describe 'Unbound scriptsblocks as input' {
+    # Unbound scriptblocks would execute in Pester's internal module state
+    BeforeAll {
+        $sb = [scriptblock]::Create('')
+        $expectedMessage = 'Unbound scriptblock*'
+    }
+    It 'Throws when provided to BeforeAll' {
+        { BeforeAll -Scriptblock $sb } | Should -Throw -ExpectedMessage $expectedMessage
+    }
+    It 'Throws when provided to AfterAll' {
+        { AfterAll -Scriptblock $sb } | Should -Throw -ExpectedMessage $expectedMessage
+    }
+    It 'Throws when provided to BeforeEach' {
+        { BeforeEach -Scriptblock $sb } | Should -Throw -ExpectedMessage $expectedMessage
+    }
+    It 'Throws when provided to AfterEach' {
+        { AfterEach -Scriptblock $sb } | Should -Throw -ExpectedMessage $expectedMessage
+    }
+}
 
 # if ($PSVersionTable.PSVersion.Major -ge 3) {
 #     # TODO: this depends on the old pester internals it would be easier to test in P

--- a/tst/functions/assert/Collection/Should-All.Tests.ps1
+++ b/tst/functions/assert/Collection/Should-All.Tests.ps1
@@ -57,4 +57,10 @@ Expected [int] 2, but got [int] 1." -replace "`r`n", "`n")
     It 'It fails when the only item not matching the filter is 0' {
         { 0 | Should-All -FilterScript { $_ -gt 0 } } | Verify-AssertionFailed
     }
+
+    It 'Throws when provided unbound scriptblock' {
+        # Unbound scriptblocks would execute in Pester's internal module state
+        $ex = { 1 | Should-All ([scriptblock]::Create('')) } | Verify-Throw
+        $ex.Exception.Message | Verify-Like 'Unbound scriptblock*'
+    }
 }

--- a/tst/functions/assert/Collection/Should-Any.Tests.ps1
+++ b/tst/functions/assert/Collection/Should-Any.Tests.ps1
@@ -61,4 +61,10 @@ Expected [int] 2, but got [int] 1." -replace "`r`n", "`n")
     It "Accepts FilterScript and Actual by position" {
         Should-Any { $true } 1, 2
     }
+
+    It 'Throws when provided unbound scriptblock' {
+        # Unbound scriptblocks would execute in Pester's internal module state
+        $ex = { 1 | Should-Any ([scriptblock]::Create('')) } | Verify-Throw
+        $ex.Exception.Message | Verify-Like 'Unbound scriptblock*'
+    }
 }

--- a/tst/functions/assert/Exception/Should-Throw.Tests.ps1
+++ b/tst/functions/assert/Exception/Should-Throw.Tests.ps1
@@ -10,7 +10,6 @@ Describe "Should-Throw" {
     }
 
     It "Passes when non-terminating exception is thrown" {
-
         { Write-Error "fail!" } | Should-Throw
     }
 
@@ -21,6 +20,12 @@ Describe "Should-Throw" {
     It 'Supports same positional parameters as Should -Throw' {
         { Write-Error -Message 'MockErrorMessage' -ErrorId 'MockErrorId' -Category 'InvalidOperation' -TargetObject 'MockTargetObject' -ErrorAction 'Stop' } |
             Should-Throw 'MockErrorMessage' 'MockErrorId' ([Microsoft.PowerShell.Commands.WriteErrorException]) 'MockBecauseString'
+    }
+
+    It 'Throws when provided unbound scriptblock' {
+        # Unbound scriptblocks would execute in Pester's internal module state
+        $ex = { ([scriptblock]::Create('')) | Should-Throw } | Verify-Throw
+        $ex.Exception.Message | Verify-Like 'Unbound scriptblock*'
     }
 
     Context "Filtering with exception type" {


### PR DESCRIPTION
## PR Summary
Throws when user provides scriptblocks that are not bound to a session state. They would be executed in Pester's module state which could cause unexpected behaviour.

Examples:

![image](https://github.com/user-attachments/assets/de8b9c60-72c0-4bed-8b43-d0515fdc8563)

![image](https://github.com/user-attachments/assets/f641d4a5-1b26-4412-bb35-f52cd65ad956)

Fix #2411

Checklist:
- [x] `Add-AssertionOperator -Test` (type: `ScriptBlock`)
- [x] `Add-ShouldOperator -Test` (type: `ScriptBlock`)
- [x] `AfterAll -Scriptblock` (type: `ScriptBlock`)
- [x] `AfterEach -Scriptblock` (type: `ScriptBlock`)
- [x] `BeforeAll -Scriptblock` (type: `ScriptBlock`)
- [x] `BeforeDiscovery -ScriptBlock` (type: `ScriptBlock`)
- [x] `BeforeEach -Scriptblock` (type: `ScriptBlock`)
- [x] `Context -Fixture` (type: `ScriptBlock`)
- [x] `Describe -Fixture` (type: `ScriptBlock`)
- [x] `InModuleScope -ScriptBlock` (type: `ScriptBlock`)
  - Not applicable as it always overrides session state to specified module
- [x] `It -Test` (type: `ScriptBlock`)
- [x] `Mock -MockWith` (type: `ScriptBlock`)
  - Already handles unbound scriptblocks. Test added
- [x] `Mock -ParameterFilter` (type: `ScriptBlock`)
  - Already handles unbound scriptblocks. Test added
- [x] `New-PesterContainer -ScriptBlock` (type: `ScriptBlock[]`)
- [x] `Should-All -FilterScript` (type: `ScriptBlock`)
- [x] `Should-Any -FilterScript` (type: `ScriptBlock`)
- [x] `Should-Throw -ScriptBlock` (type: `ScriptBlock`)
- [x] `Run.Scriptblock`
- [x] `Run.Container`

## PR Checklist

- [x] PR has meaningful title
- [x] Summary describes changes
- [x] PR is ready to be merged
  - If not, use the arrow next to `Create Pull Request` to mark it as a draft. PR can be marked `Ready for review` when it's ready.
- [x] Tests are added/update *(if required)*
- [ ] Documentation is updated/added *(if required)*