### PR TITLE
Remove coverageGutters, make coverage relative to repo root, add repo root

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -65,6 +65,7 @@ param (
 )
 
 $ErrorActionPreference = 'Stop'
+$ErrorView = 'NormalView'
 Get-Module Pester | Remove-Module
 
 if ($Clean -and $PSVersionTable.PSVersion -lt [version]'5.1') {
@@ -105,6 +106,10 @@ if ($Clean) {
     }
 
     function Format-NicelyMini ($value) {
+        if ($null -eq $value) {
+            return '$null'
+        }
+
         if ($value -is [bool]) {
             if ($value) {
                 '$true'
@@ -148,7 +153,12 @@ if ($Clean) {
         foreach ($r in $section.PSObject.Properties.Name) {
             $option = $section.$r
             $default = Format-NicelyMini $option.Default
-            $type = $option.Default.GetType() -as [string]
+            if ("RepoRoot" -eq $r) {
+                # RepoRoot is a special case, because it is not actually an option, but a property that returns the value of the option. This is done to make it easier to use in scripts, but it causes issues when generating help, because it does not have a default value. So we need to get the default value from the actual option.
+                $default = Format-NicelyMini '<path of .git>'
+            }
+            # When the value is null this would throw if we checked the type of default value.
+            $type = $option.GetType().BaseType.GenericTypeArguments[0] -as [string]
             "    ${r}: $($option.Description)$eol    Type: ${type}$eol    Default value: ${default}$eol"
         }
     }

--- a/src/csharp/Pester/CodeCoverageConfiguration.cs
+++ b/src/csharp/Pester/CodeCoverageConfiguration.cs
@@ -31,6 +31,7 @@ namespace Pester
         private BoolOption _useBps;
         private BoolOption _singleHitBreakpoints;
         private DecimalOption _coveragePercentTarget;
+        private StringOption _reportRoot;
 
         public static CodeCoverageConfiguration Default { get { return new CodeCoverageConfiguration(); } }
 
@@ -41,7 +42,7 @@ namespace Pester
         public CodeCoverageConfiguration() : base("Options to enable and configure Pester's code coverage feature.")
         {
             Enabled = new BoolOption("Enable CodeCoverage.", false);
-            OutputFormat = new StringOption("Format to use for code coverage report. Possible values: JaCoCo, CoverageGutters, Cobertura", "JaCoCo");
+            OutputFormat = new StringOption("Format to use for code coverage report. Possible values: JaCoCo, Cobertura", "JaCoCo");
             OutputPath = new StringOption("Path relative to the current directory where code coverage report is saved.", "coverage.xml");
             OutputEncoding = new StringOption("Encoding of the output file.", "UTF8");
             Path = new StringArrayOption("Directories or files to be used for code coverage, by default the Path(s) from general settings are used, unless overridden here.", new string[0]);
@@ -50,6 +51,7 @@ namespace Pester
             UseBreakpoints = new BoolOption("When false, use Profiler based tracer to do CodeCoverage instead of using breakpoints.", false);
             CoveragePercentTarget = new DecimalOption("Target percent of code coverage that you want to achieve, default 75%.", 75m);
             SingleHitBreakpoints = new BoolOption("Remove breakpoint when it is hit. This increases performance of breakpoint based CodeCoverage.", true);
+            ReportRoot = new StringOption("Root path for the code coverage report. Uses Run.RepoRoot by default.", null);
         }
 
         public CodeCoverageConfiguration(IDictionary configuration) : this()
@@ -66,6 +68,7 @@ namespace Pester
                 configuration.AssignValueIfNotNull<bool>(nameof(UseBreakpoints), v => UseBreakpoints = v);
                 configuration.AssignValueIfNotNull<decimal>(nameof(CoveragePercentTarget), v => CoveragePercentTarget = v);
                 configuration.AssignValueIfNotNull<bool>(nameof(SingleHitBreakpoints), v => SingleHitBreakpoints = v);
+                configuration.AssignObjectIfNotNull<string>(nameof(ReportRoot), v => ReportRoot = v);
             }
         }
 
@@ -225,6 +228,22 @@ namespace Pester
                 else
                 {
                     _singleHitBreakpoints = new BoolOption(_singleHitBreakpoints, value.Value);
+                }
+            }
+        }
+
+        public StringOption ReportRoot
+        {
+            get { return _reportRoot; }
+            set
+            {
+                if (_reportRoot == null)
+                {
+                    _reportRoot = value;
+                }
+                else
+                {
+                    _reportRoot = new StringOption(_reportRoot, value?.Value);
                 }
             }
         }

--- a/src/csharp/Pester/RunConfiguration.cs
+++ b/src/csharp/Pester/RunConfiguration.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections;
+﻿using System.IO;
+using System.Collections;
 using System.Management.Automation;
 
 // those types implement Pester configuration in a way that allows it to show information about each item
@@ -33,6 +34,7 @@ namespace Pester
         private BoolOption _skipRun;
         private StringOption _skipRemainingOnFailure;
         private BoolOption _failOnNullOrEmptyForEach;
+        private StringOption _repoRoot;
 
         public static RunConfiguration Default { get { return new RunConfiguration(); } }
         public static RunConfiguration ShallowClone(RunConfiguration configuration)
@@ -54,7 +56,8 @@ namespace Pester
                 configuration.AssignValueIfNotNull<bool>(nameof(PassThru), v => PassThru = v);
                 configuration.AssignValueIfNotNull<bool>(nameof(SkipRun), v => SkipRun = v);
                 configuration.AssignObjectIfNotNull<string>(nameof(SkipRemainingOnFailure), v => SkipRemainingOnFailure = v);
-                configuration.AssignValueIfNotNull<bool>(nameof(FailOnNullOrEmptyForEach ), v => FailOnNullOrEmptyForEach  = v);
+                configuration.AssignValueIfNotNull<bool>(nameof(FailOnNullOrEmptyForEach), v => FailOnNullOrEmptyForEach = v);
+                configuration.AssignObjectIfNotNull<string>(nameof(RepoRoot), v => RepoRoot = v);
             }
         }
 
@@ -70,7 +73,8 @@ namespace Pester
             PassThru = new BoolOption("Return result object to the pipeline after finishing the test run.", false);
             SkipRun = new BoolOption("Runs the discovery phase but skips run. Use it with PassThru to get object populated with all tests.", false);
             SkipRemainingOnFailure = new StringOption("Skips remaining tests after failure for selected scope, options are None, Run, Container and Block.", "None");
-            FailOnNullOrEmptyForEach  = new BoolOption("Fails discovery when -ForEach is provided $null or @() in a block or test. Can be overridden for a specific Describe/Context/It using -AllowNullOrEmptyForEach.", true);
+            FailOnNullOrEmptyForEach = new BoolOption("Fails discovery when -ForEach is provided $null or @() in a block or test. Can be overridden for a specific Describe/Context/It using -AllowNullOrEmptyForEach.", true);
+            RepoRoot = new StringOption("Root directory of the repository. Found by searching for the .git directory recursively. When not found, the current working directory is used.", FindRepoRoot());
         }
 
         public StringArrayOption Path
