### PR TITLE
Fix #2467: Add soft assertion support to new Should-* assertions

### DIFF
--- a/src/Pester.Runtime.ps1
+++ b/src/Pester.Runtime.ps1
@@ -1599,6 +1599,14 @@ function Invoke-ScriptBlock {
             SwitchTimerUserCode           = $switchTimerUserCode
         }
 
+        $assertionContext = @{
+            Configuration   = $Configuration
+            AddErrorCallback = {
+                param($err)
+                $null = $parameters.ErrorRecord.Add($err)
+            }
+        }
+
         # here we are moving into the user scope if the provided
         # scriptblock was bound to user scope, so we want to take some actions
         # typically switching between user and framework timer. There are still tiny pieces of
@@ -1615,16 +1623,23 @@ function Invoke-ScriptBlock {
                 & $OnUserScopeTransition
             }
         }
-        do {
-            $standardOutput = if ($NoNewScope) {
-                . $wrapperScriptBlock $parameters
-            }
-            else {
-                & $wrapperScriptBlock $parameters
-            }
-            # if the code reaches here we did not break
-            #$break = $false
-        } while ($false)
+        $previousAssertionContext = $script:PesterAssertionContext
+        try {
+            $script:PesterAssertionContext = $assertionContext
+            do {
+                $standardOutput = if ($NoNewScope) {
+                    . $wrapperScriptBlock $parameters
+                }
+                else {
+                    & $wrapperScriptBlock $parameters
+                }
+                # if the code reaches here we did not break
+                #$break = $false
+            } while ($false)
+        }
+        finally {
+            $script:PesterAssertionContext = $previousAssertionContext
+        }
     }
     catch {
         $err = $_

--- a/src/functions/Mock.ps1
+++ b/src/functions/Mock.ps1
@@ -1175,7 +1175,13 @@ function Test-ParameterFilter {
         # TODO: not binding the bound parameters here because it would make the parameters unbound when the user does
         # not provide a param block, which they would never provide, so that is okay, but if there is a workaround this then
         # it would be nice to have. maybe changing the order in which I bind?
-        & $private:______mock_parameters.ScriptBlock @______arguments
+        $previousAssertionMockParameterFilter = & $private:______mock_parameters.Set_PesterAssertionMockParameterFilter -IsActive $true
+        try {
+            & $private:______mock_parameters.ScriptBlock @______arguments
+        }
+        finally {
+            $null = & $private:______mock_parameters.Set_PesterAssertionMockParameterFilter -IsActive $previousAssertionMockParameterFilter
+        }
     }
 
     if ($PesterPreference.Debug.WriteDebugMessages.Value) {
@@ -1196,6 +1202,7 @@ function Test-ParameterFilter {
         SessionState       = $SessionState
         Context            = $context
         Set_StrictMode     = $SafeCommands['Set-StrictMode']
+        Set_PesterAssertionMockParameterFilter = ${function:Set-PesterAssertionMockParameterFilter}
         WriteDebugMessages = $PesterPreference.Debug.WriteDebugMessages.Value
         Write_DebugMessage = if ($PesterPreference.Debug.WriteDebugMessages.Value) {
             { param ($Message) & $SafeCommands["Write-PesterDebugMessage"] -Scope Mock -Message $Message }

--- a/src/functions/assert/Boolean/Should-BeFalse.ps1
+++ b/src/functions/assert/Boolean/Should-BeFalse.ps1
@@ -48,6 +48,6 @@
     $Actual = $collectedInput.Actual
     if ($Actual -isnot [bool] -or $Actual) {
         $Message = Get-AssertionMessage -Expected $false -Actual $Actual -Because $Because  -DefaultMessage "Expected <expectedType> <expected>,<because> but got: <actualType> <actual>."
-        throw [Pester.Factory]::CreateShouldErrorRecord($Message, $MyInvocation.ScriptName, $MyInvocation.ScriptLineNumber, $MyInvocation.Line.TrimEnd([System.Environment]::NewLine), $true)
+        return (Invoke-AssertionFailed -Message $Message -InvocationInfo $MyInvocation)
     }
 }

--- a/src/functions/assert/Boolean/Should-BeFalsy.ps1
+++ b/src/functions/assert/Boolean/Should-BeFalsy.ps1
@@ -48,6 +48,6 @@
     $Actual = $collectedInput.Actual
     if ($Actual) {
         $Message = Get-AssertionMessage -Expected $false -Actual $Actual -Because $Because -DefaultMessage 'Expected <expectedType> <expected> or a falsy value: 0, "", $null or @(),<because> but got: <actualType> <actual>.'
-        throw [Pester.Factory]::CreateShouldErrorRecord($Message, $MyInvocation.ScriptName, $MyInvocation.ScriptLineNumber, $MyInvocation.Line.TrimEnd([System.Environment]::NewLine), $true)
+        return (Invoke-AssertionFailed -Message $Message -InvocationInfo $MyInvocation)
     }
 }

--- a/src/functions/assert/Boolean/Should-BeTrue.ps1
+++ b/src/functions/assert/Boolean/Should-BeTrue.ps1
@@ -48,6 +48,6 @@
     $Actual = $collectedInput.Actual
     if ($Actual -isnot [bool] -or -not $Actual) {
         $Message = Get-AssertionMessage -Expected $true -Actual $Actual -Because $Because -DefaultMessage "Expected <expectedType> <expected>,<because> but got: <actualType> <actual>."
-        throw [Pester.Factory]::CreateShouldErrorRecord($Message, $MyInvocation.ScriptName, $MyInvocation.ScriptLineNumber, $MyInvocation.Line.TrimEnd([System.Environment]::NewLine), $true)
+        return (Invoke-AssertionFailed -Message $Message -InvocationInfo $MyInvocation)
     }
 }

--- a/src/functions/assert/Boolean/Should-BeTruthy.ps1
+++ b/src/functions/assert/Boolean/Should-BeTruthy.ps1
@@ -49,6 +49,6 @@
     $Actual = $collectedInput.Actual
     if (-not $Actual) {
         $Message = Get-AssertionMessage -Expected $true -Actual $Actual -Because $Because -DefaultMessage "Expected <expectedType> <expected> or a truthy value,<because> but got: <actualType> <actual>."
-        throw [Pester.Factory]::CreateShouldErrorRecord($Message, $MyInvocation.ScriptName, $MyInvocation.ScriptLineNumber, $MyInvocation.Line.TrimEnd([System.Environment]::NewLine), $true)
+        return (Invoke-AssertionFailed -Message $Message -InvocationInfo $MyInvocation)
     }
 }

