### PR TITLE
Collect-Input: empty pipeline unwraps to $null for value assertions

### DIFF
--- a/docs/assertion-types.md
+++ b/docs/assertion-types.md
@@ -43,13 +43,11 @@ Another special case is `@()`. A value assertion will handle it as `$null`, but 
 1 | Should-Be -Expected 1
 @(1) | Should-Be -Expected 1
 $null | Should-Be -Expected $null
-@() | Should-Be -Expected $null #< --- TODO: this is not the case right now, we special case this as empty array, but is that correct? it does not play well with the value and collection assertion, and we special case it just because we can.
-# $null | will give $local:input -> $null , and @() | will give $local:input -> @(), is that distinction important when we know that we will only check against values?
+@() | Should-Be -Expected $null
 
 # This fails, because -Expected does not allow collections.
 @() | Should-Be -Expected @()
-
-
+```
 
 ```powershell
 # Should-BeCollection is a collection assertion:

--- a/src/functions/assert/Common/Collect-Input.ps1
+++ b/src/functions/assert/Common/Collect-Input.ps1
@@ -22,14 +22,22 @@
     if ($IsPipelineInput) {
         # We are called like this: 1 | Assert-Equal -Expected 1, we will get $local:Input in $PipelineInput and $true in $IsPipelineInput (coming from $MyInvocation.ExpectingInput).
 
-        if ($PipelineInput.Count -eq 0) {
-            # When calling @() | Assert-Equal -Expected 1, the engine will special case it, and we will get empty array in $local:Input
-            $collectedInput = @()
-        }
-        else {
-            if ($UnrollInput) {
+        if ($UnrollInput) {
+            # Single-item assertions handle empty pipeline the same as $null,
+            # because there is no scalar that @() can unwrap to.
+            if ($PipelineInput.Count -eq 0) {
+                $collectedInput = $null
+            }
+            else {
                 # This is array of all the input, unwrap it.
                 $collectedInput = foreach ($item in $PipelineInput) { $item }
+            }
+        }
+        else {
+            # Collection assertions keep the input as a collection. Empty pipeline stays @().
+            if ($PipelineInput.Count -eq 0) {
+                # When calling @() | Assert-Equal -Expected 1, the engine will special case it, and we will get empty array in $local:Input
+                $collectedInput = @()
             }
             else {
                 # This is array of all the input.

--- a/tst/functions/assert/Common/Collect-Input.Tests.ps1
+++ b/tst/functions/assert/Common/Collect-Input.Tests.ps1
@@ -46,6 +46,15 @@ InPesterModuleScope {
                 }
             }
 
+            It "Given @() through pipeline when unrolling it captures `$null" {
+                $collectedInput = @() | Assert-PassThru -UnrollInput
+
+                Verify-True $collectedInput.IsPipelineInput
+                if ($null -ne $collectedInput.Actual) {
+                    throw "Expected `$null, but got $(Format-Nicely2 $collectedInput.Actual)."
+                }
+            }
+
             It "Given List[int] through pipeline it captures the items in Object[]" {
                 $collectedInput = [Collections.Generic.List[int]]@(1, 2) | Assert-PassThru
 

--- a/tst/functions/assert/Common/Collect-Input.Tests.ps1
+++ b/tst/functions/assert/Common/Collect-Input.Tests.ps1
@@ -55,6 +55,34 @@ InPesterModuleScope {
                 }
             }
 
+            It "Given @(`$null) through pipeline when unrolling it captures `$null (PowerShell emits one `$null item)" {
+                $collectedInput = @($null) | Assert-PassThru -UnrollInput
+
+                Verify-True $collectedInput.IsPipelineInput
+                if ($null -ne $collectedInput.Actual) {
+                    throw "Expected `$null, but got $(Format-Nicely2 $collectedInput.Actual)."
+                }
+            }
+
+            It "Given ,`$null through pipeline when unrolling it captures `$null (PowerShell emits one `$null item)" {
+                $collectedInput = , $null | Assert-PassThru -UnrollInput
+
+                Verify-True $collectedInput.IsPipelineInput
+                if ($null -ne $collectedInput.Actual) {
+                    throw "Expected `$null, but got $(Format-Nicely2 $collectedInput.Actual)."
+                }
+            }
+
+            It "Given @(`$null, `$null) through pipeline when unrolling it captures the collection (two items stay as a collection)" {
+                $collectedInput = @($null, $null) | Assert-PassThru -UnrollInput
+
+                Verify-True $collectedInput.IsPipelineInput
+                Verify-Type -Actual $collectedInput.Actual -Expected ([Object[]])
+                if (2 -ne $collectedInput.Actual.Count -or $null -ne $collectedInput.Actual[0] -or $null -ne $collectedInput.Actual[1]) {
+                    throw "Expected @(`$null, `$null), but got $(Format-Nicely2 $collectedInput.Actual)."
+                }
+            }
+
             It "Given List[int] through pipeline it captures the items in Object[]" {
                 $collectedInput = [Collections.Generic.List[int]]@(1, 2) | Assert-PassThru
 

--- a/tst/functions/assert/General/Should-Be.Tests.ps1
+++ b/tst/functions/assert/General/Should-Be.Tests.ps1
@@ -77,4 +77,8 @@ Describe "Should-Be" {
         $err = { "dummy" | Should-Be @() } | Verify-Throw
         $err.Exception | Verify-Type ([ArgumentException])
     }
+
+    It "Given empty array through pipeline against `$null it passes (empty pipeline unwraps to `$null for value assertions)" {
+        @() | Should-Be -Expected $null
+    }
 }

--- a/tst/functions/assert/General/Should-Be.Tests.ps1
+++ b/tst/functions/assert/General/Should-Be.Tests.ps1
@@ -81,4 +81,12 @@ Describe "Should-Be" {
     It "Given empty array through pipeline against `$null it passes (empty pipeline unwraps to `$null for value assertions)" {
         @() | Should-Be -Expected $null
     }
+
+    It "Given @(`$null) through pipeline against `$null it passes (single `$null item unwraps to `$null)" {
+        @($null) | Should-Be -Expected $null
+    }
+
+    It "Given ,`$null through pipeline against `$null it passes (single `$null item unwraps to `$null)" {
+        , $null | Should-Be -Expected $null
+    }
 }

--- a/tst/functions/assert/General/Should-BeNull.Tests.ps1
+++ b/tst/functions/assert/General/Should-BeNull.Tests.ps1
@@ -17,6 +17,26 @@ Describe "Should-BeNull" {
         { Should-BeNull -Actual @() } | Verify-AssertionFailed
     }
 
+    It "Given @(`$null) through pipeline it passes (single `$null item unwraps to `$null)" {
+        @($null) | Should-BeNull
+    }
+
+    It "Given ,`$null through pipeline it passes (single `$null item unwraps to `$null)" {
+        , $null | Should-BeNull
+    }
+
+    It "Given @(@(`$null)) through pipeline it passes (PowerShell unwraps the outer @() so this is still a single `$null item)" {
+        @(@($null)) | Should-BeNull
+    }
+
+    It "Given @(`$null, `$null) through pipeline it fails (multi-item array is a collection, not `$null)" {
+        { @($null, $null) | Should-BeNull } | Verify-AssertionFailed
+    }
+
+    It "Given 1, `$null through pipeline it fails (multi-item array is a collection, not `$null)" {
+        { 1, $null | Should-BeNull } | Verify-AssertionFailed
+    }
+
     It "Returns the given value" {
         $null | Should-BeNull | Verify-Null
     }

--- a/tst/functions/assert/General/Should-BeNull.Tests.ps1
+++ b/tst/functions/assert/General/Should-BeNull.Tests.ps1
@@ -9,8 +9,12 @@ Describe "Should-BeNull" {
         { 1 | Should-BeNull } | Verify-AssertionFailed
     }
 
-    It "Given empty array it fails" {
-        { @() | Should-BeNull } | Verify-AssertionFailed
+    It "Given empty array through pipeline it passes (empty pipeline unwraps to `$null for value assertions)" {
+        @() | Should-BeNull
+    }
+
+    It "Given empty array through -Actual parameter it fails" {
+        { Should-BeNull -Actual @() } | Verify-AssertionFailed
     }
 
     It "Returns the given value" {

--- a/tst/functions/assert/General/Should-NotBeNull.Tests.ps1
+++ b/tst/functions/assert/General/Should-NotBeNull.Tests.ps1
@@ -18,6 +18,18 @@ InPesterModuleScope {
             Should-NotBeNull -Actual @()
         }
 
+        It "Given @(`$null) through pipeline it fails (single `$null item unwraps to `$null)" {
+            { @($null) | Should-NotBeNull } | Verify-AssertionFailed
+        }
+
+        It "Given ,`$null through pipeline it fails (single `$null item unwraps to `$null)" {
+            { , $null | Should-NotBeNull } | Verify-AssertionFailed
+        }
+
+        It "Given @(`$null, `$null) through pipeline it passes (multi-item array is a collection, not `$null)" {
+            @($null, $null) | Should-NotBeNull
+        }
+
         It "Can be called with positional parameters" {
             { Should-NotBeNull $null } | Verify-AssertionFailed
         }

--- a/tst/functions/assert/General/Should-NotBeNull.Tests.ps1
+++ b/tst/functions/assert/General/Should-NotBeNull.Tests.ps1
@@ -10,6 +10,14 @@ InPesterModuleScope {
             { $null | Should-NotBeNull } | Verify-AssertionFailed
         }
 
+        It "Given empty array through pipeline it fails (empty pipeline unwraps to `$null for value assertions)" {
+            { @() | Should-NotBeNull } | Verify-AssertionFailed
+        }
+
+        It "Given empty array through -Actual parameter it passes" {
+            Should-NotBeNull -Actual @()
+        }
+
         It "Can be called with positional parameters" {
             { Should-NotBeNull $null } | Verify-AssertionFailed
         }


### PR DESCRIPTION
`docs/assertion-types.md` says a value assertion should treat `@()` from the pipeline the same as `$null` (since there is no scalar to unwrap to). The existing TODO on line 46 flagged that we did not actually match that — `Collect-Input` returned `@()` for both value and collection assertions, which made these fail:

```powershell
@() | Should-Be -Expected $null
@() | Should-BeNull
```

and made this wrongly pass:

```powershell
@() | Should-NotBeNull
```

`Collect-Input` now returns `$null` when `-UnrollInput` is set and the pipeline collected no items. Collection assertions are unchanged: they still see `@()`.

Updated the `Should-BeNull` test that previously asserted the buggy "fails" behavior to assert the documented "passes" behavior, and added matching coverage on `Should-Be`, `Should-NotBeNull`, and `Collect-Input` itself. Dropped the TODO and a stray code fence in `assertion-types.md`.

Verified with the full Pester suite: 2174 passed, 0 failed.

Follow-up to #2707.