### PR TITLE
Enhance module compatibility: support nested module resolution slash notation

### DIFF
--- a/src/functions/InModuleScope.ps1
+++ b/src/functions/InModuleScope.ps1
@@ -156,10 +156,10 @@
     Set-ScriptBlockScope -ScriptBlock $ScriptBlock -SessionState $sessionState
     Set-ScriptBlockScope -ScriptBlock $wrapper -SessionState $sessionState
     $splat = @{
-        ScriptBlock    = $ScriptBlock
-        Parameters     = $Parameters
-        ArgumentList   = $ArgumentList
-        SessionState   = $sessionState
+        ScriptBlock  = $ScriptBlock
+        Parameters   = $Parameters
+        ArgumentList = $ArgumentList
+        SessionState = $sessionState
     }
 
     Write-ScriptBlockInvocationHint -Hint "InModuleScope" -ScriptBlock $ScriptBlock
@@ -172,6 +172,84 @@ function Get-CompatibleModule {
         [Parameter(Mandatory = $true)]
         [string] $ModuleName
     )
+
+    # Slash/backslash notation: RootModule/NestedModule[/DeeperNestedModule...]
+    # Resolves the full nested path from left to right so deeply nested modules can be targeted.
+    if ($ModuleName -match '[/\\]') {
+        # Split on / or \ and trim whitespace from each segment.
+        $modulePathSegments = @($ModuleName -split '[/\\]')
+        $modulePathSegments = @($modulePathSegments | & $SafeCommands['ForEach-Object'] { $_.Trim() })
+        $hasEmptySegment = @($modulePathSegments | & $SafeCommands['Where-Object'] { [string]::IsNullOrEmpty($_) }).Count -gt 0
+
+        # Require at least two non-empty segments (root + one nested level).
+        if ($modulePathSegments.Count -lt 2 -or $hasEmptySegment) {
+            throw "Invalid ModuleName format '$ModuleName'. Expected format: 'RootModuleName/NestedModuleName[/DeeperNestedModuleName...]'."
+        }
+
+        # Seed the search with all copies of the root module (Get-Module -All covers reimports).
+        $rootModuleName = $modulePathSegments[0]
+        if ($PesterPreference.Debug.WriteDebugMessages.Value) {
+            Write-PesterDebugMessage -Scope Runtime "Nested path notation detected in ModuleName '$ModuleName'. Resolving from root module '$rootModuleName'."
+        }
+
+        $currentModules = @(& $SafeCommands['Get-Module'] -Name $rootModuleName -All -ErrorAction SilentlyContinue)
+        if ($currentModules.Count -eq 0) {
+            throw "No modules named '$rootModuleName' are currently loaded."
+        }
+
+        # Walk each path segment after the root, narrowing $currentModules to the matched nested module at each level.
+        $resolvedPath = $rootModuleName
+        for ($index = 1; $index -lt $modulePathSegments.Count; $index++) {
+            $nestedModuleName = $modulePathSegments[$index]
+            $nextModules = [System.Collections.Generic.List[object]]@()      # matches for this segment
+            $availableNested = [System.Collections.Generic.List[string]]@()  # all sibling names, for error messages
+
+            if ($PesterPreference.Debug.WriteDebugMessages.Value) {
+                Write-PesterDebugMessage -Scope Runtime "Resolving nested module segment '$nestedModuleName' under '$resolvedPath'."
+            }
+
+            # Scan NestedModules of every candidate at the current level.
+            foreach ($parentModule in $currentModules) {
+                foreach ($nestedModule in @($parentModule.NestedModules)) {
+                    # Collect unique sibling names so the error message can list available options.
+                    if (-not [string]::IsNullOrEmpty($nestedModule.Name) -and -not $availableNested.Contains($nestedModule.Name)) {
+                        $availableNested.Add($nestedModule.Name)
+                    }
+
+                    if ($nestedModule.Name -eq $nestedModuleName) {
+                        $nextModules.Add($nestedModule)
+                    }
+                }
+            }
+
+            # No match: segment name is wrong or the nested module is not loaded.
+            if ($nextModules.Count -eq 0) {
+                $availableList = if ($availableNested.Count -gt 0) { $availableNested -join ', ' } else { '(none)' }
+                throw "No nested module named '$nestedModuleName' was found under '$resolvedPath'. Available nested modules: $availableList."
+            }
+
+            # More than one match: ambiguous — multiple loaded copies of the same module exist.
+            if ($nextModules.Count -gt 1) {
+                throw "Multiple nested modules named '$nestedModuleName' were found under '$resolvedPath' across loaded module copies. Make sure to remove any extra copies of the module from your session before testing."
+            }
+
+            $resolvedNested = $nextModules[0]
+            # Only Script/Manifest modules expose a usable session state for InModuleScope.
+            if ($resolvedNested.ModuleType -notin 'Script', 'Manifest') {
+                throw "Nested module '$nestedModuleName' in path '$resolvedPath/$nestedModuleName' is not a Script or Manifest module. Detected module type: '$($resolvedNested.ModuleType)'."
+            }
+
+            # Narrow to the single resolved module and advance the path tracker for the next iteration.
+            $currentModules = @($resolvedNested)
+            $resolvedPath = "$resolvedPath/$nestedModuleName"
+        }
+
+        if ($PesterPreference.Debug.WriteDebugMessages.Value) {
+            Write-PesterDebugMessage -Scope Runtime "Found nested module $($currentModules[0].Name) version $($currentModules[0].Version) in path $resolvedPath."
+        }
+
+        return $currentModules[0]
+    }
 
     try {
         if ($PesterPreference.Debug.WriteDebugMessages.Value) {

--- a/src/functions/Mock.ps1
+++ b/src/functions/Mock.ps1
@@ -662,6 +662,11 @@ function Resolve-Command {
                 Write-PesterDebugMessage -Scope Mock "Found module $($module.Name) version $($module.Version)."
             }
 
+            # Normalize $ModuleName to the plain module name in case slash notation ('Root/Nested')
+            # was used. All downstream uses (TargetModule, mock-table keys, IsFromTargetModule) must
+            # use the plain name, not the slash string.
+            $ModuleName = $module.Name
+
             # this is the target session state in which we will insert the mock
             $SessionState = $module.SessionState
         }

--- a/tst/functions/InModuleScope.Tests.ps1
+++ b/tst/functions/InModuleScope.Tests.ps1
@@ -234,27 +234,23 @@ Describe 'Get-CompatibleModule' {
         }
     }
 