--- a/src/functions/assert/Collection/Should-All.ps1
+++ b/src/functions/assert/Collection/Should-All.ps1
@@ -53,7 +53,7 @@
 
     if ($null -eq $Actual -or 0 -eq @($Actual).Count) {
         $Message = Get-AssertionMessage -Expected $Expected -Actual $Actual -Data $data -Because $Because -DefaultMessage "Expected all items in collection to pass filter <expected>, but <actualType> <actual> contains no items to compare."
-        throw [Pester.Factory]::CreateShouldErrorRecord($Message, $MyInvocation.ScriptName, $MyInvocation.ScriptLineNumber, $MyInvocation.Line.TrimEnd([System.Environment]::NewLine), $true)
+        return (Invoke-AssertionFailed -Message $Message -InvocationInfo $MyInvocation)
     }
 
     $failReasons = $null
@@ -105,6 +105,6 @@
             }
             $Message += "`nReasons :`n$failReasons"
         }
-        throw [Pester.Factory]::CreateShouldErrorRecord($Message, $MyInvocation.ScriptName, $MyInvocation.ScriptLineNumber, $MyInvocation.Line.TrimEnd([System.Environment]::NewLine), $true)
+        return (Invoke-AssertionFailed -Message $Message -InvocationInfo $MyInvocation)
     }
 }

--- a/src/functions/assert/Collection/Should-Any.ps1
+++ b/src/functions/assert/Collection/Should-Any.ps1
@@ -52,7 +52,7 @@
 
     if ($null -eq $Actual -or 0 -eq @($Actual).Count) {
         $Message = Get-AssertionMessage -Expected $Expected -Actual $Actual -Data $data -Because $Because -DefaultMessage "Expected at least one item in collection to pass filter <expected>, but <actualType> <actual> contains no items to compare."
-        throw [Pester.Factory]::CreateShouldErrorRecord($Message, $MyInvocation.ScriptName, $MyInvocation.ScriptLineNumber, $MyInvocation.Line.TrimEnd([System.Environment]::NewLine), $true)
+        return (Invoke-AssertionFailed -Message $Message -InvocationInfo $MyInvocation)
     }
 
     $failReasons = $null
@@ -96,6 +96,6 @@
             }
             $Message += "`nReasons :`n$failReasons"
         }
-        throw [Pester.Factory]::CreateShouldErrorRecord($Message, $MyInvocation.ScriptName, $MyInvocation.ScriptLineNumber, $MyInvocation.Line.TrimEnd([System.Environment]::NewLine), $true)
+        return (Invoke-AssertionFailed -Message $Message -InvocationInfo $MyInvocation)
     }
 }

--- a/src/functions/assert/Collection/Should-BeCollection.ps1
+++ b/src/functions/assert/Collection/Should-BeCollection.ps1
@@ -56,25 +56,25 @@
 
     if (-not (Is-Collection -Value $Actual)) {
         $Message = Get-AssertionMessage -Expected $Expected -Actual $Actual -Because $Because -DefaultMessage "Actual <actualType> <actual> is not a collection."
-        throw [Pester.Factory]::CreateShouldErrorRecord($Message, $MyInvocation.ScriptName, $MyInvocation.ScriptLineNumber, $MyInvocation.Line.TrimEnd([System.Environment]::NewLine), $true)
+        return (Invoke-AssertionFailed -Message $Message -InvocationInfo $MyInvocation)
     }
 
     if ($PSCmdlet.ParameterSetName -eq 'Count') {
         if ($Count -ne $Actual.Count) {
             $Message = Get-AssertionMessage -Expected $Count -Actual $Actual -Because $Because -Data @{ actualCount = $Actual.Count } -DefaultMessage "Expected <expected> items in <actualType> <actual>,<because> but it has <actualCount> items."
-            throw [Pester.Factory]::CreateShouldErrorRecord($Message, $MyInvocation.ScriptName, $MyInvocation.ScriptLineNumber, $MyInvocation.Line.TrimEnd([System.Environment]::NewLine), $true)
+            return (Invoke-AssertionFailed -Message $Message -InvocationInfo $MyInvocation)
         }
         return
     }
 
     if (-not (Is-Collection -Value $Expected)) {
         $Message = Get-AssertionMessage -Expected $Expected -Actual $Actual -Because $Because -DefaultMessage "Expected <expectedType> <expected> is not a collection."
-        throw [Pester.Factory]::CreateShouldErrorRecord($Message, $MyInvocation.ScriptName, $MyInvocation.ScriptLineNumber, $MyInvocation.Line.TrimEnd([System.Environment]::NewLine), $true)
+        return (Invoke-AssertionFailed -Message $Message -InvocationInfo $MyInvocation)
     }
 
     if (-not (Is-CollectionSize -Expected $Expected -Actual $Actual)) {
         $Message = Get-AssertionMessage -Expected $Expected -Actual $Actual -Because $Because -DefaultMessage "Expected <expectedType> <expected> to be present in <actualType> <actual>,<because> but they don't have the same number of items."
-        throw [Pester.Factory]::CreateShouldErrorRecord($Message, $MyInvocation.ScriptName, $MyInvocation.ScriptLineNumber, $MyInvocation.Line.TrimEnd([System.Environment]::NewLine), $true)
+        return (Invoke-AssertionFailed -Message $Message -InvocationInfo $MyInvocation)
     }
 
     if (-Not $InOrder) {
@@ -122,7 +122,7 @@
             $expectedDifference = $(for ($e = 0; $e -lt $actualLength; $e++) { if ($same -ne $expectedCopy[$e]) { "$(Format-Nicely2 $expectedCopy[$e]) (index $e)" } }) -join ", "
 
             $Message = Get-AssertionMessage -Expected $Expected -Actual $Actual -Because $Because -Data @{ expectedDifference = $expectedDifference; actualDifference = $actualDifference } -DefaultMessage "Expected <expectedType> <expected> to be present in <actualType> <actual> in any order, but some values were not.`nMissing in actual: <expectedDifference>`nExtra in actual: <actualDifference>"
-            throw [Pester.Factory]::CreateShouldErrorRecord($Message, $MyInvocation.ScriptName, $MyInvocation.ScriptLineNumber, $MyInvocation.Line.TrimEnd([System.Environment]::NewLine), $true)
+            return (Invoke-AssertionFailed -Message $Message -InvocationInfo $MyInvocation)
         }
     }
 }

