### PR TITLE
Remove Mock fallthrough 

### DIFF
--- a/src/functions/Mock.ps1
+++ b/src/functions/Mock.ps1
@@ -348,7 +348,7 @@ function Should-InvokeVerifiableInternal {
     }
 
     return [Pester.ShouldResult] @{
-        Succeeded      = $true
+        Succeeded = $true
     }
 }
 
@@ -460,7 +460,9 @@ function Should-InvokeInternal {
         #     $params.ScriptBlock = New-BlockWithoutParameterAliases -Metadata $ContextInfo.Hook.Metadata -Block $params.ScriptBlock
         # }
 
-        if (Test-ParameterFilter @params) {
+        $filterResult = Test-ParameterFilter @params
+        $passed = $filterResult[0]
+        if ($passed) {
             $null = $matchingCalls.Add($historyEntry)
         }
         else {
@@ -530,7 +532,7 @@ function Should-InvokeInternal {
     }
 
     return [Pester.ShouldResult] @{
-        Succeeded      = $true
+        Succeeded = $true
     }
 }
 
@@ -798,7 +800,7 @@ function Invoke-MockInternal {
     switch ($FromBlock) {
         Begin {
             $MockCallState['InputObjects'] = [System.Collections.Generic.List[object]]@()
-            $MockCallState['ShouldExecuteOriginalCommand'] = $false
+            $MockCallState['MatchedNoBehavior'] = $false
             $MockCallState['BeginBoundParameters'] = $BoundParameters.Clone()
             # argument list must not be null, if the bootstrap functions has no parameters
             # we get null and need to replace it with empty array to make the splatting work
@@ -816,7 +818,7 @@ function Invoke-MockInternal {
             $SessionState = if ($CallerSessionState) { $CallerSessionState } else { $Hook.SessionState }
 
             # the @() are needed for powerShell3 otherwise it throws CheckAutomationNullInCommandArgumentArray (unless there is any breakpoint defined anywhere, then it works just fine :DDD)
-            $behavior = FindMatchingBehavior -Behaviors @($Behaviors) -BoundParameters $BoundParameters -ArgumentList @($ArgumentList) -SessionState $SessionState -Hook $Hook
+            $behavior, $failedFilterInvocations = FindMatchingBehavior -Behaviors @($Behaviors) -BoundParameters $BoundParameters -ArgumentList @($ArgumentList) -SessionState $SessionState -Hook $Hook
 
             if ($null -ne $behavior) {
                 $call = @{
@@ -841,7 +843,8 @@ function Invoke-MockInternal {
                 return
             }
             else {
-                $MockCallState['ShouldExecuteOriginalCommand'] = $true
+                $MockCallState['MatchedNoBehavior'] = $true
+                $MockCallState['FailedFilterInvocations'] = $failedFilterInvocations
                 if ($null -ne $InputObject) {
                     $null = $MockCallState['InputObjects'].AddRange(@($InputObject))
                 }
@@ -851,69 +854,21 @@ function Invoke-MockInternal {
         }
 
         End {
-            if ($MockCallState['ShouldExecuteOriginalCommand']) {
+            if ($MockCallState['MatchedNoBehavior']) {
                 if ($PesterPreference.Debug.WriteDebugMessages.Value) {
-                    Write-PesterDebugMessage -Scope Mock "Invoking the original command."
+                    Write-PesterDebugMessage -Scope Mock "The mock did not match any filtered behavior, and there was no default behavior. Failing."
                 }
 
-                $MockCallState['BeginBoundParameters'] = Reset-ConflictingParameters -BoundParameters $MockCallState['BeginBoundParameters']
-
-                if ($MockCallState['InputObjects'].Count -gt 0) {
-                    $scriptBlock = {
-                        param ($Command, $ArgumentList, $BoundParameters, $InputObjects)
-                        $InputObjects | & $Command @ArgumentList @BoundParameters
-                    }
-                }
-                else {
-                    $scriptBlock = {
-                        param ($Command, $ArgumentList, $BoundParameters, $InputObjects)
-                        & $Command @ArgumentList @BoundParameters
-                    }
+                $failedFilterInvocations = $MockCallState['FailedFilterInvocations']
+                if ($null -eq $failedFilterInvocations -or $failedFilterInvocations.Count -eq 0) {
+                    # No behaviors in this scope, but the bootstrap function is installed —
+                    # an outer Mock leaked into a nested Invoke-Pester run.
+                    throw "No mock for command '$($Hook.CommandName)' is defined in this scope, but the bootstrap is active (typically a Mock from an outer scope leaked into a nested Invoke-Pester run). Add a Mock for '$($Hook.CommandName)' in this scope, or restructure the test so the outer Mock does not leak."
                 }
 
-                $SessionState = if ($CallerSessionState) {
-                    $CallerSessionState
-                }
-                else {
-                    $Hook.SessionState
-                }
+                $filterList = ($failedFilterInvocations | & $SafeCommands['ForEach-Object'] { "    $_" }) -join [System.Environment]::NewLine
 
-                Set-ScriptBlockScope -ScriptBlock $scriptBlock -SessionState $SessionState
-
-                # In order to mock Set-Variable correctly we need to write the variable
-                # two scopes above
-                if ("Set-Variable" -eq $Hook.OriginalCommand.Name) {
-                    if ($PesterPreference.Debug.WriteDebugMessages.Value) {
-                        Write-PesterDebugMessage -Scope Mock "Original command is Set-Variable, patching the call."
-                    }
-                    if ($MockCallState['BeginBoundParameters'].Keys -notcontains "Scope") {
-                        $MockCallState['BeginBoundParameters'].Add( "Scope", 2)
-                    }
-                    # local is the same as scope 0, in that case we also write to scope 2
-                    elseif ("Local", "0" -contains $MockCallState['BeginBoundParameters'].Scope) {
-                        $MockCallState['BeginBoundParameters'].Scope = 2
-                    }
-                    elseif ($MockCallState['BeginBoundParameters'].Scope -match "\d+") {
-                        $MockCallState['BeginBoundParameters'].Scope = 2 + $matches[0]
-                    }
-                    else {
-                        # not sure what the user did, but we won't change it
-                    }
-                }
-
-                if ($null -eq ($MockCallState['BeginArgumentList'])) {
-                    $arguments = @()
-                }
-                else {
-                    $arguments = $MockCallState['BeginArgumentList']
-                }
-                if ($PesterPreference.Debug.WriteDebugMessages.Value) {
-                    Write-ScriptBlockInvocationHint -Hint "Mock - Original Command" -ScriptBlock $scriptBlock
-                }
-                & $scriptBlock -Command $Hook.OriginalCommand `
-                    -ArgumentList $arguments `
-                    -BoundParameters $MockCallState['BeginBoundParameters'] `
-                    -InputObjects $MockCallState['InputObjects']
+                throw "No mock for command '$($Hook.CommandName)' matched the call: none of the parameter filters matched, and there is no default mock to fall back to. Add a default mock (e.g. ``Mock $($Hook.CommandName) { ... }``) or adjust an existing -ParameterFilter.$([System.Environment]::NewLine)$([System.Environment]::NewLine)The following parameter filters were evaluated and did not match:$([System.Environment]::NewLine)$filterList"
             }
         }
     }
@@ -980,6 +935,7 @@ function FindMatchingBehavior {
         Write-PesterDebugMessage -Scope Mock "Finding behavior to use, one that passes filter or a default:"
     }
 
+    $failedFilterInvocations = [System.Collections.Generic.List[String]]@()
     $foundDefaultBehavior = $false
     $defaultBehavior = $null
     foreach ($b in $Behaviors) {
@@ -999,11 +955,17 @@ function FindMatchingBehavior {
                 SessionState    = $Hook.CallerSessionState
             }
 
-            if (Test-ParameterFilter @params) {
+            $filterResult = Test-ParameterFilter @params
+            $passed = $filterResult[0]
+            $filterInvocations = $filterResult[1]
+            if ($passed) {
                 if ($PesterPreference.Debug.WriteDebugMessages.Value) {
                     Write-PesterDebugMessage -Scope Mock "{ $($b.ScriptBlock) } passed parameter filter and will be used for the mock call."
                 }
-                return $b
+                return $b, $null
+            }
+            else {
+                $failedFilterInvocations.AddRange($filterInvocations)
             }
         }
     }
@@ -1012,13 +974,13 @@ function FindMatchingBehavior {
         if ($PesterPreference.Debug.WriteDebugMessages.Value) {
             Write-PesterDebugMessage -Scope Mock "{ $($defaultBehavior.ScriptBlock) } is a default behavior and will be used for the mock call."
         }
-        return $defaultBehavior
+        return $defaultBehavior, $null
     }
 
     if ($PesterPreference.Debug.WriteDebugMessages.Value) {
-        Write-PesterDebugMessage -Scope Mock "No parametrized or default behaviors were found filter."
+        Write-PesterDebugMessage -Scope Mock "No parametrized or default behaviors were found."
     }
-    return $null
+    return $null, $failedFilterInvocations
 }
 
 function LastThat {
@@ -1241,8 +1203,11 @@ function Test-ParameterFilter {
         else { $null }
     }
 
+    $parameterFilterInvocations = [Collections.Generic.List[string]]@()
+
     $result = & $wrapper $parameters
-    if ($result) {
+    $passed = [bool]$result
+    if ($passed) {
         if ($PesterPreference.Debug.WriteDebugMessages.Value) {
             Write-PesterDebugMessage -Scope Mock -Message "Mock filter returned value '$result', which is truthy. Filter passed."
         }
@@ -1251,8 +1216,21 @@ function Test-ParameterFilter {
         if ($PesterPreference.Debug.WriteDebugMessages.Value) {
             Write-PesterDebugMessage -Scope Mock -Message "Mock filter returned value '$result', which is falsy. Filter did not pass."
         }
+
+        # Filter did not pass, serialize the values and store them for future reference in case we don't find any behavior.
+        $filterText = $scriptBlock.ToString().Trim()
+        $hasContext = 0 -lt $Context.Count
+        $contextText = if ($hasContext) {
+            'bound parameters: ' + (($Context.GetEnumerator() | & $SafeCommands['ForEach-Object'] { "$($_.Key) = $($_.Value)" }) -join ', ')
+        }
+        else {
+            'no bound parameters'
+        }
+        $filterCall = "{ $filterText }  $contextText"
+        $parameterFilterInvocations.Add($filterCall)
     }
-    $result
+    # Return as a single 2-element array so multi-assignment works even when $result is empty/$null/array.
+    , @($passed, $parameterFilterInvocations)
 }
 
 function Get-ContextToDefine {

--- a/src/functions/Pester.SessionState.Mock.ps1
+++ b/src/functions/Pester.SessionState.Mock.ps1
@@ -1001,9 +1001,9 @@ function Invoke-Mock {
     )
 
     if ('End' -eq $FromBlock) {
-        if (-not $MockCallState.ShouldExecuteOriginalCommand) {
+        if (-not $MockCallState.MatchedNoBehavior) {
             if ($PesterPreference.Debug.WriteDebugMessages.Value) {
-                Write-PesterDebugMessage -Scope MockCore "Mock for $CommandName was invoked from block $FromBlock, and should not execute the original command, returning."
+                Write-PesterDebugMessage -Scope MockCore "Mock for $CommandName was invoked from block $FromBlock, and matched at least one behavior, returning."
             }
             return
         }

--- a/src/functions/Pester.SessionState.Mock.ps1
+++ b/src/functions/Pester.SessionState.Mock.ps1
@@ -62,8 +62,7 @@ function Mock {
     Optionally, you may create a Parameter Filter which will examine the
     parameters passed to the mocked command and will invoke the mocked
     behavior only if the values of the parameter values pass the filter. If
-    they do not, the original command implementation will be invoked instead
-    of a mock.
+    they do not, and there is no default mock, the call will throw.
 
     You may create multiple mocks for the same command, each using a different
     ParameterFilter. ParameterFilters will be evaluated in reverse order of
@@ -772,11 +771,9 @@ function Should-InvokeAssertion {
     .NOTES
     The parameter filter passed to Should -Invoke does not necessarily have to match the parameter filter
     (if any) which was used to create the Mock.  Should -Invoke will find any entry in the command history
-    which matches its parameter filter, regardless of how the Mock was created.  However, if any calls to the
-    mocked command are made which did not match any mock's parameter filter (resulting in the original command
-    being executed instead of a mock), these calls to the original command are not tracked in the call history.
-    In other words, Should -Invoke can only be used to check for calls to the mocked implementation, not
-    to the original.
+    which matches its parameter filter, regardless of how the Mock was created.  If a call does not match
+    any mock's parameter filter and there is no default mock, the call throws instead of invoking the
+    original command, so every tracked call is a call to a mock behavior.
     #>
     [CmdletBinding(DefaultParameterSetName = 'ParameterFilter')]
     param(
@@ -1009,7 +1006,7 @@ function Invoke-Mock {
         }
         else {
             if ($PesterPreference.Debug.WriteDebugMessages.Value) {
-                Write-PesterDebugMessage -Scope MockCore "Mock for $CommandName was invoked from block $FromBlock, and should execute the original command, forwarding the call to Invoke-MockInternal without call history and without behaviors."
+                Write-PesterDebugMessage -Scope MockCore "Mock for $CommandName was invoked from block $FromBlock, no behaviors in scope, forwarding to Invoke-MockInternal (will throw)."
             }
             Invoke-MockInternal @PSBoundParameters -Behaviors @() -CallHistory @{}
             return
@@ -1018,7 +1015,7 @@ function Invoke-Mock {
 
     if ('Begin' -eq $FromBlock) {
         if ($PesterPreference.Debug.WriteDebugMessages.Value) {
-            Write-PesterDebugMessage -Scope MockCore "Mock for $CommandName was invoked from block $FromBlock, and should execute the original command, Invoke-MockInternal without call history and without behaviors."
+            Write-PesterDebugMessage -Scope MockCore "Mock for $CommandName was invoked from block $FromBlock, no behaviors in scope, forwarding to Invoke-MockInternal (will throw)."
         }
         Invoke-MockInternal @PSBoundParameters -Behaviors @() -CallHistory @{}
         return

--- a/tst/functions/Mock.Tests.ps1
+++ b/tst/functions/Mock.Tests.ps1
@@ -40,41 +40,6 @@ BeforeAll {
         ${OutBuffer} ) {
         return "Please strip me of my common parameters. They are far too common."
     }
-
-    function PipelineInputFunction {
-        param(
-            [Parameter(ValueFromPipeline = $True)]
-            [int]$PipeInt1,
-            [Parameter(ValueFromPipeline = $True)]
-            [int[]]$PipeInt2,
-            [Parameter(ValueFromPipeline = $True)]
-            [string]$PipeStr,
-            [Parameter(ValueFromPipelineByPropertyName = $True)]
-            [int]$PipeIntProp,
-            [Parameter(ValueFromPipelineByPropertyName = $True)]
-            [int[]]$PipeArrayProp,
-            [Parameter(ValueFromPipelineByPropertyName = $True)]
-            [string]$PipeStringProp
-        )
-        begin {
-            $p = 0
-        }
-        process {
-            foreach ($i in $input) {
-                $p += 1
-                write-output @{
-                    index          = $p;
-                    val            = $i;
-                    PipeInt1       = $PipeInt1;
-                    PipeInt2       = $PipeInt2;
-                    PipeStr        = $PipeStr;
-                    PipeIntProp    = $PipeIntProp;
-                    PipeArrayProp  = $PipeArrayProp;
-                    PipeStringProp = $PipeStringProp;
-                }
-            }
-        }
-    }
 }
 
 Describe "When the caller mocks a command Pester uses internally" {
@@ -373,10 +338,9 @@ Describe 'When calling Mock, StrictMode is enabled, and variables are used in th
 }
 
 Describe "When calling Mock on existing function without matching bound params" {
-    It "Should redirect to real function" {
+    It "Should throw because no parameter filter matched the call" {
         Mock FunctionUnderTest { return "fake results" } -parameterFilter { $param1 -eq "test" }
-        $result = FunctionUnderTest "badTest"
-        $result | Should -Be "I am a real world test"
+        { FunctionUnderTest "badTest" } | Should -Throw "*no default mock to fall back to*"
     }
 }
 
@@ -389,10 +353,9 @@ Describe "When calling Mock on existing function with matching bound params" {
 }
 
 Describe  "When calling Mock on existing function without matching unbound arguments" {
-    It "Should redirect to real function" {
+    It "Should throw because no parameter filter matched the call" {
         Mock FunctionUnderTestWithoutParams { return "fake results" } -parameterFilter { $param1 -eq "test" -and $args[0] -eq 'notArg0' }
-        $result = FunctionUnderTestWithoutParams -param1 "test" "arg0"
-        $result | Should -Be "I am a real world test with no params"
+        { FunctionUnderTestWithoutParams -param1 "test" "arg0" } | Should -Throw "*no default mock to fall back to*"
     }
 }
 
@@ -518,15 +481,6 @@ Describe 'When calling Mock on a module-internal function.' {
         BeforeAll {
             Mock -ModuleName TestModule InternalFunction { 'I am the mock test' }
             Mock -ModuleName TestModule Start-Sleep { }
-            Mock -ModuleName TestModule2 InternalFunction -ParameterFilter { $args[0] -eq 'Test' } {
-                "I'm the mock who's been passed parameter Test"
-            }
-            # Mock -ModuleName TestModule2 InternalFunction2 {
-            #     # this does not work in v5 because we are running the mock in the test scope
-            #     # so this module internal function is not accessible to the mock body
-            #     InternalFunction 'Test'
-            # }
-            Mock -ModuleName TestModule2 Get-CallerModuleName -ParameterFilter { $false }
             Mock -ModuleName TestModule2 Get-Content { }
         }
 
@@ -552,24 +506,12 @@ Describe 'When calling Mock on a module-internal function.' {
             TestModule2\PublicFunction | Should -Be 'I am the second module internal function'
         }
 
-
-        # this does not work because mock bodies are now run in test scope
-        # and so the internal function hidden in the mock body is not accessible
-        # It 'Should call mocks from inside another mock' {
-        #     TestModule2\PublicFunction2 | Should -Be "I'm the mock who's been passed parameter Test"
-        # }
-
         It 'Should work even if the function is weird and steps on the automatic $ExecutionContext variable.' {
             TestModule2\FuncThatOverwritesExecutionContext | Should -Be 'I am the second module internal function'
             TestModule\FuncThatOverwritesExecutionContext | Should -Be 'I am the mock test'
         }
 
-        It 'Should call the original command from the proper scope if no parameter filters match' {
-            TestModule2\ScopeTest | Should -Be 'TestModule2'
-        }
-
         It 'Does not trigger the mocked Get-Content from Pester internals' {
-            Mock -ModuleName TestModule2 Get-CallerModuleName -ParameterFilter { $false }
             Should -Invoke -ModuleName TestModule2 -CommandName Get-Content -Times 0 -Scope It
         }
     }
@@ -632,6 +574,7 @@ Describe "When Applying multiple Mocks on a single command where one has no filt
 Describe "When Creating Verifiable Mock that is not called" {
     Context "In the test script's scope" {
         It "Should throw" {
+            Mock FunctionUnderTest { return "default" }
             Mock FunctionUnderTest { return "I am a verifiable test" } -Verifiable -parameterFilter { $param1 -eq "one" }
             FunctionUnderTest "three" | Out-Null
             $result = $null
@@ -654,6 +597,7 @@ Describe "When Creating Verifiable Mock that is not called" {
                 }
             } | Import-Module -Force
 
+            Mock -ModuleName TestModule ModuleFunctionUnderTest { return "default" }
             Mock -ModuleName TestModule ModuleFunctionUnderTest { return "I am a verifiable test" } -Verifiable -parameterFilter { $param1 -eq "one" }
             TestModule\ModuleFunctionUnderTest "three" | Out-Null
 
@@ -1942,104 +1886,6 @@ Describe 'Mocking New-Object' {
     }
 }
 
-Describe 'Mocking a function taking input from pipeline' {
-    BeforeAll {
-        $psobj = New-Object -TypeName psobject -Property @{'PipeIntProp' = '1'; 'PipeArrayProp' = 1; 'PipeStringProp' = 1 }
-        $psArrayobj = New-Object -TypeName psobject -Property @{'PipeArrayProp' = @(1) }
-        $noMockArrayResult = @(1, 2) | PipelineInputFunction
-        $noMockIntResult = 1 | PipelineInputFunction
-        $noMockStringResult = '1' | PipelineInputFunction
-        $noMockResultByProperty = $psobj | PipelineInputFunction -PipeStr 'val'
-        $noMockArrayResultByProperty = $psArrayobj | PipelineInputFunction -PipeStr 'val'
-
-        Mock PipelineInputFunction { write-output 'mocked' } -ParameterFilter { $PipeStr -eq 'blah' }
-    }
-    context 'when calling original function with an array' {
-        BeforeAll {
-            $result = @(1, 2) | PipelineInputFunction
-        }
-
-        it 'Returns actual implementation' {
-            $result[0].keys | ForEach {
-                $result[0][$_] | Should -Be $noMockArrayResult[0][$_]
-                $result[1][$_] | Should -Be $noMockArrayResult[1][$_]
-            }
-        }
-    }
-
-    context 'when calling original function with an int' {
-        BeforeAll {
-            $result = 1 | PipelineInputFunction
-        }
-        it 'Returns actual implementation' {
-            $result.keys | ForEach {
-                $result[$_] | Should -Be $noMockIntResult[$_]
-            }
-        }
-    }
-
-    context 'when calling original function with a string' {
-        BeforeAll {
-            $result = '1' | PipelineInputFunction
-        }
-        it 'Returns actual implementation' {
-            $result.keys | ForEach {
-                $result[$_] | Should -Be $noMockStringResult[$_]
-            }
-        }
-    }
-
-    context 'when calling original function and pipeline is bound by property name' {
-        BeforeAll {
-            $result = $psobj | PipelineInputFunction -PipeStr 'val'
-        }
-
-        it 'Returns actual implementation' {
-            $result.keys | ForEach {
-                $result[$_] | Should -Be $noMockResultByProperty[$_]
-            }
-        }
-    }
-
-    context 'when calling original function and forcing a parameter binding exception' {
-        BeforeAll {
-            Mock PipelineInputFunction {
-                if ($MyInvocation.ExpectingInput) {
-                    throw New-Object -TypeName System.Management.Automation.ParameterBindingException
-                }
-                write-output $MyInvocation.ExpectingInput
-            }
-            $result = $psobj | PipelineInputFunction
-        }
-
-        it 'falls back to no pipeline input' {
-            $result | Should -Be $false
-        }
-    }
-
-    context 'when calling original function and pipeline is bound by property name with array values' {
-        BeforeAll {
-            $result = $psArrayobj | PipelineInputFunction -PipeStr 'val'
-        }
-
-        it 'Returns actual implementation' {
-            $result.keys | ForEach {
-                $result[$_] | Should -Be $noMockArrayResultByProperty[$_]
-            }
-        }
-    }
-
-    context 'when calling the mocked function' {
-        BeforeAll {
-            $result = 'blah' | PipelineInputFunction
-        }
-
-        it 'Returns mocked implementation' {
-            $result | Should -Be 'mocked'
-        }
-    }
-}
-
 Describe 'Mocking module-qualified calls' {
 
     BeforeAll {
@@ -2289,6 +2135,9 @@ Describe 'Nested Mock calls' {
     BeforeAll {
         $testDate = New-Object DateTime(2012, 6, 13)
 
+        Mock Get-Date -ParameterFilter { $Date -eq $testDate -and $Format -eq 'o' } {
+            '2012-06-13T00:00:00.0000000'
+        }
         Mock Get-Date -ParameterFilter { $null -eq $Date } {
             Get-Date -Date $testDate -Format o
         }
@@ -2453,83 +2302,6 @@ Describe "Restoring original commands when mock scopes exit" {
     }
 }
 
-Describe "Mocking Set-Variable" {
-    It "sets variable correctly when mocking Set-Variable without -Scope parameter" {
-
-        Set-Variable -Name v1 -Value 1
-        $v1 | Should -Be 1 -Because "we defined it without mocking Set-Variable"
-
-        # we mock the command but the mock will never be triggered because
-        # the filter will never pass, so this mock will always call through
-        # to the real Set-Variable
-        Mock Set-Variable -ParameterFilter { $false }
-
-        Set-Variable -Name v2 -Value 10
-
-        # if mock works correctly then then we should see
-        # 10 here because calling through to the Set-Variable
-        # should work the same as calling it directly
-        $v2 | Should -Be 10
-    }
-
-    It "sets variable correctly when mocking Set-Variable without -Scope 0 parameter" {
-
-        Set-Variable -Name v1 -Value 1
-        $v1 | Should -Be 1 -Because "we defined it without mocking Set-Variable"
-
-        Mock Set-Variable -ParameterFilter { $false }
-
-        Set-Variable -Name v2 -Value 11 -Scope 0
-        $v2 | Should -Be 11
-    }
-
-    It "sets variable correctly when mocking Set-Variable without -Scope Local parameter" {
-
-        Set-Variable -Name v1 -Value 1
-        $v1 | Should -Be 1 -Because "we defined it without mocking Set-Variable"
-
-        Mock Set-Variable -ParameterFilter { $false }
-
-        Set-Variable -Name v2 -Value 12 -Scope Local
-
-        $v2 | Should -Be 12
-    }
-
-    It "sets variable correctly when mocking Set-Variable with -Scope 3 parameter" {
-        & {
-            # scope 3
-            & {
-                # scope 2
-                & {
-                    # scope 1
-                    & {
-                        Set-Variable -Name v1 -Value 2 -Scope 3
-                    }
-                }
-            }
-
-            $v1 | Should -Be 2 -Because "we defined it without mocking Set-Variable"
-        }
-
-
-        & {
-            # scope 3
-            & {
-                # scope 2
-                & {
-                    # scope 1
-                    & {
-                        Mock Set-Variable -ParameterFilter { $false }
-                        Set-Variable -Name v2 -Value 11 -Scope 3
-                    }
-                }
-            }
-            $v2 | Should -Be 11
-        }
-    }
-
-}
-
 Describe "Mocking functions with conflicting parameters" {
     InPesterModuleScope {
         Context "Faked conflicting parameter" {
@@ -2546,6 +2318,7 @@ Describe "Mocking functions with conflicting parameters" {
                     $ParamToAvoid
                 }
 
+                Mock Get-ExampleTest { "default mock" }
                 Mock Get-ExampleTest { "World" } -ParameterFilter { $_ParamToAvoid -eq "Hello" }
             }
 
@@ -2553,8 +2326,8 @@ Describe "Mocking functions with conflicting parameters" {
                 Get-ExampleTest -ParamToAvoid "Hello" | Should -Be "World"
             }
 
-            It 'defaults to the original function' {
-                Get-ExampleTest -ParamToAvoid "Bye" | Should -Be "Bye"
+            It 'falls back to the default mock when no parameter filter matches' {
+                Get-ExampleTest -ParamToAvoid "Bye" | Should -Be "default mock"
             }
 
             Context "Should -Invoke" {
@@ -3137,8 +2910,12 @@ Describe 'Mocking with nested Pester runs' {
                         Get-Command | Should -Be 2
                     }
 
-                    It 'outer mock is not available' {
-                        Get-Date | Should -Not -Be 1
+                    It 'outer mock bootstrap leaks but throws instead of falling through' {
+                        # The outer Mock Get-Date {1} installs a bootstrap alias in the script
+                        # session state that is visible to this nested Invoke-Pester run.
+                        # Pester 6 never falls through to the original command, so calling
+                        # Get-Date here without mocking it locally throws with a clear message.
+                        { Get-Date } | Should -Throw "*No mock for command 'Get-Date' is defined in this scope*"
                     }
                 }
             }) -Output None -PassThru


### PR DESCRIPTION
## PR Summary

Mock no longer falls through to the original command when no behavior matches. It throws instead. Fix #2178.

```powershell
Invoke-Pester -Container (New-PesterContainer -ScriptBlock {
    Describe "a" {
        It "b" {
            function FunctionUnderTest ($param1) {}
            Mock FunctionUnderTest { "fake" } -ParameterFilter { $param1 -eq "test" }
            FunctionUnderTest -param1 "other"
        }
    }
})
```

```
[-] b
  RuntimeException: No mock for command 'FunctionUnderTest' matched the call: none of
  the parameter filters matched, and there is no default mock to fall back to. Add a
  default mock (e.g. `Mock FunctionUnderTest { ... }`) or adjust an existing -ParameterFilter.

  The following parameter filters were evaluated and did not match:
      mock filter: {  $param1 -eq "test"  } without any parameters
```

A separate message points at the bootstrap-leak case (outer Mock leaking into a nested
`Invoke-Pester` whose own mock table is empty) since there are no filters to show in that path.
