### PR TITLE
Support ExcludeFromCodeCoverage attribute

### DIFF
--- a/src/csharp/Pester/CoverageLocationVisitor.cs
+++ b/src/csharp/Pester/CoverageLocationVisitor.cs
@@ -1,7 +1,5 @@
 ﻿using System.Collections.Generic;
-using System.Collections.ObjectModel;
 using System.Diagnostics.CodeAnalysis;
-using System.Management.Automation;
 using System.Management.Automation.Language;
 
 namespace Pester

--- a/src/csharp/Pester/CoverageLocationVisitor.cs
+++ b/src/csharp/Pester/CoverageLocationVisitor.cs
@@ -1,0 +1,74 @@
+﻿using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Diagnostics.CodeAnalysis;
+using System.Management.Automation;
+using System.Management.Automation.Language;
+
+namespace Pester
+{
+    public class CoverageVisitor : AstVisitor2
+    {
+        public readonly List<Ast> CoverageLocations = [];
+
+        public override AstVisitAction VisitScriptBlock(ScriptBlockAst scriptBlockAst)
+        {
+            if (scriptBlockAst.ParamBlock?.Attributes != null)
+            {
+                foreach (var attribute in scriptBlockAst.ParamBlock.Attributes)
+                {
+                    if (attribute.TypeName.GetReflectionType() == typeof(ExcludeFromCodeCoverageAttribute))
+                    {
+                        return AstVisitAction.SkipChildren;
+                    }
+                }
+            }
+            return AstVisitAction.Continue;
+        }
+
+        public override AstVisitAction VisitCommand(CommandAst commandAst)
+        {
+            CoverageLocations.Add(commandAst);
+            return AstVisitAction.Continue;
+        }
+
+        public override AstVisitAction VisitCommandExpression(CommandExpressionAst commandExpressionAst)
+        {
+            CoverageLocations.Add(commandExpressionAst);
+            return AstVisitAction.Continue;
+        }
+
+        public override AstVisitAction VisitDynamicKeywordStatement(DynamicKeywordStatementAst dynamicKeywordStatementAst)
+        {
+            CoverageLocations.Add(dynamicKeywordStatementAst);
+            return AstVisitAction.Continue;
+        }
+
+        public override AstVisitAction VisitBreakStatement(BreakStatementAst breakStatementAst)
+        {
+            CoverageLocations.Add(breakStatementAst);
+            return AstVisitAction.Continue;
+        }
+
+        public override AstVisitAction VisitContinueStatement(ContinueStatementAst continueStatementAst)
+        {
+            CoverageLocations.Add(continueStatementAst);
+            return AstVisitAction.Continue;
+        }
+
+        public override AstVisitAction VisitExitStatement(ExitStatementAst exitStatementAst)
+        {
+            CoverageLocations.Add(exitStatementAst);
+            return AstVisitAction.Continue;
+        }
+
+        public override AstVisitAction VisitThrowStatement(ThrowStatementAst throwStatementAst)
+        {
+            CoverageLocations.Add(throwStatementAst);
+            return AstVisitAction.Continue;
+        }
+
+        // ReturnStatementAst is excluded as it's not behaving consistent.
+        // "return" is not hit in 5.1 but fixed in a later version. Using "return 123" we get hit on 123 but not return.
+        // See https://github.com/pester/Pester/issues/1465#issuecomment-604323645
+    }
+}

--- a/src/functions/Coverage.ps1
+++ b/src/functions/Coverage.ps1
@@ -284,28 +284,9 @@ function Get-CommandsInFile {
     $tokens = $null
     $ast = [System.Management.Automation.Language.Parser]::ParseFile($Path, [ref] $tokens, [ref] $errors)
 
-    if ($PSVersionTable.PSVersion.Major -ge 5) {
-        # In PowerShell 5.0, dynamic keywords for DSC configurations are represented by the DynamicKeywordStatementAst
-        # class.  They still trigger breakpoints, but are not a child class of CommandBaseAst anymore.
-
-        # ReturnStatementAst is excluded as it's not behaving consistent.
-        # "return" is not hit in 5.1 but fixed in a later version. Using "return 123" we get hit on 123 but not return.
-        # See https://github.com/pester/Pester/issues/1465#issuecomment-604323645
-        $predicate = {
-            $args[0] -is [System.Management.Automation.Language.DynamicKeywordStatementAst] -or
-            $args[0] -is [System.Management.Automation.Language.CommandBaseAst] -or
-            $args[0] -is [System.Management.Automation.Language.BreakStatementAst] -or
-            $args[0] -is [System.Management.Automation.Language.ContinueStatementAst] -or
-            $args[0] -is [System.Management.Automation.Language.ExitStatementAst] -or
-            $args[0] -is [System.Management.Automation.Language.ThrowStatementAst]
-        }
-    }
-    else {
-        $predicate = { $args[0] -is [System.Management.Automation.Language.CommandBaseAst] }
-    }
-
-    $searchNestedScriptBlocks = $true
-    $ast.FindAll($predicate, $searchNestedScriptBlocks)
+    $visitor = [Pester.CoverageVisitor]::new()
+    $ast.Visit($visitor)
+    return $visitor.CoverageLocations
 }
 
 function Test-CoverageOverlapsCommand {


### PR DESCRIPTION
## PR Summary
Alternative implementation of #2593 for discussion.

The AstVisitor could also be expanded to handle some of the post-processing like `IsClosingLoopCondition` more efficiently. If we'd like to keep debugging in PowerShell, we could use a PowerShell class as well as long as this feature is Pester v6 exclusive.

## PR Checklist

- [ ] PR has meaningful title
- [ ] Summary describes changes
- [ ] PR is ready to be merged
  - If not, use the arrow next to `Create Pull Request` to mark it as a draft. PR can be marked `Ready for review` when it's ready.
- [ ] Tests are added/update *(if required)*
- [ ] Documentation is updated/added *(if required)*