### PR TITLE
Fix #2533: Add Should-MatchString and Should-NotMatchString assertions

### DIFF
--- a/src/Module.ps1
+++ b/src/Module.ps1
@@ -83,6 +83,8 @@ $script:SafeCommands['Set-DynamicParameterVariable'] = $ExecutionContext.Session
 
     'Should-BeLikeString'
     'Should-NotBeLikeString'
+    'Should-MatchString'
+    'Should-NotMatchString'
 
     'Should-Invoke'
     'Should-NotInvoke'

--- a/src/Pester.psd1
+++ b/src/Pester.psd1
@@ -105,6 +105,8 @@
 
         'Should-BeLikeString'
         'Should-NotBeLikeString'
+        'Should-MatchString'
+        'Should-NotMatchString'
 
         'Should-Invoke'
         'Should-NotInvoke'

--- a/src/functions/assert/String/Should-MatchString.ps1
+++ b/src/functions/assert/String/Should-MatchString.ps1
@@ -1,0 +1,89 @@
+function Test-MatchString {
+    param (
+        [String]$Expected,
+        $Actual,
+        [switch]$CaseSensitive
+    )
+
+    if (-not $CaseSensitive) {
+        $Actual -match $Expected
+    }
+    else {
+        $Actual -cmatch $Expected
+    }
+}
+
+function Should-MatchString {
+    <#
+    .SYNOPSIS
+    Tests whether a string matches a regular expression pattern.
+
+    .DESCRIPTION
+    The `Should-MatchString` assertion compares the actual string to the expected regular expression pattern using the `-match` operator. The `-match` operator is case-insensitive by default, but you can make it case-sensitive by using the `-CaseSensitive` switch.
+
+    .PARAMETER Expected
+    The expected regular expression pattern.
+
+    .PARAMETER Actual
+    The actual value.
+
+    .PARAMETER CaseSensitive
+    Indicates that the comparison should be case-sensitive.
+
+    .PARAMETER Because
+    The reason why the actual value should match the regular expression pattern.
+
+    .EXAMPLE
+    ```powershell
+    "hello" | Should-MatchString "h.*o"
+    ```
+
+    This assertion will pass, because the actual value matches the regular expression pattern.
+
+    .EXAMPLE
+    ```powershell
+    "hello" | Should-MatchString "H.*O" -CaseSensitive
+    ```
+
+    This assertion will fail, because the actual value does not case-sensitively match the regular expression pattern.
+
+    .LINK
+    https://pester.dev/docs/commands/Should-MatchString
+
+    .LINK
+    https://pester.dev/docs/assertions
+    #>
+    [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseProcessBlockForPipelineCommand', '')]
+    param (
+        [Parameter(Position = 1, ValueFromPipeline = $true)]
+        $Actual,
+        [Parameter(Position = 0, Mandatory = $true)]
+        $Expected,
+        [Switch]$CaseSensitive,
+        [String]$Because
+    )
+
+    $collectedInput = Collect-Input -ParameterInput $Actual -PipelineInput $local:Input -IsPipelineInput $MyInvocation.ExpectingInput -UnrollInput
+    $Actual = $collectedInput.Actual
+
+    if ($Actual -isnot [string]) {
+        throw [ArgumentException]"Actual is expected to be string, to avoid confusing behavior that -match operator exhibits with collections. To assert on collections use Should-Any, Should-All or some other collection assertion."
+    }
+
+    if ($Expected -isnot [string]) {
+        throw [ArgumentException]"Expected is expected to be string, to avoid confusing behavior that -match operator exhibits with collections."
+    }
+
+    $stringsMatch = Test-MatchString -Expected $Expected -Actual $Actual -CaseSensitive:$CaseSensitive
+    if (-not $stringsMatch) {
+        $caseSensitiveMessage = ""
+        if ($CaseSensitive) {
+            $caseSensitiveMessage = " case sensitively"
+        }
+
+        $Message = Get-AssertionMessage -Expected $null -Actual $Actual -Because $Because -DefaultMessage "Expected the string '$Actual' to$caseSensitiveMessage match pattern '$Expected',<because> but it did not."
+        throw [Pester.Factory]::CreateShouldErrorRecord($Message, $MyInvocation.ScriptName, $MyInvocation.ScriptLineNumber, $MyInvocation.Line.TrimEnd([System.Environment]::NewLine), $true)
+    }
+
+    if ($script:______isInMockParameterFilter) { return $true }
+}

--- a/src/functions/assert/String/Should-NotMatchString.ps1
+++ b/src/functions/assert/String/Should-NotMatchString.ps1
@@ -1,0 +1,89 @@
+function Test-NotMatchString {
+    param (
+        [String]$Expected,
+        $Actual,
+        [switch]$CaseSensitive
+    )
+
+    if (-not $CaseSensitive) {
+        $Actual -notmatch $Expected
+    }
+    else {
+        $Actual -cnotmatch $Expected
+    }
+}
+
+function Should-NotMatchString {
+    <#
+    .SYNOPSIS
+    Tests whether a string does not match a regular expression pattern.
+
+    .DESCRIPTION
+    The `Should-NotMatchString` assertion compares the actual string to the expected regular expression pattern using the `-notmatch` operator. The `-notmatch` operator is case-insensitive by default, but you can make it case-sensitive by using the `-CaseSensitive` switch.
+
+    .PARAMETER Expected
+    The expected regular expression pattern.
+
+    .PARAMETER Actual
+    The actual value.
+
+    .PARAMETER CaseSensitive
+    Indicates that the comparison should be case-sensitive.
+
+    .PARAMETER Because
+    The reason why the actual value should not match the regular expression pattern.
+
+    .EXAMPLE
+    ```powershell
+    "hello" | Should-NotMatchString "^world$"
+    ```
+
+    This assertion will pass, because the actual value does not match the regular expression pattern.
+
+    .EXAMPLE
+    ```powershell
+    "hello" | Should-NotMatchString "h.*o" -CaseSensitive
+    ```
+
+    This assertion will fail, because the actual value case-sensitively matches the regular expression pattern.
+
+    .LINK
+    https://pester.dev/docs/commands/Should-NotMatchString
+
+    .LINK
+    https://pester.dev/docs/assertions
+    #>
+    [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseProcessBlockForPipelineCommand', '')]
+    param (
+        [Parameter(Position = 1, ValueFromPipeline = $true)]
+        $Actual,
+        [Parameter(Position = 0, Mandatory = $true)]
+        $Expected,
+        [Switch]$CaseSensitive,
+        [String]$Because
+    )
+
+    $collectedInput = Collect-Input -ParameterInput $Actual -PipelineInput $local:Input -IsPipelineInput $MyInvocation.ExpectingInput -UnrollInput
+    $Actual = $collectedInput.Actual
+
+    if ($Actual -isnot [string]) {
+        throw [ArgumentException]"Actual is expected to be string, to avoid confusing behavior that -match operator exhibits with collections. To assert on collections use Should-Any, Should-All or some other collection assertion."
+    }
+
+    if ($Expected -isnot [string]) {
+        throw [ArgumentException]"Expected is expected to be string, to avoid confusing behavior that -match operator exhibits with collections."
+    }
+
+    $stringsDoNotMatch = Test-NotMatchString -Expected $Expected -Actual $Actual -CaseSensitive:$CaseSensitive
+    if (-not $stringsDoNotMatch) {
+        $caseSensitiveMessage = ""
+        if ($CaseSensitive) {
+            $caseSensitiveMessage = " case sensitively"
+        }
+
+        $Message = Get-AssertionMessage -Expected $null -Actual $Actual -Because $Because -DefaultMessage "Expected the string '$Actual' to$caseSensitiveMessage not match pattern '$Expected',<because> but it matched it."
+        throw [Pester.Factory]::CreateShouldErrorRecord($Message, $MyInvocation.ScriptName, $MyInvocation.ScriptLineNumber, $MyInvocation.Line.TrimEnd([System.Environment]::NewLine), $true)
+    }
+
+    if ($script:______isInMockParameterFilter) { return $true }
+}

--- a/tst/functions/assert/String/Should-MatchString.Tests.ps1
+++ b/tst/functions/assert/String/Should-MatchString.Tests.ps1
@@ -1,0 +1,147 @@
+Set-StrictMode -Version Latest
+
+Describe "Should-MatchString" {
+    Context "Case insensitive matching" {
+        It "Passes when the string matches the regular expression" {
+            Should-MatchString -Expected "foo.*bar" -Actual "foobar"
+        }
+
+        It "Passes for strings with different case" {
+            Should-MatchString -Expected "FOO.*BAR" -Actual "foobar"
+        }
+
+        It "Passes for multiple regex examples. comparing '<actual>':'<expected>'" -TestCases @(
+            @{ Actual = "abc123"; Expected = "^[a-z]+\d+$" }
+            @{ Actual = "hello world"; Expected = "^hello\s+world$" }
+            @{ Actual = "abc"; Expected = "^[A-Z]+$" }
+        ) {
+            param ($Actual, $Expected)
+            Should-MatchString -Actual $Actual -Expected $Expected
+        }
+
+        It "Fails when the regular expression does not match" {
+            { Should-MatchString -Expected "^\d+$" -Actual "foobar" } | Should -Throw -ErrorId "PesterAssertionFailed"
+        }
+    }
+
+    Context "Case sensitive matching" {
+        It "Fails when only case-insensitive matching would succeed" {
+            { Should-MatchString -Actual "foobar" -Expected "FOO.*BAR" -CaseSensitive } | Should -Throw -ErrorId "PesterAssertionFailed"
+        }
+
+        It "Passes when the case-sensitive pattern matches" {
+            Should-MatchString -Actual "FooBar" -Expected "Foo.*Bar" -CaseSensitive
+        }
+    }
+
+    It "Allows actual to be passed from pipeline" {
+        "abc123" | Should-MatchString -Expected "^[a-z]+\d+$"
+    }
+
+    It "Allows expected to be passed by position" {
+        Should-MatchString "^[a-z]+\d+$" -Actual "abc123"
+    }
+
+    It "Allows actual to be passed by pipeline and expected by position" {
+        "abc123" | Should-MatchString "^[a-z]+\d+$"
+    }
+
+    It "Throws when given a collection as actual" {
+        $err = { "abc", "def" | Should-MatchString -Expected "abc" } | Should -Throw -PassThru
+        $err.Exception.Message | Should -Be "Actual is expected to be string, to avoid confusing behavior that -match operator exhibits with collections. To assert on collections use Should-Any, Should-All or some other collection assertion."
+    }
+
+    It "Throws when given a non-string pattern" {
+        $err = { Should-MatchString -Actual "abc" -Expected 123 } | Should -Throw -PassThru
+        $err.Exception.Message | Should -Be "Expected is expected to be string, to avoid confusing behavior that -match operator exhibits with collections."
+    }
+
+    It "Can be called with positional parameters" {
+        { Should-MatchString "^\d+$" "abc" } | Should -Throw -ErrorId "PesterAssertionFailed"
+    }
+
+    Context "Verify messages" {
+        It "Returns the correct message for failed matches" {
+            $err = { Should-MatchString -Actual "ab" -Expected "\d" -Because "reason" } | Should -Throw -PassThru
+            $err.Exception.Message | Should -Be "Expected the string 'ab' to match pattern '\d', because reason, but it did not."
+        }
+
+        It "Returns the correct message for failed case-sensitive matches" {
+            $err = { Should-MatchString -Actual "ab" -Expected "AB" -CaseSensitive } | Should -Throw -PassThru
+            $err.Exception.Message | Should -Be "Expected the string 'ab' to case sensitively match pattern 'AB', but it did not."
+        }
+    }
+}
+
+Describe "Should-NotMatchString" {
+    Context "Case insensitive matching" {
+        It "Passes when the string does not match the regular expression" {
+            Should-NotMatchString -Expected "^\d+$" -Actual "foobar"
+        }
+
+        It "Fails when the string matches the regular expression" {
+            { Should-NotMatchString -Expected "foo.*bar" -Actual "foobar" } | Should -Throw -ErrorId "PesterAssertionFailed"
+        }
+
+        It "Fails for strings with different case" {
+            { Should-NotMatchString -Expected "FOO.*BAR" -Actual "foobar" } | Should -Throw -ErrorId "PesterAssertionFailed"
+        }
+
+        It "Passes for multiple regex examples. comparing '<actual>':'<expected>'" -TestCases @(
+            @{ Actual = "abc123"; Expected = "^\d+$" }
+            @{ Actual = "hello world"; Expected = "^goodbye$" }
+            @{ Actual = "abc"; Expected = "^\d{3}$" }
+        ) {
+            param ($Actual, $Expected)
+            Should-NotMatchString -Actual $Actual -Expected $Expected
+        }
+    }
+
+    Context "Case sensitive matching" {
+        It "Passes when only case-insensitive matching would succeed" {
+            Should-NotMatchString -Actual "foobar" -Expected "FOO.*BAR" -CaseSensitive
+        }
+
+        It "Fails when the case-sensitive pattern matches" {
+            { Should-NotMatchString -Actual "FooBar" -Expected "Foo.*Bar" -CaseSensitive } | Should -Throw -ErrorId "PesterAssertionFailed"
+        }
+    }
+
+    It "Allows actual to be passed from pipeline" {
+        "abc123" | Should-NotMatchString -Expected "^\d+$"
+    }
+
+    It "Allows expected to be passed by position" {
+        Should-NotMatchString "^\d+$" -Actual "abc123"
+    }
+
+    It "Allows actual to be passed by pipeline and expected by position" {
+        "abc123" | Should-NotMatchString "^\d+$"
+    }
+
+    It "Throws when given a collection as actual" {
+        $err = { "abc", "def" | Should-NotMatchString -Expected "abc" } | Should -Throw -PassThru
+        $err.Exception.Message | Should -Be "Actual is expected to be string, to avoid confusing behavior that -match operator exhibits with collections. To assert on collections use Should-Any, Should-All or some other collection assertion."
+    }
+
+    It "Throws when given a non-string pattern" {
+        $err = { Should-NotMatchString -Actual "abc" -Expected 123 } | Should -Throw -PassThru
+        $err.Exception.Message | Should -Be "Expected is expected to be string, to avoid confusing behavior that -match operator exhibits with collections."
+    }
+
+    It "Can be called with positional parameters" {
+        { Should-NotMatchString "^a" "abc" } | Should -Throw -ErrorId "PesterAssertionFailed"
+    }
+
+    Context "Verify messages" {
+        It "Returns the correct message for failed non-matches" {
+            $err = { Should-NotMatchString -Actual "ab" -Expected ".*" -Because "reason" } | Should -Throw -PassThru
+            $err.Exception.Message | Should -Be "Expected the string 'ab' to not match pattern '.*', because reason, but it matched it."
+        }
+
+        It "Returns the correct message for failed case-sensitive non-matches" {
+            $err = { Should-NotMatchString -Actual "AB" -Expected "A.*" -CaseSensitive } | Should -Throw -PassThru
+            $err.Exception.Message | Should -Be "Expected the string 'AB' to case sensitively not match pattern 'A.*', but it matched it."
+        }
+    }
+}


### PR DESCRIPTION
Fixes #2533

Adds Should-MatchString and Should-NotMatchString for regex pattern matching, following the established naming convention and implementation patterns of existing string assertions.

Features:
- Regex match/not-match assertions
- -CaseSensitive switch
- Pipeline input support
- Consistent error messages