### PR TITLE
Fix `Should-Throw`/`Should -Throw` to handle expected message with escaped wildcard

### DIFF
--- a/src/functions/assert/Exception/Should-Throw.ps1
+++ b/src/functions/assert/Exception/Should-Throw.ps1
@@ -25,6 +25,7 @@ function Should-Throw {
     ```powershell
     { throw 'error' } | Should-Throw
     { throw 'error' } | Should-Throw -ExceptionMessage 'error'
+    { throw 'wildcard character []' } | Should-Throw -ExceptionMessage '*character `[`]'
     { throw 'error' } | Should-Throw -ExceptionType 'System.Management.Automation.RuntimeException'
     { throw 'error' } | Should-Throw -FullyQualifiedErrorId 'RuntimeException'
     { throw 'error' } | Should-Throw -FullyQualifiedErrorId '*Exception'
@@ -100,7 +101,7 @@ function Should-Throw {
 
     $filterOnMessage = -not ([string]::IsNullOrWhiteSpace($ExceptionMessage))
     if ($filterOnMessage) {
-        $filters += "with message '$ExceptionMessage'"
+        $filters += "with message like '$([System.Management.Automation.WildcardPattern]::Unescape($ExceptionMessage))'"
         if ($err.ExceptionMessage -notlike $ExceptionMessage) {
             $buts += "the message was '$($err.ExceptionMessage)'"
         }

--- a/src/functions/assertions/PesterThrow.ps1
+++ b/src/functions/assertions/PesterThrow.ps1
@@ -98,7 +98,7 @@
 
     $filterOnMessage = -not [string]::IsNullOrWhitespace($ExpectedMessage)
     if ($filterOnMessage) {
-        $filters += "message like $(Format-Nicely [System.Management.Automation.WildcardPattern]::Unescape($ExpectedMessage))"
+        $filters += "message like $(Format-Nicely ([System.Management.Automation.WildcardPattern]::Unescape($ExpectedMessage)))"
         if ($actualExceptionWasThrown -and (-not (Get-DoValuesMatch $actualExceptionMessage $ExpectedMessage))) {
             $buts += "the message was $(Format-Nicely $actualExceptionMessage)"
         }

--- a/src/functions/assertions/PesterThrow.ps1
+++ b/src/functions/assertions/PesterThrow.ps1
@@ -98,7 +98,8 @@
 
     $filterOnMessage = -not [string]::IsNullOrWhitespace($ExpectedMessage)
     if ($filterOnMessage) {
-        $filters += "message like $(Format-Nicely ([System.Management.Automation.WildcardPattern]::Unescape($ExpectedMessage)))"
+        $unescapedExpectedMessage = [System.Management.Automation.WildcardPattern]::Unescape($ExpectedMessage)
+        $filters += "message like $(Format-Nicely $unescapedExpectedMessage)"
         if ($actualExceptionWasThrown -and (-not (Get-DoValuesMatch $actualExceptionMessage $ExpectedMessage))) {
             $buts += "the message was $(Format-Nicely $actualExceptionMessage)"
         }

--- a/src/functions/assertions/PesterThrow.ps1
+++ b/src/functions/assertions/PesterThrow.ps1
@@ -70,7 +70,9 @@
         # this is for Should -Not -Throw. Once *any* exception was thrown we should fail the assertion
         # there is no point in filtering the exception, because there should be none
         $succeeded = -not $actualExceptionWasThrown
-        if ($true -eq $succeeded) { return [Pester.ShouldResult]@{Succeeded = $succeeded } }
+        if ($true -eq $succeeded) {
+            return [Pester.ShouldResult]@{Succeeded = $succeeded }
+        }
 
         $failureMessage = "Expected no exception to be thrown,$(Format-Because $Because) but an exception `"$actualExceptionMessage`" was thrown $actualExceptionLine."
         return [Pester.ShouldResult] @{
@@ -96,7 +98,7 @@
 
     $filterOnMessage = -not [string]::IsNullOrWhitespace($ExpectedMessage)
     if ($filterOnMessage) {
-        $filters += "message like $(Format-Nicely $ExpectedMessage)"
+        $filters += "message like $(Format-Nicely [System.Management.Automation.WildcardPattern]::Unescape($ExpectedMessage))"
         if ($actualExceptionWasThrown -and (-not (Get-DoValuesMatch $actualExceptionMessage $ExpectedMessage))) {
             $buts += "the message was $(Format-Nicely $actualExceptionMessage)"
         }
@@ -120,7 +122,12 @@
         $failureMessage = "Expected an exception$(if($filter) { " with $filter" }) to be thrown,$(Format-Because $Because) but $but. $actualExceptionLine".Trim()
 
         $ActualValue = $actualExceptionMessage
-        $ExpectedValue = if ($filterOnExceptionType) { "type $(Format-Nicely $ExceptionType)" } else { 'any exception' }
+        $ExpectedValue = if ($filterOnExceptionType) {
+            "type $(Format-Nicely $ExceptionType)"
+        }
+        else {
+            'any exception'
+        }
 
         return [Pester.ShouldResult] @{
             Succeeded      = $false

--- a/tst/functions/assert/Exception/Should-Throw.Tests.ps1
+++ b/tst/functions/assert/Exception/Should-Throw.Tests.ps1
@@ -53,6 +53,10 @@ Describe "Should-Throw" {
         It "Fails when exception does not match the message with wildcard" {
             { { throw [ArgumentException]"A is null!" } | Should-Throw -ExceptionMessage '*flabbergasted*' } | Verify-AssertionFailed
         }
+
+        It "Passes when exception match the message with escaped wildcard" {
+            { throw [ArgumentException]"[]" } | Should-Throw -ExceptionMessage '`[`]'
+        }
     }
 
     Context "Filtering with FullyQualifiedErrorId" {
@@ -112,6 +116,11 @@ Describe "Should-Throw" {
         It "Given exception that does not match on type, message and FullyQualifiedErrorId it returns the correct message" {
             $err = { { throw [ArgumentException]"halt!" } | Should-Throw -ExceptionType ([System.InvalidOperationException]) -ExceptionMessage 'fail!'  -FullyQualifiedErrorId 'fail!' } | Verify-AssertionFailed
             $err.Exception.Message | Verify-Equal "Expected an exception, of type [InvalidOperationException], with message 'fail!' and with FullyQualifiedErrorId 'fail!' to be thrown, but the exception type was [ArgumentException], the message was 'halt!' and the FullyQualifiedErrorId was 'halt!'."
+        }
+
+        It "Given exception that does not match on a message with escaped wildcard it returns the correct message" {
+            $err = { { throw [ArgumentException]"[!]" } | Should-Throw -ExceptionMessage '`[`]' } | Verify-AssertionFailed
+            $err.Exception.Message | Verify-Equal "Expected an exception, with message like '[]' to be thrown, but the message was '[!]'."
         }
     }
 

--- a/tst/functions/assert/Exception/Should-Throw.Tests.ps1
+++ b/tst/functions/assert/Exception/Should-Throw.Tests.ps1
@@ -90,7 +90,7 @@ Describe "Should-Throw" {
 
         It "Given exception that does not match on message it returns the correct message" {
             $err = { { throw [ArgumentException]"fail!" } | Should-Throw -ExceptionMessage 'halt!' } | Verify-AssertionFailed
-            $err.Exception.Message | Verify-Equal "Expected an exception, with message 'halt!' to be thrown, but the message was 'fail!'."
+            $err.Exception.Message | Verify-Equal "Expected an exception, with message like 'halt!' to be thrown, but the message was 'fail!'."
         }
 
         It "Given exception that does not match on FullyQualifiedErrorId it returns the correct message" {
@@ -100,7 +100,7 @@ Describe "Should-Throw" {
 
         It "Given exception that does not match on type and message it returns the correct message" {
             $err = { { throw [ArgumentException]"fail!" } | Should-Throw -ExceptionType ([System.InvalidOperationException]) -ExceptionMessage 'halt!' } | Verify-AssertionFailed
-            $err.Exception.Message | Verify-Equal "Expected an exception, of type [InvalidOperationException], with message 'halt!' to be thrown, but the exception type was [ArgumentException] and the message was 'fail!'."
+            $err.Exception.Message | Verify-Equal "Expected an exception, of type [InvalidOperationException], with message like 'halt!' to be thrown, but the exception type was [ArgumentException] and the message was 'fail!'."
         }
 
         It "Given exception that does not match on type and FullyQualifiedErrorId it returns the correct message" {
@@ -110,12 +110,12 @@ Describe "Should-Throw" {
 
         It "Given exception that does not match on message and FullyQualifiedErrorId it returns the correct message" {
             $err = { { throw [ArgumentException]"halt!" } | Should-Throw -ExceptionMessage 'fail!'  -FullyQualifiedErrorId 'fail!' } | Verify-AssertionFailed
-            $err.Exception.Message | Verify-Equal "Expected an exception, with message 'fail!', with FullyQualifiedErrorId 'fail!' to be thrown, but the message was 'halt!' and the FullyQualifiedErrorId was 'halt!'."
+            $err.Exception.Message | Verify-Equal "Expected an exception, with message like 'fail!', with FullyQualifiedErrorId 'fail!' to be thrown, but the message was 'halt!' and the FullyQualifiedErrorId was 'halt!'."
         }
 
         It "Given exception that does not match on type, message and FullyQualifiedErrorId it returns the correct message" {
             $err = { { throw [ArgumentException]"halt!" } | Should-Throw -ExceptionType ([System.InvalidOperationException]) -ExceptionMessage 'fail!'  -FullyQualifiedErrorId 'fail!' } | Verify-AssertionFailed
-            $err.Exception.Message | Verify-Equal "Expected an exception, of type [InvalidOperationException], with message 'fail!' and with FullyQualifiedErrorId 'fail!' to be thrown, but the exception type was [ArgumentException], the message was 'halt!' and the FullyQualifiedErrorId was 'halt!'."
+            $err.Exception.Message | Verify-Equal "Expected an exception, of type [InvalidOperationException], with message like 'fail!' and with FullyQualifiedErrorId 'fail!' to be thrown, but the exception type was [ArgumentException], the message was 'halt!' and the FullyQualifiedErrorId was 'halt!'."
         }
 
         It "Given exception that does not match on a message with escaped wildcard it returns the correct message" {

--- a/tst/functions/assertions/PesterThrow.Tests.ps1
+++ b/tst/functions/assertions/PesterThrow.Tests.ps1
@@ -166,7 +166,7 @@ InPesterModuleScope {
 
             It "returns the correct assertion message when message filter is used and contain escaped wildcard character" {
                 $err = { { throw [ArgumentException]"[!]" } | Should -Throw -ExpectedMessage '`[`]' } | Verify-AssertionFailed
-                $err.Exception.Message | Verify-Equal "Expected an exception with message like '[]' to be thrown, but the message was '[!]'. from ##path##:1 char:" -replace "##path##", $testScriptPath
+                $err.Exception.Message | Verify-Equal ("Expected an exception with message like '[]' to be thrown, but the message was '[!]'. from ##path##:1 char:" -replace "##path##", $testScriptPath)
             }
 
             It 'returns the correct assertion message when exceptions messages differ' {

--- a/tst/functions/assertions/PesterThrow.Tests.ps1
+++ b/tst/functions/assertions/PesterThrow.Tests.ps1
@@ -166,7 +166,7 @@ InPesterModuleScope {
 
             It "returns the correct assertion message when message filter is used and contain escaped wildcard character" {
                 $err = { { throw [ArgumentException]"[!]" } | Should -Throw -ExpectedMessage '`[`]' } | Verify-AssertionFailed
-                $err.Exception.Message | Verify-Equal "Expected an exception with message like '[]' to be thrown, but the message was '[!]'."
+                $err.Exception.Message | Verify-Equal "Expected an exception with message like '[]' to be thrown, but the message was '[!]'. from ##path##:1 char:" -replace "##path##", $testScriptPath
             }
 
             It 'returns the correct assertion message when exceptions messages differ' {

--- a/tst/functions/assertions/PesterThrow.Tests.ps1
+++ b/tst/functions/assertions/PesterThrow.Tests.ps1
@@ -164,6 +164,11 @@ InPesterModuleScope {
                 $err.Exception.Message | Verify-Equal "Expected an exception with FullyQualifiedErrorId 'id' to be thrown, but no exception was thrown."
             }
 
+            It "returns the correct assertion message when message filter is used and contain escaped wildcard character" {
+                $err = { { throw [ArgumentException]"[!]" } | Should -Throw -ExpectedMessage '`[`]' } | Verify-AssertionFailed
+                $err.Exception.Message | Verify-Equal "Expected an exception with message like '[]' to be thrown, but the message was '[!]'."
+            }
+
             It 'returns the correct assertion message when exceptions messages differ' {
                 $testDrive = (Get-PSDrive TestDrive).Root
                 $testScriptPath = Join-Path $testDrive test.ps1


### PR DESCRIPTION
<!-- Thank you for contributing to Pester! -->

## PR Summary

This target v6. This resolves #2558 so that when the expected message containing escaped wildcard is output is removes the escaped character so it shows the correct expected message that differ from the actual value.

Fix #2558 

## PR Checklist

- [x] PR has meaningful title
- [x] Summary describes changes
- [x] PR is ready to be merged
  - If not, use the arrow next to `Create Pull Request` to mark it as a draft. PR can be marked `Ready for review` when it's ready.
- [x] Tests are added/update *(if required)*
- [ ] Documentation is updated/added *(if required)*

<!-- Before you continue, please review [Contributing to Pester](https://pester.dev/docs/contributing/introduction).

Our continuous integration system doesn't send any notifications about failed tests. Please return to the opened pull request (after ~60 minutes) to check if everything is OK. -->
