### PR TITLE
Fix #2649: Catch ToString() exceptions in NUnit3 output

### DIFF
--- a/src/functions/TestResults.NUnit3.ps1
+++ b/src/functions/TestResults.NUnit3.ps1
@@ -554,7 +554,12 @@ function Format-CDataString ($Output) {
     $linesCount = $out.Length
     $o = for ($i = 0; $i -lt $linesCount; $i++) {
         # The input is array of objects, convert them to strings.
-        $line = if ($null -eq $out[$i]) { [String]::Empty } else { $out[$i].ToString() }
+        $line = if ($null -eq $out[$i]) {
+            [String]::Empty
+        }
+        else {
+            try { $out[$i].ToString() } catch { "<Output object ToString() failed: $($_.Exception.Message)>" }
+        }
 
         if (0 -gt $line.IndexOfAny($script:invalidCDataChars)) {
             # No special chars that need replacing.

--- a/tst/Pester.RSpec.TestResults.NUnit3.ts.ps1
+++ b/tst/Pester.RSpec.TestResults.NUnit3.ts.ps1
@@ -955,4 +955,42 @@ i -PassThru:$PassThru {
             $xmlResult.Validate({ throw $args[1].Exception })
         }
     }
+
+    # Regression test for https://github.com/pester/Pester/issues/2649
+    # When a test outputs an object whose ToString() throws, the NUnit3 report
+    # writer (Format-CDataString) would crash, losing the entire report.
+    # The fix wraps ToString() in try/catch and uses a fallback string.
+    b "NUnit3 report handles objects with broken ToString()" {
+        t "should produce valid report when test output object throws on ToString" {
+            $sb = {
+                Describe 'Describe' {
+                    It 'Outputs broken object' {
+                        # Output an object whose ToString() will throw
+                        $broken = [PSCustomObject]@{ Name = 'X' }
+                        $broken | Add-Member -MemberType ScriptMethod -Name ToString -Force -Value {
+                            throw [System.InvalidOperationException]::new('ToString failed')
+                        }
+                        $broken
+                        $true | Should -Be $true
+                    }
+                }
+            }
+
+            $r = Invoke-Pester -Configuration ([PesterConfiguration]@{
+                Run    = @{ ScriptBlock = $sb; PassThru = $true }
+                Output = @{ Verbosity = 'None' }
+            })
+
+            # The test itself should pass
+            $r.Result | Verify-Equal 'Passed'
+
+            # Converting to NUnit3 report should NOT throw
+            $xmlResult = $r | ConvertTo-NUnitReport -Format NUnit3
+
+            # The output section should contain the fallback message
+            $xmlTest = $xmlResult.'test-run'.'test-suite'.'test-suite'.'test-case'
+            $xmlTest.result | Verify-Equal 'Passed'
+            $xmlTest.output.'#cdata-section' | Verify-Like '*ToString() failed*'
+        }
+    }
 }


### PR DESCRIPTION
Fix #2649

NUnit3 report writing crashed when a test output object's `ToString()` method throws. Wrapped in try/catch with a descriptive fallback string.

Copilot-generated fix.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>