### PR TITLE
Fix formatting for Set-ItResult with because, removing trailing comma and redundant "because"

### DIFF
--- a/src/functions/Set-ItResult.ps1
+++ b/src/functions/Set-ItResult.ps1
@@ -81,7 +81,8 @@
     }
 
     if ($Because) {
-        [String]$message += ", because $(Format-Because $Because)"
+        [String]$formatted = Format-Because $Because
+        [String]$message += ",$($formatted.SubString(0, $formatted.Length - 1))"
     }
 
     throw [Pester.Factory]::CreateErrorRecord(

--- a/tst/functions/Set-ItResult.Tests.ps1
+++ b/tst/functions/Set-ItResult.Tests.ps1
@@ -19,6 +19,15 @@ Describe "Testing Set-ItResult" {
         }
     }
 
+    It "Set-ItResult appends the -Because reason to the message" {
+        try {
+            Set-ItResult -Skipped -Because "we are forcing it to skip"
+        }
+        catch {
+            $_.Exception.Message | Should -Be "is skipped, because we are forcing it to skip"
+        }
+    }
+
     It "Set-ItResult can be called without -Because" {
         try {
             Set-ItResult -Skipped


### PR DESCRIPTION
<!-- Thank you for contributing to Pester! -->

## PR Summary
<!-- Please describe what your pull request fixes, or how it improves Pester.

If your pull request resolves a reported issue, please mention it by using `Fix #<issue_number>` on a new line, this will close the linked issue automatically when this PR is merged. For more info see: [Closing issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/).

If your pull request integrates Pester with another system, please tell us how the change can be tested. -->
Fix #2588

Fixes the formatting of the `Set-ItResult` exception message when a `-Because` is provided.

This change removes the "because" being added to the message before including the content of `Format-Because` (which includes the "because"). It also strips out the trailing comma, as it's not needed or expected here.

The current message is formatted with a redundant "because" and a trailing comma.

ex:
```powershell
try {
    Set-ItResult -Skipped -Because "we are forcing it to skip"
} catch {
    $_.Exception.Message
}
```

Expected:
```powershell
is skipped, because we are forcing it to skip
```

Actual:
```powershell
is skipped, because  because we are forcing it to skip,
```

## PR Checklist

- [X] PR has meaningful title
- [X] Summary describes changes
- [X] PR is ready to be merged
  - If not, use the arrow next to `Create Pull Request` to mark it as a draft. PR can be marked `Ready for review` when it's ready.
- [X] Tests are added/update *(if required)*
- [ ] Documentation is updated/added *(if required)*

<!-- Before you continue, please review [Contributing to Pester](https://pester.dev/docs/contributing/introduction).

Our continuous integration system doesn't send any notifications about failed tests. Please return to the opened pull request (after ~60 minutes) to check if everything is OK. -->
