### PR TITLE
Update example for InModuleScope

### DIFF
--- a/src/functions/InModuleScope.ps1
+++ b/src/functions/InModuleScope.ps1
@@ -37,12 +37,13 @@
     Export-ModuleMember -Function PublicFunction
 
     # The test script:
+    BeforeAll {
+        Import-Module MyModule
+    }
 
-    Import-Module MyModule
-
-    InModuleScope MyModule {
-        Describe 'Testing MyModule' {
-            It 'Tests the Private function' {
+    Describe 'Testing MyModule' {
+        It 'Tests the Private function' {
+            InModuleScope MyModule {
                 PrivateFunction | Should -Be $true
             }
         }
@@ -51,7 +52,7 @@
 
     Normally you would not be able to access "PrivateFunction" from
     the PowerShell session, because the module only exported
-    "PublicFunction".  Using InModuleScope allowed this call to
+    "PublicFunction". Using InModuleScope allowed this call to
     "PrivateFunction" to work successfully.
 
     .EXAMPLE


### PR DESCRIPTION
## PR Summary
Update InModuleScope example to follow v5 best practice by not wrapping entire blocks.

Fix #2629

## PR Checklist

- [x] PR has meaningful title
- [x] Summary describes changes
- [x] PR is ready to be merged
  - If not, use the arrow next to `Create Pull Request` to mark it as a draft. PR can be marked `Ready for review` when it's ready.
- [ ] Tests are added/update *(if required)*
- [x] Documentation is updated/added *(if required)*