### PR TITLE
WIP: Add Reasons to Block and Test Results

### DIFF
--- a/2049-testing/2049.tests.ps1
+++ b/2049-testing/2049.tests.ps1
@@ -1,0 +1,68 @@
+
+Describe 'All The Tests' {
+	Context 'Reasons' {
+		It 'Skips...' {
+			Set-ItResult -Skipped -Because 'I am skipped'
+		}
+		It 'Does not skip' {
+			$true | Should -BeTrue
+		}
+		It 'is Inconclusive' {
+			Set-ItResult -Inconclusive -Because 'I am inconclusive!'
+		}
+		It 'is Failed!' {
+			$true | Should -BeFalse -Because 'I am failed test'
+		}
+	}
+
+	Context 'No Reasons' {
+		It 'Skips...' {
+			Set-ItResult -Skipped
+		}
+		It 'Does not skip' {
+			$true | Should -BeTrue
+		}
+		It 'is Inconclusive' {
+			Set-ItResult -Inconclusive
+		}
+		It 'is Failed!' {
+			$true | Should -BeFalse
+		}
+	}
+
+	Context 'It Reasons' {
+		It 'Skips' -Skip -Reason 'I am Skipped' {
+			$true | Should -BeTrue
+		}
+	}
+
+	Context 'It No Reasons' {
+		It 'Skips' -Skip {
+			$true | Should -BeTrue
+		}
+	}
+
+	Context 'Context Reasons' -Skip -Reason 'I am Skipped' {
+		It 'Skips' {
+			$true | Should -BeTrue
+		}
+	}
+
+	Context 'Context No Reasons' -Skip {
+		It 'Skips' {
+			$true | Should -BeTrue
+		}
+	}
+
+	Describe 'Describe Reasons' -Skip -Reason 'I am Skipped' {
+		It 'Skips' {
+			$true | Should -BeTrue
+		}
+	}
+
+	Describe 'Describe No Reasons' -Skip {
+		It 'Skips' {
+			$true | Should -BeTrue
+		}
+	}
+}

--- a/2049-testing/mytests.ps1
+++ b/2049-testing/mytests.ps1
@@ -1,0 +1,11 @@
+﻿$pesterConfig = [PesterConfiguration]::Default
+$pesterConfig.TestResult.Enabled = $true
+$pesterConfig.Run.Path = '.\2049.tests.ps1'
+$pesterConfig.Run.PassThru = $true
+$pesterConfig.Debug.WriteDebugMessages = $true
+
+foreach ($fmt in 'NUnitXml NUnit2.5 NUnit3 JUnitXml'.split(' ')) {
+    $pesterConfig.TestResult.OutputFormat = $fmt
+    $pesterConfig.TestResult.OutputPath = "results.$fmt.xml"
+    Invoke-Pester -Configuration $pesterConfig
+}

--- a/src/Pester.Runtime.ps1
+++ b/src/Pester.Runtime.ps1
@@ -181,6 +181,7 @@ function New-ParametrizedBlock {
         [String[]] $Tag = @(),
         [HashTable] $FrameworkData = @{ },
         [Switch] $Skip,
+        [String] $Reason,
         $Data
     )
 
@@ -191,7 +192,7 @@ function New-ParametrizedBlock {
     foreach ($d in @($Data)) {
         # shallow clone to give every block it's own copy
         $fmwData = $FrameworkData.Clone()
-        New-Block -GroupId $groupId -Name $Name -ScriptBlock $ScriptBlock -StartLine $StartLine -Tag $Tag -FrameworkData $fmwData -Skip:$Skip -Data $d
+        New-Block -GroupId $groupId -Name $Name -ScriptBlock $ScriptBlock -StartLine $StartLine -Tag $Tag -FrameworkData $fmwData -Skip:$Skip -Reason:$Reason -Data $d
     }
 }
 
@@ -208,6 +209,7 @@ function New-Block {
         [HashTable] $FrameworkData = @{ },
         [String] $GroupId,
         [Switch] $Skip,
+        [String] $Reason,
         $Data
     )
 