-    Context 'when two root modules share a nested module name (disambiguation use-case)' {
+    Context 'when two root modules have a nested module with the SAME name (disambiguation use-case)' {
         BeforeAll {
             $sharedNestedName = 'SharedRepository'
             $rootA = 'ClientA'
             $rootB = 'ClientB'
-            $manifestA = "TestDrive:/$rootA.psd1"
-            $manifestB = "TestDrive:/$rootB.psd1"
-            $nestedA = "TestDrive:/$sharedNestedName`_A.psm1"
-            $nestedB = "TestDrive:/$sharedNestedName`_B.psm1"
-            # Both root modules have a nested module called 'SharedRepository'
-            Set-Content -Path $nestedA -Value '[string]$Script:RepoId = "RepoA"'
-            Set-Content -Path $nestedB -Value '[string]$Script:RepoId = "RepoB"'
-            # Rename nested copies so they each load as 'SharedRepository' (same base name)
-            $nestedPathA = "TestDrive:/$sharedNestedName.psm1"
-            $nestedPathB = "TestDrive:/B_$sharedNestedName.psm1"
-            Set-Content -Path $nestedPathA -Value '[string]$Script:RepoId = "RepoA"'
-            Set-Content -Path $nestedPathB -Value '[string]$Script:RepoId = "RepoB"'
-            New-ModuleManifest -Path $manifestA -NestedModules ".\$sharedNestedName.psm1"
-            New-ModuleManifest -Path $manifestB -NestedModules ".\B_$sharedNestedName.psm1"
-            Import-Module $manifestA -Force
-            Import-Module $manifestB -Force
+
+            # Two nested modules with the *same* base name in different folders, so both load
+            # as 'SharedRepository'. A plain -ModuleName is then ambiguous and slash notation is
+            # required to pick one. Each copy stamps a different value so we can prove which one
+            # was resolved by its content, not just by its name.
+            $null = New-Item -ItemType Directory -Path "TestDrive:/A", "TestDrive:/B"
+            Set-Content -Path "TestDrive:/A/$sharedNestedName.psm1" -Value '[string]$Script:RepoId = "RepoA"'
+            Set-Content -Path "TestDrive:/B/$sharedNestedName.psm1" -Value '[string]$Script:RepoId = "RepoB"'
+            New-ModuleManifest -Path "TestDrive:/$rootA.psd1" -NestedModules ".\A\$sharedNestedName.psm1"
+            New-ModuleManifest -Path "TestDrive:/$rootB.psd1" -NestedModules ".\B\$sharedNestedName.psm1"
+            Import-Module "TestDrive:/$rootA.psd1" -Force
+            Import-Module "TestDrive:/$rootB.psd1" -Force
         }
 
         AfterAll {
@@ -262,11 +258,20 @@ Describe 'Get-CompatibleModule' {
             Get-Module $rootB -ErrorAction SilentlyContinue | Remove-Module -Force
         }
 
-        It 'should resolve to ClientA nested module via slash notation' {
-            $name = InModuleScope -ModuleName "$rootA/$sharedNestedName" -ScriptBlock {
-                $ExecutionContext.SessionState.Module.Name
-            }
-            $name | Should -Be $sharedNestedName
+        It 'loads both nested modules under the same name, so a plain name is ambiguous' {
+            # Guard: proves the scenario actually exercises disambiguation. If only one module
+            # named SharedRepository were loaded, slash notation would add nothing here.
+            @(Get-Module $sharedNestedName -All).Count | Should -BeGreaterThan 1
+        }
+
+        It 'resolves to the ClientA copy via slash notation (verified by content)' {
+            $repoId = InModuleScope -ModuleName "$rootA/$sharedNestedName" -ScriptBlock { $Script:RepoId }
+            $repoId | Should -Be 'RepoA'
+        }
+
+        It 'resolves to the ClientB copy via slash notation (verified by content)' {
+            $repoId = InModuleScope -ModuleName "$rootB/$sharedNestedName" -ScriptBlock { $Script:RepoId }
+            $repoId | Should -Be 'RepoB'
         }
     }
 }

--- a/tst/functions/InModuleScope.Tests.ps1
+++ b/tst/functions/InModuleScope.Tests.ps1
@@ -125,6 +125,150 @@ Describe 'Get-CompatibleModule' {
         }
     }
 
+    Context 'when module name uses slash notation RootModule/NestedModule' {
+        BeforeAll {
+            $nestedModuleName = 'NestedModule'
+            $rootModuleName = 'RootWithNestedModule'
+            $moduleManifestPath = "TestDrive:/$rootModuleName.psd1"
+            $nestedScriptPath = "TestDrive:/$nestedModuleName.psm1"
+            Set-Content -Path $nestedScriptPath -Value '[string]$Script:NestedVar = "NestedValue"'
+            New-ModuleManifest -Path $moduleManifestPath -NestedModules ".\$nestedModuleName.psm1"
+            Import-Module $moduleManifestPath -Force
+        }
+
+        AfterAll {
+            Get-Module $rootModuleName -ErrorAction SilentlyContinue | Remove-Module -Force
+        }
+
+        It 'should return the nested module via forward-slash delimiter' {
+            $moduleInfo = InPesterModuleScope { Get-CompatibleModule -ModuleName 'RootWithNestedModule/NestedModule' }
+            $moduleInfo | Should -Not -BeNullOrEmpty
+            @($moduleInfo).Count | Should -Be 1
+            $moduleInfo.Name | Should -Be 'NestedModule'
+            $moduleInfo.ModuleType | Should -Be 'Script'
+        }
+
+        It 'should return the nested module via backslash delimiter' {
+            $moduleInfo = InPesterModuleScope { Get-CompatibleModule -ModuleName 'RootWithNestedModule\NestedModule' }
+            $moduleInfo | Should -Not -BeNullOrEmpty
+            @($moduleInfo).Count | Should -Be 1
+            $moduleInfo.Name | Should -Be 'NestedModule'
+            $moduleInfo.ModuleType | Should -Be 'Script'
+        }
+
+        It 'should execute in the nested module session state' {
+            $name = InModuleScope -ModuleName 'RootWithNestedModule/NestedModule' -ScriptBlock {
+                $ExecutionContext.SessionState.Module.Name
+            }
+            $name | Should -Be 'NestedModule'
+        }
+
+        It 'should read a variable defined in the nested module' {
+            InModuleScope -ModuleName 'RootWithNestedModule/NestedModule' -ScriptBlock {
+                $Script:NestedVar | Should -Be 'NestedValue'
+            }
+        }
+
+        It 'should throw when root module is not loaded' {
+            $sb = { InPesterModuleScope { Get-CompatibleModule -ModuleName 'NonExistentRoot/NestedModule' } }
+            $sb | Should -Throw "No modules named 'NonExistentRoot' are currently loaded."
+        }
+
+        It 'should throw with available names when nested module is not found in root' {
+            $sb = { InPesterModuleScope { Get-CompatibleModule -ModuleName 'RootWithNestedModule/NoSuchNested' } }
+            $sb | Should -Throw "No nested module named 'NoSuchNested' was found under 'RootWithNestedModule'*"
+        }
+    }
+
+    Context 'when module name uses deep slash notation RootModule/NestedModule/LeafModule' {
+        BeforeAll {
+            $rootModuleName = 'DeepRootModule'
+            $midModuleName = 'DeepMidModule'
+            $leafModuleName = 'DeepLeafModule'
+
+            $rootManifestPath = "TestDrive:/$rootModuleName.psd1"
+            $midManifestPath = "TestDrive:/$midModuleName.psd1"
+            $leafScriptPath = "TestDrive:/$leafModuleName.psm1"
+
+            Set-Content -Path $leafScriptPath -Value '[string]$Script:DeepNestedVar = "DeepNestedValue"'
+            New-ModuleManifest -Path $midManifestPath -NestedModules ".\$leafModuleName.psm1"
+            New-ModuleManifest -Path $rootManifestPath -NestedModules ".\$midModuleName.psd1"
+
+            Import-Module $rootManifestPath -Force
+        }
+
+        AfterAll {
+            Get-Module $rootModuleName -ErrorAction SilentlyContinue | Remove-Module -Force
+        }
+
+        It 'should resolve the leaf module via forward-slash deep path' {
+            $moduleInfo = InPesterModuleScope { Get-CompatibleModule -ModuleName 'DeepRootModule/DeepMidModule/DeepLeafModule' }
+            $moduleInfo | Should -Not -BeNullOrEmpty
+            $moduleInfo.Name | Should -Be 'DeepLeafModule'
+            $moduleInfo.ModuleType | Should -Be 'Script'
+        }
+
+        It 'should resolve the leaf module via mixed slash and backslash deep path' {
+            $moduleInfo = InPesterModuleScope { Get-CompatibleModule -ModuleName 'DeepRootModule\DeepMidModule/DeepLeafModule' }
+            $moduleInfo | Should -Not -BeNullOrEmpty
+            $moduleInfo.Name | Should -Be 'DeepLeafModule'
+            $moduleInfo.ModuleType | Should -Be 'Script'
+        }
+
+        It 'should execute in the deeply nested module session state' {
+            $name = InModuleScope -ModuleName 'DeepRootModule/DeepMidModule/DeepLeafModule' -ScriptBlock {
+                $ExecutionContext.SessionState.Module.Name
+            }
+            $name | Should -Be 'DeepLeafModule'
+        }
+
+        It 'should read a variable defined in the deeply nested module' {
+            InModuleScope -ModuleName 'DeepRootModule/DeepMidModule/DeepLeafModule' -ScriptBlock {
+                $Script:DeepNestedVar | Should -Be 'DeepNestedValue'
+            }
+        }
+
+        It 'should throw with available names when a deeper nested segment is not found' {
+            $sb = { InPesterModuleScope { Get-CompatibleModule -ModuleName 'DeepRootModule/DeepMidModule/NoSuchLeaf' } }
+            $sb | Should -Throw "No nested module named 'NoSuchLeaf' was found under 'DeepRootModule/DeepMidModule'*"
+        }
+    }
+
+    Context 'when two root modules share a nested module name (disambiguation use-case)' {
+        BeforeAll {
+            $sharedNestedName = 'SharedRepository'
+            $rootA = 'ClientA'
+            $rootB = 'ClientB'
+            $manifestA = "TestDrive:/$rootA.psd1"
+            $manifestB = "TestDrive:/$rootB.psd1"
+            $nestedA = "TestDrive:/$sharedNestedName`_A.psm1"
+            $nestedB = "TestDrive:/$sharedNestedName`_B.psm1"
+            # Both root modules have a nested module called 'SharedRepository'
+            Set-Content -Path $nestedA -Value '[string]$Script:RepoId = "RepoA"'
+            Set-Content -Path $nestedB -Value '[string]$Script:RepoId = "RepoB"'
+            # Rename nested copies so they each load as 'SharedRepository' (same base name)
+            $nestedPathA = "TestDrive:/$sharedNestedName.psm1"
+            $nestedPathB = "TestDrive:/B_$sharedNestedName.psm1"
+            Set-Content -Path $nestedPathA -Value '[string]$Script:RepoId = "RepoA"'
+            Set-Content -Path $nestedPathB -Value '[string]$Script:RepoId = "RepoB"'
+            New-ModuleManifest -Path $manifestA -NestedModules ".\$sharedNestedName.psm1"
+            New-ModuleManifest -Path $manifestB -NestedModules ".\B_$sharedNestedName.psm1"
+            Import-Module $manifestA -Force
+            Import-Module $manifestB -Force
+        }
+
+        AfterAll {
+            Get-Module $rootA -ErrorAction SilentlyContinue | Remove-Module -Force
+            Get-Module $rootB -ErrorAction SilentlyContinue | Remove-Module -Force
+        }
+
+        It 'should resolve to ClientA nested module via slash notation' {
+            $name = InModuleScope -ModuleName "$rootA/$sharedNestedName" -ScriptBlock {
+                $ExecutionContext.SessionState.Module.Name
+            }
+            $name | Should -Be $sharedNestedName
+        }
+    }
 }
 
 Describe 'InModuleScope arguments and parameter binding' {

--- a/tst/functions/Mock.Tests.ps1
+++ b/tst/functions/Mock.Tests.ps1
@@ -3233,35 +3233,32 @@ Describe "Mocking using deep module path notation 'Root/Mid/Leaf'" {
     }
 }
 