--- a/src/functions/assert/Collection/Should-ContainCollection.ps1
+++ b/src/functions/assert/Collection/Should-ContainCollection.ps1
@@ -49,6 +49,6 @@
     $Actual = $collectedInput.Actual
     if ($Actual -notcontains $Expected) {
         $Message = Get-AssertionMessage -Expected $Expected -Actual $Actual -Because $Because -DefaultMessage "Expected <expectedType> <expected> to be present in <actualType> <actual>, but it was not there."
-        throw [Pester.Factory]::CreateShouldErrorRecord($Message, $MyInvocation.ScriptName, $MyInvocation.ScriptLineNumber, $MyInvocation.Line.TrimEnd([System.Environment]::NewLine), $true)
+        return (Invoke-AssertionFailed -Message $Message -InvocationInfo $MyInvocation)
     }
 }

--- a/src/functions/assert/Collection/Should-NotContainCollection.ps1
+++ b/src/functions/assert/Collection/Should-NotContainCollection.ps1
@@ -49,6 +49,6 @@
     $Actual = $collectedInput.Actual
     if ($Actual -contains $Expected) {
         $Message = Get-AssertionMessage -Expected $Expected -Actual $Actual -Because $Because -DefaultMessage "Expected <expectedType> <expected> to not be present in collection <actual>, but it was there."
-        throw [Pester.Factory]::CreateShouldErrorRecord($Message, $MyInvocation.ScriptName, $MyInvocation.ScriptLineNumber, $MyInvocation.Line.TrimEnd([System.Environment]::NewLine), $true)
+        return (Invoke-AssertionFailed -Message $Message -InvocationInfo $MyInvocation)
     }
 }

--- a/src/functions/assert/Common/Invoke-AssertionFailed.ps1
+++ b/src/functions/assert/Common/Invoke-AssertionFailed.ps1
@@ -1,0 +1,66 @@
+﻿$script:PesterAssertionContext = $null
+$script:PesterAssertionInMockParameterFilter = $false
+
+function Set-PesterAssertionMockParameterFilter {
+    param (
+        [bool] $IsActive
+    )
+
+    $previousState = $script:PesterAssertionInMockParameterFilter
+    $script:PesterAssertionInMockParameterFilter = $IsActive
+
+    $previousState
+}
+
+function Get-AssertionFailureContext {
+    if ($script:PesterAssertionInMockParameterFilter) {
+        return @{
+            ShouldThrow      = $true
+            AddErrorCallback = $null
+        }
+    }
+
+    $context = $script:PesterAssertionContext
+    if ($null -eq $context) {
+        return @{
+            ShouldThrow      = $true
+            AddErrorCallback = $null
+        }
+    }
+
+    $shouldThrow = 'Stop' -eq $context.Configuration.Should.ErrorAction.Value
+
+    @{
+        ShouldThrow      = $shouldThrow
+        AddErrorCallback = if ($shouldThrow) { $null } else { $context.AddErrorCallback }
+    }
+}
+
+function Invoke-AssertionFailed {
+    param (
+        [Parameter(Mandatory)]
+        [string] $Message,
+
+        [Parameter(Mandatory)]
+        [Management.Automation.InvocationInfo] $InvocationInfo,
+
+        $ShouldResult
+    )
+
+    $failureContext = Get-AssertionFailureContext
+    $lineText = if ($null -eq $InvocationInfo.Line) { $null } else { $InvocationInfo.Line.TrimEnd([System.Environment]::NewLine) }
+    $errorRecord = [Pester.Factory]::CreateShouldErrorRecord($Message, $InvocationInfo.ScriptName, $InvocationInfo.ScriptLineNumber, $lineText, $failureContext.ShouldThrow, $ShouldResult)
+
+    if ($null -eq $failureContext.AddErrorCallback -or $failureContext.ShouldThrow) {
+        throw $errorRecord
+    }
+
+    try {
+        throw $errorRecord
+    }
+    catch {
+        $errorRecord = $_
+    }
+
+    & $failureContext.AddErrorCallback $errorRecord
+}

--- a/src/functions/assert/Equivalence/Should-BeEquivalent.ps1
+++ b/src/functions/assert/Equivalence/Should-BeEquivalent.ps1
@@ -714,7 +714,7 @@ function Should-BeEquivalent {
         $optionsFormatted = Format-EquivalencyOptions -Options $Options
         # the parameter is -Option not -Options
         $message = Get-AssertionMessage -Actual $actual -Expected $Expected -Option $optionsFormatted -Pretty -CustomMessage "Expected and actual are not equivalent!`nExpected:`n<expected>`n`nActual:`n<actual>`n`nSummary:`n$areDifferent`n<options>"
-        throw [Pester.Factory]::CreateShouldErrorRecord($message, $MyInvocation.ScriptName, $MyInvocation.ScriptLineNumber, $MyInvocation.Line.TrimEnd([System.Environment]::NewLine), $true)
+        return (Invoke-AssertionFailed -Message $message -InvocationInfo $MyInvocation)
     }
 
     Write-EquivalenceResult -Equivalence "`$Actual and `$Expected are equivalent."

