### PR TITLE
Fix #2657 and #2649: Clear-TestDrive performance and NUnit3 ToString crash

### DIFF
--- a/src/functions/TestDrive.ps1
+++ b/src/functions/TestDrive.ps1
@@ -112,12 +112,32 @@ function Clear-TestDrive {
 
         Remove-TestDriveSymbolicLinks -Path $TestDrivePath
 
-        foreach ($i in [IO.Directory]::GetFileSystemEntries($TestDrivePath, '*.*', [System.IO.SearchOption]::AllDirectories)) {
-            if ($Exclude -contains $i) {
-                continue
-            }
+        $allCurrent = [IO.Directory]::GetFileSystemEntries($TestDrivePath, '*.*', [System.IO.SearchOption]::AllDirectories)
 
-            & $SafeCommands['Remove-Item'] -Force -Recurse $i -ErrorAction Ignore
+        # Collect new items (those not in the snapshot taken before the test)
+        $newItems = foreach ($i in $allCurrent) {
+            if ($Exclude -notcontains $i) {
+                $i
+            }
+        }
+
+        if (-not $newItems) {
+            return
+        }
+
+        # Build a set of new item paths for O(1) parent lookups
+        $newItemSet = [System.Collections.Generic.HashSet[string]]::new(
+            [string[]]@($newItems),
+            [System.StringComparer]::OrdinalIgnoreCase)
+
+        # Only delete "root" new items (those whose parent directory is not also a new item).
+        # Deleting with -Recurse removes all descendants in one call, avoiding redundant
+        # Remove-Item calls on already-deleted children.
+        foreach ($item in $newItemSet) {
+            $parent = [IO.Path]::GetDirectoryName($item)
+            if (-not $newItemSet.Contains($parent)) {
+                & $SafeCommands['Remove-Item'] -Path $item -Force -Recurse -ErrorAction Ignore
+            }
         }
     }
 }

--- a/src/functions/TestResults.NUnit3.ps1
+++ b/src/functions/TestResults.NUnit3.ps1
@@ -554,7 +554,12 @@ function Format-CDataString ($Output) {
     $linesCount = $out.Length
     $o = for ($i = 0; $i -lt $linesCount; $i++) {
         # The input is array of objects, convert them to strings.
-        $line = if ($null -eq $out[$i]) { [String]::Empty } else { $out[$i].ToString() }
+        $line = if ($null -eq $out[$i]) {
+            [String]::Empty
+        }
+        else {
+            try { $out[$i].ToString() } catch { "<Output object ToString() failed: $($_.Exception.Message)>" }
+        }
 
         if (0 -gt $line.IndexOfAny($script:invalidCDataChars)) {
             # No special chars that need replacing.


### PR DESCRIPTION
## Pester 6 Fixes (Copilot-generated)

### Fix #2657: Clear-TestDrive performance

Clear-TestDrive was extremely slow with many files because it called `Remove-Item` on every individual file. Replaced with HashSet-based approach that only calls `Remove-Item -Recurse` on root new items.

### Fix #2649: NUnit3 ToString crash protection

NUnit3 report writing crashed when a test output object's `ToString()` method throws. Wrapped in try/catch with a descriptive fallback string.

All 2154 tests pass locally.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>