-Describe "Disambiguating nested modules with same name across two root modules using slash notation" {
-    # Scenario from PR #2412: ClientA and ClientB each have a nested module named 'Repository'.
-    # Without slash notation both would throw 'Multiple script or manifest modules named Repository'.
+Describe "Disambiguating nested modules with the same name across two root modules using slash notation" {
+    # Scenario from PR #2412: ClientA and ClientB each have a nested module named 'Repository'
+    # (same name, loaded from different folders). With two same-named modules loaded a plain
+    # -ModuleName 'Repository' throws 'Multiple script or manifest modules named Repository';
+    # slash notation targets exactly one of them.
 
     BeforeAll {
         $sharedName = 'Repository'
         $rootA = 'ClientA'
         $rootB = 'ClientB'
 
-        $nestedPathA = "TestDrive:/$sharedName`_A.psm1"
-        $nestedPathB = "TestDrive:/$sharedName`_B.psm1"
-        Set-Content -Path $nestedPathA -Value {
+        # Same base name, different folders, so both load as 'Repository'.
+        $null = New-Item -ItemType Directory -Path "TestDrive:/A", "TestDrive:/B"
+        Set-Content -Path "TestDrive:/A/$sharedName.psm1" -Value {
             function Get-Data { 'dataA' }
             function Invoke-Api { Get-Data }
         }
-        Set-Content -Path $nestedPathB -Value {
+        Set-Content -Path "TestDrive:/B/$sharedName.psm1" -Value {
             function Get-Data { 'dataB' }
             function Invoke-Api { Get-Data }
         }
 
-        $manifestA = "TestDrive:/$rootA.psd1"
-        $manifestB = "TestDrive:/$rootB.psd1"
-
-        # Both nested scripts load as 'Repository' because the -NestedModules name
-        # determines the loaded module name.
-        New-ModuleManifest -Path $manifestA -NestedModules ".\$sharedName`_A.psm1" -FunctionsToExport 'Invoke-Api'
-        New-ModuleManifest -Path $manifestB -NestedModules ".\$sharedName`_B.psm1" -FunctionsToExport 'Invoke-Api'
-        Import-Module $manifestA -Force
-        Import-Module $manifestB -Force
+        New-ModuleManifest -Path "TestDrive:/$rootA.psd1" -NestedModules ".\A\$sharedName.psm1" -FunctionsToExport 'Invoke-Api'
+        New-ModuleManifest -Path "TestDrive:/$rootB.psd1" -NestedModules ".\B\$sharedName.psm1" -FunctionsToExport 'Invoke-Api'
+        Import-Module "TestDrive:/$rootA.psd1" -Force
+        Import-Module "TestDrive:/$rootB.psd1" -Force
     }
 
     AfterAll {
@@ -3269,16 +3266,22 @@ Describe "Disambiguating nested modules with same name across two root modules u
         Get-Module $rootB -ErrorAction SilentlyContinue | Remove-Module -Force
     }
 
-    It 'Should mock Get-Data only in ClientA nested module' {
-        Mock -CommandName 'Get-Data' -ModuleName "$rootA/$sharedName`_A" -MockWith { 'mockedA' }
-        # ClientA's Invoke-Api calls the mocked Get-Data
-        InModuleScope "$rootA/$sharedName`_A" { Invoke-Api } | Should -Be 'mockedA'
+    It 'loads both nested modules under the same name, so a plain name is ambiguous' {
+        # Guard: confirms the scenario genuinely exercises disambiguation.
+        @(Get-Module $sharedName -All).Count | Should -BeGreaterThan 1
     }
 
-    It 'Should-Invoke uses slash notation to check ClientA call history' {
-        Mock -CommandName 'Get-Data' -ModuleName "$rootA/$sharedName`_A" -MockWith { 'mockedA' }
-        InModuleScope "$rootA/$sharedName`_A" { Invoke-Api } | Out-Null
-        Should -Invoke 'Get-Data' -ModuleName "$rootA/$sharedName`_A" -Exactly -Times 1
+    It 'mocks Get-Data in the ClientA copy, leaving the identically-named ClientB copy untouched' {
+        Mock -CommandName 'Get-Data' -ModuleName "$rootA/$sharedName" -MockWith { 'mockedA' }
+        InModuleScope "$rootA/$sharedName" { Invoke-Api } | Should -Be 'mockedA'
+        # the mock must not bleed into the same-named nested module under ClientB
+        InModuleScope "$rootB/$sharedName" { Invoke-Api } | Should -Be 'dataB'
+    }
+
+    It 'Should-Invoke uses slash notation to check the ClientA copy call history' {
+        Mock -CommandName 'Get-Data' -ModuleName "$rootA/$sharedName" -MockWith { 'mockedA' }
+        InModuleScope "$rootA/$sharedName" { Invoke-Api } | Out-Null
+        Should -Invoke 'Get-Data' -ModuleName "$rootA/$sharedName" -Exactly -Times 1
     }
 }
 

--- a/tst/functions/Mock.Tests.ps1
+++ b/tst/functions/Mock.Tests.ps1
@@ -3126,7 +3126,163 @@ Describe 'Mocking in manifest modules' {
     }
 }
 
-Describe 'Mocking with nested Pester runs' {
+Describe "Mocking using 'RootModule/NestedModule' slash notation" {
+    # Primary use-case: two simultaneously loaded root modules that each have a nested module
+    # with the same name (e.g. two REST clients both exposing a 'Repository' sub-module).
+    # Slash notation lets you target the correct one unambiguously.
+
+    BeforeAll {
+        $nestedName = 'SlashNotationNested'
+        $rootName = 'SlashNotationRoot'
+        $manifestPath = "TestDrive:/$rootName.psd1"
+        $nestedPath = "TestDrive:/$nestedName.psm1"
+
+        Set-Content -Path $nestedPath -Value {
+            function Get-InternalData {
+                'real'
+            }
+
+            function Get-PublicData {
+                Get-InternalData
+            }
+        }
+        New-ModuleManifest -Path $manifestPath -NestedModules ".\$nestedName.psm1" -FunctionsToExport 'Get-PublicData'
+        Import-Module $manifestPath -Force
+    }
+
+    AfterAll {
+        Get-Module $rootName -ErrorAction SilentlyContinue | Remove-Module -Force
+    }
+
+    It 'Should mock an internal command in the nested module using slash notation' {
+        Mock -CommandName 'Get-InternalData' -ModuleName "$rootName/$nestedName" -MockWith { 'mocked' }
+        $result = Get-PublicData
+        $result | Should -Be 'mocked'
+    }
+
+    It 'Should-Invoke matches call history when using slash notation' {
+        Mock -CommandName 'Get-InternalData' -ModuleName "$rootName/$nestedName" -MockWith { 'mocked' }
+        $null = Get-PublicData
+        Should -Invoke -CommandName 'Get-InternalData' -ModuleName "$rootName/$nestedName" -Exactly -Times 1
+    }
+
+    It 'Should-NotInvoke passes when command was not called' {
+        Mock -CommandName 'Get-InternalData' -ModuleName "$rootName/$nestedName" -MockWith { 'mocked' }
+        Should -Not -Invoke -CommandName 'Get-InternalData' -ModuleName "$rootName/$nestedName"
+    }
+
+    It 'Should-Invoke accepts plain nested module name after mock was set up with slash notation' {
+        # The mock was set up targeting the nested module; its TargetModule is the plain nested name.
+        Mock -CommandName 'Get-InternalData' -ModuleName "$rootName/$nestedName" -MockWith { 'mocked' }
+        $null = Get-PublicData
+        Should -Invoke -CommandName 'Get-InternalData' -ModuleName $nestedName -Exactly -Times 1
+    }
+
+    It 'Mock cleanup removes the bootstrap function from the nested module session state' {
+        # After the It block completes the mock is torn down; calling the real function returns 'real'.
+        Get-PublicData | Should -Be 'real'
+    }
+}
+
+Describe "Mocking using deep module path notation 'Root/Mid/Leaf'" {
+    BeforeAll {
+        $rootName = 'DeepSlashRoot'
+        $midName = 'DeepSlashMid'
+        $leafName = 'DeepSlashLeaf'
+
+        $rootManifestPath = "TestDrive:/$rootName.psd1"
+        $midManifestPath = "TestDrive:/$midName.psd1"
+        $leafScriptPath = "TestDrive:/$leafName.psm1"
+
+        Set-Content -Path $leafScriptPath -Value {
+            function Get-DeepInternalData {
+                'real-deep'
+            }
+
+            function Get-DeepPublicData {
+                Get-DeepInternalData
+            }
+        }
+
+        New-ModuleManifest -Path $midManifestPath -NestedModules ".\$leafName.psm1"
+        New-ModuleManifest -Path $rootManifestPath -NestedModules ".\$midName.psd1"
+
+        Import-Module $rootManifestPath -Force
+    }
+
+    AfterAll {
+        Get-Module $rootName -ErrorAction SilentlyContinue | Remove-Module -Force
+    }
+
+    It 'Should mock an internal command in the deeply nested module using slash notation' {
+        Mock -CommandName 'Get-DeepInternalData' -ModuleName "$rootName/$midName/$leafName" -MockWith { 'mocked-deep' }
+        $result = InModuleScope "$rootName/$midName/$leafName" { Get-DeepPublicData }
+        $result | Should -Be 'mocked-deep'
+    }
+
+    It 'Should-Invoke matches call history when using deep slash notation' {
+        Mock -CommandName 'Get-DeepInternalData' -ModuleName "$rootName/$midName/$leafName" -MockWith { 'mocked-deep' }
+        $null = InModuleScope "$rootName/$midName/$leafName" { Get-DeepPublicData }
+        Should -Invoke -CommandName 'Get-DeepInternalData' -ModuleName "$rootName/$midName/$leafName" -Exactly -Times 1
+    }
+
+    It 'Should-Invoke accepts plain leaf module name after deep-path mock setup' {
+        Mock -CommandName 'Get-DeepInternalData' -ModuleName "$rootName/$midName/$leafName" -MockWith { 'mocked-deep' }
+        $null = InModuleScope "$rootName/$midName/$leafName" { Get-DeepPublicData }
+        Should -Invoke -CommandName 'Get-DeepInternalData' -ModuleName $leafName -Exactly -Times 1
+    }
+}
+
+Describe "Disambiguating nested modules with same name across two root modules using slash notation" {
+    # Scenario from PR #2412: ClientA and ClientB each have a nested module named 'Repository'.
+    # Without slash notation both would throw 'Multiple script or manifest modules named Repository'.
+
+    BeforeAll {
+        $sharedName = 'Repository'
+        $rootA = 'ClientA'
+        $rootB = 'ClientB'
+
+        $nestedPathA = "TestDrive:/$sharedName`_A.psm1"
+        $nestedPathB = "TestDrive:/$sharedName`_B.psm1"
+        Set-Content -Path $nestedPathA -Value {
+            function Get-Data { 'dataA' }
+            function Invoke-Api { Get-Data }
+        }
+        Set-Content -Path $nestedPathB -Value {
+            function Get-Data { 'dataB' }
+            function Invoke-Api { Get-Data }
+        }
+
+        $manifestA = "TestDrive:/$rootA.psd1"
+        $manifestB = "TestDrive:/$rootB.psd1"
+
+        # Both nested scripts load as 'Repository' because the -NestedModules name
+        # determines the loaded module name.
+        New-ModuleManifest -Path $manifestA -NestedModules ".\$sharedName`_A.psm1" -FunctionsToExport 'Invoke-Api'
+        New-ModuleManifest -Path $manifestB -NestedModules ".\$sharedName`_B.psm1" -FunctionsToExport 'Invoke-Api'
+        Import-Module $manifestA -Force
+        Import-Module $manifestB -Force
+    }
+
+    AfterAll {
+        Get-Module $rootA -ErrorAction SilentlyContinue | Remove-Module -Force
+        Get-Module $rootB -ErrorAction SilentlyContinue | Remove-Module -Force
+    }
+
+    It 'Should mock Get-Data only in ClientA nested module' {
+        Mock -CommandName 'Get-Data' -ModuleName "$rootA/$sharedName`_A" -MockWith { 'mockedA' }
+        # ClientA's Invoke-Api calls the mocked Get-Data
+        InModuleScope "$rootA/$sharedName`_A" { Invoke-Api } | Should -Be 'mockedA'
+    }
+
+    It 'Should-Invoke uses slash notation to check ClientA call history' {
+        Mock -CommandName 'Get-Data' -ModuleName "$rootA/$sharedName`_A" -MockWith { 'mockedA' }
+        InModuleScope "$rootA/$sharedName`_A" { Invoke-Api } | Out-Null
+        Should -Invoke 'Get-Data' -ModuleName "$rootA/$sharedName`_A" -Exactly -Times 1
+    }
+}
+
+Describe 'Mocking in nested Invoke-Pester runs' {
     BeforeAll {
         Mock Get-Date { 1 }
 


### PR DESCRIPTION
<!-- Thank you for contributing to Pester! -->

## PR Summary
<!-- Please describe what your pull request fixes, or how it improves Pester.

If your pull request resolves a reported issue, please mention it by using `Fix #<issue_number>` on a new line, this will close the linked issue automatically when this PR is merged. For more info see: [Closing issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/).

If your pull request integrates Pester with another system, please tell us how the change can be tested. -->

Enable users to specify a nested module unambiguously in `-ModuleName` parameters across all Pester mocking and scoping commands (`Mock`, `InModuleScope`, `Should-Invoke`, `Should-NotInvoke`) using rooted nested-module notation (`'RootModuleName/NestedModuleName'` and `'RootModuleName\NestedModuleName'`). When this notation is detected, resolve the root module first, then locate the nested module within it and return its session state. Plain module names (without slash notation) must continue to work without any change in behavior.

## PR Checklist

- [x] PR has meaningful title
- [x] Summary describes changes
- [x] PR is ready to be merged
  - If not, use the arrow next to `Create Pull Request` to mark it as a draft. PR can be marked `Ready for review` when it's ready.
- [x] Tests are added/update *(if required)*
- [x] Documentation is updated/added *(if required)*

<!-- Before you continue, please review [Contributing to Pester](https://pester.dev/docs/contributing/introduction).

Our continuous integration system doesn't send any notifications about failed tests. Please return to the opened pull request (after ~60 minutes) to check if everything is OK. -->

## Domain Concept Identification

### Existing Concepts (from codebase)

- **ModuleName**: A string parameter accepted by `Mock`, `Should-Invoke`, `Should-NotInvoke`, and `InModuleScope` that identifies the target PowerShell module into which a mock is injected or within which test code is executed. Currently expects a simple module name (e.g., `"Pester"`, `"MyModule"`).
- **Get-CompatibleModule**: Internal Pester function (`src/functions/InModuleScope.ps1`) that resolves a module name string to a loaded `PSModuleInfo` object via `Get-Module -Name $ModuleName -All`. Used by both `InModuleScope` and `Resolve-Command` (in `Mock.ps1`). It is the single gateway for module resolution throughout the mocking and scoping system.
- **Resolve-Command**: Internal function (`src/functions/Mock.ps1`) that resolves the command to be mocked within a module's session state. Delegates module lookup entirely to `Get-CompatibleModule`.
- **TargetModule**: The resolved module name stored on `MockBehavior` and context info objects, used as part of the mock table key (`"$ModuleName||$CommandName"`) to track call history per module scope.
- **NestedModules**: A PowerShell module manifest concept (`psd1`) where a root/manifest module loads subordinate script modules. The nested modules share the root's session state when loaded via a manifest. Pester already has a test (`tst/functions/InModuleScope.Tests.ps1`, line ~325) demonstrating `InModuleScope` working against manifest modules that have nested modules.
- **RootModule (manifest key)**: In `Pester.psd1`, `RootModule = 'Pester.psm1'`. In the PowerShell module system, a manifest's `RootModule` is the primary script module; `NestedModules` lists additional modules loaded alongside it.

### New Concepts Required

- **ModuleName slash-notation**: A `RootModule/NestedModule` string format (e.g., `"Pester/Pester.Runtime"`) to be parsed by `Get-CompatibleModule` (and propagated through `Resolve-Command`) that uniquely identifies a nested module within a specific root module. This concept does not yet exist anywhere in the Pester codebase.
- **Module disambiguation path**: The resolution algorithm that, given `RootModule/NestedModule`, first finds the root module, then narrows the loaded `NestedModules` list to find the specific nested module, returning its `PSModuleInfo` — enabling disambiguation when the same nested module name appears under different root modules.

### Key Business Rules

- **Format rule**: When `ModuleName` contains exactly one `/`, the left side is the root/manifest module name and the right side is the nested module name. A plain name (no `/`) retains current behavior — no breaking change.
- **Root must exist**: The root module named by the left side must be currently loaded and be of type `Script` or `Manifest`; otherwise error with a clear message.
- **Nested must be a child**: The nested module named by the right side must be found in the root module's `NestedModules` list or otherwise be a module that was loaded as a consequence of importing the root; otherwise error.
- **Ambiguity resolution**: If multiple root modules share the same name, the slash notation still requires the root to be unambiguous (same rule as today for plain names). The value-add is when the *nested* module name is ambiguous across different roots.
- **Consistency**: The resolved `TargetModule` stored on `MockBehavior` must remain a plain module name (or the full slash path — TBD, see Key Design Decisions), so that internal comparisons such as `$ModuleName -eq $command.Mock.Hook.OriginalCommand.Module.Name` remain correct.

---

## Strategic Approach

### Solution Direction

- Parse `ModuleName` for the `RootModule/NestedModule` separator in `Get-CompatibleModule` (the single module-resolution gateway). When detected, split on the first `/`, resolve the root module, then look up the nested module within it. Return the nested module's `PSModuleInfo`. All callers of `Get-CompatibleModule` — `InModuleScope` and `Resolve-Command` — automatically gain the capability.
- `InModuleScope` and external-API functions (`Mock`, `Should-Invoke`, `Should-NotInvoke`) accept `[string] $ModuleName` unchanged; no parameter type changes are needed.

### Key Design Decisions

- **Where to parse the slash notation** — Options: (a) in `Get-CompatibleModule` only, (b) at each call site. → **Recommendation**: Option (a). `Get-CompatibleModule` is the sole resolution gateway; centralising the logic there avoids duplication and ensures `InModuleScope`, `Mock`, and assert commands all behave consistently without touching call sites.

- **What to store as TargetModule on MockBehavior** — Options: (a) store the plain nested module name, (b) store the full `RootModule/NestedModule` path. The stored value is used in the mock call-history key (`"$ModuleName||$CommandName"`) and in comparisons like `$ModuleName -eq $command.Mock.Hook.OriginalCommand.Module.Name`. PowerShell's `Module.Name` is always a plain name. → **Recommendation**: Store the resolved nested module's plain `Name` (e.g., `"Pester.Runtime"`), not the slash path. This keeps internal comparisons correct. `Resolve-Command` already sets `TargetModule = $ModuleName` *after* calling `Get-CompatibleModule`; the resolved plain name must be propagated back to the callers, meaning `Resolve-Command` should capture `$module.Name` (the resolved nested module name) and use that as `TargetModule`.

- **Nested module lookup strategy** — Options: (a) iterate `$rootModule.NestedModules`, (b) call `Get-Module -Name $nestedModuleName` and filter to those where the `RootModule*` parent is the resolved root, (c) use `Get-Module -All` and filter by checking `$_.Path` starts with the root module's directory. → **Recommendation**: Option (a) — directly enumerate `$rootModule.NestedModules` and match by name. This is most precise and does not depend on path assumptions. It also mirrors how PowerShell itself tracks nested module relationships.

### Alternatives Considered

- **Add a separate `-NestedModuleName` parameter to `Mock`, `InModuleScope`, etc.**: Rejected because it requires changes to all public API surfaces, breaks existing scripts that splat parameters, increases complexity for consumers, and creates two mechanisms for the same concept.
- **Use `Get-Module -Name $nestedName` and disambiguate by checking parent**: Partially viable but fragile — PowerShell's module graph doesn't always expose a clear parent link from a nested module back to its manifest. Direct enumeration of `$rootModule.NestedModules` is more reliable.

---

## Risk & Gap Analysis

### Requirement Ambiguities

- **What constitutes the "root"**: The left side of `/` — is it always the *manifest* module name, or can it also be any parent psm1 that imported nested modules explicitly? Modules imported via `Import-Module` with `-NestedModules` behave differently from manifest-defined nesting. Needs clarification.
- **Slash in module names**: PowerShell module names do not normally contain `/`, but this is not enforced by the module system. If a module is legitimately named `A/B`, the parsing would break. The probability is extremely low, but the edge case should be documented.

### Edge Cases

- **Single slash with no right side** (`"Pester/"`) or **no left side** (`"/Runtime"`): Parser must validate and throw a descriptive error rather than silently producing unexpected behavior.
- **Root module found but nested module not found within it**: Must throw an error that names both the root and the attempted nested module name, rather than a generic `Get-Module` error.
- **Nested module already loaded as a top-level module** (imported independently in the same session alongside being a nested module of a root): The slash notation disambiguates which instance to use. The algorithm must return the instance that is nested under the specified root, not any independently loaded copy.
- **Root module has not been imported yet**: `Get-Module -Name $rootName` returns nothing. Error message should guide the user to import it.
- **Manifest modules whose `RootModule` key is a nested module**: `Pester.psd1` sets `RootModule = 'Pester.psm1'`. When someone writes `Pester/Pester.psm1`, the right side matches the `RootModule` value, not a `NestedModules` entry — edge case that may need consideration.

### Technical Risks

- **TargetModule key mismatch in MockTable**: The mock call-history hashtable is keyed on `"$ModuleName||$CommandName"`. If the caller passes `"Pester/Pester.Runtime"` to `Mock` and the resolved TargetModule stored is `"Pester.Runtime"`, but `Should-Invoke` is later called with `ModuleName = "Pester/Pester.Runtime"`, the lookup must also resolve and use the plain name. `Resolve-Command` is called by `Should-Invoke` too; as long as it always normalises to the plain nested name, the key matches. Risk is low if the resolution always normalises — but needs a test.
- **`$ModuleName -eq $command.Mock.Hook.OriginalCommand.Module.Name` comparison** in `Resolve-Command` (lines 735, 755): This compares `TargetModule` to `OriginalCommand.Module.Name`. If `TargetModule` is stored as the slash path rather than the plain name, these comparisons silently fail, breaking `IsFromTargetModule`. Medium risk — mitigated by the decision to store the plain name.
- **`EscapeSingleQuotedStringContent $ModuleName`** used in the mock bootstrap script body (`Mock.ps1` line 170): The bootstrap script embeds `ModuleName` in a single-quoted string literal. The `/` character is safe in single-quoted strings, but if the slash notation is used as-is (rather than the resolved plain name), the embedded string literal would be `'Pester/Pester.Runtime'` — still valid PowerShell but would break the `Invoke_Mock` dispatch which uses `ModuleName` as a key. Low-medium risk — resolved by always normalising before embedding.

### Acceptance Criteria Coverage

| AC# | Description                                                                         | Addressable?  | Gaps/Notes                                                                              |
| --- | ----------------------------------------------------------------------------------- | ------------- | --------------------------------------------------------------------------------------- |
| 1   | `Mock -ModuleName 'Root/Nested' Get-Item {}` sets up a mock in the nested module    | Yes           | Requires `Get-CompatibleModule` to parse and resolve; `TargetModule` must be normalised |
| 2   | `InModuleScope 'Root/Nested' { ... }` executes in the nested module's session state | Yes           | Same `Get-CompatibleModule` change covers this                                          |
| 3   | `Should-Invoke -ModuleName 'Root/Nested' Get-Item` correctly finds call history     | Yes           | Depends on consistent normalisation of `TargetModule` to plain name                     |
| 4   | Plain `ModuleName` (no `/`) continues to work unchanged                             | Yes           | Conditional branch — no existing code path changes                                      |
| 5   | Clear error when root module not found                                              | Yes           | Must add explicit error message for split-notation path                                 |
| 6   | Clear error when nested module not found under root                                 | Yes           | Must add explicit error message — not covered by current `Get-Module` error             |
| —   | Multi-level nesting (`A/B/C`)                                                       | Yes           | Must support 1 to N level  |
