### PR TITLE
Remove about topics in related links

### DIFF
--- a/src/Pester.RSpec.ps1
+++ b/src/Pester.RSpec.ps1
@@ -333,9 +333,6 @@ function New-PesterConfiguration {
 
     .LINK
     https://pester.dev/docs/commands/Invoke-Pester
-
-    .LINK
-    about_PesterConfiguration
     #>
     [CmdletBinding()]
     [OutputType([PesterConfiguration])]


### PR DESCRIPTION
## PR Summary
Removes about_PesterConfiguration from related links in `New-PesterConfiguration` as it generates broken (empty) markdown links in platyPS. about_pesterConfiguration is already mentioned in Description-section.

Related https://github.com/pester/docs/pull/329#discussion_r1845457577

## PR Checklist

- [x] PR has meaningful title
- [x] Summary describes changes
- [x] PR is ready to be merged
  - If not, use the arrow next to `Create Pull Request` to mark it as a draft. PR can be marked `Ready for review` when it's ready.
- [ ] Tests are added/update *(if required)*
- [x] Documentation is updated/added *(if required)*