### PR TITLE
Improve Should-BeString to show string diff with arrow marker

### DIFF
--- a/src/functions/assert/String/Should-BeString.ps1
+++ b/src/functions/assert/String/Should-BeString.ps1
@@ -96,8 +96,74 @@ function Should-BeString {
 
     $stringsAreEqual = Test-StringEqual -Expected $Expected -Actual $Actual -CaseSensitive:$CaseSensitive -IgnoreWhitespace:$IgnoreWhiteSpace -TrimWhitespace:$TrimWhitespace
     if (-not ($stringsAreEqual)) {
-        $Message = Get-AssertionMessage -Expected $Expected -Actual $Actual -Because $Because -DefaultMessage "Expected <expectedType> <expected>, but got <actualType> <actual>."
+        if ($Actual -is [string]) {
+            $Message = Get-StringDifferenceMessage -Expected $Expected -Actual $Actual -CaseSensitive:$CaseSensitive -Because $Because
+        }
+        else {
+            $Message = Get-AssertionMessage -Expected $Expected -Actual $Actual -Because $Because -DefaultMessage "Expected <expectedType> <expected>, but got <actualType> <actual>."
+        }
         Invoke-AssertionFailed -Message $Message -CallerCmdlet $PSCmdlet
     }
     Set-AssertionPassResult
+}
+
+function Get-StringDifferenceMessage {
+    param (
+        [Parameter(Mandatory)]
+        [AllowEmptyString()]
+        [string] $Expected,
+        [Parameter(Mandatory)]
+        [AllowEmptyString()]
+        [string] $Actual,
+        [switch] $CaseSensitive,
+        [string] $Because
+    )
+
+    $maxLength = [Math]::Max($Expected.Length, $Actual.Length)
+
+    $differenceIndex = $null
+    for ($i = 0; $i -lt $maxLength -and ($null -eq $differenceIndex); ++$i) {
+        if ($CaseSensitive) {
+            if ($Expected[$i] -cne $Actual[$i]) { $differenceIndex = $i }
+        }
+        else {
+            if ($Expected[$i] -ne $Actual[$i]) { $differenceIndex = $i }
+        }
+    }
+
+    $because = if ($Because) { " because $Because," } else { "" }
+
+    $sb = [System.Text.StringBuilder]::new()
+    $null = $sb.AppendLine("Expected strings to be the same,$because but they were different.")
+
+    if ($Expected.Length -ne $Actual.Length) {
+        $null = $sb.AppendLine("Expected length: $($Expected.Length)")
+        $null = $sb.AppendLine("Actual length:   $($Actual.Length)")
+    }
+    else {
+        $null = $sb.AppendLine("String lengths are both $($Expected.Length).")
+    }
+    $null = $sb.AppendLine("Strings differ at index $differenceIndex.")
+
+    $expectedExpanded = Expand-SpecialCharacters -InputObject $Expected
+    $actualExpanded = Expand-SpecialCharacters -InputObject $Actual
+
+    # Recompute difference index on expanded strings
+    $maxLength = [Math]::Max($expectedExpanded.Length, $actualExpanded.Length)
+    $expandedDiffIndex = $null
+    for ($i = 0; $i -lt $maxLength -and ($null -eq $expandedDiffIndex); ++$i) {
+        if ($CaseSensitive) {
+            if ($expectedExpanded[$i] -cne $actualExpanded[$i]) { $expandedDiffIndex = $i }
+        }
+        else {
+            if ($expectedExpanded[$i] -ne $actualExpanded[$i]) { $expandedDiffIndex = $i }
+        }
+    }
+
+    $prefix = "Expected: '"
+    $null = $sb.AppendLine("$prefix$expectedExpanded'")
+    $null = $sb.AppendLine("But was:  '$actualExpanded'")
+    $null = $sb.Append((' ' * ($prefix.Length - 1)) + ('-' * $expandedDiffIndex) + '^')
+
+    $sb.ToString()
 }

