### PR TITLE
Use versioned links for online v5 docs

### DIFF
--- a/src/Main.ps1
+++ b/src/Main.ps1
@@ -60,7 +60,7 @@ function Add-ShouldOperator {
 
     Example of how to create a simple custom assertion that checks if the input string is 'Awesome'
     .LINK
-    https://pester.dev/docs/commands/Add-ShouldOperator
+    https://pester.dev/docs/v5/commands/Add-ShouldOperator
     #>
     [CmdletBinding()]
     param (
@@ -273,7 +273,7 @@ function Add-AssertionDynamicParameterSet {
         $attribute.Mandatory = $false
         $attribute.Position = ($i++)
         # Only visible in command reference on https://pester.dev. Remove if/when migrated to external help (markdown as source).
-        $attribute.HelpMessage = 'Depends on operator being used. See `Get-ShouldOperator -Name <Operator>` or https://pester.dev/docs/assertions/ for help.'
+        $attribute.HelpMessage = 'Depends on operator being used. See `Get-ShouldOperator -Name <Operator>` or https://pester.dev/docs/v5/assertions/ for help.'
 
         $null = $dynamic.Attributes.Add($attribute)
     }
@@ -572,10 +572,10 @@ function Invoke-Pester {
     to see other testresult options like  output path and format and their default values.
 
     .LINK
-    https://pester.dev/docs/commands/Invoke-Pester
+    https://pester.dev/docs/v5/commands/Invoke-Pester
 
     .LINK
-    https://pester.dev/docs/quick-start
+    https://pester.dev/docs/v5/quick-start
     #>
 
     # Currently doesn't work. $IgnoreUnsafeCommands filter used in rule as workaround
@@ -1365,10 +1365,10 @@ function ConvertTo-Pester4Result {
     in the Pester 5 format and converts it to a new Pester 4-compatible result-object.
 
     .LINK
-    https://pester.dev/docs/commands/ConvertTo-Pester4Result
+    https://pester.dev/docs/v5/commands/ConvertTo-Pester4Result
 
     .LINK
-    https://pester.dev/docs/commands/Invoke-Pester
+    https://pester.dev/docs/v5/commands/Invoke-Pester
     #>
     [CmdletBinding()]
     param(
@@ -1499,10 +1499,10 @@ function BeforeDiscovery {
     dynamically create a Describe-block and tests for each file found.
 
     .LINK
-    https://pester.dev/docs/commands/BeforeDiscovery
+    https://pester.dev/docs/v5/commands/BeforeDiscovery
 
     .LINK
-    https://pester.dev/docs/usage/data-driven-tests
+    https://pester.dev/docs/v5/usage/data-driven-tests
     #>
     [CmdletBinding()]
     param (

--- a/src/Pester.RSpec.ps1
+++ b/src/Pester.RSpec.ps1
@@ -288,7 +288,7 @@ function New-PesterConfiguration {
 
     Calling New-PesterConfiguration is equivalent to calling [PesterConfiguration]::Default which was used in early versions of Pester 5.
 
-    For a complete list of options, see `Get-Help about_PesterConfiguration` or https://pester.dev/docs/usage/configuration
+    For a complete list of options, see `Get-Help about_PesterConfiguration` or https://pester.dev/docs/v5/usage/configuration
 
     .PARAMETER Hashtable
     Override the default values for the options defined in the provided dictionary/hashtable.
@@ -329,13 +329,13 @@ function New-PesterConfiguration {
     the new configuration.
 
     .LINK
-    https://pester.dev/docs/commands/New-PesterConfiguration
+    https://pester.dev/docs/v5/commands/New-PesterConfiguration
 
     .LINK
-    https://pester.dev/docs/usage/Configuration
+    https://pester.dev/docs/v5/usage/Configuration
 
     .LINK
-    https://pester.dev/docs/commands/Invoke-Pester
+    https://pester.dev/docs/v5/commands/Invoke-Pester
 
     .LINK
     about_PesterConfiguration
@@ -534,13 +534,13 @@ function New-PesterContainer {
     the required ContainerInfo-object that enables us to do this directly.
 
     .LINK
-    https://pester.dev/docs/commands/New-PesterContainer
+    https://pester.dev/docs/v5/commands/New-PesterContainer
 
     .LINK
-    https://pester.dev/docs/commands/Invoke-Pester
+    https://pester.dev/docs/v5/commands/Invoke-Pester
 
     .LINK
-    https://pester.dev/docs/usage/data-driven-tests
+    https://pester.dev/docs/v5/usage/data-driven-tests
     #>
     [CmdletBinding(DefaultParameterSetName = "Path")]
     param(

--- a/src/functions/Context.ps1
+++ b/src/functions/Context.ps1
@@ -61,16 +61,16 @@
     Example of how to use Context for grouping different tests
 
     .LINK
-    https://pester.dev/docs/commands/Context
+    https://pester.dev/docs/v5/commands/Context
 
     .LINK
-    https://pester.dev/docs/usage/test-file-structure
+    https://pester.dev/docs/v5/usage/test-file-structure
 
     .LINK
-    https://pester.dev/docs/usage/mocking
+    https://pester.dev/docs/v5/usage/mocking
 
     .LINK
-    https://pester.dev/docs/usage/testdrive
+    https://pester.dev/docs/v5/usage/testdrive
     #>
     param(
         [Parameter(Mandatory = $true, Position = 0)]

--- a/src/functions/Describe.ps1
+++ b/src/functions/Describe.ps1
@@ -68,16 +68,16 @@
     Using Describe to group tests logically at the root of the script/container
 
     .LINK
-    https://pester.dev/docs/commands/Describe
+    https://pester.dev/docs/v5/commands/Describe
 
     .LINK
-    https://pester.dev/docs/usage/test-file-structure
+    https://pester.dev/docs/v5/usage/test-file-structure
 
     .LINK
-    https://pester.dev/docs/usage/mocking
+    https://pester.dev/docs/v5/usage/mocking
 
     .LINK
-    https://pester.dev/docs/usage/testdrive
+    https://pester.dev/docs/v5/usage/testdrive
     #>
 
     param(

--- a/src/functions/Get-ShouldOperator.ps1
+++ b/src/functions/Get-ShouldOperator.ps1
@@ -28,10 +28,10 @@
     -Name is a dynamic parameter that tab completes all available options.
 
     .LINK
-    https://pester.dev/docs/commands/Get-ShouldOperator
+    https://pester.dev/docs/v5/commands/Get-ShouldOperator
 
     .LINK
-    https://pester.dev/docs/commands/Should
+    https://pester.dev/docs/v5/commands/Should
     #>
     [CmdletBinding()]
     param ()

--- a/src/functions/InModuleScope.ps1
+++ b/src/functions/InModuleScope.ps1
@@ -99,7 +99,7 @@
     them in using `-Parameters` or `-ArgumentList`.
 
     .LINK
-    https://pester.dev/docs/commands/InModuleScope
+    https://pester.dev/docs/v5/commands/InModuleScope
     #>
     [CmdletBinding()]
     param (

--- a/src/functions/It.ps1
+++ b/src/functions/It.ps1
@@ -108,16 +108,16 @@
     current hashtable are made available as variables inside It.
 
     .LINK
-    https://pester.dev/docs/commands/It
+    https://pester.dev/docs/v5/commands/It
 
     .LINK
-    https://pester.dev/docs/commands/Describe
+    https://pester.dev/docs/v5/commands/Describe
 
     .LINK
-    https://pester.dev/docs/commands/Context
+    https://pester.dev/docs/v5/commands/Context
 
     .LINK
-    https://pester.dev/docs/commands/Set-ItResult
+    https://pester.dev/docs/v5/commands/Set-ItResult
     #>
     [CmdletBinding(DefaultParameterSetName = 'Normal')]
     param(

--- a/src/functions/New-Fixture.ps1
+++ b/src/functions/New-Fixture.ps1
@@ -55,19 +55,19 @@
     Creates a new folder named Cleaner in the current directory and creates the scripts in it.
 
     .LINK
-    https://pester.dev/docs/commands/New-Fixture
+    https://pester.dev/docs/v5/commands/New-Fixture
 
     .LINK
-    https://pester.dev/docs/commands/Describe
+    https://pester.dev/docs/v5/commands/Describe
 
     .LINK
-    https://pester.dev/docs/commands/Context
+    https://pester.dev/docs/v5/commands/Context
 
     .LINK
-    https://pester.dev/docs/commands/It
+    https://pester.dev/docs/v5/commands/It
 
     .LINK
-    https://pester.dev/docs/commands/Should
+    https://pester.dev/docs/v5/commands/Should
     #>
     param (
         [Parameter(Mandatory = $true)]

--- a/src/functions/New-MockObject.ps1
+++ b/src/functions/New-MockObject.ps1
@@ -65,10 +65,10 @@
     of any call and the associated arguments in a property named `_Kill`
 
     .LINK
-    https://pester.dev/docs/commands/New-MockObject
+    https://pester.dev/docs/v5/commands/New-MockObject
 
     .LINK
-    https://pester.dev/docs/usage/mocking
+    https://pester.dev/docs/v5/usage/mocking
     #>
     [CmdletBinding(DefaultParameterSetName = "Type")]
     param (

--- a/src/functions/Pester.SessionState.Mock.ps1
+++ b/src/functions/Pester.SessionState.Mock.ps1
@@ -214,10 +214,10 @@ function Mock {
     mocked by using the -ModuleName parameter.
 
     .LINK
-    https://pester.dev/docs/commands/Mock
+    https://pester.dev/docs/v5/commands/Mock
 
     .LINK
-    https://pester.dev/docs/usage/mocking
+    https://pester.dev/docs/v5/usage/mocking
     #>
     [CmdletBinding()]
     param(
@@ -615,7 +615,7 @@ function Assert-VerifiableMock {
     USE Should -InvokeVerifiable INSTEAD.
 
     .LINK
-    https://pester.dev/docs/commands/Assert-VerifiableMock
+    https://pester.dev/docs/v5/commands/Assert-VerifiableMock
     #>
 
     # Should does not accept a session state, so invoking it directly would
@@ -682,7 +682,7 @@ function Assert-MockCalled {
     USE Should -Invoke INSTEAD.
 
     .LINK
-    https://pester.dev/docs/commands/Assert-MockCalled
+    https://pester.dev/docs/v5/commands/Assert-MockCalled
     #>
     [CmdletBinding(DefaultParameterSetName = 'ParameterFilter')]
     param(

--- a/src/functions/Set-ItResult.ps1
+++ b/src/functions/Set-ItResult.ps1
@@ -49,7 +49,7 @@
     ```
 
     .LINK
-    https://pester.dev/docs/commands/Set-ItResult
+    https://pester.dev/docs/v5/commands/Set-ItResult
 #>
     [CmdletBinding()]
     param(

--- a/src/functions/SetupTeardown.ps1
+++ b/src/functions/SetupTeardown.ps1
@@ -42,10 +42,10 @@
         The example uses BeforeEach to ensure a clean sample-file is used for each test.
 
     .LINK
-        https://pester.dev/docs/commands/BeforeEach
+        https://pester.dev/docs/v5/commands/BeforeEach
 
     .LINK
-        https://pester.dev/docs/usage/setup-and-teardown
+        https://pester.dev/docs/v5/usage/setup-and-teardown
     #>
     [CmdletBinding()]
     param
@@ -108,10 +108,10 @@ function AfterEach {
         The example uses AfterEach to remove a temporary file after each test.
 
     .LINK
-        https://pester.dev/docs/commands/AfterEach
+        https://pester.dev/docs/v5/commands/AfterEach
 
     .LINK
-        https://pester.dev/docs/usage/setup-and-teardown
+        https://pester.dev/docs/v5/usage/setup-and-teardown
     #>
     [CmdletBinding()]
     param
@@ -184,10 +184,10 @@ function BeforeAll {
         the results in separate tests.
 
     .LINK
-        https://pester.dev/docs/commands/BeforeAll
+        https://pester.dev/docs/v5/commands/BeforeAll
 
     .LINK
-        https://pester.dev/docs/usage/setup-and-teardown
+        https://pester.dev/docs/v5/usage/setup-and-teardown
     #>
     [CmdletBinding()]
     param
@@ -250,10 +250,10 @@ function AfterAll {
         the tests in the Describe-block.
 
     .LINK
-        https://pester.dev/docs/commands/AfterAll
+        https://pester.dev/docs/v5/commands/AfterAll
 
     .LINK
-        https://pester.dev/docs/usage/setup-and-teardown
+        https://pester.dev/docs/v5/usage/setup-and-teardown
 #>
     [CmdletBinding()]
     param

--- a/src/functions/TestResults.ps1
+++ b/src/functions/TestResults.ps1
@@ -78,10 +78,10 @@ function Export-NUnitReport {
     exports it as an NUnit 2.5-compatible XML-report.
 
     .LINK
-    https://pester.dev/docs/commands/Export-NUnitReport
+    https://pester.dev/docs/v5/commands/Export-NUnitReport
 
     .LINK
-    https://pester.dev/docs/commands/Invoke-Pester
+    https://pester.dev/docs/v5/commands/Invoke-Pester
     #>
     param (
         [parameter(Mandatory = $true, ValueFromPipeline = $true)]
@@ -128,10 +128,10 @@ function Export-JUnitReport {
     exports it as an JUnit 4-compatible XML-report.
 
     .LINK
-    https://pester.dev/docs/commands/Export-JUnitReport
+    https://pester.dev/docs/v5/commands/Export-JUnitReport
 
     .LINK
-    https://pester.dev/docs/commands/Invoke-Pester
+    https://pester.dev/docs/v5/commands/Invoke-Pester
     #>
     param (
         [parameter(Mandatory = $true, ValueFromPipeline = $true)]
@@ -265,10 +265,10 @@ function ConvertTo-NUnitReport {
     converts it to an NUnit 2.5-compatible XML-report. The returned object is a string.
 
     .LINK
-    https://pester.dev/docs/commands/ConvertTo-NUnitReport
+    https://pester.dev/docs/v5/commands/ConvertTo-NUnitReport
 
     .LINK
-    https://pester.dev/docs/commands/Invoke-Pester
+    https://pester.dev/docs/v5/commands/Invoke-Pester
     #>
     param (
         [parameter(Mandatory = $true, ValueFromPipeline = $true)]
@@ -355,10 +355,10 @@ function ConvertTo-JUnitReport {
     converts it to an JUnit 4-compatible XML-report. The returned object is a string.
 
     .LINK
-    https://pester.dev/docs/commands/ConvertTo-JUnitReport
+    https://pester.dev/docs/v5/commands/ConvertTo-JUnitReport
 
     .LINK
-    https://pester.dev/docs/commands/Invoke-Pester
+    https://pester.dev/docs/v5/commands/Invoke-Pester
     #>
     param (
         [parameter(Mandatory = $true, ValueFromPipeline = $true)]

--- a/src/functions/assertions/Should.ps1
+++ b/src/functions/assertions/Should.ps1
@@ -87,10 +87,10 @@ function Should {
     Asserting that `Get-Application -Name Blarg` will throw an exception with a specific message.
 
     .LINK
-    https://pester.dev/docs/commands/Should
+    https://pester.dev/docs/v5/commands/Should
 
     .LINK
-    https://pester.dev/docs/assertions
+    https://pester.dev/docs/v5/assertions
     #>
     [CmdletBinding()]
     param (
@@ -107,7 +107,7 @@ function Should {
 
         # A bit of Regex lets us know if the line used the old form
         if ($myLine -match '^\s{0,}should\s{1,}(?<Operator>[^\-\@\s]+)') {
-            $shouldErrorMsg = "Legacy Should syntax (without dashes) is not supported in Pester 5. Please refer to migration guide at: https://pester.dev/docs/migrations/v3-to-v4"
+            $shouldErrorMsg = "Legacy Should syntax (without dashes) is not supported in Pester 5. Please refer to migration guide at: https://pester.dev/docs/v5/migrations/v3-to-v4"
             throw $shouldErrorMsg
         }
         else {

--- a/tst/Help.Tests.ps1
+++ b/tst/Help.Tests.ps1
@@ -33,7 +33,7 @@ Describe "Testing module help" -Tag 'Help' -ForEach @{ exportedFunctions = $expo
             $help.psobject.properties.name -match 'relatedLinks' | Should -Not -BeNullOrEmpty -Because 'all exported functions should at least have link to online version as first Uri'
 
             $firstUri = $help.relatedLinks.navigationLink | Where-Object uri | Select-Object -First 1 -ExpandProperty uri
-            $firstUri | Should -Be "https://pester.dev/docs/commands/$($help.Name)" -Because 'first uri-link should be to online version of this help topic'
+            $firstUri | Should -Be "https://pester.dev/docs/v5/commands/$($help.Name)" -Because 'first uri-link should be to online version of this help topic'
         }
 
         # Skipping Assert-MockCalled and Assert-VerifiableMock which are deprecated and missing docs


### PR DESCRIPTION
## PR Summary

Updates website links to use versioned URLs to make sure they don't break when v6 is released.

Fix #2503

## PR Checklist

- [x] PR has meaningful title
- [x] Summary describes changes
- [x] PR is ready to be merged
  - If not, use the arrow next to `Create Pull Request` to mark it as a draft. PR can be marked `Ready for review` when it's ready.
- [x] Tests are added/update *(if required)*
- [x] Documentation is updated/added *(if required)*