### PR TITLE
Fix #2490: Add missing .DESCRIPTION to Should-* assertion functions

### DIFF
--- a/src/functions/assert/Boolean/Should-BeFalse.ps1
+++ b/src/functions/assert/Boolean/Should-BeFalse.ps1
@@ -3,6 +3,9 @@
     .SYNOPSIS
     Compares the actual value to a boolean $false. It does not convert input values to boolean, and will fail for any value that is not $false.
 
+    .DESCRIPTION
+    This assertion only passes for the Boolean value `$false. It does not coerce input, so `$null, 0, or other falsy values still fail.
+
     .PARAMETER Actual
     The actual value to compare to $false.
 

--- a/src/functions/assert/Boolean/Should-BeFalsy.ps1
+++ b/src/functions/assert/Boolean/Should-BeFalsy.ps1
@@ -3,6 +3,9 @@
     .SYNOPSIS
     Compares the actual value to a boolean $false or a falsy value: 0, "", $null or @(). It converts the input value to a boolean.
 
+    .DESCRIPTION
+    This assertion evaluates the input using PowerShell truthiness rules. It passes for values such as `$false, 0, `""`, `$null, and empty collections.
+
     .PARAMETER Actual
     The actual value to compare to $false.
 

--- a/src/functions/assert/Boolean/Should-BeTrue.ps1
+++ b/src/functions/assert/Boolean/Should-BeTrue.ps1
@@ -3,6 +3,9 @@
     .SYNOPSIS
     Compares the actual value to a boolean $true. It does not convert input values to boolean, and will fail for any value is not $true.
 
+    .DESCRIPTION
+    This assertion only passes for the Boolean value `$true. It does not coerce input, so truthy non-Boolean values still fail.
+
     .PARAMETER Actual
     The actual value to compare to $true.
 

--- a/src/functions/assert/Boolean/Should-BeTruthy.ps1
+++ b/src/functions/assert/Boolean/Should-BeTruthy.ps1
@@ -3,6 +3,9 @@
     .SYNOPSIS
     Compares the actual value to a boolean $true. It converts input values to boolean, and will fail for any value is not $true, or truthy.
 
+    .DESCRIPTION
+    This assertion evaluates the input using PowerShell truthiness rules. It passes for values that PowerShell treats as true, not just the Boolean `$true.
+
     .PARAMETER Actual
     The actual value to compare to $true.
 

--- a/src/functions/assert/Collection/Should-All.ps1
+++ b/src/functions/assert/Collection/Should-All.ps1
@@ -3,6 +3,9 @@
     .SYNOPSIS
     Compares all items in a collection to a filter script. If the filter returns true, or does not throw for all the items in the collection, the assertion passes.
 
+    .DESCRIPTION
+    This assertion runs the filter script against every item in the collection. Nested Should-* failures are treated as filter failures and included in the reported reasons.
+
     .PARAMETER FilterScript
     A script block that filters the input collection. The script block can use Should-* assertions or throw exceptions to indicate failure.
 

--- a/src/functions/assert/Collection/Should-Any.ps1
+++ b/src/functions/assert/Collection/Should-Any.ps1
@@ -3,6 +3,9 @@
     .SYNOPSIS
     Compares all items in a collection to a filter script. If the filter returns true, or does not throw for any of the items in the collection, the assertion passes.
 
+    .DESCRIPTION
+    This assertion runs the filter script against each item until one passes. Nested Should-* failures are treated as filter failures and included in the reported reasons when nothing matches.
+
     .PARAMETER FilterScript
     A script block that filters the input collection. The script block can use Should-* assertions or throw exceptions to indicate failure.
 

--- a/src/functions/assert/Collection/Should-BeCollection.ps1
+++ b/src/functions/assert/Collection/Should-BeCollection.ps1
@@ -3,6 +3,9 @@
     .SYNOPSIS
     Compares collections for equality, by comparing their sizes and each item in them. It does not compare the types of the input collections.
 
+    .DESCRIPTION
+    This assertion verifies that both values are collections and compares their contents rather than their collection types. When you use `-Count`, it only checks the number of items.
+
     .PARAMETER Expected
     A collection of items.
 

--- a/src/functions/assert/Collection/Should-ContainCollection.ps1
+++ b/src/functions/assert/Collection/Should-ContainCollection.ps1
@@ -3,6 +3,9 @@
     .SYNOPSIS
     Compares collections to see if the expected collection is present in the provided collection. It does not compare the types of the input collections.
 