--- a/src/functions/assert/String/Should-BeString.ps1
+++ b/src/functions/assert/String/Should-BeString.ps1
@@ -133,17 +133,18 @@ function Get-StringDifferenceMessage {
 
     $because = if ($Because) { " because $Because," } else { "" }
 
-    $sb = [System.Text.StringBuilder]::new()
-    $null = $sb.AppendLine("Expected strings to be the same,$because but they were different.")
+    $lines = @(
+        "Expected strings to be the same,$because but they were different."
+    )
 
     if ($Expected.Length -ne $Actual.Length) {
-        $null = $sb.AppendLine("Expected length: $($Expected.Length)")
-        $null = $sb.AppendLine("Actual length:   $($Actual.Length)")
+        $lines += "Expected length: $($Expected.Length)"
+        $lines += "Actual length:   $($Actual.Length)"
     }
     else {
-        $null = $sb.AppendLine("String lengths are both $($Expected.Length).")
+        $lines += "String lengths are both $($Expected.Length)."
     }
-    $null = $sb.AppendLine("Strings differ at index $differenceIndex.")
+    $lines += "Strings differ at index $differenceIndex."
 
     $expectedExpanded = Expand-SpecialCharacters -InputObject $Expected
     $actualExpanded = Expand-SpecialCharacters -InputObject $Actual
@@ -161,9 +162,9 @@ function Get-StringDifferenceMessage {
     }
 
     $prefix = "Expected: '"
-    $null = $sb.AppendLine("$prefix$expectedExpanded'")
-    $null = $sb.AppendLine("But was:  '$actualExpanded'")
-    $null = $sb.Append((' ' * ($prefix.Length - 1)) + ('-' * $expandedDiffIndex) + '^')
+    $lines += "$prefix$expectedExpanded'"
+    $lines += "But was:  '$actualExpanded'"
+    $lines += (' ' * ($prefix.Length - 1)) + ('-' * $expandedDiffIndex) + '^'
 
-    $sb.ToString()
+    $lines -join "`n"
 }

--- a/tst/functions/assert/String/Should-BeString.Tests.ps1
+++ b/tst/functions/assert/String/Should-BeString.Tests.ps1
@@ -118,6 +118,21 @@ Describe "Should-BeString" {
 
     It "Throws with default message when test fails" {
         $err = { Should-BeString -Expected "abc" -Actual "bde" } | Verify-AssertionFailed
-        $err.Exception.Message | Verify-Equal "Expected [string] 'abc', but got [string] 'bde'."
+        $err.Exception.Message | Verify-Like "*Expected strings to be the same*but they were different*"
+        $err.Exception.Message | Verify-Like "*Strings differ at index 0*"
+        $err.Exception.Message | Verify-Like "*Expected: 'abc'*"
+        $err.Exception.Message | Verify-Like "*But was:  'bde'*"
+    }
+
+    It "Shows difference index and arrow marker" {
+        $err = { "hello world" | Should-BeString "Hello World" -CaseSensitive } | Verify-AssertionFailed
+        $err.Exception.Message | Verify-Like "*Strings differ at index 0*"
+        $err.Exception.Message | Verify-Like "*^*"
+    }
+
+    It "Shows expanded whitespace characters in diff" {
+        $err = { "abc`ndef" | Should-BeString "abc`r`ndef" } | Verify-AssertionFailed
+        $err.Exception.Message | Verify-Like "*abc\r\ndef*"
+        $err.Exception.Message | Verify-Like "*abc\ndef*"
     }
 }