--- a/src/functions/assert/Exception/Should-Throw.ps1
+++ b/src/functions/assert/Exception/Should-Throw.ps1
@@ -1,4 +1,4 @@
-function Should-Throw {
+﻿function Should-Throw {
     <#
     .SYNOPSIS
     Asserts that a script block throws an exception.
@@ -128,7 +128,7 @@ function Should-Throw {
 
         $Message = Get-AssertionMessage -Expected $Expected -Actual $ScriptBlock -Because $Because `
             -DefaultMessage $defaultMessage
-        throw [Pester.Factory]::CreateShouldErrorRecord($Message, $MyInvocation.ScriptName, $MyInvocation.ScriptLineNumber, $MyInvocation.Line.TrimEnd([System.Environment]::NewLine), $true)
+        return (Invoke-AssertionFailed -Message $Message -InvocationInfo $MyInvocation)
     }
 
     $err.ErrorRecord

--- a/src/functions/assert/General/Should-Be.ps1
+++ b/src/functions/assert/General/Should-Be.ps1
@@ -42,6 +42,6 @@
 
     if ((Ensure-ExpectedIsNotCollection $Expected) -ne $Actual) {
         $Message = Get-AssertionMessage -Expected $Expected -Actual $Actual -Because $Because -DefaultMessage "Expected <expectedType> <expected>,<because> but got <actualType> <actual>."
-        throw [Pester.Factory]::CreateShouldErrorRecord($Message, $MyInvocation.ScriptName, $MyInvocation.ScriptLineNumber, $MyInvocation.Line.TrimEnd([System.Environment]::NewLine), $true)
+        return (Invoke-AssertionFailed -Message $Message -InvocationInfo $MyInvocation)
     }
 }

--- a/src/functions/assert/General/Should-BeGreaterThan.ps1
+++ b/src/functions/assert/General/Should-BeGreaterThan.ps1
@@ -40,6 +40,6 @@
     $Actual = $collectedInput.Actual
     if ((Ensure-ExpectedIsNotCollection $Expected) -ge $Actual) {
         $Message = Get-AssertionMessage -Expected $Expected -Actual $Actual -Because $Because -DefaultMessage "Expected the actual value to be greater than <expectedType> <expected>,<because> but it was not. Actual: <actualType> <actual>"
-        throw [Pester.Factory]::CreateShouldErrorRecord($Message, $MyInvocation.ScriptName, $MyInvocation.ScriptLineNumber, $MyInvocation.Line.TrimEnd([System.Environment]::NewLine), $true)
+        return (Invoke-AssertionFailed -Message $Message -InvocationInfo $MyInvocation)
     }
 }

--- a/src/functions/assert/General/Should-BeGreaterThanOrEqual.ps1
+++ b/src/functions/assert/General/Should-BeGreaterThanOrEqual.ps1
@@ -40,6 +40,6 @@
     $Actual = $collectedInput.Actual
     if ((Ensure-ExpectedIsNotCollection $Expected) -gt $Actual) {
         $Message = Get-AssertionMessage -Expected $Expected -Actual $Actual -Because $Because -DefaultMessage "Expected the actual value to be greater than or equal to <expectedType> <expected>,<because> but it was not. Actual: <actualType> <actual>"
-        throw [Pester.Factory]::CreateShouldErrorRecord($Message, $MyInvocation.ScriptName, $MyInvocation.ScriptLineNumber, $MyInvocation.Line.TrimEnd([System.Environment]::NewLine), $true)
+        return (Invoke-AssertionFailed -Message $Message -InvocationInfo $MyInvocation)
     }
 }

--- a/src/functions/assert/General/Should-BeLessThan.ps1
+++ b/src/functions/assert/General/Should-BeLessThan.ps1
@@ -40,6 +40,6 @@
     $Actual = $collectedInput.Actual
     if ((Ensure-ExpectedIsNotCollection $Expected) -le $Actual) {
         $Message = Get-AssertionMessage -Expected $Expected -Actual $Actual -Because $Because -DefaultMessage "Expected the actual value to be less than <expectedType> <expected>,<because> but it was not. Actual: <actualType> <actual>"
-        throw [Pester.Factory]::CreateShouldErrorRecord($Message, $MyInvocation.ScriptName, $MyInvocation.ScriptLineNumber, $MyInvocation.Line.TrimEnd([System.Environment]::NewLine), $true)
+        return (Invoke-AssertionFailed -Message $Message -InvocationInfo $MyInvocation)
     }
 }

--- a/src/functions/assert/General/Should-BeLessThanOrEqual.ps1
+++ b/src/functions/assert/General/Should-BeLessThanOrEqual.ps1
@@ -49,6 +49,6 @@
     $Actual = $collectedInput.Actual
     if ((Ensure-ExpectedIsNotCollection $Expected) -lt $Actual) {
         $Message = Get-AssertionMessage -Expected $Expected -Actual $Actual -Because $Because -DefaultMessage "Expected the actual value to be less than or equal to <expectedType> <expected>,<because> but it was not. Actual: <actualType> <actual>"
-        throw [Pester.Factory]::CreateShouldErrorRecord($Message, $MyInvocation.ScriptName, $MyInvocation.ScriptLineNumber, $MyInvocation.Line.TrimEnd([System.Environment]::NewLine), $true)
+        return (Invoke-AssertionFailed -Message $Message -InvocationInfo $MyInvocation)
     }
 }

--- a/src/functions/assert/General/Should-BeNull.ps1
+++ b/src/functions/assert/General/Should-BeNull.ps1
@@ -34,6 +34,6 @@
     $Actual = $collectedInput.Actual
     if ($null -ne $Actual) {
         $Message = Get-AssertionMessage -Expected $null -Actual $Actual -Because $Because -DefaultMessage "Expected `$null,<because> but got <actualType> '<actual>'."
-        throw [Pester.Factory]::CreateShouldErrorRecord($Message, $MyInvocation.ScriptName, $MyInvocation.ScriptLineNumber, $MyInvocation.Line.TrimEnd([System.Environment]::NewLine), $true)
+        return (Invoke-AssertionFailed -Message $Message -InvocationInfo $MyInvocation)
     }
 }

--- a/src/functions/assert/General/Should-BeSame.ps1
+++ b/src/functions/assert/General/Should-BeSame.ps1
@@ -57,6 +57,6 @@
     $Actual = $collectedInput.Actual
     if (-not ([object]::ReferenceEquals($Expected, $Actual))) {
         $Message = Get-AssertionMessage -Expected $Expected -Actual $Actual -Because $Because -DefaultMessage "Expected <expectedType> <expected>,<because> to be the same instance but it was not. Actual: <actualType> <actual>"
-        throw [Pester.Factory]::CreateShouldErrorRecord($Message, $MyInvocation.ScriptName, $MyInvocation.ScriptLineNumber, $MyInvocation.Line.TrimEnd([System.Environment]::NewLine), $true)
+        return (Invoke-AssertionFailed -Message $Message -InvocationInfo $MyInvocation)
     }
 }

