### PR TITLE
Fix #2467: Add soft assertion support to new Should-* assertions

### DIFF
--- a/src/functions/assert/Boolean/Should-BeFalse.ps1
+++ b/src/functions/assert/Boolean/Should-BeFalse.ps1
@@ -1,4 +1,4 @@
-function Should-BeFalse {
+﻿function Should-BeFalse {
     <#
     .SYNOPSIS
     Compares the actual value to a boolean $false. It does not convert input values to boolean, and will fail for any value that is not $false.
@@ -38,6 +38,7 @@ function Should-BeFalse {
     https://pester.dev/docs/assertions
     #>
     [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseProcessBlockForPipelineCommand', '')]
+    [CmdletBinding()]
     param (
         [Parameter(ValueFromPipeline = $true)]
         $Actual,
@@ -48,7 +49,7 @@ function Should-BeFalse {
     $Actual = $collectedInput.Actual
     if ($Actual -isnot [bool] -or $Actual) {
         $Message = Get-AssertionMessage -Expected $false -Actual $Actual -Because $Because  -DefaultMessage "Expected <expectedType> <expected>,<because> but got: <actualType> <actual>."
-        throw (New-ShouldErrorRecord -Message $Message -Invocation $MyInvocation)
+        Invoke-AssertionFailed -Message $Message -CallerCmdlet $PSCmdlet
     }
     Set-AssertionPassResult
 }

--- a/src/functions/assert/Boolean/Should-BeFalsy.ps1
+++ b/src/functions/assert/Boolean/Should-BeFalsy.ps1
@@ -1,4 +1,4 @@
-function Should-BeFalsy {
+﻿function Should-BeFalsy {
     <#
     .SYNOPSIS
     Compares the actual value to a boolean $false or a falsy value: 0, "", $null or @(). It converts the input value to a boolean.
@@ -38,6 +38,7 @@ function Should-BeFalsy {
     https://pester.dev/docs/assertions
     #>
     [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseProcessBlockForPipelineCommand', '')]
+    [CmdletBinding()]
     param (
         [Parameter(ValueFromPipeline = $true)]
         $Actual,
@@ -48,7 +49,7 @@ function Should-BeFalsy {
     $Actual = $collectedInput.Actual
     if ($Actual) {
         $Message = Get-AssertionMessage -Expected $false -Actual $Actual -Because $Because -DefaultMessage 'Expected <expectedType> <expected> or a falsy value: 0, "", $null or @(),<because> but got: <actualType> <actual>.'
-        throw (New-ShouldErrorRecord -Message $Message -Invocation $MyInvocation)
+        Invoke-AssertionFailed -Message $Message -CallerCmdlet $PSCmdlet
     }
     Set-AssertionPassResult
 }

--- a/src/functions/assert/Boolean/Should-BeTrue.ps1
+++ b/src/functions/assert/Boolean/Should-BeTrue.ps1
@@ -1,4 +1,4 @@
-function Should-BeTrue {
+﻿function Should-BeTrue {
     <#
     .SYNOPSIS
     Compares the actual value to a boolean $true. It does not convert input values to boolean, and will fail for any value is not $true.
@@ -38,6 +38,7 @@ function Should-BeTrue {
     https://pester.dev/docs/assertions
     #>
     [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseProcessBlockForPipelineCommand', '')]
+    [CmdletBinding()]
     param (
         [Parameter(ValueFromPipeline = $true)]
         $Actual,
@@ -48,7 +49,7 @@ function Should-BeTrue {
     $Actual = $collectedInput.Actual
     if ($Actual -isnot [bool] -or -not $Actual) {
         $Message = Get-AssertionMessage -Expected $true -Actual $Actual -Because $Because -DefaultMessage "Expected <expectedType> <expected>,<because> but got: <actualType> <actual>."
-        throw (New-ShouldErrorRecord -Message $Message -Invocation $MyInvocation)
+        Invoke-AssertionFailed -Message $Message -CallerCmdlet $PSCmdlet
     }
     Set-AssertionPassResult
 }

--- a/src/functions/assert/Boolean/Should-BeTruthy.ps1
+++ b/src/functions/assert/Boolean/Should-BeTruthy.ps1
@@ -1,4 +1,4 @@
-function Should-BeTruthy {
+﻿function Should-BeTruthy {
     <#
     .SYNOPSIS
     Compares the actual value to a boolean $true. It converts input values to boolean, and will fail for any value is not $true, or truthy.
@@ -39,6 +39,7 @@ function Should-BeTruthy {
     https://pester.dev/docs/assertions
     #>
     [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseProcessBlockForPipelineCommand', '')]
+    [CmdletBinding()]
     param (
         [Parameter(ValueFromPipeline = $true)]
         $Actual,
@@ -49,7 +50,7 @@ function Should-BeTruthy {
     $Actual = $collectedInput.Actual
     if (-not $Actual) {
         $Message = Get-AssertionMessage -Expected $true -Actual $Actual -Because $Because -DefaultMessage "Expected <expectedType> <expected> or a truthy value,<because> but got: <actualType> <actual>."
-        throw (New-ShouldErrorRecord -Message $Message -Invocation $MyInvocation)
+        Invoke-AssertionFailed -Message $Message -CallerCmdlet $PSCmdlet
     }
     Set-AssertionPassResult
 }

--- a/src/functions/assert/Collection/Should-All.ps1
+++ b/src/functions/assert/Collection/Should-All.ps1
@@ -1,4 +1,4 @@
-function Should-All {
+﻿function Should-All {
     <#
     .SYNOPSIS
     Compares all items in a collection to a filter script. If the filter returns true, or does not throw for all the items in the collection, the assertion passes.
@@ -53,7 +53,7 @@ function Should-All {
 
     if ($null -eq $Actual -or 0 -eq @($Actual).Count) {
         $Message = Get-AssertionMessage -Expected $Expected -Actual $Actual -Data $data -Because $Because -DefaultMessage "Expected all items in collection to pass filter <expected>, but <actualType> <actual> contains no items to compare."
-        throw (New-ShouldErrorRecord -Message $Message -Invocation $MyInvocation)
+        Invoke-AssertionFailed -Message $Message -CallerCmdlet $PSCmdlet
     }
 
     $failReasons = $null
@@ -105,7 +105,7 @@ function Should-All {
             }
             $Message += "`nReasons :`n$failReasons"
         }
-        throw (New-ShouldErrorRecord -Message $Message -Invocation $MyInvocation)
+        Invoke-AssertionFailed -Message $Message -CallerCmdlet $PSCmdlet
     }
     Set-AssertionPassResult
 }

--- a/src/functions/assert/Collection/Should-Any.ps1
+++ b/src/functions/assert/Collection/Should-Any.ps1
@@ -1,4 +1,4 @@
-function Should-Any {
+﻿function Should-Any {
     <#
     .SYNOPSIS
     Compares all items in a collection to a filter script. If the filter returns true, or does not throw for any of the items in the collection, the assertion passes.
@@ -36,6 +36,7 @@ function Should-Any {
 
     #>
     [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseProcessBlockForPipelineCommand', '')]
+    [CmdletBinding()]
     param (
         [Parameter(ValueFromPipeline = $true, Position = 1)]
         $Actual,
@@ -52,7 +53,7 @@ function Should-Any {
 
     if ($null -eq $Actual -or 0 -eq @($Actual).Count) {
         $Message = Get-AssertionMessage -Expected $Expected -Actual $Actual -Data $data -Because $Because -DefaultMessage "Expected at least one item in collection to pass filter <expected>, but <actualType> <actual> contains no items to compare."
-        throw (New-ShouldErrorRecord -Message $Message -Invocation $MyInvocation)
+        Invoke-AssertionFailed -Message $Message -CallerCmdlet $PSCmdlet
     }
 
     $failReasons = $null
@@ -96,7 +97,7 @@ function Should-Any {
             }
             $Message += "`nReasons :`n$failReasons"
         }
-        throw (New-ShouldErrorRecord -Message $Message -Invocation $MyInvocation)
+        Invoke-AssertionFailed -Message $Message -CallerCmdlet $PSCmdlet
     }
     Set-AssertionPassResult
 }

--- a/src/functions/assert/Collection/Should-BeCollection.ps1
+++ b/src/functions/assert/Collection/Should-BeCollection.ps1
@@ -1,4 +1,4 @@
-function Should-BeCollection {
+﻿function Should-BeCollection {
     <#
     .SYNOPSIS
     Compares collections for equality, by comparing their sizes and each item in them. It does not compare the types of the input collections.
@@ -41,6 +41,7 @@ function Should-BeCollection {
     https://pester.dev/docs/assertions
     #>
     [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseProcessBlockForPipelineCommand', '')]
+    [CmdletBinding()]
     param (
         [Parameter(Position = 1, ValueFromPipeline = $true)]
         $Actual,
@@ -56,13 +57,13 @@ function Should-BeCollection {
 
     if (-not (Is-Collection -Value $Actual)) {
         $Message = Get-AssertionMessage -Expected $Expected -Actual $Actual -Because $Because -DefaultMessage "Actual <actualType> <actual> is not a collection."
-        throw (New-ShouldErrorRecord -Message $Message -Invocation $MyInvocation)
+        Invoke-AssertionFailed -Message $Message -CallerCmdlet $PSCmdlet
     }
 
     if ($PSCmdlet.ParameterSetName -eq 'Count') {
         if ($Count -ne $Actual.Count) {
             $Message = Get-AssertionMessage -Expected $Count -Actual $Actual -Because $Because -Data @{ actualCount = $Actual.Count } -DefaultMessage "Expected <expected> items in <actualType> <actual>,<because> but it has <actualCount> items."
-            throw (New-ShouldErrorRecord -Message $Message -Invocation $MyInvocation)
+            Invoke-AssertionFailed -Message $Message -CallerCmdlet $PSCmdlet
         }
         Set-AssertionPassResult
         return
@@ -70,12 +71,12 @@ function Should-BeCollection {
 
     if (-not (Is-Collection -Value $Expected)) {
         $Message = Get-AssertionMessage -Expected $Expected -Actual $Actual -Because $Because -DefaultMessage "Expected <expectedType> <expected> is not a collection."
-        throw (New-ShouldErrorRecord -Message $Message -Invocation $MyInvocation)
+        Invoke-AssertionFailed -Message $Message -CallerCmdlet $PSCmdlet
     }
 
     if (-not (Is-CollectionSize -Expected $Expected -Actual $Actual)) {
         $Message = Get-AssertionMessage -Expected $Expected -Actual $Actual -Because $Because -DefaultMessage "Expected <expectedType> <expected> to be present in <actualType> <actual>,<because> but they don't have the same number of items."
-        throw (New-ShouldErrorRecord -Message $Message -Invocation $MyInvocation)
+        Invoke-AssertionFailed -Message $Message -CallerCmdlet $PSCmdlet
     }
 
     if (-Not $InOrder) {
@@ -123,7 +124,7 @@ function Should-BeCollection {
             $expectedDifference = $(for ($e = 0; $e -lt $actualLength; $e++) { if ($same -ne $expectedCopy[$e]) { "$(Format-Nicely2 $expectedCopy[$e]) (index $e)" } }) -join ", "
 
             $Message = Get-AssertionMessage -Expected $Expected -Actual $Actual -Because $Because -Data @{ expectedDifference = $expectedDifference; actualDifference = $actualDifference } -DefaultMessage "Expected <expectedType> <expected> to be present in <actualType> <actual> in any order, but some values were not.`nMissing in actual: <expectedDifference>`nExtra in actual: <actualDifference>"
-            throw (New-ShouldErrorRecord -Message $Message -Invocation $MyInvocation)
+            Invoke-AssertionFailed -Message $Message -CallerCmdlet $PSCmdlet
         }
     }
     Set-AssertionPassResult

--- a/src/functions/assert/Collection/Should-ContainCollection.ps1
+++ b/src/functions/assert/Collection/Should-ContainCollection.ps1
@@ -1,4 +1,4 @@
-function Should-ContainCollection {
+﻿function Should-ContainCollection {
     <#
     .SYNOPSIS
     Compares collections to see if the expected collection is present in the provided collection. It does not compare the types of the input collections.
@@ -37,6 +37,7 @@ function Should-ContainCollection {
 
     #>
     [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseProcessBlockForPipelineCommand', '')]
+    [CmdletBinding()]
     param (
         [Parameter(Position = 1, ValueFromPipeline = $true)]
         $Actual,
@@ -49,7 +50,7 @@ function Should-ContainCollection {
     $Actual = $collectedInput.Actual
     if ($Actual -notcontains $Expected) {
         $Message = Get-AssertionMessage -Expected $Expected -Actual $Actual -Because $Because -DefaultMessage "Expected <expectedType> <expected> to be present in <actualType> <actual>, but it was not there."
-        throw (New-ShouldErrorRecord -Message $Message -Invocation $MyInvocation)
+        Invoke-AssertionFailed -Message $Message -CallerCmdlet $PSCmdlet
     }
     Set-AssertionPassResult
 }

--- a/src/functions/assert/Collection/Should-NotContainCollection.ps1
+++ b/src/functions/assert/Collection/Should-NotContainCollection.ps1
@@ -1,4 +1,4 @@
-function Should-NotContainCollection {
+﻿function Should-NotContainCollection {
     <#
     .SYNOPSIS
     Compares collections to ensure that the expected collection is not present in the provided collection. It does not compare the types of the input collections.
@@ -37,6 +37,7 @@ function Should-NotContainCollection {
 
     #>
     [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseProcessBlockForPipelineCommand', '')]
+    [CmdletBinding()]
     param (
         [Parameter(Position = 1, ValueFromPipeline = $true)]
         $Actual,
@@ -49,7 +50,7 @@ function Should-NotContainCollection {
     $Actual = $collectedInput.Actual
     if ($Actual -contains $Expected) {
         $Message = Get-AssertionMessage -Expected $Expected -Actual $Actual -Because $Because -DefaultMessage "Expected <expectedType> <expected> to not be present in collection <actual>, but it was there."
-        throw (New-ShouldErrorRecord -Message $Message -Invocation $MyInvocation)
+        Invoke-AssertionFailed -Message $Message -CallerCmdlet $PSCmdlet
     }
     Set-AssertionPassResult
 }

--- a/src/functions/assert/Common/Invoke-AssertionFailed.ps1
+++ b/src/functions/assert/Common/Invoke-AssertionFailed.ps1
@@ -1,0 +1,63 @@
+﻿function Invoke-AssertionFailed {
+    param (
+        [Parameter(Mandatory)]
+        [string] $Message,
+
+        [Parameter(Mandatory)]
+        [System.Management.Automation.PSCmdlet] $CallerCmdlet,
+
+        $Expected,
+        $Actual,
+        [string] $Because,
+        [switch] $Pretty
+    )
+
+    $newShouldErrorRecordParameters = @{}
+    if ($PSBoundParameters.ContainsKey('Expected')) { $newShouldErrorRecordParameters.Expected = $Expected }
+    if ($PSBoundParameters.ContainsKey('Actual')) { $newShouldErrorRecordParameters.Actual = $Actual }
+    if ($PSBoundParameters.ContainsKey('Because')) { $newShouldErrorRecordParameters.Because = $Because }
+    if ($PSBoundParameters.ContainsKey('Pretty')) { $newShouldErrorRecordParameters.Pretty = $Pretty }
+
+    $pesterRuntimeInvocationContext = $CallerCmdlet.SessionState.PSVariable.GetValue('______parameters')
+    $isInsidePesterRuntime = $null -ne $pesterRuntimeInvocationContext
+
+    $shouldThrow = $null
+    $errorActionIsDefined = $CallerCmdlet.MyInvocation.BoundParameters.ContainsKey('ErrorAction')
+    if ($errorActionIsDefined) {
+        $shouldThrow = 'Stop' -eq $CallerCmdlet.MyInvocation.BoundParameters['ErrorAction']
+    }
+
+    $addErrorCallback = $null
+
+    if ($null -eq $shouldThrow -or -not $shouldThrow) {
+        if (-not $isInsidePesterRuntime) {
+            $shouldThrow = $true
+        }
+        else {
+            if ($null -eq $shouldThrow) {
+                if ($null -ne $CallerCmdlet.SessionState.PSVariable.GetValue('______isInMockParameterFilter')) {
+                    $shouldThrow = $true
+                }
+                else {
+                    $shouldThrow = 'Stop' -eq $pesterRuntimeInvocationContext.Configuration.Should.ErrorAction.Value
+                }
+            }
+
+            if (-not $shouldThrow) {
+                $addErrorCallback = {
+                    param($err)
+                    $null = $pesterRuntimeInvocationContext.ErrorRecord.Add($err)
+                }
+            }
+        }
+    }
+
+    $errorRecord = New-ShouldErrorRecord -Message $Message -Invocation $CallerCmdlet.MyInvocation -Terminating:$shouldThrow @newShouldErrorRecordParameters
+
+    if ($shouldThrow) {
+        throw $errorRecord
+    }
+
+    try { throw $errorRecord } catch { $errorRecord = $_ }
+    & $addErrorCallback $errorRecord
+}

--- a/src/functions/assert/Equivalence/Should-BeEquivalent.ps1
+++ b/src/functions/assert/Equivalence/Should-BeEquivalent.ps1
@@ -1,4 +1,4 @@
-function Test-Same ($Expected, $Actual) {
+﻿function Test-Same ($Expected, $Actual) {
     [object]::ReferenceEquals($Expected, $Actual)
 }
 
@@ -714,7 +714,7 @@ function Should-BeEquivalent {
         $optionsFormatted = Format-EquivalencyOptions -Options $Options
         # the parameter is -Option not -Options
         $message = Get-AssertionMessage -Actual $actual -Expected $Expected -Option $optionsFormatted -Pretty -CustomMessage "Expected and actual are not equivalent!`nExpected:`n<expected>`n`nActual:`n<actual>`n`nSummary:`n$areDifferent`n<options>"
-        throw (New-ShouldErrorRecord -Message $message -Invocation $MyInvocation)
+        Invoke-AssertionFailed -Message $message -CallerCmdlet $PSCmdlet
     }
 
     Write-EquivalenceResult -Equivalence "`$Actual and `$Expected are equivalent."

--- a/src/functions/assert/Exception/Should-Throw.ps1
+++ b/src/functions/assert/Exception/Should-Throw.ps1
@@ -50,6 +50,7 @@
 
     #>
     [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseProcessBlockForPipelineCommand', '')]
+    [CmdletBinding()]
     param (
         [Parameter(ValueFromPipeline = $true, Mandatory = $true)]
         [ScriptBlock]$ScriptBlock,
@@ -128,7 +129,7 @@
 
         $Message = Get-AssertionMessage -Expected $Expected -Actual $ScriptBlock -Because $Because `
             -DefaultMessage $defaultMessage
-        throw (New-ShouldErrorRecord -Message $Message -Invocation $MyInvocation)
+        Invoke-AssertionFailed -Message $Message -CallerCmdlet $PSCmdlet
     }
 
     $err.ErrorRecord

--- a/src/functions/assert/General/Should-Be.ps1
+++ b/src/functions/assert/General/Should-Be.ps1
@@ -1,4 +1,4 @@
-function Should-Be {
+﻿function Should-Be {
     <#
     .SYNOPSIS
     Compares the expected value to actual value, to see if they are equal.
@@ -28,6 +28,7 @@ function Should-Be {
 
     #>
     [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseProcessBlockForPipelineCommand', '')]
+    [CmdletBinding()]
     param (
         [Parameter(Position = 1, ValueFromPipeline = $true)]
         $Actual,
@@ -42,7 +43,7 @@ function Should-Be {
 
     if ((Ensure-ExpectedIsNotCollection $Expected) -ne $Actual) {
         $Message = Get-AssertionMessage -Expected $Expected -Actual $Actual -Because $Because -DefaultMessage "Expected <expectedType> <expected>,<because> but got <actualType> <actual>."
-        throw (New-ShouldErrorRecord -Message $Message -Invocation $MyInvocation)
+        Invoke-AssertionFailed -Message $Message -CallerCmdlet $PSCmdlet
     }
     Set-AssertionPassResult
 }

--- a/src/functions/assert/General/Should-BeGreaterThan.ps1
+++ b/src/functions/assert/General/Should-BeGreaterThan.ps1
@@ -1,4 +1,4 @@
-function Should-BeGreaterThan {
+﻿function Should-BeGreaterThan {
     <#
     .SYNOPSIS
     Compares the expected value to actual value, to see if the actual value is greater than the expected value.
@@ -28,6 +28,7 @@ function Should-BeGreaterThan {
     #>
 
     [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseProcessBlockForPipelineCommand', '')]
+    [CmdletBinding()]
     param (
         [Parameter(Position = 1, ValueFromPipeline = $true)]
         $Actual,
@@ -40,7 +41,7 @@ function Should-BeGreaterThan {
     $Actual = $collectedInput.Actual
     if ((Ensure-ExpectedIsNotCollection $Expected) -ge $Actual) {
         $Message = Get-AssertionMessage -Expected $Expected -Actual $Actual -Because $Because -DefaultMessage "Expected the actual value to be greater than <expectedType> <expected>,<because> but it was not. Actual: <actualType> <actual>"
-        throw (New-ShouldErrorRecord -Message $Message -Invocation $MyInvocation)
+        Invoke-AssertionFailed -Message $Message -CallerCmdlet $PSCmdlet
     }
     Set-AssertionPassResult
 }

--- a/src/functions/assert/General/Should-BeGreaterThanOrEqual.ps1
+++ b/src/functions/assert/General/Should-BeGreaterThanOrEqual.ps1
@@ -1,4 +1,4 @@
-function Should-BeGreaterThanOrEqual {
+﻿function Should-BeGreaterThanOrEqual {
     <#
     .SYNOPSIS
     Compares the expected value to actual value, to see if the actual value is greater than or equal to the expected value.
@@ -28,6 +28,7 @@ function Should-BeGreaterThanOrEqual {
 
     #>
     [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseProcessBlockForPipelineCommand', '')]
+    [CmdletBinding()]
     param (
         [Parameter(Position = 1, ValueFromPipeline = $true)]
         $Actual,
@@ -40,7 +41,7 @@ function Should-BeGreaterThanOrEqual {
     $Actual = $collectedInput.Actual
     if ((Ensure-ExpectedIsNotCollection $Expected) -gt $Actual) {
         $Message = Get-AssertionMessage -Expected $Expected -Actual $Actual -Because $Because -DefaultMessage "Expected the actual value to be greater than or equal to <expectedType> <expected>,<because> but it was not. Actual: <actualType> <actual>"
-        throw (New-ShouldErrorRecord -Message $Message -Invocation $MyInvocation)
+        Invoke-AssertionFailed -Message $Message -CallerCmdlet $PSCmdlet
     }
     Set-AssertionPassResult
 }

--- a/src/functions/assert/General/Should-BeLessThan.ps1
+++ b/src/functions/assert/General/Should-BeLessThan.ps1
@@ -1,4 +1,4 @@
-function Should-BeLessThan {
+﻿function Should-BeLessThan {
     <#
     .SYNOPSIS
     Compares the expected value to actual value, to see if the actual value is less than the expected value.
@@ -28,6 +28,7 @@ function Should-BeLessThan {
 
     #>
     [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseProcessBlockForPipelineCommand', '')]
+    [CmdletBinding()]
     param (
         [Parameter(Position = 1, ValueFromPipeline = $true)]
         $Actual,
@@ -40,7 +41,7 @@ function Should-BeLessThan {
     $Actual = $collectedInput.Actual
     if ((Ensure-ExpectedIsNotCollection $Expected) -le $Actual) {
         $Message = Get-AssertionMessage -Expected $Expected -Actual $Actual -Because $Because -DefaultMessage "Expected the actual value to be less than <expectedType> <expected>,<because> but it was not. Actual: <actualType> <actual>"
-        throw (New-ShouldErrorRecord -Message $Message -Invocation $MyInvocation)
+        Invoke-AssertionFailed -Message $Message -CallerCmdlet $PSCmdlet
     }
     Set-AssertionPassResult
 }

--- a/src/functions/assert/General/Should-BeLessThanOrEqual.ps1
+++ b/src/functions/assert/General/Should-BeLessThanOrEqual.ps1
@@ -1,4 +1,4 @@
-function Should-BeLessThanOrEqual {
+﻿function Should-BeLessThanOrEqual {
     <#
     .SYNOPSIS
     Compares the expected value to actual value, to see if the actual value is less than or equal to the expected value.
@@ -37,6 +37,7 @@ function Should-BeLessThanOrEqual {
     https://pester.dev/docs/assertions
     #>
     [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseProcessBlockForPipelineCommand', '')]
+    [CmdletBinding()]
     param (
         [Parameter(Position = 1, ValueFromPipeline = $true)]
         $Actual,
@@ -49,7 +50,7 @@ function Should-BeLessThanOrEqual {
     $Actual = $collectedInput.Actual
     if ((Ensure-ExpectedIsNotCollection $Expected) -lt $Actual) {
         $Message = Get-AssertionMessage -Expected $Expected -Actual $Actual -Because $Because -DefaultMessage "Expected the actual value to be less than or equal to <expectedType> <expected>,<because> but it was not. Actual: <actualType> <actual>"
-        throw (New-ShouldErrorRecord -Message $Message -Invocation $MyInvocation)
+        Invoke-AssertionFailed -Message $Message -CallerCmdlet $PSCmdlet
     }
     Set-AssertionPassResult
 }

--- a/src/functions/assert/General/Should-BeNull.ps1
+++ b/src/functions/assert/General/Should-BeNull.ps1
@@ -1,4 +1,4 @@
-function Should-BeNull {
+﻿function Should-BeNull {
     <#
     .SYNOPSIS
     Asserts that the input is `$null`.
@@ -24,6 +24,7 @@ function Should-BeNull {
     #>
 
     [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseProcessBlockForPipelineCommand', '')]
+    [CmdletBinding()]
     param (
         [Parameter(Position = 1, ValueFromPipeline = $true)]
         $Actual,
@@ -34,7 +35,7 @@ function Should-BeNull {
     $Actual = $collectedInput.Actual
     if ($null -ne $Actual) {
         $Message = Get-AssertionMessage -Expected $null -Actual $Actual -Because $Because -DefaultMessage "Expected `$null,<because> but got <actualType> '<actual>'."
-        throw (New-ShouldErrorRecord -Message $Message -Invocation $MyInvocation)
+        Invoke-AssertionFailed -Message $Message -CallerCmdlet $PSCmdlet
     }
     Set-AssertionPassResult
 }

--- a/src/functions/assert/General/Should-BeSame.ps1
+++ b/src/functions/assert/General/Should-BeSame.ps1
@@ -1,4 +1,4 @@
-function Should-BeSame {
+﻿function Should-BeSame {
     <#
     .SYNOPSIS
     Compares the expected value to actual value, to see if they are the same instance.
@@ -39,6 +39,7 @@ function Should-BeSame {
     https://pester.dev/docs/assertions
     #>
     [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseProcessBlockForPipelineCommand', '')]
+    [CmdletBinding()]
     param (
         [Parameter(Position = 1, ValueFromPipeline = $true)]
         $Actual,
@@ -57,7 +58,7 @@ function Should-BeSame {
     $Actual = $collectedInput.Actual
     if (-not ([object]::ReferenceEquals($Expected, $Actual))) {
         $Message = Get-AssertionMessage -Expected $Expected -Actual $Actual -Because $Because -DefaultMessage "Expected <expectedType> <expected>,<because> to be the same instance but it was not. Actual: <actualType> <actual>"
-        throw (New-ShouldErrorRecord -Message $Message -Invocation $MyInvocation)
+        Invoke-AssertionFailed -Message $Message -CallerCmdlet $PSCmdlet
     }
     Set-AssertionPassResult
 }

--- a/src/functions/assert/General/Should-HaveType.ps1
+++ b/src/functions/assert/General/Should-HaveType.ps1
@@ -1,4 +1,4 @@
-function Should-HaveType {
+﻿function Should-HaveType {
     <#
     .SYNOPSIS
     Asserts that the input is of the expected type.
@@ -28,6 +28,7 @@ function Should-HaveType {
 
     #>
     [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseProcessBlockForPipelineCommand', '')]
+    [CmdletBinding()]
     param (
         [Parameter(Position = 1, ValueFromPipeline = $true)]
         $Actual,
@@ -40,7 +41,7 @@ function Should-HaveType {
     $Actual = $collectedInput.Actual
     if ($Actual -isnot $Expected) {
         $Message = Get-AssertionMessage -Expected $Expected -Actual $Actual -Because $Because -DefaultMessage "Expected value to have type <expected>,<because> but got <actualType> <actual>."
-        throw (New-ShouldErrorRecord -Message $Message -Invocation $MyInvocation)
+        Invoke-AssertionFailed -Message $Message -CallerCmdlet $PSCmdlet
     }
     Set-AssertionPassResult
 }

--- a/src/functions/assert/General/Should-NotBe.ps1
+++ b/src/functions/assert/General/Should-NotBe.ps1
@@ -1,4 +1,4 @@
-function Should-NotBe {
+﻿function Should-NotBe {
     <#
     .SYNOPSIS
     Compares the expected value to actual value, to see if they are not equal.
@@ -28,6 +28,7 @@ function Should-NotBe {
 
     #>
     [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseProcessBlockForPipelineCommand', '')]
+    [CmdletBinding()]
     param (
         [Parameter(Position = 1, ValueFromPipeline = $true)]
         $Actual,
@@ -41,7 +42,7 @@ function Should-NotBe {
     $Actual = $collectedInput.Actual
     if ((Ensure-ExpectedIsNotCollection $Expected) -eq $Actual) {
         $Message = Get-AssertionMessage -Expected $Expected -Actual $Actual -Because $Because -DefaultMessage "Expected <expectedType> <expected>, to be different than the actual value,<because> but they were equal."
-        throw (New-ShouldErrorRecord -Message $Message -Invocation $MyInvocation)
+        Invoke-AssertionFailed -Message $Message -CallerCmdlet $PSCmdlet
     }
     Set-AssertionPassResult
 }

--- a/src/functions/assert/General/Should-NotBeNull.ps1
+++ b/src/functions/assert/General/Should-NotBeNull.ps1
@@ -1,4 +1,4 @@
-function Should-NotBeNull {
+﻿function Should-NotBeNull {
     <#
     .SYNOPSIS
     Asserts that the input is not `$null`.
@@ -24,6 +24,7 @@ function Should-NotBeNull {
     https://pester.dev/docs/assertions
     #>
     [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseProcessBlockForPipelineCommand', '')]
+    [CmdletBinding()]
     param (
         [Parameter(Position = 1, ValueFromPipeline = $true)]
         $Actual,
@@ -34,7 +35,7 @@ function Should-NotBeNull {
     $Actual = $collectedInput.Actual
     if ($null -eq $Actual) {
         $Message = Get-AssertionMessage -Expected $null -Actual $Actual -Because $Because -DefaultMessage "Expected not `$null,<because> but got `$null."
-        throw (New-ShouldErrorRecord -Message $Message -Invocation $MyInvocation)
+        Invoke-AssertionFailed -Message $Message -CallerCmdlet $PSCmdlet
     }
     Set-AssertionPassResult
 }

--- a/src/functions/assert/General/Should-NotBeSame.ps1
+++ b/src/functions/assert/General/Should-NotBeSame.ps1
@@ -1,4 +1,4 @@
-function Should-NotBeSame {
+﻿function Should-NotBeSame {
     <#
     .SYNOPSIS
     Compares the expected value to actual value, to see if the actual value is not the same instance as the expected value.
@@ -38,6 +38,7 @@ function Should-NotBeSame {
     https://pester.dev/docs/assertions
     #>
     [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseProcessBlockForPipelineCommand', '')]
+    [CmdletBinding()]
     param (
         [Parameter(Position = 1, ValueFromPipeline = $true)]
         $Actual,
@@ -52,7 +53,7 @@ function Should-NotBeSame {
     $Actual = $collectedInput.Actual
     if ([object]::ReferenceEquals($Expected, $Actual)) {
         $Message = Get-AssertionMessage -Expected $Expected -Actual $Actual -Because $Because -DefaultMessage "Expected <expectedType> <expected>, to not be the same instance,<because> but they were the same instance."
-        throw (New-ShouldErrorRecord -Message $Message -Invocation $MyInvocation)
+        Invoke-AssertionFailed -Message $Message -CallerCmdlet $PSCmdlet
     }
     Set-AssertionPassResult
 }

--- a/src/functions/assert/General/Should-NotHaveType.ps1
+++ b/src/functions/assert/General/Should-NotHaveType.ps1
@@ -1,4 +1,4 @@
-function Should-NotHaveType {
+﻿function Should-NotHaveType {
     <#
     .SYNOPSIS
     Asserts that the input is not of the expected type.
@@ -30,6 +30,7 @@ function Should-NotHaveType {
     https://pester.dev/docs/assertions
     #>
     [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseProcessBlockForPipelineCommand', '')]
+    [CmdletBinding()]
     param (
         [Parameter(Position = 1, ValueFromPipeline = $true)]
         $Actual,
@@ -42,7 +43,7 @@ function Should-NotHaveType {
     $Actual = $collectedInput.Actual
     if ($Actual -is $Expected) {
         $Message = Get-AssertionMessage -Expected $Expected -Actual $Actual -Because $Because -DefaultMessage "Expected value to be of different type than <expected>,<because> but got <actualType> <actual>."
-        throw (New-ShouldErrorRecord -Message $Message -Invocation $MyInvocation)
+        Invoke-AssertionFailed -Message $Message -CallerCmdlet $PSCmdlet
     }
     Set-AssertionPassResult
 }

--- a/src/functions/assert/Parameter/Should-HaveParameter.ps1
+++ b/src/functions/assert/Parameter/Should-HaveParameter.ps1
@@ -52,7 +52,8 @@
     #>
 
     [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseProcessBlockForPipelineCommand', '')]
-    param(
+    [CmdletBinding()]
+    param (
         [String] $ParameterName,
         $Type,
         [String] $DefaultValue,

--- a/src/functions/assert/Parameter/Should-NotHaveParameter.ps1
+++ b/src/functions/assert/Parameter/Should-NotHaveParameter.ps1
@@ -33,7 +33,8 @@
 
 
     [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseProcessBlockForPipelineCommand', '')]
-    param(
+    [CmdletBinding()]
+    param (
         [String] $ParameterName,
         [Parameter(ValueFromPipeline = $true)]
         $Actual,

--- a/src/functions/assert/String/Should-BeEmptyString.ps1
+++ b/src/functions/assert/String/Should-BeEmptyString.ps1
@@ -1,4 +1,4 @@
-function Should-BeEmptyString {
+﻿function Should-BeEmptyString {
     <#
     .SYNOPSIS
     Ensures that input is an empty string.
@@ -42,6 +42,7 @@ function Should-BeEmptyString {
     https://pester.dev/docs/assertions
     #>
     [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseProcessBlockForPipelineCommand', '')]
+    [CmdletBinding()]
     param (
         [Parameter(Position = 0, ValueFromPipeline = $true)]
         $Actual,
@@ -53,7 +54,7 @@ function Should-BeEmptyString {
 
     if ($Actual -isnot [String] -or -not [String]::IsNullOrEmpty( $Actual)) {
         $formattedMessage = Get-AssertionMessage -Actual $Actual -Because $Because -DefaultMessage "Expected a [string] that is empty,<because> but got <actualType>: <actual>" -Pretty
-        throw (New-ShouldErrorRecord -Message $formattedMessage -Invocation $MyInvocation)
+        Invoke-AssertionFailed -Message $formattedMessage -CallerCmdlet $PSCmdlet
     }
     Set-AssertionPassResult
 }

--- a/src/functions/assert/String/Should-BeLikeString.ps1
+++ b/src/functions/assert/String/Should-BeLikeString.ps1
@@ -1,4 +1,4 @@
-function Test-Like {
+﻿function Test-Like {
     param (
         [String]$Expected,
         $Actual,
@@ -57,6 +57,7 @@ function Should-BeLikeString {
     https://pester.dev/docs/assertions
     #>
     [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseProcessBlockForPipelineCommand', '')]
+    [CmdletBinding()]
     param (
         [Parameter(Position = 1, ValueFromPipeline = $true)]
         $Actual,
@@ -81,7 +82,7 @@ function Should-BeLikeString {
         }
 
         $Message = Get-AssertionMessage -Expected $null -Actual $Actual -Because $Because -DefaultMessage "Expected the string '$Actual' to$caseSensitiveMessage be like '$Expected',<because> but it did not."
-        throw (New-ShouldErrorRecord -Message $Message -Invocation $MyInvocation)
+        Invoke-AssertionFailed -Message $Message -CallerCmdlet $PSCmdlet
     }
     Set-AssertionPassResult
 }

--- a/src/functions/assert/String/Should-BeString.ps1
+++ b/src/functions/assert/String/Should-BeString.ps1
@@ -1,4 +1,4 @@
-function Test-StringEqual {
+﻿function Test-StringEqual {
     param (
         [String]$Expected,
         $Actual,
@@ -79,6 +79,7 @@ function Should-BeString {
     https://pester.dev/docs/assertions
     #>
     [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseProcessBlockForPipelineCommand', '')]
+    [CmdletBinding()]
     param (
         [Parameter(Position = 1, ValueFromPipeline = $true)]
         $Actual,
@@ -96,7 +97,7 @@ function Should-BeString {
     $stringsAreEqual = Test-StringEqual -Expected $Expected -Actual $Actual -CaseSensitive:$CaseSensitive -IgnoreWhitespace:$IgnoreWhiteSpace -TrimWhitespace:$TrimWhitespace
     if (-not ($stringsAreEqual)) {
         $Message = Get-AssertionMessage -Expected $Expected -Actual $Actual -Because $Because -DefaultMessage "Expected <expectedType> <expected>, but got <actualType> <actual>."
-        throw (New-ShouldErrorRecord -Message $Message -Invocation $MyInvocation)
+        Invoke-AssertionFailed -Message $Message -CallerCmdlet $PSCmdlet
     }
     Set-AssertionPassResult
 }

--- a/src/functions/assert/String/Should-MatchString.ps1
+++ b/src/functions/assert/String/Should-MatchString.ps1
@@ -1,4 +1,4 @@
-function Test-MatchString {
+﻿function Test-MatchString {
     param (
         [String]$Expected,
         $Actual,
@@ -54,6 +54,7 @@ function Should-MatchString {
     https://pester.dev/docs/assertions
     #>
     [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseProcessBlockForPipelineCommand', '')]
+    [CmdletBinding()]
     param (
         [Parameter(Position = 1, ValueFromPipeline = $true)]
         $Actual,
@@ -82,7 +83,7 @@ function Should-MatchString {
         }
 
         $Message = Get-AssertionMessage -Expected $null -Actual $Actual -Because $Because -DefaultMessage "Expected the string '$Actual' to$caseSensitiveMessage match pattern '$Expected',<because> but it did not."
-        throw [Pester.Factory]::CreateShouldErrorRecord($Message, $MyInvocation.ScriptName, $MyInvocation.ScriptLineNumber, $MyInvocation.Line.TrimEnd([System.Environment]::NewLine), $true)
+        Invoke-AssertionFailed -Message $Message -CallerCmdlet $PSCmdlet
     }
 
     if ($script:______isInMockParameterFilter) { return $true }

--- a/src/functions/assert/String/Should-NotBeEmptyString.ps1
+++ b/src/functions/assert/String/Should-NotBeEmptyString.ps1
@@ -1,4 +1,4 @@
-function Should-NotBeEmptyString {
+﻿function Should-NotBeEmptyString {
     <#
     .SYNOPSIS
     Ensures that the input is a string, and that the input is not $null or empty string.
@@ -42,6 +42,7 @@ function Should-NotBeEmptyString {
     https://pester.dev/docs/assertions
     #>
     [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseProcessBlockForPipelineCommand', '')]
+    [CmdletBinding()]
     param (
         [Parameter(Position = 0, ValueFromPipeline = $true)]
         $Actual,
@@ -53,7 +54,7 @@ function Should-NotBeEmptyString {
 
     if ($Actual -isnot [String] -or [String]::IsNullOrEmpty($Actual)) {
         $formattedMessage = Get-AssertionMessage -Actual $Actual -Because $Because -DefaultMessage "Expected a [string] that is not `$null or empty,<because> but got <actualType>: <actual>" -Pretty
-        throw (New-ShouldErrorRecord -Message $formattedMessage -Invocation $MyInvocation)
+        Invoke-AssertionFailed -Message $formattedMessage -CallerCmdlet $PSCmdlet
     }
     Set-AssertionPassResult
 }

--- a/src/functions/assert/String/Should-NotBeLikeString.ps1
+++ b/src/functions/assert/String/Should-NotBeLikeString.ps1
@@ -1,4 +1,4 @@
-function Test-NotLike {
+﻿function Test-NotLike {
     param (
         [String]$Expected,
         $Actual,
@@ -65,6 +65,7 @@ function Should-NotBeLikeString {
     https://pester.dev/docs/assertions
     #>
     [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseProcessBlockForPipelineCommand', '')]
+    [CmdletBinding()]
     param (
         [Parameter(Position = 1, ValueFromPipeline = $true)]
         $Actual,
@@ -90,7 +91,7 @@ function Should-NotBeLikeString {
             $formattedMessage = Get-CustomFailureMessage -Expected $Expected -Actual $Actual -Because $Because -CaseSensitive:$CaseSensitive
         }
 
-        throw (New-ShouldErrorRecord -Message $formattedMessage -Invocation $MyInvocation -Expected $Expected -Actual $Actual -Because $Because)
+        Invoke-AssertionFailed -Message $formattedMessage -CallerCmdlet $PSCmdlet -Expected $Expected -Actual $Actual -Because $Because
     }
     Set-AssertionPassResult
 }

--- a/src/functions/assert/String/Should-NotBeString.ps1
+++ b/src/functions/assert/String/Should-NotBeString.ps1
@@ -1,4 +1,4 @@
-function Get-StringNotEqualDefaultFailureMessage ([String]$Expected, $Actual) {
+﻿function Get-StringNotEqualDefaultFailureMessage ([String]$Expected, $Actual) {
     "Expected the strings to be different but they were the same '$Expected'."
 }
 
@@ -49,6 +49,7 @@ function Should-NotBeString {
     https://pester.dev/docs/assertions
     #>
     [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseProcessBlockForPipelineCommand', '')]
+    [CmdletBinding()]
     param (
         [Parameter(Position = 1, ValueFromPipeline = $true)]
         $Actual,
@@ -74,7 +75,7 @@ function Should-NotBeString {
             $formattedMessage = Get-CustomFailureMessage -Expected $Expected -Actual $Actual -Because $Because
         }
 
-        throw (New-ShouldErrorRecord -Message $formattedMessage -Invocation $MyInvocation -Expected $Expected -Actual $Actual -Because $Because)
+        Invoke-AssertionFailed -Message $formattedMessage -CallerCmdlet $PSCmdlet -Expected $Expected -Actual $Actual -Because $Because
     }
     Set-AssertionPassResult
 }

--- a/src/functions/assert/String/Should-NotBeWhiteSpaceString.ps1
+++ b/src/functions/assert/String/Should-NotBeWhiteSpaceString.ps1
@@ -1,4 +1,4 @@
-function Should-NotBeWhiteSpaceString {
+﻿function Should-NotBeWhiteSpaceString {
     <#
     .SYNOPSIS
     Ensures that the input is a string, and that the input is not $null, empty, or whitespace only string.
@@ -43,6 +43,7 @@ function Should-NotBeWhiteSpaceString {
     https://pester.dev/docs/assertions
     #>
     [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseProcessBlockForPipelineCommand', '')]
+    [CmdletBinding()]
     param (
         [Parameter(Position = 0, ValueFromPipeline = $true)]
         $Actual,
@@ -54,7 +55,7 @@ function Should-NotBeWhiteSpaceString {
 
     if ($Actual -isnot [string] -or [string]::IsNullOrWhiteSpace($Actual)) {
         $formattedMessage = Get-AssertionMessage -Actual $Actual -Because $Because -DefaultMessage "Expected a [string] that is not `$null, empty or whitespace,<because> but got <actualType>: <actual>" -Pretty
-        throw (New-ShouldErrorRecord -Message $formattedMessage -Invocation $MyInvocation)
+        Invoke-AssertionFailed -Message $formattedMessage -CallerCmdlet $PSCmdlet
     }
     Set-AssertionPassResult
 }

--- a/src/functions/assert/String/Should-NotMatchString.ps1
+++ b/src/functions/assert/String/Should-NotMatchString.ps1
@@ -1,4 +1,4 @@
-function Test-NotMatchString {
+﻿function Test-NotMatchString {
     param (
         [String]$Expected,
         $Actual,
@@ -54,6 +54,7 @@ function Should-NotMatchString {
     https://pester.dev/docs/assertions
     #>
     [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseProcessBlockForPipelineCommand', '')]
+    [CmdletBinding()]
     param (
         [Parameter(Position = 1, ValueFromPipeline = $true)]
         $Actual,
@@ -82,7 +83,7 @@ function Should-NotMatchString {
         }
 
         $Message = Get-AssertionMessage -Expected $null -Actual $Actual -Because $Because -DefaultMessage "Expected the string '$Actual' to$caseSensitiveMessage not match pattern '$Expected',<because> but it matched it."
-        throw [Pester.Factory]::CreateShouldErrorRecord($Message, $MyInvocation.ScriptName, $MyInvocation.ScriptLineNumber, $MyInvocation.Line.TrimEnd([System.Environment]::NewLine), $true)
+        Invoke-AssertionFailed -Message $Message -CallerCmdlet $PSCmdlet
     }
 
     if ($script:______isInMockParameterFilter) { return $true }

--- a/src/functions/assert/Time/Should-BeAfter.ps1
+++ b/src/functions/assert/Time/Should-BeAfter.ps1
@@ -1,4 +1,4 @@
-function Should-BeAfter {
+﻿function Should-BeAfter {
     <#
     .SYNOPSIS
     Asserts that the provided [datetime] is after the expected [datetime].
@@ -110,7 +110,7 @@ function Should-BeAfter {
 
     if ($Actual -le $Expected) {
         $Message = Get-AssertionMessage -Expected $Expected -Actual $Actual -Because $Because -DefaultMessage "Expected the provided [datetime] to be after <expectedType> <expected>,<because> but it was before: <actual>"
-        throw (New-ShouldErrorRecord -Message $Message -Invocation $MyInvocation)
+        Invoke-AssertionFailed -Message $Message -CallerCmdlet $PSCmdlet
     }
     Set-AssertionPassResult
 }

--- a/src/functions/assert/Time/Should-BeBefore.ps1
+++ b/src/functions/assert/Time/Should-BeBefore.ps1
@@ -1,4 +1,4 @@
-function Should-BeBefore {
+﻿function Should-BeBefore {
     <#
     .SYNOPSIS
     Asserts that the provided [datetime] is before the expected [datetime].
@@ -110,7 +110,7 @@ function Should-BeBefore {
 
     if ($Actual -ge $Expected) {
         $Message = Get-AssertionMessage -Expected $Expected -Actual $Actual -Because $Because -DefaultMessage "Expected the provided [datetime] to be before <expectedType> <expected>,<because> but it was after: <actual>"
-        throw (New-ShouldErrorRecord -Message $Message -Invocation $MyInvocation)
+        Invoke-AssertionFailed -Message $Message -CallerCmdlet $PSCmdlet
     }
     Set-AssertionPassResult
 }

--- a/src/functions/assert/Time/Should-BeFasterThan.ps1
+++ b/src/functions/assert/Time/Should-BeFasterThan.ps1
@@ -1,4 +1,4 @@
-function Should-BeFasterThan {
+﻿function Should-BeFasterThan {
     <#
     .SYNOPSIS
     Asserts that the provided [timespan] or [scriptblock] is faster than the expected [timespan].
@@ -36,6 +36,7 @@ function Should-BeFasterThan {
     https://pester.dev/docs/assertions
     #>
     [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseProcessBlockForPipelineCommand', '')]
+    [CmdletBinding()]
     param (
         [Parameter(Position = 1, ValueFromPipeline = $true)]
         $Actual,
@@ -58,7 +59,7 @@ function Should-BeFasterThan {
 
         if ($sw.Elapsed -ge $Expected) {
             $Message = Get-AssertionMessage -Expected $Expected -Actual $sw.Elapsed -Because $Because -Data @{ scriptblock = $Actual } -DefaultMessage "Expected the provided [scriptblock] to execute faster than <expectedType> <expected>,<because> but it took <actual> to run.`nScriptBlock: <scriptblock>"
-            throw (New-ShouldErrorRecord -Message $Message -Invocation $MyInvocation)
+            Invoke-AssertionFailed -Message $Message -CallerCmdlet $PSCmdlet
         }
         Set-AssertionPassResult
         return
@@ -67,7 +68,7 @@ function Should-BeFasterThan {
     if ($Actual -is [timespan]) {
         if ($Actual -ge $Expected) {
             $Message = Get-AssertionMessage -Expected $Expected -Actual $Actual -Because $Because -DefaultMessage "The provided [timespan] should be shorter than <expectedType> <expected>,<because> but it was longer: <actual>"
-            throw (New-ShouldErrorRecord -Message $Message -Invocation $MyInvocation)
+            Invoke-AssertionFailed -Message $Message -CallerCmdlet $PSCmdlet
         }
         Set-AssertionPassResult
         return

--- a/src/functions/assert/Time/Should-BeSlowerThan.ps1
+++ b/src/functions/assert/Time/Should-BeSlowerThan.ps1
@@ -1,4 +1,4 @@
-function Should-BeSlowerThan {
+﻿function Should-BeSlowerThan {
     <#
     .SYNOPSIS
     Asserts that the provided [timespan] is slower than the expected [timespan].
@@ -43,6 +43,7 @@ function Should-BeSlowerThan {
     https://pester.dev/docs/assertions
     #>
     [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseProcessBlockForPipelineCommand', '')]
+    [CmdletBinding()]
     param (
         [Parameter(Position = 1, ValueFromPipeline = $true)]
         $Actual,
@@ -64,7 +65,7 @@ function Should-BeSlowerThan {
 
         if ($sw.Elapsed -le $Expected) {
             $Message = Get-AssertionMessage -Expected $Expected -Actual $sw.Elapsed -Because $Because -Data @{ scriptblock = $Actual } -DefaultMessage "The provided [scriptblock] should execute slower than <expectedType> <expected>,<because> but it took <actual> to run.`nScriptBlock: <scriptblock>"
-            throw (New-ShouldErrorRecord -Message $Message -Invocation $MyInvocation)
+            Invoke-AssertionFailed -Message $Message -CallerCmdlet $PSCmdlet
         }
         Set-AssertionPassResult
         return
@@ -73,7 +74,7 @@ function Should-BeSlowerThan {
     if ($Actual -is [timespan]) {
         if ($Actual -le $Expected) {
             $Message = Get-AssertionMessage -Expected $Expected -Actual $Actual -Because $Because -DefaultMessage "The provided [timespan] should be longer than <expectedType> <expected>,<because> but it was shorter: <actual>"
-            throw (New-ShouldErrorRecord -Message $Message -Invocation $MyInvocation)
+            Invoke-AssertionFailed -Message $Message -CallerCmdlet $PSCmdlet
         }
         Set-AssertionPassResult
         return

--- a/src/functions/assertions/Should.ps1
+++ b/src/functions/assertions/Should.ps1
@@ -247,9 +247,55 @@ function Test-AssertionResult {
     )
 
     if (-not $TestResult.Succeeded) {
-        $errorRecord = [Pester.Factory]::CreateShouldErrorRecord($TestResult.FailureMessage, $file, $lineNumber, $lineText, $shouldThrow, $TestResult)
+        $currentFile = $file
+        $currentLineNumber = $lineNumber
+        $currentLineText = $lineText
+        $currentShouldThrow = $ShouldThrow
+        $currentAddErrorCallback = $AddErrorCallback
 
-        if ($null -eq $AddErrorCallback -or $ShouldThrow) {
+        if ($null -eq $currentFile -and $null -ne $PSCmdlet) {
+            $pesterRuntimeInvocationContext = $PSCmdlet.SessionState.PSVariable.GetValue('______parameters')
+            $isInsidePesterRuntime = $null -ne $pesterRuntimeInvocationContext
+
+            $errorActionIsDefined = $PSCmdlet.MyInvocation.BoundParameters.ContainsKey('ErrorAction')
+            if ($errorActionIsDefined) {
+                $currentShouldThrow = 'Stop' -eq $PSCmdlet.MyInvocation.BoundParameters['ErrorAction']
+            }
+
+            if ($null -eq $currentShouldThrow -or -not $currentShouldThrow) {
+                if (-not $isInsidePesterRuntime) {
+                    $currentShouldThrow = $true
+                }
+                else {
+                    if ($null -eq $currentShouldThrow) {
+                        if ($null -ne $PSCmdlet.SessionState.PSVariable.GetValue('______isInMockParameterFilter')) {
+                            $currentShouldThrow = $true
+                        }
+                        else {
+                            $currentShouldThrow = 'Stop' -eq $pesterRuntimeInvocationContext.Configuration.Should.ErrorAction.Value
+                        }
+                    }
+
+                    if (-not $currentShouldThrow) {
+                        $currentAddErrorCallback = {
+                            param($err)
+                            $null = $pesterRuntimeInvocationContext.ErrorRecord.Add($err)
+                        }
+                    }
+                }
+            }
+
+            $currentFile = $PSCmdlet.MyInvocation.ScriptName
+            $currentLineNumber = $PSCmdlet.MyInvocation.ScriptLineNumber
+            $currentLineText = $PSCmdlet.MyInvocation.Line
+            if ($null -ne $currentLineText) {
+                $currentLineText = $currentLineText.TrimEnd([System.Environment]::NewLine)
+            }
+        }
+
+        $errorRecord = [Pester.Factory]::CreateShouldErrorRecord($TestResult.FailureMessage, $currentFile, $currentLineNumber, $currentLineText, $currentShouldThrow, $TestResult)
+
+        if ($null -eq $currentAddErrorCallback -or $currentShouldThrow) {
             # throw this error to fail the test immediately
             throw $errorRecord
         }
@@ -265,7 +311,7 @@ function Test-AssertionResult {
         }
 
         # collect the error via the provided callback
-        & $AddErrorCallback $err
+        & $currentAddErrorCallback $err
     }
     else {
         #extract data to return if there are any on the object

--- a/tst/Pester.Mock.RSpec.ts.ps1
+++ b/tst/Pester.Mock.RSpec.ts.ps1
@@ -360,6 +360,41 @@ i -PassThru:$PassThru {
             $err[-3] | Verify-Equal "Expected: 'a'"
             $err[-2] | Verify-Equal "But was:  'b'"
         }
+
+        t "new assertions will throw even when Should ErrorAction preference is set to Continue and fails the test" {
+            $sb = {
+                Describe "a" {
+                    It "it" {
+
+                        function f ($Name) { "real function" }
+                        Mock f -MockWith { "default mock" }
+                        Mock f -ParameterFilter { $Name | Should-Be "a" } -MockWith { "mock with filter" }
+
+                        f "b"
+                        "won't reach this"
+                    }
+                }
+            }
+
+            $r = Invoke-Pester -Configuration ([PesterConfiguration]@{
+                    Run    = @{
+                        ScriptBlock = $sb
+                        PassThru    = $true
+                    }
+                    Should = @{
+                        ErrorAction = 'Continue'
+                    }
+                    Output = @{
+                        CIFormat = 'None'
+                    }
+                })
+
+            $t = $r.Containers[0].Blocks[0].Tests[0]
+            $t.StandardOutput | Verify-Null
+            $err = $t.ErrorRecord[0] -split "`n"
+            $err[-3] | Verify-Equal "Expected: 'a'"
+            $err[-2] | Verify-Equal "But was:  'b'"
+        }
     }
 
     b "splatting on default params" {

--- a/tst/Pester.Mock.RSpec.ts.ps1
+++ b/tst/Pester.Mock.RSpec.ts.ps1
@@ -391,9 +391,7 @@ i -PassThru:$PassThru {
 
             $t = $r.Containers[0].Blocks[0].Tests[0]
             $t.StandardOutput | Verify-Null
-            $err = $t.ErrorRecord[0] -split "`n"
-            $err[-3] | Verify-Equal "Expected: 'a'"
-            $err[-2] | Verify-Equal "But was:  'b'"
+            $t.ErrorRecord[0].Exception.Message | Verify-Equal "Expected [string] 'a', but got [string] 'b'."
         }
     }
 

--- a/tst/Pester.RSpec.ts.ps1
+++ b/tst/Pester.RSpec.ts.ps1
@@ -449,6 +449,57 @@ i -PassThru:$PassThru {
             $test.ErrorRecord.Count | Verify-Equal 2
         }
 
+        t "Non-terminating new assertions fail the test after running to completion" {
+            $sb = {
+                Describe "d1" {
+                    It "i1" {
+                        Should-Be -Actual 1 -Expected 2
+                        Should-BeTrue -Actual $false
+                        "but still output this"
+                    }
+                }
+            }
+            $r = Invoke-Pester -Configuration ([PesterConfiguration]@{
+                    Run    = @{ ScriptBlock = $sb; PassThru = $true }
+                    Should = @{ ErrorAction = 'Continue' }
+                })
+
+            $test = $r.Containers[0].Blocks[0].Tests[0]
+            $test | Verify-NotNull
+            $test.Result | Verify-Equal "Failed"
+            $test.ErrorRecord.Count | Verify-Equal 2
+            $test.ErrorRecord[0].TargetObject.Terminating | Verify-False
+            $test.ErrorRecord[1].TargetObject.Terminating | Verify-False
+            $test.StandardOutput | Verify-Equal "but still output this"
+        }
+
+        t "New assertions fail immediately when -ErrorAction is set to Stop" {
+            $sb = {
+                Describe "d1" {
+                    It "i1" {
+                        1 | Should-Be 2 -ErrorAction Stop
+                        "do not output this"
+                    }
+                }
+            }
+            $r = Invoke-Pester -Configuration ([PesterConfiguration]@{
+                    Run    = @{ ScriptBlock = $sb; PassThru = $true }
+                    Should = @{ ErrorAction = 'Continue' }
+                })
+
+            $test = $r.Containers[0].Blocks[0].Tests[0]
+            $test | Verify-NotNull
+            $test.Result | Verify-Equal "Failed"
+            $test.ErrorRecord[0].TargetObject.Terminating | Verify-True
+            $test.StandardOutput | Verify-Null
+        }
+
+        t "New assertions throw when called outside of Pester" {
+            $PesterPreference = [PesterConfiguration]@{ Should = @{ ErrorAction = 'Continue' } }
+            $err = { 1 | Should-Be 2 } | Verify-Throw
+            $err.Exception.Message | Verify-Equal "Expected [int] 2, but got [int] 1."
+        }
+
         t "Should throws when called outside of Pester" {
             $PesterPreference = [PesterConfiguration]@{ Should = @{ ErrorAction = 'Continue' } }
             $err = { 1 | Should -Be 2 } | Verify-Throw


### PR DESCRIPTION
Fixes #2467

Adds soft assertion support (ErrorAction = Continue) to new Should-* assertions using the same proven approach as old Should:

- Added [CmdletBinding()] to all Should-* functions
- Shared Invoke-AssertionFailed helper uses \.SessionState.PSVariable.GetValue('______parameters') to access runtime context
- No changes to Pester.Runtime.ps1 or Mock.ps1 needed

Behavior:
- Outside Pester: always throws (unchanged)
- In mock parameter filter: always throws (unchanged)  
- ErrorAction = Stop (default): throws on first failure (unchanged)
- ErrorAction = Continue: records failure, continues test