@@ -245,6 +247,7 @@ function New-Block {
     $block.FrameworkData = $FrameworkData
     $block.GroupId = $GroupId
     $block.Skip = $Skip
+    $block.Reason = $Reason
     $block.Data = $Data
 
     # we attach the current block to the parent, and put it to the parent
@@ -506,7 +509,8 @@ function New-Test {
         [String[]] $Tag = @(),
         $Data,
         [String] $GroupId,
-        [Switch] $Skip
+        [Switch] $Skip,
+        [String] $Reason
     )
 
     if ($PesterPreference.Debug.WriteDebugMessages.Value) {
@@ -541,6 +545,7 @@ function New-Test {
     $test.StartLine = $StartLine
     $test.Tag = $Tag
     $test.Skip = $Skip
+    $test.Reason = $Reason
     $test.Data = $Data
     $test.FrameworkData.Runtime.Phase = 'Discovery'
 
@@ -806,6 +811,7 @@ function Invoke-TestItem {
                     }
                     else {
                         $Test.Skipped = $true
+                        $Test.Reason = $result.ErrorRecord.Exception.Message
                     }
                 }
                 else {
@@ -2496,6 +2502,7 @@ function PostProcess-DiscoveredBlock {
                         }
 
                         $t.Skip = $true
+                        $t.Reason = $b.Reason
                     }
                 }
             }
@@ -2561,12 +2568,14 @@ function PostProcess-DiscoveredBlock {
                 if ($PesterPreference.Debug.WriteDebugMessages.Value) {
                     if ($b.IsRoot) {
                         Write-PesterDebugMessage -Scope Skip "($($b.BlockContainer)) Container will be skipped because all included children are marked as skipped."
-                    } else {
+                    }
+                    else {
                         Write-PesterDebugMessage -Scope Skip "($($b.Path -join '.')) Block will be skipped because all included children are marked as skipped."
                     }
                 }
                 $b.Skip = $true
-            } elseif ($b.Skip -and -not $shouldSkipBasedOnChildren) {
+            }
+            elseif ($b.Skip -and -not $shouldSkipBasedOnChildren) {
                 if ($PesterPreference.Debug.WriteDebugMessages.Value) {
                     Write-PesterDebugMessage -Scope Skip "($($b.Path -join '.')) Block was marked as skipped, but one or more children are explicitly requested to be run, so the block itself will not be skipped."
                 }
@@ -2893,14 +2902,15 @@ function New-ParametrizedTest () {
         [String[]] $Tag = @(),
         # do not use [hashtable[]] because that throws away the order if user uses [ordered] hashtable
         [object[]] $Data,
-        [Switch] $Skip
+        [Switch] $Skip,
+        [String] $Reason
     )
 
     # using the position of It as Id for the the test so we can join multiple testcases together, this should be unique enough because it only needs to be unique for the current block.
     # TODO: Id is used by NUnit2.5 and 3 testresults to group. A better way to solve this?
     $groupId = "${StartLine}:${StartColumn}"
     foreach ($d in $Data) {
-        New-Test -GroupId $groupId -Name $Name -Tag $Tag -ScriptBlock $ScriptBlock -StartLine $StartLine -Data $d -Skip:$Skip
+        New-Test -GroupId $groupId -Name $Name -Tag $Tag -ScriptBlock $ScriptBlock -StartLine $StartLine -Data $d -Skip:$Skip -Reason:$Reason
     }
 }
 

--- a/src/csharp/Pester/Block.cs
+++ b/src/csharp/Pester/Block.cs
@@ -45,6 +45,7 @@ namespace Pester
         public string GroupId { get; set; }
         public List<string> Tag { get; set; }
         public bool Skip { get; set; }
+        public string Reason { get; set; }
 
         public string ItemType { get; } = "Block";
 

--- a/src/csharp/Pester/Test.cs
+++ b/src/csharp/Pester/Test.cs
@@ -47,6 +47,7 @@ namespace Pester
         public ScriptBlock ScriptBlock { get; set; }
         public List<string> Tag { get; set; }
         public bool Skip { get; set; }