--- a/src/functions/assert/General/Should-HaveType.ps1
+++ b/src/functions/assert/General/Should-HaveType.ps1
@@ -40,6 +40,6 @@
     $Actual = $collectedInput.Actual
     if ($Actual -isnot $Expected) {
         $Message = Get-AssertionMessage -Expected $Expected -Actual $Actual -Because $Because -DefaultMessage "Expected value to have type <expected>,<because> but got <actualType> <actual>."
-        throw [Pester.Factory]::CreateShouldErrorRecord($Message, $MyInvocation.ScriptName, $MyInvocation.ScriptLineNumber, $MyInvocation.Line.TrimEnd([System.Environment]::NewLine), $true)
+        return (Invoke-AssertionFailed -Message $Message -InvocationInfo $MyInvocation)
     }
 }

--- a/src/functions/assert/General/Should-NotBe.ps1
+++ b/src/functions/assert/General/Should-NotBe.ps1
@@ -41,6 +41,6 @@
     $Actual = $collectedInput.Actual
     if ((Ensure-ExpectedIsNotCollection $Expected) -eq $Actual) {
         $Message = Get-AssertionMessage -Expected $Expected -Actual $Actual -Because $Because -DefaultMessage "Expected <expectedType> <expected>, to be different than the actual value,<because> but they were equal."
-        throw [Pester.Factory]::CreateShouldErrorRecord($Message, $MyInvocation.ScriptName, $MyInvocation.ScriptLineNumber, $MyInvocation.Line.TrimEnd([System.Environment]::NewLine), $true)
+        return (Invoke-AssertionFailed -Message $Message -InvocationInfo $MyInvocation)
     }
 }

--- a/src/functions/assert/General/Should-NotBeNull.ps1
+++ b/src/functions/assert/General/Should-NotBeNull.ps1
@@ -34,6 +34,6 @@
     $Actual = $collectedInput.Actual
     if ($null -eq $Actual) {
         $Message = Get-AssertionMessage -Expected $null -Actual $Actual -Because $Because -DefaultMessage "Expected not `$null,<because> but got `$null."
-        throw [Pester.Factory]::CreateShouldErrorRecord($Message, $MyInvocation.ScriptName, $MyInvocation.ScriptLineNumber, $MyInvocation.Line.TrimEnd([System.Environment]::NewLine), $true)
+        return (Invoke-AssertionFailed -Message $Message -InvocationInfo $MyInvocation)
     }
 }

--- a/src/functions/assert/General/Should-NotBeSame.ps1
+++ b/src/functions/assert/General/Should-NotBeSame.ps1
@@ -52,6 +52,6 @@
     $Actual = $collectedInput.Actual
     if ([object]::ReferenceEquals($Expected, $Actual)) {
         $Message = Get-AssertionMessage -Expected $Expected -Actual $Actual -Because $Because -DefaultMessage "Expected <expectedType> <expected>, to not be the same instance,<because> but they were the same instance."
-        throw [Pester.Factory]::CreateShouldErrorRecord($Message, $MyInvocation.ScriptName, $MyInvocation.ScriptLineNumber, $MyInvocation.Line.TrimEnd([System.Environment]::NewLine), $true)
+        return (Invoke-AssertionFailed -Message $Message -InvocationInfo $MyInvocation)
     }
 }

--- a/src/functions/assert/General/Should-NotHaveType.ps1
+++ b/src/functions/assert/General/Should-NotHaveType.ps1
@@ -42,6 +42,6 @@
     $Actual = $collectedInput.Actual
     if ($Actual -is $Expected) {
         $Message = Get-AssertionMessage -Expected $Expected -Actual $Actual -Because $Because -DefaultMessage "Expected value to be of different type than <expected>,<because> but got <actualType> <actual>."
-        throw [Pester.Factory]::CreateShouldErrorRecord($Message, $MyInvocation.ScriptName, $MyInvocation.ScriptLineNumber, $MyInvocation.Line.TrimEnd([System.Environment]::NewLine), $true)
+        return (Invoke-AssertionFailed -Message $Message -InvocationInfo $MyInvocation)
     }
 }

--- a/src/functions/assert/Mock/Should-Invoke.ps1
+++ b/src/functions/assert/Mock/Should-Invoke.ps1
@@ -184,7 +184,7 @@
     if ($PSBoundParameters.ContainsKey('Verifiable')) {
         $PSBoundParameters.Remove('Verifiable')
         $testResult = Should-InvokeVerifiable @PSBoundParameters
-        Test-AssertionResult $testResult
+        Test-AssertionResult -TestResult $testResult -InvocationInfo $MyInvocation
         return
     }
 
@@ -195,5 +195,5 @@
     $PSBoundParameters["CallerSessionState"] = $PSCmdlet.SessionState
     $testResult = Should-InvokeAssertion @PSBoundParameters
 
-    Test-AssertionResult $testResult
+    Test-AssertionResult -TestResult $testResult -InvocationInfo $MyInvocation
 }

--- a/src/functions/assert/Mock/Should-NotInvoke.ps1
+++ b/src/functions/assert/Mock/Should-NotInvoke.ps1
@@ -173,7 +173,7 @@
     if ($PSBoundParameters.ContainsKey('Verifiable')) {
         $PSBoundParameters.Remove('Verifiable')
         $testResult = Should-InvokeVerifiable @PSBoundParameters
-        Test-AssertionResult $testResult
+        Test-AssertionResult -TestResult $testResult -InvocationInfo $MyInvocation
         return
     }
 
@@ -183,5 +183,5 @@
     $PSBoundParameters["CallerSessionState"] = $PSCmdlet.SessionState
     $testResult = Should-InvokeAssertion @PSBoundParameters
 
-    Test-AssertionResult $testResult
+    Test-AssertionResult -TestResult $testResult -InvocationInfo $MyInvocation
 }