+    .DESCRIPTION
+    This assertion uses PowerShell containment to check whether the actual collection contains the expected value. The comparison uses the contained value's own equality semantics.
+
     .PARAMETER Expected
     A collection of items.
 

--- a/src/functions/assert/Collection/Should-NotContainCollection.ps1
+++ b/src/functions/assert/Collection/Should-NotContainCollection.ps1
@@ -3,6 +3,9 @@
     .SYNOPSIS
     Compares collections to ensure that the expected collection is not present in the provided collection. It does not compare the types of the input collections.
 
+    .DESCRIPTION
+    This assertion uses PowerShell containment to check that the actual collection does not contain the expected value. The comparison uses the contained value's own equality semantics.
+
     .PARAMETER Expected
     A collection of items.
 

--- a/src/functions/assert/Equivalence/Should-BeEquivalent.ps1
+++ b/src/functions/assert/Equivalence/Should-BeEquivalent.ps1
@@ -619,6 +619,9 @@ function Should-BeEquivalent {
     .SYNOPSIS
     Compares two objects for equivalency, by recursively comparing their properties for equivalency.
 
+    .DESCRIPTION
+    This assertion performs a deep comparison of the actual and expected objects, recursing through nested properties and collections. Use `-ExcludePath`, `-ExcludePathsNotOnExpected`, or `-Comparator Equality` to narrow what counts as equivalent.
+
     .PARAMETER Actual
     The actual object to compare.
 

--- a/src/functions/assert/Exception/Should-Throw.ps1
+++ b/src/functions/assert/Exception/Should-Throw.ps1
@@ -3,6 +3,9 @@ function Should-Throw {
     .SYNOPSIS
     Asserts that a script block throws an exception.
 
+    .DESCRIPTION
+    This assertion executes the script block and expects it to throw. Optional filters let you match the exception type, message, or FullyQualifiedErrorId, and `-AllowNonTerminatingError` accepts non-terminating errors.
+
     .PARAMETER ScriptBlock
     The script block that should throw an exception.
 

--- a/src/functions/assert/General/Should-Be.ps1
+++ b/src/functions/assert/General/Should-Be.ps1
@@ -3,6 +3,9 @@
     .SYNOPSIS
     Compares the expected value to actual value, to see if they are equal.
 
+    .DESCRIPTION
+    This assertion compares values using PowerShell equality semantics. Use the collection-specific assertions when you need to compare arrays or other collections.
+
     .PARAMETER Expected
     The expected value.
 

--- a/src/functions/assert/General/Should-BeGreaterThan.ps1
+++ b/src/functions/assert/General/Should-BeGreaterThan.ps1
@@ -3,6 +3,9 @@
     .SYNOPSIS
     Compares the expected value to actual value, to see if the actual value is greater than the expected value.
 
+    .DESCRIPTION
+    This assertion uses PowerShell comparison semantics and passes only when the actual value is strictly greater than the expected value.
+
     .PARAMETER Expected
     The expected value.
 

--- a/src/functions/assert/General/Should-BeGreaterThanOrEqual.ps1
+++ b/src/functions/assert/General/Should-BeGreaterThanOrEqual.ps1
@@ -3,6 +3,9 @@
     .SYNOPSIS
     Compares the expected value to actual value, to see if the actual value is greater than or equal to the expected value.
 
+    .DESCRIPTION
+    This assertion uses PowerShell comparison semantics and passes when the actual value is greater than or equal to the expected value.
+
     .PARAMETER Expected
     The expected value.
 

--- a/src/functions/assert/General/Should-BeLessThan.ps1
+++ b/src/functions/assert/General/Should-BeLessThan.ps1
@@ -3,6 +3,9 @@
     .SYNOPSIS
     Compares the expected value to actual value, to see if the actual value is less than the expected value.
 
+    .DESCRIPTION
+    This assertion uses PowerShell comparison semantics and passes only when the actual value is strictly less than the expected value.
+
     .PARAMETER Expected
     The expected value.
 

--- a/src/functions/assert/General/Should-BeLessThanOrEqual.ps1
+++ b/src/functions/assert/General/Should-BeLessThanOrEqual.ps1
@@ -3,6 +3,9 @@
     .SYNOPSIS
     Compares the expected value to actual value, to see if the actual value is less than or equal to the expected value.
 
+    .DESCRIPTION
+    This assertion uses PowerShell comparison semantics and passes when the actual value is less than or equal to the expected value.
+
     .PARAMETER Expected
     The expected value.
 

--- a/src/functions/assert/General/Should-BeNull.ps1
+++ b/src/functions/assert/General/Should-BeNull.ps1
@@ -3,6 +3,9 @@
     .SYNOPSIS
     Asserts that the input is `$null`.
 
+    .DESCRIPTION
+    This assertion passes only when the actual value is exactly `$null. Empty strings, empty collections, and other falsy values do not count as null.
+
     .PARAMETER Actual
     The actual value.
 

--- a/src/functions/assert/General/Should-BeSame.ps1
+++ b/src/functions/assert/General/Should-BeSame.ps1
@@ -3,6 +3,9 @@
     .SYNOPSIS
     Compares the expected value to actual value, to see if they are the same instance.
 
+    .DESCRIPTION
+    This assertion checks reference equality rather than value equality. Use it with reference types when you need to verify that both variables point to the same instance.
+
     .PARAMETER Expected
     The expected value.
 

--- a/src/functions/assert/General/Should-HaveType.ps1
+++ b/src/functions/assert/General/Should-HaveType.ps1
@@ -3,6 +3,9 @@
     .SYNOPSIS
     Asserts that the input is of the expected type.
 
+    .DESCRIPTION
+    This assertion uses `-is` to verify that the actual value is assignable to the expected type. Derived types and implemented interfaces also satisfy the check.
+
     .PARAMETER Expected
     The expected type.
 

--- a/src/functions/assert/General/Should-NotBe.ps1
+++ b/src/functions/assert/General/Should-NotBe.ps1
@@ -3,6 +3,9 @@
     .SYNOPSIS
     Compares the expected value to actual value, to see if they are not equal.
 
+    .DESCRIPTION
+    This assertion compares values using PowerShell equality semantics and passes only when they are different. Use the collection-specific assertions when you need to compare arrays or other collections.
+
     .PARAMETER Expected
     The expected value.
 

--- a/src/functions/assert/General/Should-NotBeNull.ps1
+++ b/src/functions/assert/General/Should-NotBeNull.ps1
@@ -3,6 +3,9 @@
     .SYNOPSIS
     Asserts that the input is not `$null`.
 
+    .DESCRIPTION
+    This assertion passes for any value other than exactly `$null. Empty strings, empty collections, and other falsy values are not treated as null.
+
     .PARAMETER Actual
     The actual value.
 

--- a/src/functions/assert/General/Should-NotBeSame.ps1
+++ b/src/functions/assert/General/Should-NotBeSame.ps1
@@ -3,6 +3,9 @@
     .SYNOPSIS
     Compares the expected value to actual value, to see if the actual value is not the same instance as the expected value.
 
+    .DESCRIPTION
+    This assertion checks reference inequality rather than value inequality. It passes when the two values are different instances, even if their contents are equal.
+
     .PARAMETER Expected
     The expected value.
 

--- a/src/functions/assert/General/Should-NotHaveType.ps1
+++ b/src/functions/assert/General/Should-NotHaveType.ps1
@@ -3,6 +3,9 @@
     .SYNOPSIS
     Asserts that the input is not of the expected type.
 
+    .DESCRIPTION
+    This assertion uses `-is` to verify that the actual value is not assignable to the expected type. Derived types and implemented interfaces still count as the expected type.
+
     .PARAMETER Expected
     The expected type.
 

--- a/src/functions/assert/Parameter/Should-HaveParameter.ps1
+++ b/src/functions/assert/Parameter/Should-HaveParameter.ps1
@@ -3,6 +3,9 @@ function Should-HaveParameter {
     .SYNOPSIS
     Asserts that a command has the expected parameter.
 
+    .DESCRIPTION
+    This assertion inspects command metadata and can also verify parameter details such as type, default value, aliases, parameter set membership, mandatory status, and argument completers.
+
     .PARAMETER ParameterName
     The name of the parameter to check. E.g. Uri
 

--- a/src/functions/assert/Parameter/Should-NotHaveParameter.ps1
+++ b/src/functions/assert/Parameter/Should-NotHaveParameter.ps1
@@ -3,6 +3,9 @@ function Should-NotHaveParameter {
     .SYNOPSIS
     Asserts that a command has does not have the parameter.
 
+    .DESCRIPTION
+    This assertion inspects command metadata to verify that a parameter is absent. It only checks the parameter name, unlike `Should-HaveParameter`, which can also validate parameter details.
+
     .PARAMETER ParameterName
     The name of the parameter to check. E.g. Uri
 

--- a/src/functions/assert/String/Should-BeEmptyString.ps1
+++ b/src/functions/assert/String/Should-BeEmptyString.ps1
@@ -3,6 +3,9 @@
     .SYNOPSIS
     Ensures that input is an empty string.
 
+    .DESCRIPTION
+    This assertion requires the actual value to be a string and uses `[string]::IsNullOrEmpty()` for the check. `$null` and non-string values still fail the assertion.
+
     .PARAMETER Actual
     The actual value that will be compared to an empty string.
 

--- a/src/functions/assert/String/Should-NotBeEmptyString.ps1
+++ b/src/functions/assert/String/Should-NotBeEmptyString.ps1
@@ -3,6 +3,9 @@
     .SYNOPSIS
     Ensures that the input is a string, and that the input is not $null or empty string.
 
+    .DESCRIPTION
+    This assertion requires the actual value to be a string and fails for `$null, `""`, and non-string values. Use it when empty should not be accepted as a valid string value.
+
     .PARAMETER Actual
     The actual value that will be compared.
 

--- a/src/functions/assert/String/Should-NotBeWhiteSpaceString.ps1
+++ b/src/functions/assert/String/Should-NotBeWhiteSpaceString.ps1
@@ -3,6 +3,9 @@
     .SYNOPSIS
     Ensures that the input is a string, and that the input is not $null, empty, or whitespace only string.
 
+    .DESCRIPTION
+    This assertion requires a string that contains at least one non-whitespace character. It fails for `$null, `""`, whitespace-only strings, and non-string values.
+
     .PARAMETER Actual
     The actual value that will be compared.
 

--- a/src/functions/assert/Time/Should-BeAfter.ps1
+++ b/src/functions/assert/Time/Should-BeAfter.ps1
@@ -3,6 +3,9 @@
     .SYNOPSIS
     Asserts that the provided [datetime] is after the expected [datetime].
 
+    .DESCRIPTION
+    This assertion accepts either an expected `[datetime]` or a fluent relative time expression. Use `-Now`, `-Ago`, or `-FromNow` to compare against the current local time.
+
     .PARAMETER Actual
     The actual [datetime] value.
 

--- a/src/functions/assert/Time/Should-BeBefore.ps1
+++ b/src/functions/assert/Time/Should-BeBefore.ps1
@@ -3,6 +3,9 @@
     .SYNOPSIS
     Asserts that the provided [datetime] is before the expected [datetime].
 
+    .DESCRIPTION
+    This assertion accepts either an expected `[datetime]` or a fluent relative time expression. Use `-Now`, `-Ago`, or `-FromNow` to compare against the current local time.
+
     .PARAMETER Actual
     The actual [datetime] value.
 

--- a/src/functions/assert/Time/Should-BeFasterThan.ps1
+++ b/src/functions/assert/Time/Should-BeFasterThan.ps1
@@ -3,6 +3,9 @@
     .SYNOPSIS
     Asserts that the provided [timespan] or [scriptblock] is faster than the expected [timespan].
 
+    .DESCRIPTION
+    This assertion accepts either a `[timespan]` or a script block to measure. Fluent time values such as `1s` are converted to a `[timespan]` before the comparison.
+
     .PARAMETER Actual
     The actual [timespan] or [scriptblock] value.
 

--- a/src/functions/assert/Time/Should-BeSlowerThan.ps1
+++ b/src/functions/assert/Time/Should-BeSlowerThan.ps1
@@ -3,6 +3,9 @@
     .SYNOPSIS
     Asserts that the provided [timespan] is slower than the expected [timespan].
 
+    .DESCRIPTION
+    This assertion accepts either a `[timespan]` or a script block to measure. Fluent time values such as `1s` are converted to a `[timespan]` before the comparison.
+
     .PARAMETER Actual
     The actual [timespan] or [scriptblock] value.
 

--- a/tst/Help.Tests.ps1
+++ b/tst/Help.Tests.ps1
@@ -23,8 +23,7 @@ Describe "Testing module help" -Tag 'Help' -ForEach @{ exportedFunctions = $expo
             $help.Synopsis | Should -Not -Match "^\s*$($_.Name)((\s+\[+?-\w+)|$)"
         }
 
-        # TODO: Missing on new Should-* assertions
-        It 'Description is defined' -Skip:($_.Name -match '^Should-') {
+        It 'Description is defined' {
             # Property is missing if undefined
             $help.description | Should -Not -BeNullOrEmpty
         }


### PR DESCRIPTION
Fixes #2490

Adds .DESCRIPTION sections to all Should-* assertion functions that were missing them. Descriptions are concise and follow the established style from the older assertion help text.