### PR TITLE
Fix container name display when running non-file types (fixes #2639).

### DIFF
--- a/src/csharp/Pester/ContainerInfo.cs
+++ b/src/csharp/Pester/ContainerInfo.cs
@@ -11,6 +11,7 @@ namespace Pester
             return new ContainerInfo();
         }
 
+        public string Name { get => ToStringConverter.ContainerItemToString(Type, Item); }
         private string _type = Constants.File;
         public string Type
         {

--- a/src/functions/Output.ps1
+++ b/src/functions/Output.ps1
@@ -560,10 +560,8 @@ function Get-WriteScreenPlugin ($Verbosity) {
         $p.ContainerRunStart = {
             param ($Context)
 
-            if ("file" -eq $Context.Block.BlockContainer.Type) {
-                # write two spaces to separate each file
-                Write-PesterHostMessage -ForegroundColor $ReportTheme.Container "`nRunning tests from '$($Context.Block.BlockContainer.Item)'"
-            }
+            # write two spaces to separate each container
+            Write-PesterHostMessage -ForegroundColor $ReportTheme.Container "`nRunning tests from '$($Context.Block.BlockContainer.Name)'"
         }
     }
 

--- a/tst/Pester.RSpec.Output.ts.ps1
+++ b/tst/Pester.RSpec.Output.ts.ps1
@@ -186,6 +186,34 @@ i -PassThru:$PassThru {
         }
     }
 
+    b 'Output for container names' {
+        t 'Script Block container names are output' {
+            $sb = {
+                $PesterPreference = [PesterConfiguration]::Default
+                $PesterPreference.Output.Verbosity = 'Detailed'
+                $PesterPreference.Output.CIFormat = 'None'
+                $PesterPreference.Output.RenderMode = 'ConsoleColor'
+
+                $container = New-PesterContainer -ScriptBlock {
+                    Describe 'd1' {
+                        It 'i1' {
+                            1 | Should -Be 1
+                        }
+                    }
+                }
+                Invoke-Pester -Container $container
+            }
+
+            $output = Invoke-InNewProcess $sb
+            # only print the relevant part of output
+            $null, $run = $output -join "`n" -split 'Running tests.'
+            $run | Write-Host
+
+            $d1Running = $output | Select-String -Pattern '^Running tests from.*\<ScriptBlock\>.*$'
+            @($d1Running).Count | Verify-Equal 1
+        }
+    }
+
     b 'Output for data-driven blocks' {
         t 'Each block generated from dataset is output' {
             # we incorrectly shared reference to the same framework data hashtable


### PR DESCRIPTION
## PR Checklist

- [x] PR has meaningful title
- [x] Summary describes changes
- [x] PR is ready to be merged
  - If not, use the arrow next to `Create Pull Request` to mark it as a draft. PR can be marked `Ready for review` when it's ready.
- [x] Tests are added/update *(if required)*
- [ ] Documentation is updated/added *(if required)*

Use a helper that formats the container name correctly for all container
types, notably also for ScriptBlocks.

fixes #2639