### PR TITLE
Fix `Should -Throw` to handle expected message with escaped wildcard (backport)

### DIFF
--- a/src/functions/assertions/PesterThrow.ps1
+++ b/src/functions/assertions/PesterThrow.ps1
@@ -98,7 +98,7 @@
 
     $filterOnMessage = -not [string]::IsNullOrWhitespace($ExpectedMessage)
     if ($filterOnMessage) {
-        $filters += "message like $(Format-Nicely [System.Management.Automation.WildcardPattern]::Unescape($ExpectedMessage))"
+        $filters += "message like $(Format-Nicely ([System.Management.Automation.WildcardPattern]::Unescape($ExpectedMessage)))"
         if ($actualExceptionWasThrown -and (-not (Get-DoValuesMatch $actualExceptionMessage $ExpectedMessage))) {
             $buts += "the message was $(Format-Nicely $actualExceptionMessage)"
         }

--- a/src/functions/assertions/PesterThrow.ps1
+++ b/src/functions/assertions/PesterThrow.ps1
@@ -98,7 +98,8 @@
 
     $filterOnMessage = -not [string]::IsNullOrWhitespace($ExpectedMessage)
     if ($filterOnMessage) {
-        $filters += "message like $(Format-Nicely ([System.Management.Automation.WildcardPattern]::Unescape($ExpectedMessage)))"
+        $unescapedExpectedMessage = [System.Management.Automation.WildcardPattern]::Unescape($ExpectedMessage)
+        $filters += "message like $(Format-Nicely $unescapedExpectedMessage)"
         if ($actualExceptionWasThrown -and (-not (Get-DoValuesMatch $actualExceptionMessage $ExpectedMessage))) {
             $buts += "the message was $(Format-Nicely $actualExceptionMessage)"
         }

--- a/src/functions/assertions/PesterThrow.ps1
+++ b/src/functions/assertions/PesterThrow.ps1
@@ -70,7 +70,9 @@
         # this is for Should -Not -Throw. Once *any* exception was thrown we should fail the assertion
         # there is no point in filtering the exception, because there should be none
         $succeeded = -not $actualExceptionWasThrown
-        if ($true -eq $succeeded) { return [Pester.ShouldResult]@{Succeeded = $succeeded } }
+        if ($true -eq $succeeded) {
+            return [Pester.ShouldResult]@{Succeeded = $succeeded }
+        }
 
         $failureMessage = "Expected no exception to be thrown,$(Format-Because $Because) but an exception `"$actualExceptionMessage`" was thrown $actualExceptionLine."
         return [Pester.ShouldResult] @{
@@ -96,7 +98,7 @@
 
     $filterOnMessage = -not [string]::IsNullOrWhitespace($ExpectedMessage)
     if ($filterOnMessage) {
-        $filters += "message like $(Format-Nicely $ExpectedMessage)"
+        $filters += "message like $(Format-Nicely [System.Management.Automation.WildcardPattern]::Unescape($ExpectedMessage))"
         if ($actualExceptionWasThrown -and (-not (Get-DoValuesMatch $actualExceptionMessage $ExpectedMessage))) {
             $buts += "the message was $(Format-Nicely $actualExceptionMessage)"
         }
@@ -120,7 +122,12 @@
         $failureMessage = "Expected an exception$(if($filter) { " with $filter" }) to be thrown,$(Format-Because $Because) but $but. $actualExceptionLine".Trim()
 
         $ActualValue = $actualExceptionMessage
-        $ExpectedValue = if ($filterOnExceptionType) { "type $(Format-Nicely $ExceptionType)" } else { 'any exception' }
+        $ExpectedValue = if ($filterOnExceptionType) {
+            "type $(Format-Nicely $ExceptionType)"
+        }
+        else {
+            'any exception'
+        }
 
         return [Pester.ShouldResult] @{
             Succeeded      = $false

--- a/tst/functions/assertions/PesterThrow.Tests.ps1
+++ b/tst/functions/assertions/PesterThrow.Tests.ps1
@@ -166,7 +166,7 @@ InPesterModuleScope {
 
             It "returns the correct assertion message when message filter is used and contain escaped wildcard character" {
                 $err = { { throw [ArgumentException]"[!]" } | Should -Throw -ExpectedMessage '`[`]' } | Verify-AssertionFailed
-                $err.Exception.Message | Verify-Equal "Expected an exception with message like '[]' to be thrown, but the message was '[!]'. from ##path##:1 char:" -replace "##path##", $testScriptPath
+                $err.Exception.Message | Verify-Equal ("Expected an exception with message like '[]' to be thrown, but the message was '[!]'. from ##path##:1 char:" -replace "##path##", $testScriptPath)
             }
 
             It 'returns the correct assertion message when exceptions messages differ' {

--- a/tst/functions/assertions/PesterThrow.Tests.ps1
+++ b/tst/functions/assertions/PesterThrow.Tests.ps1
@@ -166,7 +166,7 @@ InPesterModuleScope {
 
             It "returns the correct assertion message when message filter is used and contain escaped wildcard character" {
                 $err = { { throw [ArgumentException]"[!]" } | Should -Throw -ExpectedMessage '`[`]' } | Verify-AssertionFailed
-                $err.Exception.Message | Verify-Equal "Expected an exception with message like '[]' to be thrown, but the message was '[!]'."
+                $err.Exception.Message | Verify-Equal "Expected an exception with message like '[]' to be thrown, but the message was '[!]'. from ##path##:1 char:" -replace "##path##", $testScriptPath
             }
 
             It 'returns the correct assertion message when exceptions messages differ' {

--- a/tst/functions/assertions/PesterThrow.Tests.ps1
+++ b/tst/functions/assertions/PesterThrow.Tests.ps1
@@ -164,6 +164,11 @@ InPesterModuleScope {
                 $err.Exception.Message | Verify-Equal "Expected an exception with FullyQualifiedErrorId 'id' to be thrown, but no exception was thrown."
             }
 
+            It "returns the correct assertion message when message filter is used and contain escaped wildcard character" {
+                $err = { { throw [ArgumentException]"[!]" } | Should -Throw -ExpectedMessage '`[`]' } | Verify-AssertionFailed
+                $err.Exception.Message | Verify-Equal "Expected an exception with message like '[]' to be thrown, but the message was '[!]'."
+            }
+
             It 'returns the correct assertion message when exceptions messages differ' {
                 $testDrive = (Get-PSDrive TestDrive).Root
                 $testScriptPath = Join-Path $testDrive test.ps1


### PR DESCRIPTION
<!-- Thank you for contributing to Pester! -->

## PR Summary

This target v5. This resolves #2558 so that when the expected message containing escaped wildcard is output is removes the escaped character so it shows the correct expected message that differ from the actual value.

Part of issue #2558 

## PR Checklist

- [x] PR has meaningful title
- [x] Summary describes changes
- [x] PR is ready to be merged
  - If not, use the arrow next to `Create Pull Request` to mark it as a draft. PR can be marked `Ready for review` when it's ready.
- [x] Tests are added/update *(if required)*
- [ ] Documentation is updated/added *(if required)*

<!-- Before you continue, please review [Contributing to Pester](https://pester.dev/docs/contributing/introduction).

Our continuous integration system doesn't send any notifications about failed tests. Please return to the opened pull request (after ~60 minutes) to check if everything is OK. -->