### PR TITLE
Fix #2722: Add missing Because parameter to Should-BeSlowerThan

### DIFF
--- a/src/functions/assert/Time/Should-BeSlowerThan.ps1
+++ b/src/functions/assert/Time/Should-BeSlowerThan.ps1
@@ -51,7 +51,8 @@
         [Parameter(Position = 1, ValueFromPipeline = $true)]
         $Actual,
         [Parameter(Position = 0)]
-        $Expected
+        $Expected,
+        [string] $Because
     )
 
     if ($Expected -isnot [timespan]) {

--- a/tst/functions/assert/Time/Should-BeFasterThan.Tests.ps1
+++ b/tst/functions/assert/Time/Should-BeFasterThan.Tests.ps1
@@ -49,7 +49,7 @@ Describe "Should-BeFasterThan" {
     }
 
     It "Has Because parameter" -ForEach @(
-        @{ Actual = { Start-Sleep -Milliseconds 10 }; Expected = "1ms"; Because = "I said so" }
+        @{ Actual = [timespan]::FromMilliseconds(100); Expected = "1ms"; Because = "I said so" }
     ) {
         { $Actual | Should-BeFasterThan -Expected $Expected -Because $Because } | Verify-AssertionFailed
     }

--- a/tst/functions/assert/Time/Should-BeFasterThan.Tests.ps1
+++ b/tst/functions/assert/Time/Should-BeFasterThan.Tests.ps1
@@ -51,6 +51,7 @@ Describe "Should-BeFasterThan" {
     It "Has Because parameter" -ForEach @(
         @{ Actual = [timespan]::FromMilliseconds(100); Expected = "1ms"; Because = "I said so" }
     ) {
-        { $Actual | Should-BeFasterThan -Expected $Expected -Because $Because } | Verify-AssertionFailed
+        $err = { $Actual | Should-BeFasterThan -Expected $Expected -Because $Because } | Verify-AssertionFailed
+        $err.Exception.Message | Verify-Like '*because I said so*'
     }
 }

--- a/tst/functions/assert/Time/Should-BeSlowerThan.Tests.ps1
+++ b/tst/functions/assert/Time/Should-BeSlowerThan.Tests.ps1
@@ -28,6 +28,7 @@ Describe "Should-BeSlowerThan" {
     It "Has Because parameter" -ForEach @(
         @{ Actual = [timespan]::FromMilliseconds(1); Expected = "1000ms"; Because = "I said so" }
     ) {
-        { $Actual | Should-BeSlowerThan -Expected $Expected -Because $Because } | Verify-AssertionFailed
+        $err = { $Actual | Should-BeSlowerThan -Expected $Expected -Because $Because } | Verify-AssertionFailed
+        $err.Exception.Message | Verify-Like '*because I said so*'
     }
 }

--- a/tst/functions/assert/Time/Should-BeSlowerThan.Tests.ps1
+++ b/tst/functions/assert/Time/Should-BeSlowerThan.Tests.ps1
@@ -24,4 +24,10 @@ Describe "Should-BeSlowerThan" {
     ) {
         { $Actual | Should-BeSlowerThan -Expected $Expected } | Verify-AssertionFailed
     }
+
+    It "Has Because parameter" -ForEach @(
+        @{ Actual = [timespan]::FromMilliseconds(1); Expected = "1000ms"; Because = "I said so" }
+    ) {
+        { $Actual | Should-BeSlowerThan -Expected $Expected -Because $Because } | Verify-AssertionFailed
+    }
 }


### PR DESCRIPTION
Fixes #2722

`Should-BeSlowerThan` referenced `\$Because` in its error messages but never declared it as a parameter — it was always null. Added the missing `[string] \$Because` parameter.

Also changed the `Should-BeFasterThan` 'Has Because parameter' test to use a deterministic `[timespan]` instead of a scriptblock with `Start-Sleep` to avoid timing flakiness on CI. Added a corresponding Because test for `Should-BeSlowerThan`.