### PR TITLE
Fix #2555 and #2561: Should-BeNull pipeline and escape chars in error messages

### DIFF
--- a/src/Format2.ps1
+++ b/src/Format2.ps1
@@ -50,6 +50,19 @@ function Format-String2 ($Value) {
         return '<empty>'
     }
 
+    # Escape control characters so they are visible in error messages.
+    # Without this, chars like ESC (0x1B used in ANSI sequences) are invisible
+    # and make error output confusing. See https://github.com/pester/Pester/issues/2561
+    $Value = $Value `
+        -replace "`0", '␀' `
+        -replace "`a", '␇' `
+        -replace "`b", '␈' `
+        -replace "`t", '␉' `
+        -replace "`f", '␌' `
+        -replace "`r", '␍' `
+        -replace "`n", '␊' `
+        -replace "`e", '␛'
+
     "'$Value'"
 }
 

--- a/src/functions/assert/General/Should-BeNull.ps1
+++ b/src/functions/assert/General/Should-BeNull.ps1
@@ -32,6 +32,15 @@
 
     $collectedInput = Collect-Input -ParameterInput $Actual -PipelineInput $local:Input -IsPipelineInput $MyInvocation.ExpectingInput -UnrollInput
     $Actual = $collectedInput.Actual
+
+    # When a function returns no output and the result is piped to Should-BeNull,
+    # PowerShell sends an empty array @() through the pipeline. Treat empty pipeline
+    # input as $null since "no output" is effectively null.
+    # See https://github.com/pester/Pester/issues/2555
+    if ($collectedInput.IsPipelineInput -and $Actual -is [array] -and $Actual.Count -eq 0) {
+        $Actual = $null
+    }
+
     if ($null -ne $Actual) {
         $Message = Get-AssertionMessage -Expected $null -Actual $Actual -Because $Because -DefaultMessage "Expected `$null,<because> but got <actualType> '<actual>'."
         throw [Pester.Factory]::CreateShouldErrorRecord($Message, $MyInvocation.ScriptName, $MyInvocation.ScriptLineNumber, $MyInvocation.Line.TrimEnd([System.Environment]::NewLine), $true)

--- a/tst/functions/assert/General/Should-BeNull.Tests.ps1
+++ b/tst/functions/assert/General/Should-BeNull.Tests.ps1
@@ -9,8 +9,15 @@ Describe "Should-BeNull" {
         { 1 | Should-BeNull } | Verify-AssertionFailed
     }
 
-    It "Given empty array it fails" {
-        { @() | Should-BeNull } | Verify-AssertionFailed
+    It "Given empty array piped it passes (void function output is empty array)" {
+        # When a function returns no output, PowerShell sends @() through the pipeline.
+        # Should-BeNull treats this as $null since "no output" is effectively null.
+        # See https://github.com/pester/Pester/issues/2555
+        @() | Should-BeNull
+    }
+
+    It "Given empty array by parameter it fails" {
+        { Should-BeNull -Actual @() } | Verify-AssertionFailed
     }
 
     It "Returns the given value" {


### PR DESCRIPTION
## Pester 6 Fixes (Copilot-driven)

Fixes two issues from the 6.0.0 milestone.

### Fix #2555: Should-BeNull treats empty pipeline input as null

When a function returns no output and the result is piped to Should-BeNull, PowerShell sends an empty array through the pipeline. Should-BeNull now recognizes this as "no output" and treats it as null, matching user expectations.

- Pipeline empty array: passes (void function output)
- Explicit parameter empty array: still fails (`Should-BeNull -Actual @()`)

### Fix #2561: Escape characters visible in assertion error messages

Format-String2 now escapes control characters as Unicode control pictures so they are visible in error messages instead of being invisible or corrupting terminal output.

| Character | Display |
|-----------|---------|
| NUL | U+2400 |
| BEL | U+2407 |
| BS | U+2408 |
| TAB | U+2409 |
| FF | U+240C |
| CR | U+240D |
| LF | U+240A |
| ESC | U+241B |

Before: `Expected [string] '', but got [string] '31;3;5m'.`
After: `Expected [string] 'hello', but got [string] 'U+241B[31m'.`

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>