### PR TITLE
Fix container name in ScriptBlock BeforeAll failures (fixes #2636).

### DIFF
--- a/src/functions/Output.ps1
+++ b/src/functions/Output.ps1
@@ -571,7 +571,7 @@ function Get-WriteScreenPlugin ($Verbosity) {
         param ($Context)
 
         if ($Context.Result.ErrorRecord.Count -gt 0) {
-            $errorHeader = "[-] $($Context.Result.Item) failed with:"
+            $errorHeader = "[-] $($Context.Result.Name) failed with:"
 
             $formatErrorParams = @{
                 Err                 = $Context.Result.ErrorRecord
@@ -592,13 +592,13 @@ function Get-WriteScreenPlugin ($Verbosity) {
             $humanTime = "$(Get-HumanTime ($Context.Result.Duration)) ($(Get-HumanTime $Context.Result.UserDuration)|$(Get-HumanTime $Context.Result.FrameworkDuration))"
 
             if ($Context.Result.Passed) {
-                Write-PesterHostMessage -ForegroundColor $ReportTheme.Pass "[+] $($Context.Result.Item)" -NoNewLine
+                Write-PesterHostMessage -ForegroundColor $ReportTheme.Pass "[+] $($Context.Result.Name)" -NoNewLine
                 Write-PesterHostMessage -ForegroundColor $ReportTheme.PassTime " $humanTime"
             }
 
             # this won't work skipping the whole file when all it's tests are skipped is not a feature yet in 5.0.0
             if ($Context.Result.Skip) {
-                Write-PesterHostMessage -ForegroundColor $ReportTheme.Skipped "[!] $($Context.Result.Item)" -NoNewLine
+                Write-PesterHostMessage -ForegroundColor $ReportTheme.Skipped "[!] $($Context.Result.Name)" -NoNewLine
                 Write-PesterHostMessage -ForegroundColor $ReportTheme.SkippedTime " $humanTime"
             }
         }

--- a/tst/Pester.RSpec.InNewProcess.ts.ps1
+++ b/tst/Pester.RSpec.InNewProcess.ts.ps1
@@ -384,7 +384,7 @@ i -PassThru:$PassThru {
                 $ps.HadErrors | Verify-False
                 $res.PassedCount | Verify-Equal 1
                 # Information-stream introduced in PSv5 for Write-Host output
-                if ($PSVersionTable.PSVersion.Major -ge 5) { $ps.Streams.Information -match 'Describe' | Verify-NotNull }
+                if ($PSVersionTable.PSVersion.Major -ge 5) { $ps.Streams.Information -match '<ScriptBlock>' | Verify-NotNull }
             }
             finally {
                 $ps.Dispose()

--- a/tst/Pester.RSpec.Output.ts.ps1
+++ b/tst/Pester.RSpec.Output.ts.ps1
@@ -222,6 +222,34 @@ i -PassThru:$PassThru {
         }
     }
 
+    b 'Output for container names' {
+        t 'Script Block container names are output when BeforeAll fails' {
+            $sb = {
+                $PesterPreference = [PesterConfiguration]::Default
+                $PesterPreference.Output.Verbosity = 'Detailed'
+                $PesterPreference.Output.RenderMode = 'ConsoleColor'
+
+                $container = New-PesterContainer -ScriptBlock {
+                    BeforeAll {
+                        throw 'bad error'
+                    }
+                    Describe 'd1' {
+                        It 'i1' {
+                            1 | Should -Be 1
+                        }
+                    }
+                }
+                Invoke-Pester -Container $container
+            }
+
+            $output = Invoke-InNewProcess $sb
+            $null, $run = $output -join "`n" -split 'Running tests.'
+            $run | Write-Host
+
+            $run | Verify-Like '*[-]*<ScriptBlock>* failed with:*'
+        }
+    }
+
     b 'Write-PesterHostMessage' {
         t 'Ansi output includes colors when set and always reset' {
             $sb = {


### PR DESCRIPTION
## PR Checklist

- [x] PR has meaningful title
- [x] Summary describes changes
- [x] PR is ready to be merged
  - If not, use the arrow next to `Create Pull Request` to mark it as a draft. PR can be marked `Ready for review` when it's ready.
- [x] Tests are added/update *(if required)*
- [ ] Documentation is updated/added *(if required)*

Replace Result.Item with Result.Name to handle the ScriptBlock case. Previously, the container name was being reported only for files, not for ScriptBlocks (because files, unlike ScriptBlocks, have Result.Item).