+        public string Reason { get; set; }
         // IDictionary to allow users use [ordered]
 
         public object Block { get; set; }

--- a/src/functions/Context.ps1
+++ b/src/functions/Context.ps1
@@ -88,6 +88,7 @@
         [ScriptBlock] $Fixture,
 
         [Switch] $Skip,
+        [String] $Reason,
         [Switch] $AllowNullOrEmptyForEach,
 
         [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidAssignmentToAutomaticVariable', '', Justification = 'ForEach is not used in Foreach-Object loop')]
@@ -120,10 +121,10 @@
                 return
             }
 
-            New-ParametrizedBlock -Name $Name -ScriptBlock $Fixture -StartLine $MyInvocation.ScriptLineNumber -StartColumn $MyInvocation.OffsetInLine -Tag $Tag -FrameworkData @{ CommandUsed = 'Context'; WrittenToScreen = $false } -Skip:$Skip -Data $ForEach
+            New-ParametrizedBlock -Name $Name -ScriptBlock $Fixture -StartLine $MyInvocation.ScriptLineNumber -StartColumn $MyInvocation.OffsetInLine -Tag $Tag -FrameworkData @{ CommandUsed = 'Context'; WrittenToScreen = $false } -Skip:$Skip -Reason:$Reason -Data $ForEach
         }
         else {
-            New-Block -Name $Name -ScriptBlock $Fixture -StartLine $MyInvocation.ScriptLineNumber -Tag $Tag -FrameworkData @{ CommandUsed = 'Context'; WrittenToScreen = $false } -Skip:$Skip
+            New-Block -Name $Name -ScriptBlock $Fixture -StartLine $MyInvocation.ScriptLineNumber -Tag $Tag -FrameworkData @{ CommandUsed = 'Context'; WrittenToScreen = $false } -Skip:$Skip -Reason:$Reason
         }
     }
     else {

--- a/src/functions/Describe.ps1
+++ b/src/functions/Describe.ps1
@@ -96,6 +96,7 @@
         [ScriptBlock] $Fixture,
 
         [Switch] $Skip,
+        [String] $Reason,
         [Switch] $AllowNullOrEmptyForEach,
 
         [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidAssignmentToAutomaticVariable', '', Justification = 'ForEach is not used in Foreach-Object loop')]
@@ -128,10 +129,10 @@
                 return
             }
 
-            New-ParametrizedBlock -Name $Name -ScriptBlock $Fixture -StartLine $MyInvocation.ScriptLineNumber -StartColumn $MyInvocation.OffsetInLine -Tag $Tag -FrameworkData @{ CommandUsed = 'Describe'; WrittenToScreen = $false } -Skip:$Skip -Data $ForEach
+            New-ParametrizedBlock -Name $Name -ScriptBlock $Fixture -StartLine $MyInvocation.ScriptLineNumber -StartColumn $MyInvocation.OffsetInLine -Tag $Tag -FrameworkData @{ CommandUsed = 'Describe'; WrittenToScreen = $false } -Skip:$Skip -Reason:$Reason -Data $ForEach
         }
         else {
-            New-Block -Name $Name -ScriptBlock $Fixture -StartLine $MyInvocation.ScriptLineNumber -Tag $Tag -FrameworkData @{ CommandUsed = 'Describe'; WrittenToScreen = $false } -Skip:$Skip
+            New-Block -Name $Name -ScriptBlock $Fixture -StartLine $MyInvocation.ScriptLineNumber -Tag $Tag -FrameworkData @{ CommandUsed = 'Describe'; WrittenToScreen = $false } -Skip:$Skip -Reason:$Reason
         }
     }
     else {

--- a/src/functions/It.ps1
+++ b/src/functions/It.ps1
@@ -133,10 +133,10 @@
 
         [Parameter(ParameterSetName = 'Skip')]
         [Switch] $Skip,
-        [Switch] $AllowNullOrEmptyForEach
+        [Switch] $AllowNullOrEmptyForEach,
 
-        # [Parameter(ParameterSetName = 'Skip')]
-        # [String] $SkipBecause,
+        [Parameter(ParameterSetName = 'Skip')]
+        [String] $Reason
     )
 
     if ($null -eq $Test) {
@@ -159,9 +159,9 @@
             return
         }
 