--- a/src/functions/assert/Parameter/Should-HaveParameter.ps1
+++ b/src/functions/assert/Parameter/Should-HaveParameter.ps1
@@ -1,4 +1,4 @@
-function Should-HaveParameter {
+﻿function Should-HaveParameter {
     <#
     .SYNOPSIS
     Asserts that a command has the expected parameter.
@@ -73,5 +73,5 @@ function Should-HaveParameter {
 
     $testResult = Should-HaveParameterAssertion @PSBoundParameters
 
-    Test-AssertionResult $testResult
+    Test-AssertionResult -TestResult $testResult -InvocationInfo $MyInvocation
 }

--- a/src/functions/assert/Parameter/Should-NotHaveParameter.ps1
+++ b/src/functions/assert/Parameter/Should-NotHaveParameter.ps1
@@ -1,4 +1,4 @@
-function Should-NotHaveParameter {
+﻿function Should-NotHaveParameter {
     <#
     .SYNOPSIS
     Asserts that a command has does not have the parameter.
@@ -49,5 +49,5 @@ function Should-NotHaveParameter {
 
     $testResult = Should-HaveParameterAssertion @PSBoundParameters
 
-    Test-AssertionResult $testResult
+    Test-AssertionResult -TestResult $testResult -InvocationInfo $MyInvocation
 }

--- a/src/functions/assert/String/Should-BeEmptyString.ps1
+++ b/src/functions/assert/String/Should-BeEmptyString.ps1
@@ -53,6 +53,6 @@
 
     if ($Actual -isnot [String] -or -not [String]::IsNullOrEmpty( $Actual)) {
         $formattedMessage = Get-AssertionMessage -Actual $Actual -Because $Because -DefaultMessage "Expected a [string] that is empty,<because> but got <actualType>: <actual>" -Pretty
-        throw [Pester.Factory]::CreateShouldErrorRecord($formattedMessage, $MyInvocation.ScriptName, $MyInvocation.ScriptLineNumber, $MyInvocation.Line.TrimEnd([System.Environment]::NewLine), $true)
+        return (Invoke-AssertionFailed -Message $formattedMessage -InvocationInfo $MyInvocation)
     }
 }

--- a/src/functions/assert/String/Should-BeLikeString.ps1
+++ b/src/functions/assert/String/Should-BeLikeString.ps1
@@ -81,6 +81,6 @@ function Should-BeLikeString {
         }
 
         $Message = Get-AssertionMessage -Expected $null -Actual $Actual -Because $Because -DefaultMessage "Expected the string '$Actual' to$caseSensitiveMessage be like '$Expected',<because> but it did not."
-        throw [Pester.Factory]::CreateShouldErrorRecord($Message, $MyInvocation.ScriptName, $MyInvocation.ScriptLineNumber, $MyInvocation.Line.TrimEnd([System.Environment]::NewLine), $true)
+        return (Invoke-AssertionFailed -Message $Message -InvocationInfo $MyInvocation)
     }
 }

--- a/src/functions/assert/String/Should-BeString.ps1
+++ b/src/functions/assert/String/Should-BeString.ps1
@@ -96,6 +96,6 @@ function Should-BeString {
     $stringsAreEqual = Test-StringEqual -Expected $Expected -Actual $Actual -CaseSensitive:$CaseSensitive -IgnoreWhitespace:$IgnoreWhiteSpace -TrimWhitespace:$TrimWhitespace
     if (-not ($stringsAreEqual)) {
         $Message = Get-AssertionMessage -Expected $Expected -Actual $Actual -Because $Because -DefaultMessage "Expected <expectedType> <expected>, but got <actualType> <actual>."
-        throw [Pester.Factory]::CreateShouldErrorRecord($Message, $MyInvocation.ScriptName, $MyInvocation.ScriptLineNumber, $MyInvocation.Line.TrimEnd([System.Environment]::NewLine), $true)
+        return (Invoke-AssertionFailed -Message $Message -InvocationInfo $MyInvocation)
     }
 }

--- a/src/functions/assert/String/Should-NotBeEmptyString.ps1
+++ b/src/functions/assert/String/Should-NotBeEmptyString.ps1
@@ -53,6 +53,6 @@
 
     if ($Actual -isnot [String] -or [String]::IsNullOrEmpty($Actual)) {
         $formattedMessage = Get-AssertionMessage -Actual $Actual -Because $Because -DefaultMessage "Expected a [string] that is not `$null or empty,<because> but got <actualType>: <actual>" -Pretty
-        throw [Pester.Factory]::CreateShouldErrorRecord($formattedMessage, $MyInvocation.ScriptName, $MyInvocation.ScriptLineNumber, $MyInvocation.Line.TrimEnd([System.Environment]::NewLine), $true)
+        return (Invoke-AssertionFailed -Message $formattedMessage -InvocationInfo $MyInvocation)
     }
 }

--- a/src/functions/assert/String/Should-NotBeLikeString.ps1
+++ b/src/functions/assert/String/Should-NotBeLikeString.ps1
@@ -90,6 +90,6 @@ function Should-NotBeLikeString {
             $formattedMessage = Get-CustomFailureMessage -Expected $Expected -Actual $Actual -Because $Because -CaseSensitive:$CaseSensitive
         }
 
-        throw [Pester.Factory]::CreateShouldErrorRecord($formattedMessage, $MyInvocation.ScriptName, $MyInvocation.ScriptLineNumber, $MyInvocation.Line.TrimEnd([System.Environment]::NewLine), $true)
+        return (Invoke-AssertionFailed -Message $formattedMessage -InvocationInfo $MyInvocation)
     }
 }

--- a/src/functions/assert/String/Should-NotBeString.ps1
+++ b/src/functions/assert/String/Should-NotBeString.ps1
@@ -74,6 +74,6 @@ function Should-NotBeString {
             $formattedMessage = Get-CustomFailureMessage -Expected $Expected -Actual $Actual -Because $Because
         }
 
-        throw [Pester.Factory]::CreateShouldErrorRecord($formattedMessage, $MyInvocation.ScriptName, $MyInvocation.ScriptLineNumber, $MyInvocation.Line.TrimEnd([System.Environment]::NewLine), $true)
+        return (Invoke-AssertionFailed -Message $formattedMessage -InvocationInfo $MyInvocation)
     }
 }

