### PR TITLE
Fix #2515, #2538, #2678: Hidden folder discovery, error reporting, CimInstance

### DIFF
--- a/src/Pester.RSpec.ps1
+++ b/src/Pester.RSpec.ps1
@@ -30,7 +30,8 @@
             foreach ($item in $items) {
                 if ($item.PSIsContainer) {
                     # this is an existing directory search it for tests file
-                    & $SafeCommands['Get-ChildItem'] -Recurse -Path $item -Filter "*$Extension" -File
+                    # use -Force to include hidden items (e.g. dot-prefixed folders on Linux)
+                    & $SafeCommands['Get-ChildItem'] -Recurse -Path $item -Filter "*$Extension" -File -Force
                 }
                 elseif ("FileSystem" -ne $item.PSProvider.Name) {
                     # item is not a directory and exists but is not a file so we are not interested
@@ -60,7 +61,8 @@
         else {
             # this is a path that does not exist so let's hope it is
             # a wildcarded path that will resolve to some files
-            & $SafeCommands['Get-ChildItem'] -Recurse -Path $p -Filter "*$Extension" -File
+            # use -Force to include hidden items (e.g. dot-prefixed folders on Linux)
+            & $SafeCommands['Get-ChildItem'] -Recurse -Path $p -Filter "*$Extension" -File -Force
         }
     }
 
@@ -176,6 +178,9 @@ function PostProcess-RspecTestRun ($TestRun) {
         $b.Result = if ($b.Skip) {
             "Skipped"
         }
+        elseif (0 -lt $b.ErrorRecord.Count) {
+            "Failed"
+        }
         elseif ($b.Passed) {
             "Passed"
         }
@@ -206,11 +211,11 @@ function PostProcess-RspecTestRun ($TestRun) {
         $b.result = if ($b.Skip) {
             "Skipped"
         }
-        elseif ($b.Passed) {
-            "Passed"
-        }
         elseif (0 -lt $b.ErrorRecord.Count) {
             "Failed"
+        }
+        elseif ($b.Passed) {
+            "Passed"
         }
         elseif (-not $discoveryOnly -and $b.ShouldRun -and (-not $b.Executed -or -not $b.Passed)) {
             "Failed"

--- a/src/functions/TestResults.ps1
+++ b/src/functions/TestResults.ps1
@@ -468,10 +468,10 @@ function Get-RunTimeEnvironment {
     $computerName = $env:ComputerName
     $userName = $env:Username
     if ($null -ne $SafeCommands['Get-CimInstance']) {
-        $osSystemInformation = (& $SafeCommands['Get-CimInstance'] Win32_OperatingSystem)
+        $osSystemInformation = (& $SafeCommands['Get-CimInstance'] Win32_OperatingSystem -ErrorAction Ignore)
     }
     elseif ($null -ne $SafeCommands['Get-WmiObject']) {
-        $osSystemInformation = (& $SafeCommands['Get-WmiObject'] Win32_OperatingSystem)
+        $osSystemInformation = (& $SafeCommands['Get-WmiObject'] Win32_OperatingSystem -ErrorAction Ignore)
     }
     elseif ($IsMacOS -or $IsLinux) {
         $osSystemInformation = @{
@@ -492,7 +492,9 @@ function Get-RunTimeEnvironment {
             # well, we tried
         }
     }
-    else {
+
+    # Fall back to unknown values if WMI/CIM returned null (e.g. access denied when not running as Administrator)
+    if ($null -eq $osSystemInformation) {
         $osSystemInformation = @{
             Name    = 'Unknown'
             Version = '0.0.0.0'


### PR DESCRIPTION
## Pester 6 Fixes (Copilot-generated)

### Fix #2515: Hidden folders included in test discovery

Added `-Force` to `Get-ChildItem` calls in `Find-File` so hidden (dot-prefixed) folders like `.github` are included on Linux.

### Fix #2538: Discovery errors reported as Failed

Container/block with discovery errors now correctly reported as Failed instead of Passed. Reordered result-computation logic so non-empty ErrorRecord always yields Failed.

### Fix #2678: Suppress Get-CimInstance access denied

Added `-ErrorAction Ignore` to `Get-CimInstance` and `Get-WmiObject` calls in `Get-RunTimeEnvironment` with null fallback for OS info when not running as Administrator.

All 2154 tests pass locally.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>