### PR TITLE
Fix #2635: ShowStartMarkers shows expanded data-driven test names

### DIFF
--- a/src/Pester.Runtime.ps1
+++ b/src/Pester.Runtime.ps1
@@ -661,6 +661,21 @@ function Invoke-TestItem {
                         $script:ScriptBlockSessionStateInternalProperty.SetValue($sb, $SessionStateInternal)
                         $sb
                     )
+                    # Write start marker after name expansion so it shows the
+                    # fully expanded test name (fixes #2635).
+                    {
+                        if ($PesterPreference.Debug.ShowStartMarkers.Value) {
+                            $level = $Test.Path.Count
+                            $margin = $ReportStrings.Margin * ($level)
+                            $out = "$($Test.ExpandedName)..."
+
+                            if ($PesterPreference.Debug.ShowNavigationMarkers.Value) {
+                                $out += ", $($Test.ScriptBlock.File):$($Test.StartLine)"
+                            }
+
+                            Write-PesterHostMessage -ForegroundColor $ReportTheme.Information "$margin[|] $out"
+                        }
+                    }
                 ) `
                     -ScriptBlock $Test.ScriptBlock `
                     -Teardown @(

--- a/src/functions/Output.ps1
+++ b/src/functions/Output.ps1
@@ -613,18 +613,6 @@ function Get-WriteScreenPlugin ($Verbosity) {
             if ($_test.First) {
                 Write-BlockToScreen $_test.Block
             }
-
-            if ($PesterPreference.Debug.ShowStartMarkers.Value) {
-                $level = $_test.Path.Count
-                $margin = $ReportStrings.Margin * ($level)
-                $out = "$($_test.ExpandedName)..."
-
-                if ($PesterPreference.Debug.ShowNavigationMarkers.Value) {
-                    $out += ", $($_test.ScriptBlock.File):$($_test.StartLine)"
-                }
-
-                Write-PesterHostMessage -ForegroundColor $ReportTheme.Information "$margin[|] $out"
-            }
         }
     }
 

--- a/tst/Pester.RSpec.Output.ts.ps1
+++ b/tst/Pester.RSpec.Output.ts.ps1
@@ -184,6 +184,37 @@ i -PassThru:$PassThru {
             $i3Start = $output | Select-String -Pattern '\[\|\] i3\.\.\.$'
             @($i3Start).Count | Verify-Equal 1
         }
+
+        t 'Start markers show expanded names for data-driven tests' {
+            $sb = {
+                $PesterPreference = [PesterConfiguration]::Default
+                $PesterPreference.Output.Verbosity = 'Detailed'
+                $PesterPreference.Debug.ShowStartMarkers = $true
+                $PesterPreference.Output.CIFormat = 'None'
+                $PesterPreference.Output.RenderMode = 'ConsoleColor'
+
+                $container = New-PesterContainer -ScriptBlock {
+                    Describe 'd1' {
+                        It 'Iteration <_>' -ForEach @(1, 2, 3) {
+                            1 | Should -Be 1
+                        }
+                    }
+                }
+                Invoke-Pester -Container $container
+            }
+
+            $output = Invoke-InNewProcess $sb
+            # only print the relevant part of output
+            $null, $run = $output -join "`n" -split 'Running tests.'
+            $run | Write-Host
+
+            $i1Start = $output | Select-String -Pattern '\[\|\] Iteration 1\.\.\.$'
+            @($i1Start).Count | Verify-Equal 1
+            $i2Start = $output | Select-String -Pattern '\[\|\] Iteration 2\.\.\.$'
+            @($i2Start).Count | Verify-Equal 1
+            $i3Start = $output | Select-String -Pattern '\[\|\] Iteration 3\.\.\.$'
+            @($i3Start).Count | Verify-Equal 1
+        }
     }
 
     b 'Output for container names' {


### PR DESCRIPTION
Fixes #2635

When `Debug.ShowStartMarkers` is enabled, data-driven test names like `Iteration <_>` were showing the raw template instead of the expanded name (`Iteration 1`).

The start marker output was in the `EachTestSetupStart` plugin step, which fires before the `<>` template expansion runs. Moved it to a setup scriptblock that executes right after name expansion in the runtime, so markers now show the fully expanded test name.

Added a test that verifies data-driven `-ForEach` names are expanded in start markers.