### PR TITLE
Pester may fail to produce report if an error message contains VT sequences

### DIFF
--- a/src/functions/TestResults.NUnit3.ps1
+++ b/src/functions/TestResults.NUnit3.ps1
@@ -538,7 +538,8 @@ function Write-NUnit3TestCaseAttributes {
     $XmlWriter.WriteAttributeString('asserts', '1') # required attr, so hardcoding 1:1 per testcase
 }
 
-function Write-NUnit3OutputElement ($Output, [System.Xml.XmlWriter] $XmlWriter) {
+function Format-CDataString ($Output) {
+
     # The characters in the range 0x01 to 0x20 are invalid for CData
     # (with the exception of the characters 0x09, 0x0A and 0x0D)
     # We convert each of these using the unicode printable version,
@@ -572,8 +573,13 @@ function Write-NUnit3OutputElement ($Output, [System.Xml.XmlWriter] $XmlWriter) 
     }
 
     $outputString = $o -join [Environment]::NewLine
+    return $outputString
+}
+
+
+function Write-NUnit3OutputElement ($Output, [System.Xml.XmlWriter] $XmlWriter) {
     $XmlWriter.WriteStartElement('output')
-    $XmlWriter.WriteCData($outputString)
+    $XmlWriter.WriteCData((Format-CDataString $output))
     $XmlWriter.WriteEndElement()
 }
 
@@ -585,12 +591,12 @@ function Write-NUnit3FailureElement ($TestResult, [System.Xml.XmlWriter] $XmlWri
     $XmlWriter.WriteStartElement('failure')
 
     $XmlWriter.WriteStartElement('message')
-    $XmlWriter.WriteCData($result.FailureMessage)
+    $XmlWriter.WriteCData((Format-CDataString $result.FailureMessage))
     $XmlWriter.WriteEndElement() # Close message
 
     if ($result.StackTrace) {
         $XmlWriter.WriteStartElement('stack-trace')
-        $XmlWriter.WriteCData($result.StackTrace)
+        $XmlWriter.WriteCData((Format-CDataString $result.StackTrace))
         $XmlWriter.WriteEndElement() # Close stack-trace
     }
 
@@ -604,7 +610,7 @@ function Write-NUnitReasonElement ($TestResult, [System.Xml.XmlWriter] $XmlWrite
     if ($result.FailureMessage) {
         $XmlWriter.WriteStartElement('reason')
         $XmlWriter.WriteStartElement('message')
-        $XmlWriter.WriteCData($result.FailureMessage)
+        $XmlWriter.WriteCData((Format-CDataString $result.FailureMessage))
         $XmlWriter.WriteEndElement() # Close message
         $XmlWriter.WriteEndElement() # Close reason
     }


### PR DESCRIPTION
<!-- Thank you for contributing to Pester! -->

## PR Summary
VT sequences are invalid in CData.
If an error message contains a VT sequence (for example to change the console color to red), then the NUnit report will fail to save.

## PR Checklist

- [x] PR has meaningful title
- [x] Summary describes changes
- [x] PR is ready to be merged
  - If not, use the arrow next to `Create Pull Request` to mark it as a draft. PR can be marked `Ready for review` when it's ready.
- [x] Tests are added/update *(if required)*
- [x] Documentation is updated/added *(if required)*

<!-- Before you continue, please review [Contributing to Pester](https://pester.dev/docs/contributing/introduction).

Our continuous integration system doesn't send any notifications about failed tests. Please return to the opened pull request (after ~60 minutes) to check if everything is OK. -->
