### PR TITLE
Update New-MockObject examples to use type object as input

### DIFF
--- a/src/functions/New-MockObject.ps1
+++ b/src/functions/New-MockObject.ps1
@@ -34,6 +34,10 @@
     $obj = New-MockObject -Type 'System.Diagnostics.Process'
     $obj.GetType().FullName
         System.Diagnostics.Process
+
+    $obj = New-MockObject -Type ([System.Diagnostics.Process])
+    $obj.GetType().FullName
+        System.Diagnostics.Process
     ```
 
     Creates a mock of a process-object with default property-values.
@@ -63,6 +67,16 @@
 
     Create a mock of a process-object and mocks the object's `Kill()`-method. The mocked method will keep a history
     of any call and the associated arguments in a property named `_Kill`
+
+    .EXAMPLE
+    ```powershell
+    $someObj = Get-ObjectFromModule
+    $mock = New-MockObject -Type $someObj.GetType()
+    $mock.GetType().FullName
+        <c2510c5c>.MyInternalClass
+    ```
+
+    Create a mock by providing a TypeInfo, e.g. to mock output using an internal module class.
 
     .LINK
     https://pester.dev/docs/commands/New-MockObject

--- a/tst/functions/New-MockObject.Tests.ps1
+++ b/tst/functions/New-MockObject.Tests.ps1
@@ -44,7 +44,7 @@ Describe 'New-MockObject' {
             # Simulate a internal module class like https://github.com/pester/Pester/issues/2564
             $someObj = & {
                 class MyInternalClass {
-                    [string] $Name
+                    [string] $Name = 'Default'
                     [string] GetName() { return $this.Name }
                 }
                 $obj = [MyInternalClass]::new()

--- a/tst/functions/New-MockObject.Tests.ps1
+++ b/tst/functions/New-MockObject.Tests.ps1
@@ -35,6 +35,28 @@ Describe 'New-MockObject' {
         { New-MockObject $type } | Should -Not -Throw
     }
 
+    It 'Mock using type input' {
+        New-MockObject -Type ([System.Diagnostics.Process]) | Should -BeOfType ([System.Diagnostics.Process])
+    }
+
+    It 'Mock internal classes using type' {
+        # Simulate a internal module class like https://github.com/pester/Pester/issues/2564
+        $someObj = & {
+            class MyInternalClass {
+                [string] $Name
+                [string] GetName() { return $this.Name }
+            }
+            $obj = [MyInternalClass]::new();
+            $obj.Name = 'Real'
+            $obj
+        }
+
+        { [MyInternalClass] } | Should -Throw -ErrorId 'TypeNotFound'
+        $mock = New-MockObject -Type $someObj.GetType() -Properties @{ Name = 'Mocked' }
+        $mock.GetType().Name | Should -Be 'MyInternalClass'
+        $mock.GetName() | Should -Be 'Mocked'
+    }
+
     Context 'Methods' {
         It "Adds a method to the object" {
             $o = New-Object -TypeName 'System.Diagnostics.Process'

--- a/tst/functions/New-MockObject.Tests.ps1
+++ b/tst/functions/New-MockObject.Tests.ps1
@@ -44,6 +44,8 @@ Describe 'New-MockObject' {
             # Simulate a internal module class like https://github.com/pester/Pester/issues/2564
             $someObj = & {
                 class MyInternalClass {
+                    MyInternalClass() { }
+
                     [string] $Name = 'Default'
                     [string] GetName() { return $this.Name }
                 }

--- a/tst/functions/New-MockObject.Tests.ps1
+++ b/tst/functions/New-MockObject.Tests.ps1
@@ -39,22 +39,24 @@ Describe 'New-MockObject' {
         New-MockObject -Type ([System.Diagnostics.Process]) | Should -BeOfType ([System.Diagnostics.Process])
     }
 
-    It 'Mock internal classes using type' {
-        # Simulate a internal module class like https://github.com/pester/Pester/issues/2564
-        $someObj = & {
-            class MyInternalClass {
-                [string] $Name
-                [string] GetName() { return $this.Name }
+    if ($PSVersionTable.PSVersion.Major -ge 5) {
+        It 'Mock internal classes using type' {
+            # Simulate a internal module class like https://github.com/pester/Pester/issues/2564
+            $someObj = & {
+                class MyInternalClass {
+                    [string] $Name
+                    [string] GetName() { return $this.Name }
+                }
+                $obj = [MyInternalClass]::new()
+                $obj.Name = 'Real'
+                $obj
             }
-            $obj = [MyInternalClass]::new();
-            $obj.Name = 'Real'
-            $obj
-        }
 
-        { [MyInternalClass] } | Should -Throw -ErrorId 'TypeNotFound'
-        $mock = New-MockObject -Type $someObj.GetType() -Properties @{ Name = 'Mocked' }
-        $mock.GetType().Name | Should -Be 'MyInternalClass'
-        $mock.GetName() | Should -Be 'Mocked'
+            { [MyInternalClass] } | Should -Throw -ErrorId 'TypeNotFound'
+            $mock = New-MockObject -Type $someObj.GetType() -Properties @{ Name = 'Mocked' }
+            $mock.GetType().Name | Should -Be 'MyInternalClass'
+            $mock.GetName() | Should -Be 'Mocked'
+        }
     }
 
     Context 'Methods' {


### PR DESCRIPTION
## PR Summary
Updates `New-MockObject` with examples for using type objects to reference classes.
Fix #2564

## PR Checklist

- [x] PR has meaningful title
- [x] Summary describes changes
- [x] PR is ready to be merged
  - If not, use the arrow next to `Create Pull Request` to mark it as a draft. PR can be marked `Ready for review` when it's ready.
- [x] Tests are added/update *(if required)*
- [x] Documentation is updated/added *(if required)*