### PR TITLE
Fix #2702: Remove unused Get-ScriptBlockScope function

### DIFF
--- a/src/functions/Pester.Scoping.ps1
+++ b/src/functions/Pester.Scoping.ps1
@@ -46,18 +46,3 @@
         Set-ScriptBlockHint -ScriptBlock $ScriptBlock
     }
 }
-
-function Get-ScriptBlockScope {
-    [CmdletBinding()]
-    param (
-        [Parameter(Mandatory = $true)]
-        [scriptblock]
-        $ScriptBlock
-    )
-
-    $sessionStateInternal = $script:ScriptBlockSessionStateInternalProperty.GetValue($ScriptBlock, $null)
-    if ($PesterPreference.Debug.WriteDebugMessages.Value) {
-        Write-PesterDebugMessage -Scope SessionState "Getting scope from ScriptBlock '$($sessionStateInternal.Hint)'"
-    }
-    $sessionStateInternal
-}


### PR DESCRIPTION
Fixes #2702

Removes `Get-ScriptBlockScope` from `Pester.Scoping.ps1` — it has zero call sites anywhere in the repo (src, tests, docs). Only the definition existed.