--- a/src/functions/assert/String/Should-NotBeWhiteSpaceString.ps1
+++ b/src/functions/assert/String/Should-NotBeWhiteSpaceString.ps1
@@ -54,6 +54,6 @@
 
     if ($Actual -isnot [string] -or [string]::IsNullOrWhiteSpace($Actual)) {
         $formattedMessage = Get-AssertionMessage -Actual $Actual -Because $Because -DefaultMessage "Expected a [string] that is not `$null, empty or whitespace,<because> but got <actualType>: <actual>" -Pretty
-        throw [Pester.Factory]::CreateShouldErrorRecord($formattedMessage, $MyInvocation.ScriptName, $MyInvocation.ScriptLineNumber, $MyInvocation.Line.TrimEnd([System.Environment]::NewLine), $true)
+        return (Invoke-AssertionFailed -Message $formattedMessage -InvocationInfo $MyInvocation)
     }
 }

--- a/src/functions/assert/Time/Should-BeAfter.ps1
+++ b/src/functions/assert/Time/Should-BeAfter.ps1
@@ -110,6 +110,6 @@
 
     if ($Actual -le $Expected) {
         $Message = Get-AssertionMessage -Expected $Expected -Actual $Actual -Because $Because -DefaultMessage "Expected the provided [datetime] to be after <expectedType> <expected>,<because> but it was before: <actual>"
-        throw [Pester.Factory]::CreateShouldErrorRecord($Message, $MyInvocation.ScriptName, $MyInvocation.ScriptLineNumber, $MyInvocation.Line.TrimEnd([System.Environment]::NewLine), $true)
+        return (Invoke-AssertionFailed -Message $Message -InvocationInfo $MyInvocation)
     }
 }

--- a/src/functions/assert/Time/Should-BeBefore.ps1
+++ b/src/functions/assert/Time/Should-BeBefore.ps1
@@ -110,6 +110,6 @@
 
     if ($Actual -ge $Expected) {
         $Message = Get-AssertionMessage -Expected $Expected -Actual $Actual -Because $Because -DefaultMessage "Expected the provided [datetime] to be before <expectedType> <expected>,<because> but it was after: <actual>"
-        throw [Pester.Factory]::CreateShouldErrorRecord($Message, $MyInvocation.ScriptName, $MyInvocation.ScriptLineNumber, $MyInvocation.Line.TrimEnd([System.Environment]::NewLine), $true)
+        return (Invoke-AssertionFailed -Message $Message -InvocationInfo $MyInvocation)
     }
 }

--- a/src/functions/assert/Time/Should-BeFasterThan.ps1
+++ b/src/functions/assert/Time/Should-BeFasterThan.ps1
@@ -58,7 +58,7 @@
 
         if ($sw.Elapsed -ge $Expected) {
             $Message = Get-AssertionMessage -Expected $Expected -Actual $sw.Elapsed -Because $Because -Data @{ scriptblock = $Actual } -DefaultMessage "Expected the provided [scriptblock] to execute faster than <expectedType> <expected>,<because> but it took <actual> to run.`nScriptBlock: <scriptblock>"
-            throw [Pester.Factory]::CreateShouldErrorRecord($Message, $MyInvocation.ScriptName, $MyInvocation.ScriptLineNumber, $MyInvocation.Line.TrimEnd([System.Environment]::NewLine), $true)
+            return (Invoke-AssertionFailed -Message $Message -InvocationInfo $MyInvocation)
         }
         return
     }
@@ -66,7 +66,7 @@
     if ($Actual -is [timespan]) {
         if ($Actual -ge $Expected) {
             $Message = Get-AssertionMessage -Expected $Expected -Actual $Actual -Because $Because -DefaultMessage "The provided [timespan] should be shorter than <expectedType> <expected>,<because> but it was longer: <actual>"
-            throw [Pester.Factory]::CreateShouldErrorRecord($Message, $MyInvocation.ScriptName, $MyInvocation.ScriptLineNumber, $MyInvocation.Line.TrimEnd([System.Environment]::NewLine), $true)
+            return (Invoke-AssertionFailed -Message $Message -InvocationInfo $MyInvocation)
         }
         return
     }

--- a/src/functions/assert/Time/Should-BeSlowerThan.ps1
+++ b/src/functions/assert/Time/Should-BeSlowerThan.ps1
@@ -64,7 +64,7 @@
 
         if ($sw.Elapsed -le $Expected) {
             $Message = Get-AssertionMessage -Expected $Expected -Actual $sw.Elapsed -Because $Because -Data @{ scriptblock = $Actual } -DefaultMessage "The provided [scriptblock] should execute slower than <expectedType> <expected>,<because> but it took <actual> to run.`nScriptBlock: <scriptblock>"
-            throw [Pester.Factory]::CreateShouldErrorRecord($Message, $MyInvocation.ScriptName, $MyInvocation.ScriptLineNumber, $MyInvocation.Line.TrimEnd([System.Environment]::NewLine), $true)
+            return (Invoke-AssertionFailed -Message $Message -InvocationInfo $MyInvocation)
         }
         return
     }
@@ -72,7 +72,7 @@
     if ($Actual -is [timespan]) {
         if ($Actual -le $Expected) {
             $Message = Get-AssertionMessage -Expected $Expected -Actual $Actual -Because $Because -DefaultMessage "The provided [timespan] should be longer than <expectedType> <expected>,<because> but it was shorter: <actual>"
-            throw [Pester.Factory]::CreateShouldErrorRecord($Message, $MyInvocation.ScriptName, $MyInvocation.ScriptLineNumber, $MyInvocation.Line.TrimEnd([System.Environment]::NewLine), $true)
+            return (Invoke-AssertionFailed -Message $Message -InvocationInfo $MyInvocation)
         }
         return
     }

