### PR TITLE
Fix coverage code for pre-v5

### DIFF
--- a/tst/functions/Coverage.Tests.ps1
+++ b/tst/functions/Coverage.Tests.ps1
@@ -97,7 +97,7 @@ InPesterModuleScope {
                 #{
                     function MyClass
                     {
-                        MyBaseClass; 'I am the constructor.'
+                        MyBaseClass # call the base constructor
                     }
 
                     function MethodOne


### PR DESCRIPTION
Forward porting a fix for powershell pre-v5, that I had to do here https://github.com/pester/Pester/pull/2572

We don't run that code on the main branch, but we might be backporting more fixes of code coverage back to v5, and this makes it easier.