-        New-ParametrizedTest -Name $Name -ScriptBlock $Test -StartLine $MyInvocation.ScriptLineNumber -StartColumn $MyInvocation.OffsetInLine -Data $ForEach -Tag $Tag -Skip:$Skip
+        New-ParametrizedTest -Name $Name -ScriptBlock $Test -StartLine $MyInvocation.ScriptLineNumber -StartColumn $MyInvocation.OffsetInLine -Data $ForEach -Tag $Tag -Skip:$Skip -Reason:$Reason
     }
     else {
-        New-Test -Name $Name -ScriptBlock $Test -StartLine $MyInvocation.ScriptLineNumber -Tag $Tag -Skip:$Skip
+        New-Test -Name $Name -ScriptBlock $Test -StartLine $MyInvocation.ScriptLineNumber -Tag $Tag -Skip:$Skip -Reason:$Reason
     }
 }

--- a/src/functions/Set-ItResult.ps1
+++ b/src/functions/Set-ItResult.ps1
@@ -81,8 +81,7 @@
     }
 
     if ($Because) {
-        [String]$formatted = Format-Because $Because
-        [String]$message += ",$($formatted.SubString(0, $formatted.Length - 1))"
+        [String]$message = $Because
     }
 
     throw [Pester.Factory]::CreateErrorRecord(

--- a/src/functions/TestResults.NUnit25.ps1
+++ b/src/functions/TestResults.NUnit25.ps1
@@ -328,10 +328,9 @@ function Write-NUnitTestCaseAttributes {
             $XmlWriter.WriteAttributeString('result', 'Ignored')
             $XmlWriter.WriteAttributeString('executed', 'False')
 
-            # TODO: This doesn't work, FailureMessage comes from Get-ErrorForXmlReport which isn't called
-            if ($TestResult.FailureMessage) {
+            if ($TestResult.Reason) {
                 $XmlWriter.WriteStartElement('reason')
-                $xmlWriter.WriteElementString('message', $TestResult.FailureMessage)
+                $xmlWriter.WriteElementString('message', $TestResult.Reason)
                 $XmlWriter.WriteEndElement() # Close reason tag
             }
 
@@ -342,10 +341,9 @@ function Write-NUnitTestCaseAttributes {
             $XmlWriter.WriteAttributeString('result', 'Inconclusive')
             $XmlWriter.WriteAttributeString('executed', 'True')
 
-            # TODO: This doesn't work, FailureMessage comes from Get-ErrorForXmlReport which isn't called
-            if ($TestResult.FailureMessage) {
+            if ($TestResult.Reason) {
                 $XmlWriter.WriteStartElement('reason')
-                $xmlWriter.WriteElementString('message', $TestResult.DisplayErrorMessage)
+                $xmlWriter.WriteElementString('message', $TestResult.Reason)
                 $XmlWriter.WriteEndElement() # Close reason tag
             }
 


### PR DESCRIPTION
## PR Summary

Add Reasons to block and test results. Allowing for providing a reason when skipping a block with `-Skip`, or seeing the reported reason when using `Set-ItResult`.

Fixes #2049

### Testing steps

Below are the steps that I took to test this change:

1. Checkout this PR.
2. Run `.\build.ps1 -Clean`
3. Run `.\2049-tests\mytests.ps1`
4. Inspect each of the generated xml files to validate that the message is present.

A few things I'm not sure on:

1. Does the XML correctly parse in tools that use the xml?
2. This feels like there should be tests wrapped around it. Where should those tests go?
3. What about documentation?

## PR Checklist

- [x] PR has meaningful title
- [x] Summary describes changes
- [x] PR is ready to be merged
  - If not, use the arrow next to `Create Pull Request` to mark it as a draft. PR can be marked `Ready for review` when it's ready.
- [ ] Tests are added/update *(if required)*
- [ ] Documentation is updated/added *(if required)*