### PR TITLE
Update Ubuntu images in CI

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -76,11 +76,11 @@ stages:
           clean: all
         strategy:
           matrix:
-            PS7_Ubuntu_20_04:
-              vmImage: ubuntu-20.04
-              pwsh: true
             PS7_Ubuntu_22_04:
               vmImage: ubuntu-22.04
+              pwsh: true
+            PS7_Ubuntu_24_04:
+              vmImage: ubuntu-24.04
               pwsh: true
             PS7_macOS_13:
               vmImage: macOS-13


### PR DESCRIPTION
## PR Summary
Ubuntu 20.04 runner image is deprecated in April, see https://github.com/actions/runner-images/issues/11101. Updating CI to use 22.04 and 24.04

## PR Checklist

- [x] PR has meaningful title
- [x] Summary describes changes
- [x] PR is ready to be merged
  - If not, use the arrow next to `Create Pull Request` to mark it as a draft. PR can be marked `Ready for review` when it's ready.
- [ ] Tests are added/update *(if required)*
- [ ] Documentation is updated/added *(if required)*