--- a/src/functions/assertions/Should.ps1
+++ b/src/functions/assertions/Should.ps1
@@ -238,16 +238,27 @@ function Invoke-Assertion {
 
     $testResult = & $AssertionEntry.Test -ActualValue $ValueToTest -Negate:$Negate -CallerSessionState $CallerSessionState @BoundParameters
 
-    Test-AssertionResult $testResult
+    Test-AssertionResult -TestResult $testResult -File $File -LineNumber $LineNumber -LineText $LineText -ShouldThrow $ShouldThrow -AddErrorCallback $AddErrorCallback
 }
 
 function Test-AssertionResult {
     param (
-        $TestResult
+        $TestResult,
+        [Management.Automation.InvocationInfo] $InvocationInfo,
+        $File,
+        $LineNumber,
+        $LineText,
+        [bool] $ShouldThrow,
+        [ScriptBlock] $AddErrorCallback
     )
 
     if (-not $TestResult.Succeeded) {
-        $errorRecord = [Pester.Factory]::CreateShouldErrorRecord($TestResult.FailureMessage, $file, $lineNumber, $lineText, $shouldThrow, $TestResult)
+        if ($null -ne $InvocationInfo) {
+            Invoke-AssertionFailed -Message $TestResult.FailureMessage -InvocationInfo $InvocationInfo -ShouldResult $TestResult
+            return
+        }
+
+        $errorRecord = [Pester.Factory]::CreateShouldErrorRecord($TestResult.FailureMessage, $File, $LineNumber, $LineText, $ShouldThrow, $TestResult)
 
         if ($null -eq $AddErrorCallback -or $ShouldThrow) {
             # throw this error to fail the test immediately

--- a/tst/Pester.Mock.RSpec.ts.ps1
+++ b/tst/Pester.Mock.RSpec.ts.ps1
@@ -360,6 +360,40 @@ i -PassThru:$PassThru {
             $err[-3] | Verify-Equal "Expected: 'a'"
             $err[-2] | Verify-Equal "But was:  'b'"
         }
+
+        t "new Should-* assertions still throw in parameter filters when Should ErrorAction preference is set to Continue" {
+            $sb = {
+                Describe "a" {
+                    It "it" {
+                        function f ($Name) { "real function" }
+                        Mock f -MockWith { "default mock" }
+                        Mock f -ParameterFilter { $Name | Should-Be "a" } -MockWith { "mock with filter" }
+
+                        f "b"
+                        "won't reach this"
+                    }
+                }
+            }
+
+            $r = Invoke-Pester -Configuration ([PesterConfiguration]@{
+                    Run    = @{
+                        ScriptBlock = $sb
+                        PassThru    = $true
+                    }
+                    Should = @{
+                        ErrorAction = 'Continue'
+                    }
+                    Output = @{
+                        CIFormat = 'None'
+                    }
+                })
+
+            $t = $r.Containers[0].Blocks[0].Tests[0]
+            $t.StandardOutput | Verify-Null
+            $t.ErrorRecord.Count | Verify-Equal 1
+            $t.ErrorRecord[0].TargetObject.Terminating | Verify-True
+            $t.ErrorRecord[0].Exception.Message | Verify-Equal "Expected [string] 'a', but got [string] 'b'."
+        }
     }
 
     b "splatting on default params" {

--- a/tst/Pester.RSpec.ts.ps1
+++ b/tst/Pester.RSpec.ts.ps1
@@ -449,6 +449,82 @@ i -PassThru:$PassThru {
             $test.ErrorRecord.Count | Verify-Equal 2
         }
 
+        t "New Should-* assertions collect multiple failures when configured to Continue" {
+            $sb = {
+                Describe "d1" {
+                    It "i1" {
+                        1 | Should-Be 2
+                        1 | Should-BeGreaterThan 2
+                        "but still output this"
+                    }
+                }
+            }
+            $r = Invoke-Pester -Configuration ([PesterConfiguration]@{
+                    Run    = @{ ScriptBlock = $sb; PassThru = $true }
+                    Should = @{ ErrorAction = 'Continue' }
+                })
+
+            $test = $r.Containers[0].Blocks[0].Tests[0]
+            $test | Verify-NotNull
+            $test.Result | Verify-Equal "Failed"
+            $test.ErrorRecord.Count | Verify-Equal 2
+            $test.ErrorRecord[0].TargetObject.Terminating | Verify-False
+            $test.ErrorRecord[1].TargetObject.Terminating | Verify-False
+            $test.StandardOutput | Verify-Equal "but still output this"
+        }
+
+        t "New Should-* assertions fail immediately when configured to Stop" {
+            $sb = {
+                Describe "d1" {
+                    It "i1" {
+                        1 | Should-Be 2
+                        "do not output this"
+                    }
+                }
+            }
+            $r = Invoke-Pester -Configuration ([PesterConfiguration]@{
+                    Run    = @{ ScriptBlock = $sb; PassThru = $true }
+                    Should = @{ ErrorAction = 'Stop' }
+                })
+
+            $test = $r.Containers[0].Blocks[0].Tests[0]
+            $test | Verify-NotNull
+            $test.Result | Verify-Equal "Failed"
+            $test.ErrorRecord.Count | Verify-Equal 1
+            $test.ErrorRecord[0].TargetObject.Terminating | Verify-True
+            $test.StandardOutput | Verify-Null
+        }
+
+        t "New Should-* assertions throw outside of Pester runtime" {
+            $modulePath = (Get-Module Pester | Select-Object -First 1 -ExpandProperty Path)
+            $job = Start-Job -ScriptBlock {
+                param($PesterPath)
+                Import-Module $PesterPath -Force | Out-Null
+                $PesterPreference = [PesterConfiguration]@{ Should = @{ ErrorAction = 'Continue' } }
+
+                try {
+                    1 | Should-Be 2
+                    [PSCustomObject]@{ Threw = $false }
+                }
+                catch {
+                    [PSCustomObject]@{
+                        Threw              = $true
+                        FullyQualifiedErrorId = $_.FullyQualifiedErrorId
+                        Message            = $_.Exception.Message
+                        Terminating        = $_.TargetObject.Terminating
+                    }
+                }
+            } -ArgumentList $modulePath
+
+            $result = $job | Wait-Job | Receive-Job
+            $job | Remove-Job -Force
+
+            $result.Threw | Verify-True
+            $result.FullyQualifiedErrorId | Verify-Equal 'PesterAssertionFailed'
+            $result.Message | Verify-Equal 'Expected [int] 2, but got [int] 1.'
+            $result.Terminating | Verify-True
+        }
+
         t "Should throws when called outside of Pester" {
             $PesterPreference = [PesterConfiguration]@{ Should = @{ ErrorAction = 'Continue' } }
             $err = { 1 | Should -Be 2 } | Verify-Throw


### PR DESCRIPTION
Fixes #2467

New Should-* assertions now support soft assertions (ErrorAction = Continue), allowing multiple assertion failures to be collected and reported together.

When Should.ErrorAction is 'Continue', assertion failures are recorded without stopping the test. When 'Stop' (default) or outside Pester runtime, assertions throw immediately as before.