### PR TITLE
Update help and tests to use parantheses around type input in BeOfType assertions

### DIFF
--- a/src/functions/assertions/BeOfType.ps1
+++ b/src/functions/assertions/BeOfType.ps1
@@ -4,6 +4,7 @@ function Should-BeOfTypeAssertion($ActualValue, $ExpectedType, [switch] $Negate,
     .SYNOPSIS
     Asserts that the actual value should be an object of a specified type
     (or a subclass of the specified type) using PowerShell's -is operator.
+    Expected type can be provided using full type name strings or a type wrapped in parantheses.
 
     .EXAMPLE
     $actual = Get-Item $env:SystemRoot
@@ -25,6 +26,11 @@ function Should-BeOfTypeAssertion($ActualValue, $ExpectedType, [switch] $Negate,
     $actual | Should -BeOfType System.IO.FileInfo
 
     This test will fail, as FileInfo is not a base class of DirectoryInfo.
+
+    .EXAMPLE
+    $actual | Should -BeOfType ([System.IO.DirectoryInfo])
+
+    Test using a type-object. Remember to use parantheses for consistent behavior with PowerShell classes.
     #>
     if ($ExpectedType -is [string]) {
         # parses type that is provided as a string in brackets (such as [int])

--- a/tst/PesterConfiguration.Tests.ps1
+++ b/tst/PesterConfiguration.Tests.ps1
@@ -15,7 +15,7 @@ Describe "PesterConfiguration.Format.ps1xml" {
             $formatData | Should -Not -BeNullOrEmpty
             $formatData.FormatViewDefinition.Count | Should -Be 1
             $formatData.FormatViewDefinition[0].Name | Should -BeExactly $section.FullName
-            $formatData.FormatViewDefinition[0].Control | Should -BeOfType [System.Management.Automation.ListControl]
+            $formatData.FormatViewDefinition[0].Control | Should -BeOfType ([System.Management.Automation.ListControl])
         }
 
         It 'View includes all options' {
@@ -35,7 +35,7 @@ Describe "PesterConfiguration.Format.ps1xml" {
             $formatData | Should -Not -BeNullOrEmpty
             $formatData.FormatViewDefinition.Count | Should -Be 1
             $formatData.FormatViewDefinition[0].Name | Should -BeExactly 'Pester.Option'
-            $formatData.FormatViewDefinition[0].Control | Should -BeOfType [System.Management.Automation.TableControl]
+            $formatData.FormatViewDefinition[0].Control | Should -BeOfType ([System.Management.Automation.TableControl])
         }
 
         It 'View includes all options' {

--- a/tst/functions/Get-ShouldOperator.Tests.ps1
+++ b/tst/functions/Get-ShouldOperator.Tests.ps1
@@ -42,7 +42,7 @@ InPesterModuleScope {
                 $BGT.PSTypeNames[0] | Should -BeExactly 'PesterAssertionOperatorHelp'
                 $BGT.Help.PSTypeNames[0] | Should -BeExactly 'MamlCommandHelpInfo#ExamplesView'
                 $BGT.Help.syntax.syntaxItem[0].name | Should -Be 'Should -BeGreaterThan'
-                $BGT.Help.syntax.syntaxItem[0].DisplayParameterSet | Should -BeOfType [string]
+                $BGT.Help.syntax.syntaxItem[0].DisplayParameterSet | Should -BeOfType ([string])
                 $BGT.Help.syntax.syntaxItem[0].DisplayParameterSet | Should -BeLike '*-ActualValue*'
             }
 

--- a/tst/functions/New-MockObject.Tests.ps1
+++ b/tst/functions/New-MockObject.Tests.ps1
@@ -86,7 +86,7 @@ Describe 'New-MockObject' {
 
         it 'Should preserve types' {
             $mockedProcess = New-MockObject -Type 'System.Diagnostics.Process' -Properties @{Id = 123 }
-            $mockedProcess.Id | Should -BeOfType [int]
+            $mockedProcess.Id | Should -BeOfType ([int])
         }
     }
 }

--- a/tst/functions/TestsRunningInCleanRunspace.Tests.ps1
+++ b/tst/functions/TestsRunningInCleanRunspace.Tests.ps1
@@ -269,7 +269,7 @@ Describe "Swallowing output" {
                     # note - the pipe command unrolls enumerable objects, so we have to wrap
                     #        results in a sacrificial array to retain its original structure
                     #        when passed to Should
-                    @(, $results) | Should -BeOfType [PSCustomObject]
+                    @(, $results) | Should -BeOfType ([PSCustomObject])
                     $results.TotalCount | Should -Be 1
 
                     # or, we could do this instead:
@@ -320,7 +320,7 @@ Describe "Swallowing output" {
                     # note - the pipe command unrolls enumerable objects, so we have to wrap
                     #        results in a sacrificial array to retain its original structure
                     #        when passed to Should
-                    @(, $results) | Should -BeOfType [PSCustomObject]
+                    @(, $results) | Should -BeOfType ([PSCustomObject])
                     $results.TotalCount | Should -Be 1
 
                     # or, we could do this instead:
@@ -372,7 +372,7 @@ Describe "Swallowing output" {
                     # note - the pipe command unrolls enumerable objects, so we have to wrap
                     #        results in a sacrificial array to retain its original structure
                     #        when passed to Should
-                    @(, $results) | Should -BeOfType [PSCustomObject]
+                    @(, $results) | Should -BeOfType ([PSCustomObject])
                     $results.TotalCount | Should -Be 1
 
                     # or, we could do this instead:


### PR DESCRIPTION
## PR Summary
Adds an example to `-BeOfType` using `TypeInfo` as input. Types has to be wrapped with parantheses to avoid PowerShell from making it a string argument which might not resolve for PowerShell classes and internal types.

Fix #2414

## PR Checklist

- [x] PR has meaningful title
- [x] Summary describes changes
- [x] PR is ready to be merged
  - If not, use the arrow next to `Create Pull Request` to mark it as a draft. PR can be marked `Ready for review` when it's ready.
- [x] Tests are added/update *(if required)*
- [x] Documentation is updated/added *(if required)*