### PR TITLE
Fix #2678: Suppress Get-CimInstance access denied error

### DIFF
--- a/src/functions/TestResults.ps1
+++ b/src/functions/TestResults.ps1
@@ -468,10 +468,10 @@ function Get-RunTimeEnvironment {
     $computerName = $env:ComputerName
     $userName = $env:Username
     if ($null -ne $SafeCommands['Get-CimInstance']) {
-        $osSystemInformation = (& $SafeCommands['Get-CimInstance'] Win32_OperatingSystem)
+        $osSystemInformation = (& $SafeCommands['Get-CimInstance'] Win32_OperatingSystem -ErrorAction Ignore)
     }
     elseif ($null -ne $SafeCommands['Get-WmiObject']) {
-        $osSystemInformation = (& $SafeCommands['Get-WmiObject'] Win32_OperatingSystem)
+        $osSystemInformation = (& $SafeCommands['Get-WmiObject'] Win32_OperatingSystem -ErrorAction Ignore)
     }
     elseif ($IsMacOS -or $IsLinux) {
         $osSystemInformation = @{
@@ -492,7 +492,9 @@ function Get-RunTimeEnvironment {
             # well, we tried
         }
     }
-    else {
+
+    # Fall back to unknown values if WMI/CIM returned null (e.g. access denied when not running as Administrator)
+    if ($null -eq $osSystemInformation) {
         $osSystemInformation = @{
             Name    = 'Unknown'
             Version = '0.0.0.0'

--- a/tst/functions/TestResults.Tests.ps1
+++ b/tst/functions/TestResults.Tests.ps1
@@ -92,10 +92,10 @@ InPesterModuleScope {
 
     }
 
-    # Regression test for https://github.com/pester/Pester/issues/2678
+    # Regression tests for https://github.com/pester/Pester/issues/2678
     # Get-CimInstance can fail with access denied when not running as Administrator.
-    # The fix adds -ErrorAction Ignore and a fallback to prevent the entire test report
-    # from failing just because OS info is unavailable.
+    # The fix adds -ErrorAction Ignore and a fallback to Unknown values so the report
+    # is not broken just because OS info is unavailable.
     Describe "Get-RunTimeEnvironment" {
         It "Returns a hashtable with expected keys without throwing" {
             $result = Get-RunTimeEnvironment
@@ -106,13 +106,34 @@ InPesterModuleScope {
             $result.Keys | Should -Contain 'user'
             $result.Keys | Should -Contain 'cwd'
             $result.Keys | Should -Contain 'clr-version'
+            $result['os-version'] | Should -Not -BeNullOrEmpty
+            $result['platform']   | Should -Not -BeNullOrEmpty
         }
 
-        It "Returns non-null os-version and platform values" {
-            # Even with access denied, the fallback should provide 'Unknown' / '0.0.0.0'
-            $result = Get-RunTimeEnvironment
-            $result['os-version'] | Should -Not -BeNullOrEmpty
-            $result['platform'] | Should -Not -BeNullOrEmpty
+        It "Falls back to Unknown OS info when Get-CimInstance returns null (access denied)" -Skip:(-not $IsWindows) {
+            # Simulate -ErrorAction Ignore swallowing an access-denied error: the call returns $null.
+            # Before the fix, $osSystemInformation stayed $null and $osSystemInformation.Version
+            # silently produced $null fields in the report; an ugly access-denied error was also
+            # printed because -ErrorAction Ignore was missing.
+            $originalCim = $SafeCommands['Get-CimInstance']
+            $originalWmi = $SafeCommands['Get-WmiObject']
+            try {
+                $SafeCommands['Get-CimInstance'] = { param($Class) }
+                if ($null -ne $originalWmi) {
+                    $SafeCommands['Get-WmiObject'] = { param($Class) }
+                }
+
+                $result = Get-RunTimeEnvironment
+
+                $result['platform']   | Should -Be 'Unknown'
+                $result['os-version'] | Should -Be '0.0.0.0'
+            }
+            finally {
+                $SafeCommands['Get-CimInstance'] = $originalCim
+                if ($null -ne $originalWmi) {
+                    $SafeCommands['Get-WmiObject'] = $originalWmi
+                }
+            }
         }
     }
 }

--- a/tst/functions/TestResults.Tests.ps1
+++ b/tst/functions/TestResults.Tests.ps1
@@ -91,4 +91,28 @@ InPesterModuleScope {
         Pop-Location
 
     }
+
+    # Regression test for https://github.com/pester/Pester/issues/2678
+    # Get-CimInstance can fail with access denied when not running as Administrator.
+    # The fix adds -ErrorAction Ignore and a fallback to prevent the entire test report
+    # from failing just because OS info is unavailable.
+    Describe "Get-RunTimeEnvironment" {
+        It "Returns a hashtable with expected keys without throwing" {
+            $result = Get-RunTimeEnvironment
+            $result | Should -BeOfType [hashtable]
+            $result.Keys | Should -Contain 'os-version'
+            $result.Keys | Should -Contain 'platform'
+            $result.Keys | Should -Contain 'machine-name'
+            $result.Keys | Should -Contain 'user'
+            $result.Keys | Should -Contain 'cwd'
+            $result.Keys | Should -Contain 'clr-version'
+        }
+
+        It "Returns non-null os-version and platform values" {
+            # Even with access denied, the fallback should provide 'Unknown' / '0.0.0.0'
+            $result = Get-RunTimeEnvironment
+            $result['os-version'] | Should -Not -BeNullOrEmpty
+            $result['platform'] | Should -Not -BeNullOrEmpty
+        }
+    }
 }


### PR DESCRIPTION
Fix #2678

Added `-ErrorAction Ignore` to `Get-CimInstance` and `Get-WmiObject` calls in `Get-RunTimeEnvironment` with null fallback when not running as Administrator.

Copilot-generated fix.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>