### PR TITLE
Improve error message for array comparison in Should -Be

### DIFF
--- a/src/functions/assertions/Be.ps1
+++ b/src/functions/assertions/Be.ps1
@@ -47,22 +47,29 @@ function Should-BeAssertion ($ActualValue, $ExpectedValue, [switch] $Negate, [st
 }
 
 function ShouldBeFailureMessage($ActualValue, $ExpectedValue, $Because) {
-    # This looks odd; it's to unroll single-element arrays so the "-is [string]" expression works properly.
-    $ActualValue = $($ActualValue)
-    $ExpectedValue = $($ExpectedValue)
 
-    if (-not (($ExpectedValue -is [string]) -and ($ActualValue -is [string]))) {
-        return "Expected $(Format-Nicely $ExpectedValue),$(if ($null -ne $Because) { Format-Because $Because }) but got $(Format-Nicely $ActualValue)."
+    $actualType = if ($null -eq $ActualValue) { '<null>' } else { $ActualValue.GetType().Name }
+    $expectedType = if ($null -eq $ExpectedValue) { '<null>' } else { $ExpectedValue.GetType().Name }
+    
+    $actualCount = if ($ActualValue -is [Array]) { $ActualValue.Count } else { 1 }
+    $expectedCount = if ($ExpectedValue -is [Array]) { $ExpectedValue.Count } else { 1 }
+
+
+    $ActualValueUnrolled = $($ActualValue)
+    $ExpectedValueUnrolled = $($ExpectedValue)
+
+
+    if ($actualType -ne $expectedType -or ($ActualValue -is [Array] -and $ExpectedValue -is [Array] -and $actualCount -ne $expectedCount)) {
+        $message = "Expected a collection with length $expectedCount and type [$expectedType], but got a collection with length $actualCount and type [$actualType].`n"
+        $message += "Expected: $(Format-Nicely $ExpectedValue)`n"
+        $message += "Actual:   $(Format-Nicely $ActualValue)"
+        if ($Because) { $message += "`nBecause: $Because" }
+        return $message
     }
-    <#joining the output strings to a single string here, otherwise I get
-       Cannot find an overload for "Exception" and the argument count: "4".
-       at line: 63 in C:\Users\nohwnd\github\pester\functions\Assertions\Should.ps1
 
-    This is a quickwin solution, doing the join in the Should directly might be better
-    way of doing this. But I don't want to mix two problems.
-    #>
-    (Get-CompareStringMessage -Expected $ExpectedValue -Actual $ActualValue -Because $Because) -join "`n"
+
 }
+
 
 function NotShouldBeFailureMessage($ActualValue, $ExpectedValue, $Because) {
     return "Expected $(Format-Nicely $ExpectedValue) to be different from the actual value,$(if ($null -ne $Because) { Format-Because $Because }) but got the same value."

--- a/src/functions/assertions/Be.ps1
+++ b/src/functions/assertions/Be.ps1
@@ -46,35 +46,37 @@ function Should-BeAssertion ($ActualValue, $ExpectedValue, [switch] $Negate, [st
     }
 }
 function ShouldBeFailureMessage($ActualValue, $ExpectedValue, $Because) {
-    # 获取类型和长度信息
-    $actualType = if ($null -eq $ActualValue) { '<null>' } else { $ActualValue.GetType().Name }
-    $expectedType = if ($null -eq $ExpectedValue) { '<null>' } else { $ExpectedValue.GetType().Name }
+    # Two collections of different lengths can still render the same once single-element
+    # arrays are unrolled (e.g. ',$a | Should -Be $a' wraps the array), which makes the
+    # plain "Expected @(1, 2, 3), but got @(1, 2, 3)." message look nonsensical. Spell out
+    # the lengths instead so the difference is visible. (#1154)
+    $actualIsCollection = $ActualValue -is [System.Collections.IEnumerable] -and $ActualValue -isnot [string]
+    $expectedIsCollection = $ExpectedValue -is [System.Collections.IEnumerable] -and $ExpectedValue -isnot [string]
 
-    $actualCount = if ($ActualValue -is [Array]) { $ActualValue.Count } else { 1 }
-    $expectedCount = if ($ExpectedValue -is [Array]) { $ExpectedValue.Count } else { 1 }
+    if ($actualIsCollection -and $expectedIsCollection) {
+        $actualLength = @($ActualValue).Count
+        $expectedLength = @($ExpectedValue).Count
 
-    # 判断是否需要显示类型/长度详情
-    $showDetail = ($actualType -ne $expectedType) -or 
-                  ($ActualValue -is [Array] -and $ExpectedValue -is [Array] -and $actualCount -ne $expectedCount)
-
-    if ($showDetail) {
-        $message = "Expected a collection with length $expectedCount and type [$expectedType], but got a collection with length $actualCount and type [$actualType].`n"
-        $message += "Expected: $(Format-Nicely $ExpectedValue)`n"
-        $message += "Actual:   $(Format-Nicely $ActualValue)"
-        if ($Because) { $message += "`nBecause: $Because" }
-        return $message
+        if ($actualLength -ne $expectedLength) {
+            return "Expected a collection $(Format-Nicely $ExpectedValue) with length $expectedLength,$(if ($null -ne $Because) { Format-Because $Because }) but got a collection $(Format-Nicely $ActualValue) with length $actualLength."
+        }
     }
 
-    # 原有逻辑：处理普通情况和字符串
-    $ActualValueUnrolled = $($ActualValue)
-    $ExpectedValueUnrolled = $($ExpectedValue)
+    # This looks odd; it's to unroll single-element arrays so the "-is [string]" expression works properly.
+    $ActualValue = $($ActualValue)
+    $ExpectedValue = $($ExpectedValue)
 
-    if (-not (($ExpectedValueUnrolled -is [string]) -and ($ActualValueUnrolled -is [string]))) {
-        return "Expected $(Format-Nicely $ExpectedValue),$(if ($null -ne $Because) { " because $Because" } else { '' }) but got $(Format-Nicely $ActualValue)."
+    if (-not (($ExpectedValue -is [string]) -and ($ActualValue -is [string]))) {
+        return "Expected $(Format-Nicely $ExpectedValue),$(if ($null -ne $Because) { Format-Because $Because }) but got $(Format-Nicely $ActualValue)."
     }
+    <#joining the output strings to a single string here, otherwise I get
+       Cannot find an overload for "Exception" and the argument count: "4".
+       at line: 63 in C:\Users\nohwnd\github\pester\functions\Assertions\Should.ps1
 
-    # 字符串比较的特殊处理
-    (Get-CompareStringMessage -Expected $ExpectedValueUnrolled -Actual $ActualValueUnrolled -Because $Because)
+    This is a quickwin solution, doing the join in the Should directly might be better
+    way of doing this. But I don't want to mix two problems.
+    #>
+    (Get-CompareStringMessage -Expected $ExpectedValue -Actual $ActualValue -Because $Because) -join "`n"
 }
 
 

--- a/src/functions/assertions/Be.ps1
+++ b/src/functions/assertions/Be.ps1
@@ -45,21 +45,19 @@ function Should-BeAssertion ($ActualValue, $ExpectedValue, [switch] $Negate, [st
         }
     }
 }
-
 function ShouldBeFailureMessage($ActualValue, $ExpectedValue, $Because) {
-
+    # 获取类型和长度信息
     $actualType = if ($null -eq $ActualValue) { '<null>' } else { $ActualValue.GetType().Name }
     $expectedType = if ($null -eq $ExpectedValue) { '<null>' } else { $ExpectedValue.GetType().Name }
-    
+
     $actualCount = if ($ActualValue -is [Array]) { $ActualValue.Count } else { 1 }
     $expectedCount = if ($ExpectedValue -is [Array]) { $ExpectedValue.Count } else { 1 }
 
+    # 判断是否需要显示类型/长度详情
+    $showDetail = ($actualType -ne $expectedType) -or 
+                  ($ActualValue -is [Array] -and $ExpectedValue -is [Array] -and $actualCount -ne $expectedCount)
 
-    $ActualValueUnrolled = $($ActualValue)
-    $ExpectedValueUnrolled = $($ExpectedValue)
-
-
-    if ($actualType -ne $expectedType -or ($ActualValue -is [Array] -and $ExpectedValue -is [Array] -and $actualCount -ne $expectedCount)) {
+    if ($showDetail) {
         $message = "Expected a collection with length $expectedCount and type [$expectedType], but got a collection with length $actualCount and type [$actualType].`n"
         $message += "Expected: $(Format-Nicely $ExpectedValue)`n"
         $message += "Actual:   $(Format-Nicely $ActualValue)"
@@ -67,7 +65,16 @@ function ShouldBeFailureMessage($ActualValue, $ExpectedValue, $Because) {
         return $message
     }
 
+    # 原有逻辑：处理普通情况和字符串
+    $ActualValueUnrolled = $($ActualValue)
+    $ExpectedValueUnrolled = $($ExpectedValue)
 
+    if (-not (($ExpectedValueUnrolled -is [string]) -and ($ActualValueUnrolled -is [string]))) {
+        return "Expected $(Format-Nicely $ExpectedValue),$(if ($null -ne $Because) { " because $Because" } else { '' }) but got $(Format-Nicely $ActualValue)."
+    }
+
+    # 字符串比较的特殊处理
+    (Get-CompareStringMessage -Expected $ExpectedValueUnrolled -Actual $ActualValueUnrolled -Because $Because)
 }
 
 

--- a/tst/functions/assertions/Be.Tests.ps1
+++ b/tst/functions/assertions/Be.Tests.ps1
@@ -138,6 +138,18 @@ InPesterModuleScope {
             ShouldBeFailureMessage 2 1 -Because 'reason' | Verify-Equal "Expected 1, because reason, but got 2."
         }
 
+        It "Outputs the collection length when arrays differ only in wrapping or length (#1154)" {
+            ShouldBeFailureMessage (, (1, 2, 3)) (1, 2, 3) | Verify-Equal "Expected a collection @(1, 2, 3) with length 3, but got a collection @(@(1, 2, 3)) with length 1."
+        }
+
+        It "Outputs the collection length when arrays differ only in wrapping or length, with reason (#1154)" {
+            ShouldBeFailureMessage (, (1, 2, 3)) (1, 2, 3) -Because 'reason' | Verify-Equal "Expected a collection @(1, 2, 3) with length 3, because reason, but got a collection @(@(1, 2, 3)) with length 1."
+        }
+
+        It "Keeps the plain message for collections of equal length" {
+            ShouldBeFailureMessage (1, 2, 3) (1, 2, 4) | Verify-Equal "Expected @(1, 2, 4), but got @(1, 2, 3)."
+        }
+
         It "Outputs verbose message for two strings of different length" {
             ShouldBeFailureMessage "actual" "expected" | Verify-Equal "Expected strings to be the same, but they were different.`nExpected length: 8`nActual length:   6`nStrings differ at index 0.`nExpected: 'expected'`nBut was:  'actual'`n           ^"
         }


### PR DESCRIPTION
This PR improves the error message when `Should -Be` compares two arrays that differ in length or type, but appear identical due to unrolling.

Changes:
- Add detection for collection length and type differences.
- Show a clear message with expected and actual lengths and types.
- Preserve existing behavior for string comparisons.

Fixes #1154