### PR TITLE
Update macOS image and PublishCodeCoverageResults task in CI

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -82,11 +82,11 @@ stages:
             PS7_Ubuntu_22_04:
               vmImage: ubuntu-22.04
               pwsh: true
-            PS7_macOS_12:
-              vmImage: macOS-12
-              pwsh: true
             PS7_macOS_13:
               vmImage: macOS-13
+              pwsh: true
+            PS7_macOS_14:
+              vmImage: macOS-14
               pwsh: true
             PS7_Windows_Server2019:
               vmImage: windows-2019

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -114,9 +114,8 @@ stages:
               script: |
                 & ./test.ps1 -CI -CC -PassThru -NoBuild
               workingDirectory: '$(Build.SourcesDirectory)'
-          - task: PublishCodeCoverageResults@1
+          - task: PublishCodeCoverageResults@2
             inputs:
-              codeCoverageTool: 'JaCoCo'
               summaryFileLocation: 'coverage.xml'
               pathToSources: '$(Build.SourcesDirectory)/bin/'
               failIfCoverageEmpty: false


### PR DESCRIPTION
## PR Summary

- Replaces deprecated macOS 12 runner image with macOS 14,
- Upgrades PublishCodeCoverageResults to v2 because v1 is deprecated. See warnings in recent CI runs.

## PR Checklist

- [x] PR has meaningful title
- [x] Summary describes changes
- [x] PR is ready to be merged
  - If not, use the arrow next to `Create Pull Request` to mark it as a draft. PR can be marked `Ready for review` when it's ready.
- [ ] Tests are added/update *(if required)*
- [ ] Documentation is updated/added *(if required)*