--- a/tst/functions/assert/String/Should-BeString.Tests.ps1
+++ b/tst/functions/assert/String/Should-BeString.Tests.ps1
@@ -118,21 +118,51 @@ Describe "Should-BeString" {
 
     It "Throws with default message when test fails" {
         $err = { Should-BeString -Expected "abc" -Actual "bde" } | Verify-AssertionFailed
-        $err.Exception.Message | Verify-Like "*Expected strings to be the same*but they were different*"
-        $err.Exception.Message | Verify-Like "*Strings differ at index 0*"
-        $err.Exception.Message | Verify-Like "*Expected: 'abc'*"
-        $err.Exception.Message | Verify-Like "*But was:  'bde'*"
+        $err.Exception.Message | Verify-Equal @'
+Expected strings to be the same, but they were different.
+String lengths are both 3.
+Strings differ at index 0.
+Expected: 'abc'
+But was:  'bde'
+          ^
+'@
     }
 
-    It "Shows difference index and arrow marker" {
+    It "Shows arrow at correct position for case-sensitive difference" {
         $err = { "hello world" | Should-BeString "Hello World" -CaseSensitive } | Verify-AssertionFailed
-        $err.Exception.Message | Verify-Like "*Strings differ at index 0*"
-        $err.Exception.Message | Verify-Like "*^*"
+        $err.Exception.Message | Verify-Equal @'
+Expected strings to be the same, but they were different.
+String lengths are both 11.
+Strings differ at index 0.
+Expected: 'Hello World'
+But was:  'hello world'
+          ^
+'@
+    }
+
+    It "Shows arrow with dashes for mid-string difference" {
+        $err = { "abc" | Should-BeString "abcdef" } | Verify-AssertionFailed
+        $err.Exception.Message | Verify-Equal @'
+Expected strings to be the same, but they were different.
+Expected length: 6
+Actual length:   3
+Strings differ at index 3.
+Expected: 'abcdef'
+But was:  'abc'
+          ---^
+'@
     }
 
     It "Shows expanded whitespace characters in diff" {
         $err = { "abc`ndef" | Should-BeString "abc`r`ndef" } | Verify-AssertionFailed
-        $err.Exception.Message | Verify-Like "*abc\r\ndef*"
-        $err.Exception.Message | Verify-Like "*abc\ndef*"
+        $err.Exception.Message | Verify-Equal @'
+Expected strings to be the same, but they were different.
+Expected length: 8
+Actual length:   7
+Strings differ at index 3.
+Expected: 'abc\r\ndef'
+But was:  'abc\ndef'
+          ----^
+'@
     }
 }

--- a/tst/functions/assert/String/Should-BeString.Tests.ps1
+++ b/tst/functions/assert/String/Should-BeString.Tests.ps1
@@ -118,31 +118,31 @@ Describe "Should-BeString" {
 
     It "Throws with default message when test fails" {
         $err = { Should-BeString -Expected "abc" -Actual "bde" } | Verify-AssertionFailed
-        $err.Exception.Message | Verify-Equal @'
+        $err.Exception.Message | Verify-Equal (@'
 Expected strings to be the same, but they were different.
 String lengths are both 3.
 Strings differ at index 0.
 Expected: 'abc'
 But was:  'bde'
           ^
-'@
+'@ -replace "`r`n", "`n")
     }
 
     It "Shows arrow at correct position for case-sensitive difference" {
         $err = { "hello world" | Should-BeString "Hello World" -CaseSensitive } | Verify-AssertionFailed
-        $err.Exception.Message | Verify-Equal @'
+        $err.Exception.Message | Verify-Equal (@'
 Expected strings to be the same, but they were different.
 String lengths are both 11.
 Strings differ at index 0.
 Expected: 'Hello World'
 But was:  'hello world'
           ^
-'@
+'@ -replace "`r`n", "`n")
     }
 
     It "Shows arrow with dashes for mid-string difference" {
         $err = { "abc" | Should-BeString "abcdef" } | Verify-AssertionFailed
-        $err.Exception.Message | Verify-Equal @'
+        $err.Exception.Message | Verify-Equal (@'
 Expected strings to be the same, but they were different.
 Expected length: 6
 Actual length:   3
@@ -150,12 +150,12 @@ Strings differ at index 3.
 Expected: 'abcdef'
 But was:  'abc'
           ---^
-'@
+'@ -replace "`r`n", "`n")
     }
 
     It "Shows expanded whitespace characters in diff" {
         $err = { "abc`ndef" | Should-BeString "abc`r`ndef" } | Verify-AssertionFailed
-        $err.Exception.Message | Verify-Equal @'
+        $err.Exception.Message | Verify-Equal (@'
 Expected strings to be the same, but they were different.
 Expected length: 8
 Actual length:   7
@@ -163,6 +163,6 @@ Strings differ at index 3.
 Expected: 'abc\r\ndef'
 But was:  'abc\ndef'
           ----^
-'@
+'@ -replace "`r`n", "`n")
     }
 }


### PR DESCRIPTION
Fixes #2462

When `Should-BeString` fails, the error message now shows:

- The difference index
- String lengths (when different)
- Expected and actual strings with expanded special characters (`\n`, `\r`, `\t`, etc.)
- An arrow marker pointing to the first difference

Before:
```
Expected [string] 'abc', but got [string] 'bde'.
```

After:
```
Expected strings to be the same, but they were different.
String lengths are both 3.
Strings differ at index 0.
Expected: 'abc'
But was:  'bde'
          ^
```

Whitespace differences are visible even without `-IgnoreWhitespace`:
```
Expected strings to be the same, but they were different.
Expected length: 8
Actual length:   7
Strings differ at index 3.
Expected: 'abc\r\ndef'
But was:  'abc\ndef'
          ----^
```