### PR TITLE
Update build script to build when needed (#2670)

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -75,7 +75,7 @@ if ($Clean -and (Test-Path "$PSScriptRoot/bin")) {
     Remove-Item "$PSScriptRoot/bin" -Recurse -Force
 }
 
-if (-not (Test-Path "$PSScriptRoot/bin")) {
+elseif (-not (Test-Path "$PSScriptRoot/bin")) {
     $Clean = $true
 }
 


### PR DESCRIPTION
## PR Summary

Update `build.ps1` to automatically "clean" when the bin directory is not present.

My testing process:

1. Run `git clean -xdf` to restore the repository to a "clean" state.
2. Run `.\test.ps1` and ensure that it builds and passes the tests.

Fix #2670 


## PR Checklist

- [x] PR has meaningful title
- [x] Summary describes changes
- [x] PR is ready to be merged
  - If not, use the arrow next to `Create Pull Request` to mark it as a draft. PR can be marked `Ready for review` when it's ready.
- [ ] ~Tests are added/update *(if required)*~ Not required
- [ ] ~Documentation is updated/added *(if required)*~ Not required