@@ -247,6 +251,39 @@ namespace Pester
                     _failOnNullOrEmptyForEach = new BoolOption(_failOnNullOrEmptyForEach, value.Value);
                 }
             }
+        }
+
+        public StringOption RepoRoot
+        {
+            get { return _repoRoot; }
+            set
+            {
+                if (_repoRoot == null)
+                {
+                    _repoRoot = value;
+                }
+                else
+                {
+                    _repoRoot = new StringOption(_repoRoot, value?.Value);
+                }
+            }
+        }
+
+        private static string FindRepoRoot()
+        {
+            var originalDir = Directory.GetCurrentDirectory();
+            var currentDir = originalDir;
+            while (!Directory.Exists(System.IO.Path.Combine(currentDir, ".git")))
+            {
+                var parentDir = Directory.GetParent(currentDir);
+                if (parentDir == null)
+                {
+                    return originalDir;
+                }
+                currentDir = parentDir.FullName;
+            }
+            return currentDir;
+
         }
     }
 }

--- a/src/en-US/about_PesterConfiguration.help.txt
+++ b/src/en-US/about_PesterConfiguration.help.txt
@@ -75,7 +75,7 @@ SECTIONS AND OPTIONS
 
         RepoRoot: Root directory of the repository. Found by searching for the .git directory recursively. When not found, the current working directory is used.
         Type: string
-        Default value: '<repo root>'
+        Default value: 'aa<path of .git>'
 
     Filter:
         Tag: Tags of Describe, Context or It to be run.
@@ -138,6 +138,10 @@ SECTIONS AND OPTIONS
         SingleHitBreakpoints: Remove breakpoint when it is hit. This increases performance of breakpoint based CodeCoverage.
         Type: bool
         Default value: $true
+
+        ReportRoot: Root path for the code coverage report. Uses Run.RepoRoot by default.
+        Type: string
+        Default value: $null
 
     TestResult:
         Enabled: Enable TestResult.

--- a/src/en-US/about_PesterConfiguration.help.txt
+++ b/src/en-US/about_PesterConfiguration.help.txt
@@ -73,6 +73,10 @@ SECTIONS AND OPTIONS
         Type: bool
         Default value: $true
 
+        RepoRoot: Root directory of the repository. Found by searching for the .git directory recursively. When not found, the current working directory is used.
+        Type: string
+        Default value: '<repo root>'
+
     Filter:
         Tag: Tags of Describe, Context or It to be run.
         Type: string[]
@@ -99,7 +103,7 @@ SECTIONS AND OPTIONS
         Type: bool
         Default value: $false
 
-        OutputFormat: Format to use for code coverage report. Possible values: JaCoCo, CoverageGutters, Cobertura
+        OutputFormat: Format to use for code coverage report. Possible values: JaCoCo, Cobertura
         Type: string
         Default value: 'JaCoCo'
 

--- a/src/en-US/about_PesterConfiguration.help.txt
+++ b/src/en-US/about_PesterConfiguration.help.txt
@@ -75,7 +75,7 @@ SECTIONS AND OPTIONS
 
         RepoRoot: Root directory of the repository. Found by searching for the .git directory recursively. When not found, the current working directory is used.
         Type: string
-        Default value: 'aa<path of .git>'
+        Default value: '<path of .git>'
 
     Filter:
         Tag: Tags of Describe, Context or It to be run.

--- a/src/functions/Coverage.Plugin.ps1
+++ b/src/functions/Coverage.Plugin.ps1
@@ -146,8 +146,8 @@
         $configuration = $run.PluginConfiguration.Coverage
 
         $coverageXmlReport = switch ($configuration.OutputFormat) {
-            'JaCoCo' { [xml](Get-JaCoCoReportXml -CommandCoverage $breakpoints -TotalMilliseconds $totalMilliseconds -CoverageReport $coverageReport -ReportRoot Get-ReportRoot) }
-            'Cobertura' { [xml](Get-CoberturaReportXml -CoverageReport $coverageReport  -TotalMilliseconds $totalMilliseconds -ReportRoot Get-ReportRoot) }
+            'JaCoCo' { [xml](Get-JaCoCoReportXml -CommandCoverage $breakpoints -TotalMilliseconds $totalMilliseconds -CoverageReport $coverageReport -ReportRoot (Get-ReportRoot)) }
+            'Cobertura' { [xml](Get-CoberturaReportXml -CoverageReport $coverageReport  -TotalMilliseconds $totalMilliseconds -ReportRoot (Get-ReportRoot)) }
             default { throw "CodeCoverage.CoverageFormat '$($configuration.OutputFormat)' is not valid, please review your configuration." }
         }
 

--- a/src/functions/Coverage.Plugin.ps1
+++ b/src/functions/Coverage.Plugin.ps1
@@ -146,9 +146,8 @@
         $configuration = $run.PluginConfiguration.Coverage
 
         $coverageXmlReport = switch ($configuration.OutputFormat) {
-            'JaCoCo' { [xml](Get-JaCoCoReportXml -CommandCoverage $breakpoints -TotalMilliseconds $totalMilliseconds -CoverageReport $coverageReport -Format 'JaCoCo') }
-            'CoverageGutters' { [xml](Get-JaCoCoReportXml -CommandCoverage $breakpoints -TotalMilliseconds $totalMilliseconds -CoverageReport $coverageReport -Format 'CoverageGutters') }
-            'Cobertura' { [xml](Get-CoberturaReportXml -CoverageReport $coverageReport  -TotalMilliseconds $totalMilliseconds) }
+            'JaCoCo' { [xml](Get-JaCoCoReportXml -CommandCoverage $breakpoints -TotalMilliseconds $totalMilliseconds -CoverageReport $coverageReport -ReportRoot Get-ReportRoot) }
+            'Cobertura' { [xml](Get-CoberturaReportXml -CoverageReport $coverageReport  -TotalMilliseconds $totalMilliseconds -ReportRoot Get-ReportRoot) }
             default { throw "CodeCoverage.CoverageFormat '$($configuration.OutputFormat)' is not valid, please review your configuration." }
         }
 
