### PR TITLE
Add configuration.Debug.ShowStartMarkers support

### DIFF
--- a/src/csharp/Pester/DebugConfiguration.cs
+++ b/src/csharp/Pester/DebugConfiguration.cs
@@ -34,6 +34,7 @@ namespace Pester
             WriteDebugMessages = new BoolOption("Write Debug messages to screen.", false);
             WriteDebugMessagesFrom = new StringArrayOption("Write Debug messages from a given source, WriteDebugMessages must be set to true for this to work. You can use like wildcards to get messages from multiple sources, as well as * to get everything.", new string[] { "Discovery", "Skip", "Mock", "CodeCoverage" });
             ShowNavigationMarkers = new BoolOption("Write paths after every block and test, for easy navigation in VSCode.", false);
+            ShowStartMarkers = new BoolOption("Write an indication when each test starts.", false);
             ReturnRawResultObject = new BoolOption("Returns unfiltered result object, this is for development only. Do not rely on this object for additional properties, non-public properties will be renamed without previous notice.", false);
         }
 
@@ -45,6 +46,7 @@ namespace Pester
                 configuration.AssignValueIfNotNull<bool>(nameof(WriteDebugMessages), v => WriteDebugMessages = v);
                 configuration.AssignArrayIfNotNull<string>(nameof(WriteDebugMessagesFrom), v => WriteDebugMessagesFrom = v);
                 configuration.AssignValueIfNotNull<bool>(nameof(ShowNavigationMarkers), v => ShowNavigationMarkers = v);
+                configuration.AssignValueIfNotNull<bool>(nameof(ShowStartMarkers), v => ShowStartMarkers = v);
                 configuration.AssignValueIfNotNull<bool>(nameof(ReturnRawResultObject), v => ReturnRawResultObject = v);
             }
         }
@@ -53,6 +55,7 @@ namespace Pester
         private BoolOption _writeDebugMessages;
         private StringArrayOption _writeDebugMessagesFrom;
         private BoolOption _showNavigationMarkers;
+        private BoolOption _showStartMarkers;
         private BoolOption _returnRawResultObject;
 
         public BoolOption ShowFullErrors
@@ -115,6 +118,22 @@ namespace Pester
                 else
                 {
                     _showNavigationMarkers = new BoolOption(_showNavigationMarkers, value.Value);
+                }
+            }
+        }
+
+        public BoolOption ShowStartMarkers
+        {
+            get { return _showStartMarkers; }
+            set
+            {
+                if (_showStartMarkers == null)
+                {
+                    _showStartMarkers = value;
+                }
+                else
+                {
+                    _showStartMarkers = new BoolOption(_showStartMarkers, value.Value);
                 }
             }
         }

--- a/src/en-US/about_PesterConfiguration.help.txt
+++ b/src/en-US/about_PesterConfiguration.help.txt
@@ -182,6 +182,10 @@ SECTIONS AND OPTIONS
         Type: bool
         Default value: $false
 
+        ShowStartMarkers: Write an indication when each test starts.
+        Type: bool
+        Default value: $false
+
         ReturnRawResultObject: Returns unfiltered result object, this is for development only. Do not rely on this object for additional properties, non-public properties will be renamed without previous notice.
         Type: bool
         Default value: $false

--- a/src/functions/Output.ps1
+++ b/src/functions/Output.ps1
@@ -607,10 +607,20 @@ function Get-WriteScreenPlugin ($Verbosity) {
     if ($PesterPreference.Output.Verbosity.Value -in 'Detailed', 'Diagnostic') {
         $p.EachTestSetupStart = {
             param ($Context)
+
+            # we are currently in scope of describe so $Test is hardtyped and conflicts
+            $_test = $Context.Test
+
             # we postponed writing the Describe / Context to grab the Expanded name, because that is done
             # during execution to get all the variables in scope, if we are the first test then write it
-            if ($Context.Test.First) {
-                Write-BlockToScreen $Context.Test.Block
+            if ($_test.First) {
+                Write-BlockToScreen $_test.Block
+            }
+
+            if ($PesterPreference.Debug.ShowStartMarkers.Value) {
+                $level = $_test.Path.Count
+                $margin = $ReportStrings.Margin * ($level)
+                Write-PesterHostMessage -ForegroundColor $ReportTheme.Information "$margin[|] $($_test.ExpandedName)..."
             }
         }
     }

--- a/tst/Pester.RSpec.Configuration.ts.ps1
+++ b/tst/Pester.RSpec.Configuration.ts.ps1
@@ -160,6 +160,10 @@ i -PassThru:$PassThru {
             [PesterConfiguration]::Default.Debug.ShowNavigationMarkers.Value | Verify-False
         }
 
+        t "Debug.ShowStartMarkers is `$false" {
+            [PesterConfiguration]::Default.Debug.ShowStartMarkers.Value | Verify-False
+        }
+
         t "TestDrive.Enabled is `$true" {
             [PesterConfiguration]::Default.TestDrive.Enabled.Value | Verify-True
         }


### PR DESCRIPTION
## PR Summary
Allow displaying an indication when each test starts:
```
[|] Test name...
```

## PR Checklist

- [x] PR has meaningful title
- [x] Summary describes changes
- [x] PR is ready to be merged
- [x] Tests are added/update *(if required)*
(Parity with ShowNavigationMarkers)
- [x] Documentation is updated/added *(if required)*

fixes #2583