### PR TITLE
Include more statements in code coverage

### DIFF
--- a/src/functions/Coverage.ps1
+++ b/src/functions/Coverage.ps1
@@ -287,9 +287,16 @@ function Get-CommandsInFile {
         # In PowerShell 5.0, dynamic keywords for DSC configurations are represented by the DynamicKeywordStatementAst
         # class.  They still trigger breakpoints, but are not a child class of CommandBaseAst anymore.
 
+        # ReturnStatementAst is excluded as it's not behaving consistent.
+        # "return" is not hit in 5.1 but fixed in a later version. Using "return 123" we get hit on 123 but not return.
+        # See https://github.com/pester/Pester/issues/1465#issuecomment-604323645
         $predicate = {
             $args[0] -is [System.Management.Automation.Language.DynamicKeywordStatementAst] -or
-            $args[0] -is [System.Management.Automation.Language.CommandBaseAst]
+            $args[0] -is [System.Management.Automation.Language.CommandBaseAst] -or
+            $args[0] -is [System.Management.Automation.Language.BreakStatementAst] -or
+            $args[0] -is [System.Management.Automation.Language.ContinueStatementAst] -or
+            $args[0] -is [System.Management.Automation.Language.ExitStatementAst] -or
+            $args[0] -is [System.Management.Automation.Language.ThrowStatementAst]
         }
     }
     else {
@@ -551,6 +558,7 @@ function Get-CoverageCommandText {
 
     $reportParentExtentTypes = @(
         [System.Management.Automation.Language.ReturnStatementAst]
+        [System.Management.Automation.Language.ExitStatementAst]
         [System.Management.Automation.Language.ThrowStatementAst]
         [System.Management.Automation.Language.AssignmentStatementAst]
         [System.Management.Automation.Language.IfStatementAst]

--- a/src/functions/Coverage.ps1
+++ b/src/functions/Coverage.ps1
@@ -249,7 +249,8 @@ function Get-CoverageBreakpoints {
         [ScriptBlock]$Logger
     )
 
-    $fileGroups = @($CoverageInfo | & $SafeCommands['Group-Object'] -Property Path)
+    # PowerShell 6.1+ sorts during Group-Object. Sorting to get equal report order for Windows PowerShell and PowerShell
+    $fileGroups = @($CoverageInfo | & $SafeCommands['Group-Object'] -Property Path | & $SafeCommands['Sort-Object'] -Property Name)
     foreach ($fileGroup in $fileGroups) {
         if ($null -ne $Logger) {
             $sw = [System.Diagnostics.Stopwatch]::StartNew()

--- a/src/functions/Coverage.ps1
+++ b/src/functions/Coverage.ps1
@@ -249,7 +249,7 @@ function Get-CoverageBreakpoints {
         [ScriptBlock]$Logger
     )
 
-    # PowerShell 6.1+ sorts during Group-Object. Sorting to get equal report order for Windows PowerShell and PowerShell
+    # PowerShell 6.1+ sorts by default in Group-Object. We need to sort for consistent output in Windows PowerShell
     $fileGroups = @($CoverageInfo | & $SafeCommands['Group-Object'] -Property Path | & $SafeCommands['Sort-Object'] -Property Name)
     foreach ($fileGroup in $fileGroups) {
         if ($null -ne $Logger) {
@@ -827,9 +827,10 @@ function Get-JaCoCoReportXml {
     [long] $endTime = [System.DateTimeOffset]::UtcNow.ToUnixTimeMilliseconds()
     [long] $startTime = [math]::Floor($endTime - $TotalMilliseconds)
 
+    # PowerShell 6.1+ sorts by default in Group-Object. We need to sort for consistent output in Windows PowerShell
     $folderGroups = $CommandCoverage | & $SafeCommands["Group-Object"] -Property {
         & $SafeCommands["Split-Path"] $_.File -Parent
-    }
+    } | & $SafeCommands["Sort-Object"] -Property Name
 
     $packageList = [System.Collections.Generic.List[psobject]]@()
 

--- a/src/functions/TestResults.NUnit25.ps1
+++ b/src/functions/TestResults.NUnit25.ps1
@@ -110,6 +110,7 @@ function Write-NUnitTestSuiteElements {
 
     $suites = @(
         # Tests only have GroupId if parameterized. All other tests are put in group with '' value
+        # PowerShell 6.1+ sorts by default in Group-Object. We need to sort for consistent output in Windows PowerShell
         $Node.Tests | & $SafeCommands['Group-Object'] -Property GroupId
     )
 

--- a/src/functions/TestResults.NUnit25.ps1
+++ b/src/functions/TestResults.NUnit25.ps1
@@ -111,7 +111,7 @@ function Write-NUnitTestSuiteElements {
     $suites = @(
         # Tests only have GroupId if parameterized. All other tests are put in group with '' value
         # PowerShell 6.1+ sorts by default in Group-Object. We need to sort for consistent output in Windows PowerShell
-        $Node.Tests | & $SafeCommands['Group-Object'] -Property GroupId
+        $Node.Tests | & $SafeCommands['Group-Object'] -Property GroupId | & $SafeCommands["Sort-Object"] -Property Name
     )
 
     foreach ($suite in $suites) {

--- a/src/functions/TestResults.NUnit3.ps1
+++ b/src/functions/TestResults.NUnit3.ps1
@@ -136,7 +136,7 @@ function Write-NUnit3TestSuiteElement {
     $blockGroups = @(
         # Blocks only have GroupId if parameterized (using -ForEach). All other blocks are put in group with '' value
         # PowerShell 6.1+ sorts by default in Group-Object. We need to sort for consistent output in Windows PowerShell
-        $Node.Blocks | & $SafeCommands['Group-Object'] -Property GroupId
+        $Node.Blocks | & $SafeCommands['Group-Object'] -Property GroupId | & $SafeCommands["Sort-Object"] -Property Name
     )
 
     foreach ($group in $blockGroups) {
@@ -171,7 +171,8 @@ function Write-NUnit3TestSuiteElement {
 
     $testGroups = @(
         # Tests only have GroupId if parameterized. All other tests are put in group with '' value
-        $Node.Tests | & $SafeCommands['Group-Object'] -Property GroupId
+        # PowerShell 6.1+ sorts by default in Group-Object. We need to sort for consistent output in Windows PowerShell
+        $Node.Tests | & $SafeCommands['Group-Object'] -Property GroupId | & $SafeCommands["Sort-Object"] -Property Name
     )
 
     foreach ($group in $testGroups) {

--- a/src/functions/TestResults.NUnit3.ps1
+++ b/src/functions/TestResults.NUnit3.ps1
@@ -135,6 +135,7 @@ function Write-NUnit3TestSuiteElement {
 
     $blockGroups = @(
         # Blocks only have GroupId if parameterized (using -ForEach). All other blocks are put in group with '' value
+        # PowerShell 6.1+ sorts by default in Group-Object. We need to sort for consistent output in Windows PowerShell
         $Node.Blocks | & $SafeCommands['Group-Object'] -Property GroupId
     )
 

--- a/tst/functions/Coverage.Tests.ps1
+++ b/tst/functions/Coverage.Tests.ps1
@@ -17,6 +17,8 @@ InPesterModuleScope {
             $testScriptPath = Join-Path -Path $root -ChildPath TestScript.ps1
             $testScript2Path = Join-Path -Path $root -ChildPath TestScript2.ps1
             $testScript3Path = Join-Path -Path $rootSubFolder -ChildPath TestScript3.ps1
+            $testScriptStatementsPath = Join-Path -Path $root -ChildPath TestScriptStatements.ps1
+            $testScriptExitPath = Join-Path -Path $root -ChildPath TestScriptExit.ps1
 
             $null = New-Item -Path $testScriptPath -ItemType File -ErrorAction SilentlyContinue
 
@@ -42,7 +44,7 @@ InPesterModuleScope {
 
                 function FunctionTwo
                 {
-                    'I am function two.  I never get called.'
+                    'I am function two. I never get called.'
                 }
 
                 FunctionOne
@@ -134,6 +136,54 @@ InPesterModuleScope {
                 'other'
 
 '@
+
+            $null = New-Item -Path $testScriptStatementsPath -ItemType File -ErrorAction SilentlyContinue
+
+            Set-Content -Path $testScriptStatementsPath -Value @'
+            try {
+                try {
+                    throw 'omg'
+                }
+                catch {
+                    throw
+                }
+            }
+            catch { }
+
+            switch (1,2,3) {
+                1 { continue; }
+                2 { break }
+                3 { 'I was skipped because 2 called break in switch.' }
+            }
+
+            :myBreakLabel foreach ($i in 1..100) {
+                foreach ($o in 1) {
+                    break myBreakLabel
+                }
+                'I was skipped by a labeled break.'
+            }
+
+            :myLoopLabel foreach ($i in 1) {
+                foreach ($o in 1..100) {
+                    continue myLoopLabel
+                }
+                'I was skipped by a labeled contiune.'
+            }
+
+            # These should not be included in code coverage
+            & { return }
+            & { return 123 }
+
+            # will exit the script
+            exit
+'@
+
+            $null = New-Item -Path $testScriptExitPath -ItemType File -ErrorAction SilentlyContinue
+
+            Set-Content -Path $testScriptExitPath -Value @'
+            # will exit the script, so keep in own file
+            exit 123
+'@
         }
 
         Context 'Entire file measured using <description>' -Foreach @(
@@ -143,14 +193,16 @@ InPesterModuleScope {
             BeforeAll {
                 # TODO: renaming, breakpoints mean "code point of interests" in most cases here, not actual breakpoints
                 # Path deliberately duplicated to make sure the code doesn't produce multiple breakpoints for the same commands
-                $breakpoints = Enter-CoverageAnalysis -CodeCoverage $testScriptPath, $testScriptPath, $testScript2Path, $testScript3Path -UseBreakpoints $UseBreakpoints
+                $breakpoints = Enter-CoverageAnalysis -CodeCoverage $testScriptPath, $testScriptPath, $testScript2Path, $testScript3Path, $testScriptStatementsPath, $testScriptExitPath -UseBreakpoints $UseBreakpoints
 
-                @($breakpoints).Count | Should -Be 19 -Because 'it has the proper number of breakpoints defined'
+                @($breakpoints).Count | Should -Be 40 -Because 'it has the proper number of breakpoints defined'
 
                 $sb = {
                     $null = & $testScriptPath
                     $null = & $testScript2Path
                     $null = & $testScript3Path
+                    $null = & $testScriptStatementsPath
+                    $null = & $testScriptExitPath
                 }
 
                 if ($UseBreakpoints) {
@@ -167,29 +219,32 @@ InPesterModuleScope {
             }
 
             It 'Reports the proper number of executed commands' {
-                $coverageReport.NumberOfCommandsExecuted | Should -Be 16
+                $coverageReport.NumberOfCommandsExecuted | Should -Be 34
             }
 
             It 'Reports the proper number of analyzed commands' {
-                $coverageReport.NumberOfCommandsAnalyzed | Should -Be 19
+                $coverageReport.NumberOfCommandsAnalyzed | Should -Be 40
             }
 
             It 'Reports the proper number of analyzed files' {
-                $coverageReport.NumberOfFilesAnalyzed | Should -Be 3
+                $coverageReport.NumberOfFilesAnalyzed | Should -Be 5
             }
 
             It 'Reports the proper number of missed commands' {
-                $coverageReport.MissedCommands.Count | Should -Be 3
+                $coverageReport.MissedCommands.Count | Should -Be 6
             }
 
             It 'Reports the correct missed command' {
                 $coverageReport.MissedCommands[0].Command | Should -Be "'I cannot get called.'"
-                $coverageReport.MissedCommands[1].Command | Should -Be "'I am function two.  I never get called.'"
+                $coverageReport.MissedCommands[1].Command | Should -Be "'I am function two. I never get called.'"
                 $coverageReport.MissedCommands[2].Command | Should -Be "'I am method two. I never get called.'"
+                $coverageReport.MissedCommands[3].Command | Should -Be "'I was skipped because 2 called break in switch.'"
+                $coverageReport.MissedCommands[4].Command | Should -Be "'I was skipped by a labeled break.'"
+                $coverageReport.MissedCommands[5].Command | Should -Be "'I was skipped by a labeled contiune.'"
             }
 
             It 'Reports the proper number of hit commands' {
-                $coverageReport.HitCommands.Count | Should -Be 16
+                $coverageReport.HitCommands.Count | Should -Be 34
             }
 
             It 'Reports the correct hit command' {
@@ -289,6 +344,28 @@ InPesterModuleScope {
                             <counter type="METHOD" missed="0" covered="1" />
                             <counter type="CLASS" missed="0" covered="1" />
                         </class>
+                        <class name="CommonRoot/TestScriptExit" sourcefilename="TestScriptExit.ps1">
+                            <method name="&lt;script&gt;" desc="()" line="2">
+                                <counter type="INSTRUCTION" missed="0" covered="2" />
+                                <counter type="LINE" missed="0" covered="1" />
+                                <counter type="METHOD" missed="0" covered="1" />
+                            </method>
+                            <counter type="INSTRUCTION" missed="0" covered="2" />
+                            <counter type="LINE" missed="0" covered="1" />
+                            <counter type="METHOD" missed="0" covered="1" />
+                            <counter type="CLASS" missed="0" covered="1" />
+                        </class>
+                        <class name="CommonRoot/TestScriptStatements" sourcefilename="TestScriptStatements.ps1">
+                            <method name="&lt;script&gt;" desc="()" line="3">
+                                <counter type="INSTRUCTION" missed="3" covered="16" />
+                                <counter type="LINE" missed="3" covered="14" />
+                                <counter type="METHOD" missed="0" covered="1" />
+                            </method>
+                            <counter type="INSTRUCTION" missed="3" covered="16" />
+                            <counter type="LINE" missed="3" covered="14" />
+                            <counter type="METHOD" missed="0" covered="1" />
+                            <counter type="CLASS" missed="0" covered="1" />
+                        </class>
                         <sourcefile name="TestScript.ps1">
                             <line nr="5" mi="0" ci="1" mb="0" cb="0" />
                             <line nr="6" mi="0" ci="1" mb="0" cb="0" />
@@ -317,10 +394,40 @@ InPesterModuleScope {
                             <counter type="METHOD" missed="0" covered="1" />
                             <counter type="CLASS" missed="0" covered="1" />
                         </sourcefile>
-                        <counter type="INSTRUCTION" missed="3" covered="15" />
-                        <counter type="LINE" missed="2" covered="14" />
-                        <counter type="METHOD" missed="2" covered="7" />
-                        <counter type="CLASS" missed="0" covered="2" />
+                        <sourcefile name="TestScriptExit.ps1">
+                            <line nr="2" mi="0" ci="2" mb="0" cb="0" />
+                            <counter type="INSTRUCTION" missed="0" covered="2" />
+                            <counter type="LINE" missed="0" covered="1" />
+                            <counter type="METHOD" missed="0" covered="1" />
+                            <counter type="CLASS" missed="0" covered="1" />
+                        </sourcefile>
+                        <sourcefile name="TestScriptStatements.ps1">
+                            <line nr="3" mi="0" ci="2" mb="0" cb="0" />
+                            <line nr="6" mi="0" ci="1" mb="0" cb="0" />
+                            <line nr="11" mi="0" ci="1" mb="0" cb="0" />
+                            <line nr="12" mi="0" ci="1" mb="0" cb="0" />
+                            <line nr="13" mi="0" ci="1" mb="0" cb="0" />
+                            <line nr="14" mi="1" ci="0" mb="0" cb="0" />
+                            <line nr="17" mi="0" ci="1" mb="0" cb="0" />
+                            <line nr="18" mi="0" ci="1" mb="0" cb="0" />
+                            <line nr="19" mi="0" ci="1" mb="0" cb="0" />
+                            <line nr="21" mi="1" ci="0" mb="0" cb="0" />
+                            <line nr="24" mi="0" ci="1" mb="0" cb="0" />
+                            <line nr="25" mi="0" ci="1" mb="0" cb="0" />
+                            <line nr="26" mi="0" ci="1" mb="0" cb="0" />
+                            <line nr="28" mi="1" ci="0" mb="0" cb="0" />
+                            <line nr="32" mi="0" ci="1" mb="0" cb="0" />
+                            <line nr="33" mi="0" ci="2" mb="0" cb="0" />
+                            <line nr="36" mi="0" ci="1" mb="0" cb="0" />
+                            <counter type="INSTRUCTION" missed="3" covered="16" />
+                            <counter type="LINE" missed="3" covered="14" />
+                            <counter type="METHOD" missed="0" covered="1" />
+                            <counter type="CLASS" missed="0" covered="1" />
+                        </sourcefile>
+                        <counter type="INSTRUCTION" missed="6" covered="32" />
+                        <counter type="LINE" missed="5" covered="28" />
+                        <counter type="METHOD" missed="2" covered="8" />
+                        <counter type="CLASS" missed="0" covered="4" />
                     </package>
                     <package name="CommonRoot/TestSubFolder">
                         <class name="CommonRoot/TestSubFolder/TestScript3"
@@ -347,10 +454,10 @@ InPesterModuleScope {
                         <counter type="METHOD" missed="0" covered="1" />
                         <counter type="CLASS" missed="0" covered="1" />
                     </package>
-                    <counter type="INSTRUCTION" missed="3" covered="16" />
-                    <counter type="LINE" missed="2" covered="15" />
-                    <counter type="METHOD" missed="2" covered="8" />
-                    <counter type="CLASS" missed="0" covered="3" />
+                    <counter type="INSTRUCTION" missed="6" covered="33" />
+                    <counter type="LINE" missed="5" covered="29" />
+                    <counter type="METHOD" missed="2" covered="9" />
+                    <counter type="CLASS" missed="0" covered="5" />
                 </report>
                 ')
             }
@@ -429,6 +536,28 @@ InPesterModuleScope {
                             <counter type="METHOD" missed="0" covered="1" />
                             <counter type="CLASS" missed="0" covered="1" />
                         </class>
+                        <class name="TestScriptExit" sourcefilename="TestScriptExit.ps1">
+                            <method name="&lt;script&gt;" desc="()" line="2">
+                                <counter type="INSTRUCTION" missed="0" covered="2" />
+                                <counter type="LINE" missed="0" covered="1" />
+                                <counter type="METHOD" missed="0" covered="1" />
+                            </method>
+                            <counter type="INSTRUCTION" missed="0" covered="2" />
+                            <counter type="LINE" missed="0" covered="1" />
+                            <counter type="METHOD" missed="0" covered="1" />
+                            <counter type="CLASS" missed="0" covered="1" />
+                        </class>
+                        <class name="TestScriptStatements" sourcefilename="TestScriptStatements.ps1">
+                            <method name="&lt;script&gt;" desc="()" line="3">
+                                <counter type="INSTRUCTION" missed="3" covered="16" />
+                                <counter type="LINE" missed="3" covered="14" />
+                                <counter type="METHOD" missed="0" covered="1" />
+                            </method>
+                            <counter type="INSTRUCTION" missed="3" covered="16" />
+                            <counter type="LINE" missed="3" covered="14" />
+                            <counter type="METHOD" missed="0" covered="1" />
+                            <counter type="CLASS" missed="0" covered="1" />
+                        </class>
                         <sourcefile name="TestScript.ps1">
                             <line nr="5" mi="0" ci="1" mb="0" cb="0" />
                             <line nr="6" mi="0" ci="1" mb="0" cb="0" />
@@ -457,10 +586,40 @@ InPesterModuleScope {
                             <counter type="METHOD" missed="0" covered="1" />
                             <counter type="CLASS" missed="0" covered="1" />
                         </sourcefile>
-                        <counter type="INSTRUCTION" missed="3" covered="15" />
-                        <counter type="LINE" missed="2" covered="14" />
-                        <counter type="METHOD" missed="2" covered="7" />
-                        <counter type="CLASS" missed="0" covered="2" />
+                        <sourcefile name="TestScriptExit.ps1">
+                            <line nr="2" mi="0" ci="2" mb="0" cb="0" />
+                            <counter type="INSTRUCTION" missed="0" covered="2" />
+                            <counter type="LINE" missed="0" covered="1" />
+                            <counter type="METHOD" missed="0" covered="1" />
+                            <counter type="CLASS" missed="0" covered="1" />
+                        </sourcefile>
+                        <sourcefile name="TestScriptStatements.ps1">
+                            <line nr="3" mi="0" ci="2" mb="0" cb="0" />
+                            <line nr="6" mi="0" ci="1" mb="0" cb="0" />
+                            <line nr="11" mi="0" ci="1" mb="0" cb="0" />
+                            <line nr="12" mi="0" ci="1" mb="0" cb="0" />
+                            <line nr="13" mi="0" ci="1" mb="0" cb="0" />
+                            <line nr="14" mi="1" ci="0" mb="0" cb="0" />
+                            <line nr="17" mi="0" ci="1" mb="0" cb="0" />
+                            <line nr="18" mi="0" ci="1" mb="0" cb="0" />
+                            <line nr="19" mi="0" ci="1" mb="0" cb="0" />
+                            <line nr="21" mi="1" ci="0" mb="0" cb="0" />
+                            <line nr="24" mi="0" ci="1" mb="0" cb="0" />
+                            <line nr="25" mi="0" ci="1" mb="0" cb="0" />
+                            <line nr="26" mi="0" ci="1" mb="0" cb="0" />
+                            <line nr="28" mi="1" ci="0" mb="0" cb="0" />
+                            <line nr="32" mi="0" ci="1" mb="0" cb="0" />
+                            <line nr="33" mi="0" ci="2" mb="0" cb="0" />
+                            <line nr="36" mi="0" ci="1" mb="0" cb="0" />
+                            <counter type="INSTRUCTION" missed="3" covered="16" />
+                            <counter type="LINE" missed="3" covered="14" />
+                            <counter type="METHOD" missed="0" covered="1" />
+                            <counter type="CLASS" missed="0" covered="1" />
+                        </sourcefile>
+                        <counter type="INSTRUCTION" missed="6" covered="32" />
+                        <counter type="LINE" missed="5" covered="28" />
+                        <counter type="METHOD" missed="2" covered="8" />
+                        <counter type="CLASS" missed="0" covered="4" />
                     </package>
                     <package name="TestSubFolder">
                         <class name="TestSubFolder/TestScript3" sourcefilename="TestScript3.ps1">
@@ -486,10 +645,10 @@ InPesterModuleScope {
                         <counter type="METHOD" missed="0" covered="1" />
                         <counter type="CLASS" missed="0" covered="1" />
                     </package>
-                    <counter type="INSTRUCTION" missed="3" covered="16" />
-                    <counter type="LINE" missed="2" covered="15" />
-                    <counter type="METHOD" missed="2" covered="8" />
-                    <counter type="CLASS" missed="0" covered="3" />
+                    <counter type="INSTRUCTION" missed="6" covered="33" />
+                    <counter type="LINE" missed="5" covered="29" />
+                    <counter type="METHOD" missed="2" covered="9" />
+                    <counter type="CLASS" missed="0" covered="5" />
                 </report>
                 ')
             }
@@ -663,7 +822,7 @@ InPesterModuleScope {
             }
 
             It 'Reports the correct missed command' {
-                $coverageReport.MissedCommands[0].Command | Should -Be "'I am function two.  I never get called.'"
+                $coverageReport.MissedCommands[0].Command | Should -Be "'I am function two. I never get called.'"
             }
 
             It 'Reports the proper number of hit commands' {
@@ -814,7 +973,7 @@ InPesterModuleScope {
 
             It 'Reports the correct missed command' {
                 $coverageReport.MissedCommands[0].Command | Should -Be "'I cannot get called.'"
-                $coverageReport.MissedCommands[1].Command | Should -Be "'I am function two.  I never get called.'"
+                $coverageReport.MissedCommands[1].Command | Should -Be "'I am function two. I never get called.'"
             }
 
             It 'Reports the proper number of hit commands' {

--- a/tst/functions/Coverage.Tests.ps1
+++ b/tst/functions/Coverage.Tests.ps1
@@ -424,9 +424,9 @@ InPesterModuleScope {
                             <counter type="METHOD" missed="0" covered="1" />
                             <counter type="CLASS" missed="0" covered="1" />
                         </sourcefile>
-                        <counter type="INSTRUCTION" missed="6" covered="32" />
-                        <counter type="LINE" missed="5" covered="28" />
-                        <counter type="METHOD" missed="2" covered="8" />
+                        <counter type="INSTRUCTION" missed="6" covered="33" />
+                        <counter type="LINE" missed="5" covered="29" />
+                        <counter type="METHOD" missed="2" covered="9" />
                         <counter type="CLASS" missed="0" covered="4" />
                     </package>
                     <package name="CommonRoot/TestSubFolder">
@@ -454,9 +454,9 @@ InPesterModuleScope {
                         <counter type="METHOD" missed="0" covered="1" />
                         <counter type="CLASS" missed="0" covered="1" />
                     </package>
-                    <counter type="INSTRUCTION" missed="6" covered="33" />
-                    <counter type="LINE" missed="5" covered="29" />
-                    <counter type="METHOD" missed="2" covered="9" />
+                    <counter type="INSTRUCTION" missed="6" covered="34" />
+                    <counter type="LINE" missed="5" covered="30" />
+                    <counter type="METHOD" missed="2" covered="10" />
                     <counter type="CLASS" missed="0" covered="5" />
                 </report>
                 ')
@@ -616,9 +616,9 @@ InPesterModuleScope {
                             <counter type="METHOD" missed="0" covered="1" />
                             <counter type="CLASS" missed="0" covered="1" />
                         </sourcefile>
-                        <counter type="INSTRUCTION" missed="6" covered="32" />
-                        <counter type="LINE" missed="5" covered="28" />
-                        <counter type="METHOD" missed="2" covered="8" />
+                        <counter type="INSTRUCTION" missed="6" covered="33" />
+                        <counter type="LINE" missed="5" covered="29" />
+                        <counter type="METHOD" missed="2" covered="9" />
                         <counter type="CLASS" missed="0" covered="4" />
                     </package>
                     <package name="TestSubFolder">
@@ -645,9 +645,9 @@ InPesterModuleScope {
                         <counter type="METHOD" missed="0" covered="1" />
                         <counter type="CLASS" missed="0" covered="1" />
                     </package>
-                    <counter type="INSTRUCTION" missed="6" covered="33" />
-                    <counter type="LINE" missed="5" covered="29" />
-                    <counter type="METHOD" missed="2" covered="9" />
+                    <counter type="INSTRUCTION" missed="6" covered="34" />
+                    <counter type="LINE" missed="5" covered="30" />
+                    <counter type="METHOD" missed="2" covered="10" />
                     <counter type="CLASS" missed="0" covered="5" />
                 </report>
                 ')
@@ -662,13 +662,13 @@ InPesterModuleScope {
                 (Clear-WhiteSpace $coberturaReportXml) | Should -Be (Clear-WhiteSpace '
                 <?xml version="1.0" ?>
                 <!DOCTYPE coverage SYSTEM "coverage-loose.dtd">
-                <coverage lines-valid="17" lines-covered="15" line-rate="0.882352941176471" branches-valid="0"
+                <coverage lines-valid="35" lines-covered="30" line-rate="0.857142857142857" branches-valid="0"
                     branches-covered="0" branch-rate="1" timestamp="" version="0.1">
                     <sources>
                         <source>CommonRoot</source>
                     </sources>
                     <packages>
-                        <package name="" line-rate="0.875" branch-rate="0">
+                        <package name="" line-rate="0.852941176470588" branch-rate="0">
                             <classes>
                                 <class name="TestScript.ps1" filename="TestScript.ps1" line-rate="0.866666666666667"
                                     branch-rate="1">
@@ -737,6 +737,36 @@ InPesterModuleScope {
                                     <methods />
                                     <lines>
                                         <line number="1" hits="1" />
+                                    </lines>
+                                </class>
+                                <class name="TestScriptExit.ps1" filename="TestScriptExit.ps1" line-rate="1"
+                                    branch-rate="1">
+                                    <methods />
+                                    <lines>
+                                        <line number="2" hits="2" />
+                                    </lines>
+                                </class>
+                                <class name="TestScriptStatements.ps1" filename="TestScriptStatements.ps1"
+                                    line-rate="0.823529411764706" branch-rate="1">
+                                    <methods />
+                                    <lines>
+                                        <line number="3" hits="2" />
+                                        <line number="6" hits="1" />
+                                        <line number="11" hits="1" />
+                                        <line number="12" hits="1" />
+                                        <line number="13" hits="1" />
+                                        <line number="14" hits="0" />
+                                        <line number="17" hits="1" />
+                                        <line number="18" hits="1" />
+                                        <line number="19" hits="1" />
+                                        <line number="21" hits="0" />
+                                        <line number="24" hits="1" />
+                                        <line number="25" hits="1" />
+                                        <line number="26" hits="1" />
+                                        <line number="28" hits="0" />
+                                        <line number="32" hits="1" />
+                                        <line number="33" hits="2" />
+                                        <line number="36" hits="1" />
                                     </lines>
                                 </class>
                             </classes>


### PR DESCRIPTION
## PR Summary
Extends code coverage to include `break`, `continue`, `exit` and `throw` statements.
`return` is not included due to inconsistent behavior (though `return 123` is already covered as a command expression)

Adds sort after `Group-Object` to save future headaches with inconsistent report/output order in Windows PowerShell vs PowerShell 6.1 which sorts by default.

Fix #1465

## PR Checklist

- [x] PR has meaningful title
- [x] Summary describes changes
- [x] PR is ready to be merged
  - If not, use the arrow next to `Create Pull Request` to mark it as a draft. PR can be marked `Ready for review` when it's ready.
- [x] Tests are added/update *(if required)*
- [ ] Documentation is updated/added *(if required)*