@@ -216,7 +215,7 @@
 }
 
 function Resolve-CodeCoverageConfiguration {
-    $supportedFormats = 'JaCoCo', 'CoverageGutters', 'Cobertura'
+    $supportedFormats = 'JaCoCo', 'Cobertura'
     if ($PesterPreference.CodeCoverage.OutputFormat.Value -notin $supportedFormats) {
         throw (Get-StringOptionErrorMessage -OptionPath 'CodeCoverage.OutputFormat' -SupportedValues $supportedFormats -Value $PesterPreference.CodeCoverage.OutputFormat.Value)
     }

--- a/src/functions/Coverage.ps1
+++ b/src/functions/Coverage.ps1
@@ -732,11 +732,10 @@ function Get-ReportRoot {
 function Get-RelativePath {
     param ( [string] $Path, [string] $RelativeTo )
     if ([System.IO.Path]::DirectorySeparatorChar -eq '/') {
-        # On Unix, also trim the alternate directory separator char, since both are used as separators
         $RelativeTo = $RelativeTo.Replace('\', '/').TrimEnd('/')
     }
     else {
-        $RelativeTo = $RelativeTo.Replace('\').TrimEnd('\')
+        $RelativeTo = $RelativeTo.Replace('/', '\').TrimEnd('\')
     }
 
     return $Path -replace "^$([regex]::Escape("$RelativeTo$([System.IO.Path]::DirectorySeparatorChar)"))?"

--- a/src/functions/Coverage.ps1
+++ b/src/functions/Coverage.ps1
@@ -233,10 +233,10 @@ function Get-CodeCoverageFilePaths {
     $testsPattern = "*$($PesterPreference.Run.TestExtension.Value)"
 
     [string[]] $filteredFiles = @(foreach ($file in (& $SafeCommands['Get-ChildItem'] -LiteralPath $Paths -File -Recurse:$RecursePaths)) {
-        if (('.ps1', '.psm1') -contains $file.Extension -and ($IncludeTests -or $file.Name -notlike $testsPattern)) {
-            $file.FullName
-        }
-    })
+            if (('.ps1', '.psm1') -contains $file.Extension -and ($IncludeTests -or $file.Name -notlike $testsPattern)) {
+                $file.FullName
+            }
+        })
 
     $uniqueFiles = [System.Collections.Generic.HashSet[string]]::new($filteredFiles)
     return $uniqueFiles
@@ -721,37 +721,13 @@ function Get-CoverageReport {
     }
 }
 
-function Get-CommonParentPath {
-    param ([string[]] $Path)
-
-    if ("CoverageGutters" -eq $PesterPreference.CodeCoverage.OutputFormat.Value) {
-        # for coverage gutters the root path is relative to the coverage.xml
-        $fullPath = $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($PesterPreference.CodeCoverage.OutputPath.Value)
-        return (& $SafeCommands['Split-Path'] -Path $fullPath | Normalize-Path )
+function Get-ReportRoot {
+    if ($null -ne $PesterPreference.CodeCoverage.ReportRoot.Value) {
+        return $PesterPreference.CodeCoverage.ReportRoot.Value
     }
-
-    $pathsToTest = @(
-        $Path |
-            Normalize-Path |
-            & $SafeCommands['Select-Object'] -Unique
-    )
-
-    if ($pathsToTest.Count -gt 0) {
-        $parentPath = & $SafeCommands['Split-Path'] -Path $pathsToTest[0] -Parent
-
-        while ($parentPath.Length -gt 0) {
-            $nonMatches = $pathsToTest -notmatch "^$([regex]::Escape($parentPath))"
-
-            if ($nonMatches.Count -eq 0) {
-                return $parentPath
-            }
-            else {
-                $parentPath = & $SafeCommands['Split-Path'] -Path $parentPath -Parent
-            }
-        }
+    else {
+        $PesterPreference.Run.RepoRoot.Value
     }
-
-    return [string]::Empty
 }
 
 function Get-RelativePath {
@@ -795,10 +771,9 @@ function Get-JaCoCoReportXml {
         [object] $CoverageReport,
         [parameter(Mandatory = $true)]
         [long] $TotalMilliseconds,
-        [string] $Format
+        [parameter(Mandatory = $true)]
+        [string] $ReportRoot
     )
-
-    $isGutters = "CoverageGutters" -eq $Format
 
     if ($null -eq $CoverageReport -or $CoverageReport.NumberOfCommandsAnalyzed -eq 0) {
         return [string]::Empty
@@ -902,9 +877,6 @@ function Get-JaCoCoReportXml {
         $packageList.Add($package)
     }
 
-    $commonParent = Get-CommonParentPath -Path $CoverageReport.AnalyzedFiles
-    $commonParentLeaf = & $SafeCommands["Split-Path"] $commonParent -Leaf
-
     # the JaCoCo xml format without the doctype, as the XML stuff does not like DTD's.
     $jaCoCoReport = '<?xml version="1.0" encoding="UTF-8" standalone="no"?>'
     $jaCoCoReport += '<report name="">'
@@ -918,26 +890,15 @@ function Get-JaCoCoReportXml {
     $reportElement.sessioninfo.dump = $endTime.ToString()
 
     foreach ($package in $packageList) {
-        $packageRelativePath = Get-RelativePath -Path $package.Name -RelativeTo $commonParent
+        $packageRelativePath = Get-RelativePath -Path $package.Name -RelativeTo $ReportRoot
 
-        # e.g. "." for gutters, and "package" for non gutters in root
-        # and "sub-dir" for gutters, and "package/sub-dir" for non-gutters
+        # "." for root and "sub-dir" for non-root, e.g. "." or "src", "src/myCode"
         $packageName = if ($null -eq $packageRelativePath -or "" -eq $packageRelativePath) {
-            if ($isGutters) {
-                "."
-            }
-            else {
-                $commonParentLeaf
-            }
+            "."
         }
         else {
             $packageRelativePathFormatted = $packageRelativePath.Replace("\", "/")
-            if ($isGutters) {
-                $packageRelativePathFormatted
-            }
-            else {
-                "$commonParentLeaf/$packageRelativePathFormatted"
-            }
+            $packageRelativePathFormatted
         }
 
         $packageElement = Add-XmlElement -Parent $reportElement -Name 'package' -Attributes @{
@@ -946,22 +907,12 @@ function Get-JaCoCoReportXml {
 
         foreach ($file in $package.Classes.Keys) {
             $class = $package.Classes.$file
-            $classElementRelativePath = (Get-RelativePath -Path $file -RelativeTo $commonParent).Replace("\", "/")
-            $classElementName = if ($isGutters) {
-                $classElementRelativePath
-            }
-            else {
-                "$commonParentLeaf/$classElementRelativePath"
-            }
+            $classElementRelativePath = (Get-RelativePath -Path $file -RelativeTo $ReportRoot).Replace("\", "/")
+            $classElementName = $classElementRelativePath
             $classElementName = $classElementName.Substring(0, $($classElementName.LastIndexOf(".")))
             $classElement = Add-XmlElement -Parent $packageElement -Name 'class' -Attributes ([ordered] @{
                     name           = $classElementName
-                    sourcefilename = if ($isGutters) {
-                        & $SafeCommands["Split-Path"] $classElementRelativePath -Leaf
-                    }
-                    else {
-                        $classElementRelativePath
-                    }
+                    sourcefilename = & $SafeCommands["Split-Path"] $classElementRelativePath -Leaf
                 })
 
             foreach ($function in $class.Methods.Keys) {
@@ -984,14 +935,9 @@ function Get-JaCoCoReportXml {
 
         foreach ($file in $package.Classes.Keys) {
             $class = $package.Classes.$file
-            $classElementRelativePath = (Get-RelativePath -Path $file -RelativeTo $commonParent).Replace("\", "/")
+            $classElementRelativePath = (Get-RelativePath -Path $file -RelativeTo $ReportRoot).Replace("\", "/")
             $sourceFileElement = Add-XmlElement -Parent $packageElement -Name 'sourcefile' -Attributes ([ordered] @{
-                    name = if ($isGutters) {
-                        & $SafeCommands["Split-Path"] $classElementRelativePath -Leaf
-                    }
-                    else {
-                        $classElementRelativePath
-                    }
+                    name = & $SafeCommands["Split-Path"] $classElementRelativePath -Leaf
                 })
 
             foreach ($line in $class.Lines.Keys) {
@@ -1033,7 +979,9 @@ function Get-CoberturaReportXml {
         [parameter(Mandatory = $true)]
         [object] $CoverageReport,
         [parameter(Mandatory = $true)]
-        [long] $TotalMilliseconds
+        [long] $TotalMilliseconds,
+        [parameter(Mandatory = $true)]
+        [string] $ReportRoot
     )
 
     if ($null -eq $CoverageReport -or $CoverageReport.NumberOfCommandsAnalyzed -eq 0) {
@@ -1043,8 +991,6 @@ function Get-CoberturaReportXml {
     # Report uses unix epoch time format (milliseconds since midnight 1/1/1970 UTC)
     [long] $endTime = [System.DateTimeOffset]::UtcNow.ToUnixTimeMilliseconds()
     [long] $startTime = [math]::Floor($endTime - $TotalMilliseconds)
-
-    $commonRoot = Get-CommonParentPath -Path $CoverageReport.AnalyzedFiles
 
     $allLines = [System.Collections.Generic.List[object]]@()
     $allLines.AddRange($CoverageReport.MissedCommands)
@@ -1114,7 +1060,7 @@ function Get-CoberturaReportXml {
             $coveredLines = foreach ($line in $lines) { if (0 -lt $line.attributes.hits) { $line } }
 
             $lineRate = Get-LineRate -CoveredLines $coveredLines.Length -TotalLines $lines.Length
-            $filename = $classGroup.Name.Substring($commonRoot.Length).Replace('\', '/').TrimStart('/')
+            $filename = $classGroup.Name.Substring($ReportRoot.Length).Replace('\', '/').TrimStart('/')
 
             $class = [ordered]@{
                 name         = 'class'
@@ -1138,7 +1084,7 @@ function Get-CoberturaReportXml {
         $totalLines = ($classes.totalLines | & $SafeCommands["Measure-Object"] -Sum).Sum
         $coveredLines = ($classes.coveredLines | & $SafeCommands["Measure-Object"] -Sum).Sum
         $lineRate = Get-LineRate -CoveredLines $coveredLines -TotalLines $totalLines
-        $packageName = $packageGroup.Name.Substring($commonRoot.Length).Replace('\', '/').TrimStart('/')
+        $packageName = $packageGroup.Name.Substring($ReportRoot.Length).Replace('\', '/').TrimStart('/')
 
         $package = [ordered]@{
             name         = 'package'
@@ -1176,7 +1122,7 @@ function Get-CoberturaReportXml {
         children   = [ordered]@{
             sources  = [ordered]@{
                 name  = 'source'
-                value = $commonRoot.Replace('\', '/')
+                value = $ReportRoot.Replace('\', '/')
             }
             packages = $packages | & $SafeCommands["Sort-Object"] { $_.attributes.name }
         }

--- a/src/functions/Coverage.ps1
+++ b/src/functions/Coverage.ps1
@@ -741,34 +741,6 @@ function Get-RelativePath {
     return $Path -replace "^$([regex]::Escape("$RelativeTo$([System.IO.Path]::DirectorySeparatorChar)"))?"
 }
 
-function Normalize-Path {
-    [CmdletBinding()]
-    param (
-        [Parameter(ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true)]
-        [Alias('PSPath', 'FullName')]
-        [string[]] $Path
-    )
-
-    # Split-Path and Join-Path will replace any AltDirectorySeparatorChar instances with the DirectorySeparatorChar
-    # (Even if it's not the one that the split / join happens on.)  So splitting / rejoining a path will give us
-    # consistent separators for later string comparison.
-
-    process {
-        if ($null -ne $Path) {
-            foreach ($p in $Path) {
-                $normalizedPath = & $SafeCommands['Split-Path'] $p -Leaf
-
-                if ($normalizedPath -ne $p) {
-                    $parent = & $SafeCommands['Split-Path'] $p -Parent
-                    $normalizedPath = & $SafeCommands['Join-Path'] $parent $normalizedPath
-                }
-
-                $normalizedPath
-            }
-        }
-    }
-}
-
 function Get-JaCoCoReportXml {
     param (
         [parameter(Mandatory = $true)]

--- a/src/functions/Coverage.ps1
+++ b/src/functions/Coverage.ps1
@@ -731,6 +731,14 @@ function Get-ReportRoot {
 
 function Get-RelativePath {
     param ( [string] $Path, [string] $RelativeTo )
+    if ([System.IO.Path]::DirectorySeparatorChar -eq '/') {
+        # On Unix, also trim the alternate directory separator char, since both are used as separators
+        $RelativeTo = $RelativeTo.Replace('\', '/').TrimEnd('/')
+    }
+    else {
+        $RelativeTo = $RelativeTo.Replace('\').TrimEnd('\')
+    }
+
     return $Path -replace "^$([regex]::Escape("$RelativeTo$([System.IO.Path]::DirectorySeparatorChar)"))?"
 }
 

--- a/src/functions/Coverage.ps1
+++ b/src/functions/Coverage.ps1
@@ -725,9 +725,8 @@ function Get-ReportRoot {
     if ($null -ne $PesterPreference.CodeCoverage.ReportRoot.Value) {
         return $PesterPreference.CodeCoverage.ReportRoot.Value
     }
-    else {
-        $PesterPreference.Run.RepoRoot.Value
-    }
+
+    $PesterPreference.Run.RepoRoot.Value
 }
 
 function Get-RelativePath {

--- a/src/functions/Output.ps1
+++ b/src/functions/Output.ps1
@@ -336,9 +336,8 @@ function Write-CoverageReport {
         $ReportStrings.FileSingular
     }
 
-    $ReportRoot = Get-CommonParentPath -Path $CoverageReport.AnalyzedFiles
     $report = $CoverageReport.MissedCommands | & $SafeCommands['Select-Object'] -Property @(
-        @{ Name = 'File'; Expression = { Get-RelativePath -Path $_.File -RelativeTo $ReportRoot } }
+        @{ Name = 'File'; Expression = { Get-RelativePath -Path $_.File -RelativeTo (Get-ReportRoot) } }
         'Class'
         'Function'
         'Line'

--- a/src/functions/Output.ps1
+++ b/src/functions/Output.ps1
@@ -336,9 +336,9 @@ function Write-CoverageReport {
         $ReportStrings.FileSingular
     }
 
-    $commonParent = Get-CommonParentPath -Path $CoverageReport.AnalyzedFiles
+    $ReportRoot = Get-CommonParentPath -Path $CoverageReport.AnalyzedFiles
     $report = $CoverageReport.MissedCommands | & $SafeCommands['Select-Object'] -Property @(
-        @{ Name = 'File'; Expression = { Get-RelativePath -Path $_.File -RelativeTo $commonParent } }
+        @{ Name = 'File'; Expression = { Get-RelativePath -Path $_.File -RelativeTo $ReportRoot } }
         'Class'
         'Function'
         'Line'

--- a/test.ps1
+++ b/test.ps1
@@ -206,7 +206,7 @@ if ($CC) {
         }
     }
 
-    [xml] $jaCoCoReport = [xml] (& $Get_JaCoCoReportXml -CommandCoverage $breakpoints -TotalMilliseconds $sw.ElapsedMilliseconds -CoverageReport $coverageReport)
+    [xml] $jaCoCoReport = [xml] (& $Get_JaCoCoReportXml -CommandCoverage $breakpoints -TotalMilliseconds $sw.ElapsedMilliseconds -CoverageReport $coverageReport -RepoRoot $PSScriptRoot)
     $jaCoCoReport.OuterXml | Set-Content -Path $PSScriptRoot/coverage.xml
     & $Write_CoverageReport -CoverageReport $coverageReport
 }

--- a/test.ps1
+++ b/test.ps1
@@ -206,7 +206,7 @@ if ($CC) {
         }
     }
 
-    [xml] $jaCoCoReport = [xml] (& $Get_JaCoCoReportXml -CommandCoverage $breakpoints -TotalMilliseconds $sw.ElapsedMilliseconds -CoverageReport $coverageReport -RepoRoot $PSScriptRoot)
+    [xml] $jaCoCoReport = [xml] (& $Get_JaCoCoReportXml -CommandCoverage $breakpoints -TotalMilliseconds $sw.ElapsedMilliseconds -CoverageReport $coverageReport -ReportRoot $PSScriptRoot)
     $jaCoCoReport.OuterXml | Set-Content -Path $PSScriptRoot/coverage.xml
     & $Write_CoverageReport -CoverageReport $coverageReport
 }

--- a/test.ps1
+++ b/test.ps1
@@ -206,7 +206,7 @@ if ($CC) {
         }
     }
 
-    [xml] $jaCoCoReport = [xml] (& $Get_JaCoCoReportXml -CommandCoverage $breakpoints -TotalMilliseconds $sw.ElapsedMilliseconds -CoverageReport $coverageReport -Format "JaCoCo")
+    [xml] $jaCoCoReport = [xml] (& $Get_JaCoCoReportXml -CommandCoverage $breakpoints -TotalMilliseconds $sw.ElapsedMilliseconds -CoverageReport $coverageReport)
     $jaCoCoReport.OuterXml | Set-Content -Path $PSScriptRoot/coverage.xml
     & $Write_CoverageReport -CoverageReport $coverageReport
 }

--- a/tst/Pester.RSpec.Coverage.ts.ps1
+++ b/tst/Pester.RSpec.Coverage.ts.ps1
@@ -50,10 +50,6 @@ i -PassThru:$PassThru {
             $c.CodeCoverage.Enabled = $true
             $c.CodeCoverage.Path = "$PSScriptRoot/CoverageTestFile.ps1"
 
-            # # makes it easier to visualize this in VSCode, if this fails
-            # # comment this line out to use Jacoco
-            # $c.CodeCoverage.OutputFormat = "CoverageGutters"
-
             try {
                 $env:PESTER_CC_DEBUG = 1
                 $env:PESTER_CC_DEBUG_FILE = "CoverageTestFile"

--- a/tst/Pester.RSpec.Output.ts.ps1
+++ b/tst/Pester.RSpec.Output.ts.ps1
@@ -416,7 +416,7 @@ i -PassThru:$PassThru {
 
             $uncoveredLine = $output | where { $_ -like "*not covered*" }
 
-            $uncoveredLine | Verify-Like 'CoverageTestFile.Missing.ps1*"not covered"*'
+            $uncoveredLine | Verify-Like 'CoverageTestFile.Missing.ps1*"not covered"'
         }
 
         t "Paths are relative to repo root option when report root is not set" {
@@ -438,7 +438,7 @@ i -PassThru:$PassThru {
 
             $uncoveredLine = $output | where { $_ -like "*not covered*" }
 
-            $uncoveredLine | Verify-Like 'tst/testProjectsForMissingCoverage/CoverageTestFile.Missing.ps1*"not covered"*'
+            $uncoveredLine | Verify-Like 'tst/testProjectsForMissingCoverage/CoverageTestFile.Missing.ps1*"not covered"'
         }
     }
 }

--- a/tst/Pester.RSpec.Output.ts.ps1
+++ b/tst/Pester.RSpec.Output.ts.ps1
@@ -438,7 +438,7 @@ i -PassThru:$PassThru {
 
             $uncoveredLine = $output | where { $_ -like "*not covered*" }
 
-            $uncoveredLine | Verify-Like 'tst/testProjectsForMissingCoverage/CoverageTestFile.Missing.ps1*not covered*'
+            $uncoveredLine | Verify-Like ('tst/testProjectsForMissingCoverage/CoverageTestFile.Missing.ps1*not covered*' -replace '/', [System.IO.Path]::DirectorySeparatorChar)
         }
     }
 }

--- a/tst/Pester.RSpec.Output.ts.ps1
+++ b/tst/Pester.RSpec.Output.ts.ps1
@@ -394,4 +394,51 @@ i -PassThru:$PassThru {
             $normalOutput | Verify-Equal $writehostOutput
         }
     }
+
+    b "Code Coverage output" {
+        t "Paths are relative to report root option when set" {
+            $sb = [ScriptBlock]::Create(('
+                $c = New-PesterConfiguration
+                $c.Run.Path = "tst/testProjectsForMissingCoverage/CoverageTestFile.Missing.Tests.ps1"
+                $c.Run.PassThru = $true
+                $c.CodeCoverage.Enabled = $true
+                $c.CodeCoverage.ExcludeTests = $true # default
+                $c.Output.Verbosity = "Detailed"
+                $c.Output.RenderMode = "Plaintext"
+
+                $c.CodeCoverage.ReportRoot = "#currentDir#/testProjectsForMissingCoverage"
+
+                $null = Invoke-Pester -Configuration $c
+            ' -replace '#currentDir#', $PSScriptRoot))
+
+            $output = Invoke-InNewProcess $sb
+            $output | Write-Host
+
+            $uncoveredLine = $output | where { $_ -like "*not covered*" }
+
+            $uncoveredLine | Verify-Like 'CoverageTestFile.Missing.ps1*"not covered"*'
+        }
+
+        t "Paths are relative to repo root option when report root is not set" {
+            $sb = {
+                $c = New-PesterConfiguration
+                $c.Run.Path = "tst/testProjectsForMissingCoverage/CoverageTestFile.Missing.Tests.ps1"
+                $c.Run.PassThru = $true
+                $c.CodeCoverage.Enabled = $true
+                $c.CodeCoverage.ExcludeTests = $true # default
+                $c.CodeCoverage.Path = "tst/testProjectsForMissingCoverage/CoverageTestFile.Missing.ps1"
+                $c.Output.Verbosity = 'Detailed'
+                $c.Output.RenderMode = 'Plaintext'
+
+                $null = Invoke-Pester -Configuration $c
+            }
+
+            $output = Invoke-InNewProcess $sb
+            $output | Write-Host
+
+            $uncoveredLine = $output | where { $_ -like "*not covered*" }
+
+            $uncoveredLine | Verify-Like 'tst/testProjectsForMissingCoverage/CoverageTestFile.Missing.ps1*"not covered"*'
+        }
+    }
 }

--- a/tst/Pester.RSpec.Output.ts.ps1
+++ b/tst/Pester.RSpec.Output.ts.ps1
@@ -416,7 +416,7 @@ i -PassThru:$PassThru {
 
             $uncoveredLine = $output | where { $_ -like "*not covered*" }
 
-            $uncoveredLine | Verify-Like 'CoverageTestFile.Missing.ps1*"not covered"'
+            $uncoveredLine | Verify-Like 'CoverageTestFile.Missing.ps1*not covered*'
         }
 
         t "Paths are relative to repo root option when report root is not set" {

--- a/tst/Pester.RSpec.Output.ts.ps1
+++ b/tst/Pester.RSpec.Output.ts.ps1
@@ -438,7 +438,7 @@ i -PassThru:$PassThru {
 
             $uncoveredLine = $output | where { $_ -like "*not covered*" }
 
-            $uncoveredLine | Verify-Like 'tst/testProjectsForMissingCoverage/CoverageTestFile.Missing.ps1*"not covered"'
+            $uncoveredLine | Verify-Like 'tst/testProjectsForMissingCoverage/CoverageTestFile.Missing.ps1*not covered*'
         }
     }
 }

--- a/tst/functions/Coverage.Tests.ps1
+++ b/tst/functions/Coverage.Tests.ps1
@@ -274,199 +274,7 @@ InPesterModuleScope {
             }
 
             It 'JaCoCo report must be correct' {
-                [String]$jaCoCoReportXml = Get-JaCoCoReportXml -CommandCoverage $breakpoints -TotalMilliseconds 10000 -CoverageReport $coverageReport -Format "JaCoCo"
-                $jaCoCoReportXml = $jaCoCoReportXml -replace 'Pester \([^\)]*', 'Pester (date'
-                $jaCoCoReportXml = $jaCoCoReportXml -replace 'start="[0-9]*"', 'start=""'
-                $jaCoCoReportXml = $jaCoCoReportXml -replace 'dump="[0-9]*"', 'dump=""'
-                $jaCoCoReportXml = $jaCoCoReportXml -replace "$([System.Environment]::NewLine)", ''
-                $jaCoCoReportXml = $jaCoCoReportXml -replace "$(Split-Path -Path $root -Leaf)", 'CommonRoot'
-                $jaCoCoReportXml = $jaCoCoReportXml.Replace($root.Replace('\', '/'), '')
-                (Clear-WhiteSpace $jaCoCoReportXml) | Should -Be (Clear-WhiteSpace '
-                <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-                <!DOCTYPE report PUBLIC "-//JACOCO//DTD Report 1.1//EN" "report.dtd">
-                <report name="Pester (date)">
-                    <sessioninfo id="this" start="" dump="" />
-                    <package name="CommonRoot">
-                        <class name="CommonRoot/TestScript" sourcefilename="TestScript.ps1">
-                            <method name="NestedFunction" desc="()" line="5">
-                                <counter type="INSTRUCTION" missed="0" covered="2" />
-                                <counter type="LINE" missed="0" covered="2" />
-                                <counter type="METHOD" missed="0" covered="1" />
-                            </method>
-                            <method name="FunctionOne" desc="()" line="9">
-                                <counter type="INSTRUCTION" missed="1" covered="6" />
-                                <counter type="LINE" missed="0" covered="5" />
-                                <counter type="METHOD" missed="0" covered="1" />
-                            </method>
-                            <method name="FunctionTwo" desc="()" line="22">
-                                <counter type="INSTRUCTION" missed="1" covered="0" />
-                                <counter type="LINE" missed="1" covered="0" />
-                                <counter type="METHOD" missed="1" covered="0" />
-                            </method>
-                            <method name="&lt;script&gt;" desc="()" line="25">
-                                <counter type="INSTRUCTION" missed="0" covered="3" />
-                                <counter type="LINE" missed="0" covered="3" />
-                                <counter type="METHOD" missed="0" covered="1" />
-                            </method>
-                            <method name="MyBaseClass" desc="()" line="31">
-                                <counter type="INSTRUCTION" missed="0" covered="1" />
-                                <counter type="LINE" missed="0" covered="1" />
-                                <counter type="METHOD" missed="0" covered="1" />
-                            </method>
-                            <method name="MyClass" desc="()" line="39">
-                                <counter type="INSTRUCTION" missed="0" covered="1" />
-                                <counter type="LINE" missed="0" covered="1" />
-                                <counter type="METHOD" missed="0" covered="1" />
-                            </method>
-                            <method name="MethodOne" desc="()" line="44">
-                                <counter type="INSTRUCTION" missed="0" covered="1" />
-                                <counter type="LINE" missed="0" covered="1" />
-                                <counter type="METHOD" missed="0" covered="1" />
-                            </method>
-                            <method name="MethodTwo" desc="()" line="49">
-                                <counter type="INSTRUCTION" missed="1" covered="0" />
-                                <counter type="LINE" missed="1" covered="0" />
-                                <counter type="METHOD" missed="1" covered="0" />
-                            </method>
-                            <counter type="INSTRUCTION" missed="3" covered="14" />
-                            <counter type="LINE" missed="2" covered="13" />
-                            <counter type="METHOD" missed="2" covered="6" />
-                            <counter type="CLASS" missed="0" covered="1" />
-                        </class>
-                        <class name="CommonRoot/TestScript2" sourcefilename="TestScript2.ps1">
-                            <method name="&lt;script&gt;" desc="()" line="1">
-                                <counter type="INSTRUCTION" missed="0" covered="1" />
-                                <counter type="LINE" missed="0" covered="1" />
-                                <counter type="METHOD" missed="0" covered="1" />
-                            </method>
-                            <counter type="INSTRUCTION" missed="0" covered="1" />
-                            <counter type="LINE" missed="0" covered="1" />
-                            <counter type="METHOD" missed="0" covered="1" />
-                            <counter type="CLASS" missed="0" covered="1" />
-                        </class>
-                        <class name="CommonRoot/TestScriptExit" sourcefilename="TestScriptExit.ps1">
-                            <method name="&lt;script&gt;" desc="()" line="2">
-                                <counter type="INSTRUCTION" missed="0" covered="2" />
-                                <counter type="LINE" missed="0" covered="1" />
-                                <counter type="METHOD" missed="0" covered="1" />
-                            </method>
-                            <counter type="INSTRUCTION" missed="0" covered="2" />
-                            <counter type="LINE" missed="0" covered="1" />
-                            <counter type="METHOD" missed="0" covered="1" />
-                            <counter type="CLASS" missed="0" covered="1" />
-                        </class>
-                        <class name="CommonRoot/TestScriptStatements" sourcefilename="TestScriptStatements.ps1">
-                            <method name="&lt;script&gt;" desc="()" line="3">
-                                <counter type="INSTRUCTION" missed="3" covered="16" />
-                                <counter type="LINE" missed="3" covered="14" />
-                                <counter type="METHOD" missed="0" covered="1" />
-                            </method>
-                            <counter type="INSTRUCTION" missed="3" covered="16" />
-                            <counter type="LINE" missed="3" covered="14" />
-                            <counter type="METHOD" missed="0" covered="1" />
-                            <counter type="CLASS" missed="0" covered="1" />
-                        </class>
-                        <sourcefile name="TestScript.ps1">
-                            <line nr="5" mi="0" ci="1" mb="0" cb="0" />
-                            <line nr="6" mi="0" ci="1" mb="0" cb="0" />
-                            <line nr="9" mi="0" ci="1" mb="0" cb="0" />
-                            <line nr="11" mi="0" ci="1" mb="0" cb="0" />
-                            <line nr="12" mi="0" ci="1" mb="0" cb="0" />
-                            <line nr="15" mi="1" ci="1" mb="0" cb="0" />
-                            <line nr="17" mi="0" ci="2" mb="0" cb="0" />
-                            <line nr="22" mi="1" ci="0" mb="0" cb="0" />
-                            <line nr="25" mi="0" ci="1" mb="0" cb="0" />
-                            <line nr="31" mi="0" ci="1" mb="0" cb="0" />
-                            <line nr="39" mi="0" ci="1" mb="0" cb="0" />
-                            <line nr="44" mi="0" ci="1" mb="0" cb="0" />
-                            <line nr="49" mi="1" ci="0" mb="0" cb="0" />
-                            <line nr="53" mi="0" ci="1" mb="0" cb="0" />
-                            <line nr="54" mi="0" ci="1" mb="0" cb="0" />
-                            <counter type="INSTRUCTION" missed="3" covered="14" />
-                            <counter type="LINE" missed="2" covered="13" />
-                            <counter type="METHOD" missed="2" covered="6" />
-                            <counter type="CLASS" missed="0" covered="1" />
-                        </sourcefile>
-                        <sourcefile name="TestScript2.ps1">
-                            <line nr="1" mi="0" ci="1" mb="0" cb="0" />
-                            <counter type="INSTRUCTION" missed="0" covered="1" />
-                            <counter type="LINE" missed="0" covered="1" />
-                            <counter type="METHOD" missed="0" covered="1" />
-                            <counter type="CLASS" missed="0" covered="1" />
-                        </sourcefile>
-                        <sourcefile name="TestScriptExit.ps1">
-                            <line nr="2" mi="0" ci="2" mb="0" cb="0" />
-                            <counter type="INSTRUCTION" missed="0" covered="2" />
-                            <counter type="LINE" missed="0" covered="1" />
-                            <counter type="METHOD" missed="0" covered="1" />
-                            <counter type="CLASS" missed="0" covered="1" />
-                        </sourcefile>
-                        <sourcefile name="TestScriptStatements.ps1">
-                            <line nr="3" mi="0" ci="2" mb="0" cb="0" />
-                            <line nr="6" mi="0" ci="1" mb="0" cb="0" />
-                            <line nr="11" mi="0" ci="1" mb="0" cb="0" />
-                            <line nr="12" mi="0" ci="1" mb="0" cb="0" />
-                            <line nr="13" mi="0" ci="1" mb="0" cb="0" />
-                            <line nr="14" mi="1" ci="0" mb="0" cb="0" />
-                            <line nr="17" mi="0" ci="1" mb="0" cb="0" />
-                            <line nr="18" mi="0" ci="1" mb="0" cb="0" />
-                            <line nr="19" mi="0" ci="1" mb="0" cb="0" />
-                            <line nr="21" mi="1" ci="0" mb="0" cb="0" />
-                            <line nr="24" mi="0" ci="1" mb="0" cb="0" />
-                            <line nr="25" mi="0" ci="1" mb="0" cb="0" />
-                            <line nr="26" mi="0" ci="1" mb="0" cb="0" />
-                            <line nr="28" mi="1" ci="0" mb="0" cb="0" />
-                            <line nr="32" mi="0" ci="1" mb="0" cb="0" />
-                            <line nr="33" mi="0" ci="2" mb="0" cb="0" />
-                            <line nr="36" mi="0" ci="1" mb="0" cb="0" />
-                            <counter type="INSTRUCTION" missed="3" covered="16" />
-                            <counter type="LINE" missed="3" covered="14" />
-                            <counter type="METHOD" missed="0" covered="1" />
-                            <counter type="CLASS" missed="0" covered="1" />
-                        </sourcefile>
-                        <counter type="INSTRUCTION" missed="6" covered="33" />
-                        <counter type="LINE" missed="5" covered="29" />
-                        <counter type="METHOD" missed="2" covered="9" />
-                        <counter type="CLASS" missed="0" covered="4" />
-                    </package>
-                    <package name="CommonRoot/TestSubFolder">
-                        <class name="CommonRoot/TestSubFolder/TestScript3"
-                            sourcefilename="TestSubFolder/TestScript3.ps1">
-                            <method name="&lt;script&gt;" desc="()" line="1">
-                                <counter type="INSTRUCTION" missed="0" covered="1" />
-                                <counter type="LINE" missed="0" covered="1" />
-                                <counter type="METHOD" missed="0" covered="1" />
-                            </method>
-                            <counter type="INSTRUCTION" missed="0" covered="1" />
-                            <counter type="LINE" missed="0" covered="1" />
-                            <counter type="METHOD" missed="0" covered="1" />
-                            <counter type="CLASS" missed="0" covered="1" />
-                        </class>
-                        <sourcefile name="TestSubFolder/TestScript3.ps1">
-                            <line nr="1" mi="0" ci="1" mb="0" cb="0" />
-                            <counter type="INSTRUCTION" missed="0" covered="1" />
-                            <counter type="LINE" missed="0" covered="1" />
-                            <counter type="METHOD" missed="0" covered="1" />
-                            <counter type="CLASS" missed="0" covered="1" />
-                        </sourcefile>
-                        <counter type="INSTRUCTION" missed="0" covered="1" />
-                        <counter type="LINE" missed="0" covered="1" />
-                        <counter type="METHOD" missed="0" covered="1" />
-                        <counter type="CLASS" missed="0" covered="1" />
-                    </package>
-                    <counter type="INSTRUCTION" missed="6" covered="34" />
-                    <counter type="LINE" missed="5" covered="30" />
-                    <counter type="METHOD" missed="2" covered="10" />
-                    <counter type="CLASS" missed="0" covered="5" />
-                </report>
-                ')
-            }
-
-            It 'JaCoCo for CoverageGutters report must be correct' {
-                # when using output for CoverageGutters in VSCodethe output needs to be slightly different,
-                # paths need to be reported relative to the output file and sourcefile name must be just the
-                # file name, adding a new formatter, instead of changing the default one
-                [String]$jaCoCoReportXml = Get-JaCoCoReportXml -CommandCoverage $breakpoints -TotalMilliseconds 10000 -CoverageReport $coverageReport -Format "CoverageGutters"
+                [String]$jaCoCoReportXml = Get-JaCoCoReportXml -CommandCoverage $breakpoints -TotalMilliseconds 10000 -CoverageReport $coverageReport -ReportRoot $TestDrive
                 $jaCoCoReportXml = $jaCoCoReportXml -replace 'Pester \([^\)]*', 'Pester (date'
                 $jaCoCoReportXml = $jaCoCoReportXml -replace 'start="[0-9]*"', 'start=""'
                 $jaCoCoReportXml = $jaCoCoReportXml -replace 'dump="[0-9]*"', 'dump=""'
@@ -654,7 +462,7 @@ InPesterModuleScope {
             }
 
             It 'Cobertura report must be correct' {
-                [String]$coberturaReportXml = Get-CoberturaReportXml -TotalMilliseconds 10000 -CoverageReport $coverageReport
+                [String]$coberturaReportXml = Get-CoberturaReportXml -TotalMilliseconds 10000 -CoverageReport $coverageReport -ReportRoot $TestDrive
                 $coberturaReportXml = $coberturaReportXml -replace 'timestamp="[0-9]*"', 'timestamp=""'
                 $coberturaReportXml = $coberturaReportXml -replace "$([System.Environment]::NewLine)", ''
                 $coberturaReportXml = $coberturaReportXml.Replace($root, 'CommonRoot')
@@ -789,14 +597,14 @@ InPesterModuleScope {
 
             It 'JaCoCo returns empty string when there are 0 analyzed commands' {
                 $coverageReport = [PSCustomObject] @{ NumberOfCommandsAnalyzed = 0 }
-                [String]$jaCoCoReportXml = Get-JaCoCoReportXml -CommandCoverage @{} -TotalMilliseconds 10000 -CoverageReport $coverageReport -Format "CoverageGutters"
+                [String]$jaCoCoReportXml = Get-JaCoCoReportXml -CommandCoverage @{} -TotalMilliseconds 10000 -CoverageReport $coverageReport -ReportRoot $TestDrive
                 $jaCoCoReportXml | Should -Not -Be $null
                 $jaCoCoReportXml | Should -Be ([String]::Empty)
             }
 
             It 'Cobertura returns empty string when there are 0 analyzed commands' {
                 $coverageReport = [PSCustomObject] @{ NumberOfCommandsAnalyzed = 0 }
-                [String]$coberturaReportXml = Get-CoberturaReportXml -CoverageReport $coverageReport -TotalMilliseconds 10000
+                [String]$coberturaReportXml = Get-CoberturaReportXml -CoverageReport $coverageReport -TotalMilliseconds 10000 -ReportRoot $TestDrive
                 $coberturaReportXml | Should -Not -Be $null
                 $coberturaReportXml | Should -Be ([String]::Empty)
             }

--- a/tst/testProjectsForMissingCoverage/CoverageTestFile.Missing.Tests.ps1
+++ b/tst/testProjectsForMissingCoverage/CoverageTestFile.Missing.Tests.ps1
@@ -1,0 +1,4 @@
+Describe "Empty test file" {
+    It "Testing nothing" {
+    }
+}

--- a/tst/testProjectsForMissingCoverage/CoverageTestFile.Missing.Tests.ps1
+++ b/tst/testProjectsForMissingCoverage/CoverageTestFile.Missing.Tests.ps1
@@ -1,3 +1,5 @@
+Set-StrictMode -Version Latest
+
 Describe "Empty test file" {
     It "Testing nothing" {
     }

--- a/tst/testProjectsForMissingCoverage/CoverageTestFile.Missing.ps1
+++ b/tst/testProjectsForMissingCoverage/CoverageTestFile.Missing.ps1
@@ -1,0 +1,4 @@
+﻿function a {
+    "hello"
+    "not covered"
+}

--- a/tst/testProjectsForMissingCoverage/CoverageTestFile.Missing.ps1
+++ b/tst/testProjectsForMissingCoverage/CoverageTestFile.Missing.ps1
@@ -1,4 +1,4 @@
 ﻿function a {
-    "hello"
     "not covered"
+    "hello"
 }


### PR DESCRIPTION
<!-- Thank you for contributing to Pester! -->

## PR Summary

Add detection of repository root, to find a common path for reports and potentially other stuff. Simply look for .git folder, which is a common way we do it in other repos that works well, and .git is basically used everywhere. If not found use the working directory, which is most often the repo root anyway. User can override the value if it does not work for them. It allows CI tools to work well, because they usually care about relative paths to the checkout directory, without forcing all paths to absolute.

Remove CoverageGutters format from coverage, because it was just JaCoCo with the paths correctly formed against coverage.xml location, which was in the repo root.

Removes the "get common folder" function which returns result dependent on the files you provided to the coverage in non-obvious way.

Fix https://github.com/pester/Pester/issues/2668

## PR Checklist

- [x] PR has meaningful title
- [ x Summary describes changes
- [x] PR is ready to be merged
  - If not, use the arrow next to `Create Pull Request` to mark it as a draft. PR can be marked `Ready for review` when it's ready.
- [x] Tests are added/update *(if required)*
- [ ] Documentation is updated/added *(if required)*

<!-- Before you continue, please review [Contributing to Pester](https://pester.dev/docs/contributing/introduction).

Our continuous integration system doesn't send any notifications about failed tests. Please return to the opened pull request (after ~60 minutes) to check if everything is OK. -->
