### PR TITLE
v5: Remove about_PesterConfiguration link in New-PesterConfiguration

### DIFF
--- a/src/Pester.RSpec.ps1
+++ b/src/Pester.RSpec.ps1
@@ -333,9 +333,6 @@ function New-PesterConfiguration {
 
     .LINK
     https://pester.dev/docs/v5/commands/Invoke-Pester
-
-    .LINK
-    about_PesterConfiguration
     #>
     [CmdletBinding()]
     param(


### PR DESCRIPTION
## PR Summary
about_* links as `.LINK` sections in comment based help breaks the docs website build. PR removes the last one from `New-PesterConfiguration` which was already removed in v6/main.

## PR Checklist

- [x] PR has meaningful title
- [x] Summary describes changes
- [x] PR is ready to be merged
  - If not, use the arrow next to `Create Pull Request` to mark it as a draft. PR can be marked `Ready for review` when it's ready.
- [ ] Tests are added/update *(if required)*
- [x] Documentation is updated/added *(if required)*