### PR TITLE
Use Unicode Control Pictures for special characters in assertions

### DIFF
--- a/src/functions/assert/String/Should-BeString.ps1
+++ b/src/functions/assert/String/Should-BeString.ps1
@@ -149,22 +149,10 @@ function Get-StringDifferenceMessage {
     $expectedExpanded = Expand-SpecialCharacters -InputObject $Expected
     $actualExpanded = Expand-SpecialCharacters -InputObject $Actual
 
-    # Recompute difference index on expanded strings
-    $maxLength = [Math]::Max($expectedExpanded.Length, $actualExpanded.Length)
-    $expandedDiffIndex = $null
-    for ($i = 0; $i -lt $maxLength -and ($null -eq $expandedDiffIndex); ++$i) {
-        if ($CaseSensitive) {
-            if ($expectedExpanded[$i] -cne $actualExpanded[$i]) { $expandedDiffIndex = $i }
-        }
-        else {
-            if ($expectedExpanded[$i] -ne $actualExpanded[$i]) { $expandedDiffIndex = $i }
-        }
-    }
-
     $prefix = "Expected: '"
     $lines += "$prefix$expectedExpanded'"
     $lines += "But was:  '$actualExpanded'"
-    $lines += (' ' * ($prefix.Length - 1)) + ('-' * $expandedDiffIndex) + '^'
+    $lines += (' ' * ($prefix.Length - 1)) + ('-' * $differenceIndex) + '^'
 
     $lines -join "`n"
 }

--- a/src/functions/assertions/Be.ps1
+++ b/src/functions/assertions/Be.ps1
@@ -207,24 +207,8 @@ function Get-CompareStringMessage {
             "Strings differ at index $differenceIndex."
         }
 
-        # find the difference in the string with expanded characters, this is the fastest and most foolproof way of
-        # getting the updated difference index. we could also inspect the new string and try to find every occurrence
-        # of special character before the difference index, but '\n' is valid piece of string
-        # or inspect the original string, but then we need to make sure that we look for all the special characters.
-        # instead we just compare it again.
-
         $actualExpanded = Expand-SpecialCharacters -InputObject $actual
         $expectedExpanded = Expand-SpecialCharacters -InputObject $ExpectedValue
-        $maxLength = if ($expectedExpanded.Length -gt $actualExpanded.Length) { $expectedExpanded.Length } else { $actualExpanded.Length }
-        $differenceIndex = $null
-        for ($i = 0; $i -lt $maxLength -and ($null -eq $differenceIndex); ++$i) {
-            $differenceIndex = if ($CaseSensitive -and ($expectedExpanded[$i] -cne $actualExpanded[$i])) {
-                $i
-            }
-            elseif ($expectedExpanded[$i] -ne $actualExpanded[$i]) {
-                $i
-            }
-        }
 
         $ellipsis = "..."
         # we will surround the output with Expected: '' and But was: '', from which the Expected: '' is longer

--- a/src/functions/assertions/Be.ps1
+++ b/src/functions/assertions/Be.ps1
@@ -312,7 +312,7 @@ function Expand-SpecialCharacters {
         [AllowEmptyString()]
         [string[]]$InputObject)
     process {
-        $InputObject -replace "`n", "\n" -replace "`r", "\r" -replace "`t", "\t" -replace "`0", "\0" -replace "`b", "\b"
+        [Pester.Formatter]::EscapeControlChars($InputObject)
     }
 }
 

--- a/tst/functions/assert/String/Should-BeString.Tests.ps1
+++ b/tst/functions/assert/String/Should-BeString.Tests.ps1
@@ -155,8 +155,6 @@ But was:  'abc'
 
     It "Shows expanded whitespace characters in diff" {
         $err = { "abc`ndef" | Should-BeString "abc`r`ndef" } | Verify-AssertionFailed
-        $cr = [char]0x240D
-        $lf = [char]0x240A
-        $err.Exception.Message | Verify-Equal ("Expected strings to be the same, but they were different.`nExpected length: 8`nActual length:   7`nStrings differ at index 3.`nExpected: 'abc${cr}${lf}def'`nBut was:  'abc${lf}def'`n          ---^" -replace "`r`n", "`n")
+        $err.Exception.Message | Verify-Equal ("Expected strings to be the same, but they were different.`nExpected length: 8`nActual length:   7`nStrings differ at index 3.`nExpected: 'abc␍␊def'`nBut was:  'abc␊def'`n          ---^" -replace "`r`n", "`n")
     }
 }

--- a/tst/functions/assert/String/Should-BeString.Tests.ps1
+++ b/tst/functions/assert/String/Should-BeString.Tests.ps1
@@ -155,14 +155,8 @@ But was:  'abc'
 
     It "Shows expanded whitespace characters in diff" {
         $err = { "abc`ndef" | Should-BeString "abc`r`ndef" } | Verify-AssertionFailed
-        $err.Exception.Message | Verify-Equal (@'
-Expected strings to be the same, but they were different.
-Expected length: 8
-Actual length:   7
-Strings differ at index 3.
-Expected: 'abc\r\ndef'
-But was:  'abc\ndef'
-          ----^
-'@ -replace "`r`n", "`n")
+        $cr = [char]0x240D
+        $lf = [char]0x240A
+        $err.Exception.Message | Verify-Equal ("Expected strings to be the same, but they were different.`nExpected length: 8`nActual length:   7`nStrings differ at index 3.`nExpected: 'abc${cr}${lf}def'`nBut was:  'abc${lf}def'`n          ---^" -replace "`r`n", "`n")
     }
 }

--- a/tst/functions/assert/String/Should-BeString.Tests.ps1
+++ b/tst/functions/assert/String/Should-BeString.Tests.ps1
@@ -155,6 +155,14 @@ But was:  'abc'
 
     It "Shows expanded whitespace characters in diff" {
         $err = { "abc`ndef" | Should-BeString "abc`r`ndef" } | Verify-AssertionFailed
-        $err.Exception.Message | Verify-Equal ("Expected strings to be the same, but they were different.`nExpected length: 8`nActual length:   7`nStrings differ at index 3.`nExpected: 'abc␍␊def'`nBut was:  'abc␊def'`n          ---^" -replace "`r`n", "`n")
+        $err.Exception.Message | Verify-Equal (@'
+Expected strings to be the same, but they were different.
+Expected length: 8
+Actual length:   7
+Strings differ at index 3.
+Expected: 'abc␍␊def'
+But was:  'abc␊def'
+          ---^
+'@ -replace "`r`n", "`n")
     }
 }

--- a/tst/functions/assertions/Be.Tests.ps1
+++ b/tst/functions/assertions/Be.Tests.ps1
@@ -151,15 +151,15 @@ InPesterModuleScope {
         }
 
         It "Replaces non-printable characters correctly" {
-            ShouldBeFailureMessage "`n`r`b`0`tx" "`n`r`b`0`ty" | Verify-Equal "Expected strings to be the same, but they were different.`nString lengths are both 6.`nStrings differ at index 5.`nExpected: '$(([char]0x240A))$(([char]0x240D))$(([char]0x2408))$(([char]0x2400))$(([char]0x2409))y'`nBut was:  '$(([char]0x240A))$(([char]0x240D))$(([char]0x2408))$(([char]0x2400))$(([char]0x2409))x'`n           -----^"
+            ShouldBeFailureMessage "`n`r`b`0`tx" "`n`r`b`0`ty" | Verify-Equal "Expected strings to be the same, but they were different.`nString lengths are both 6.`nStrings differ at index 5.`nExpected: '␊␍␈␀␉y'`nBut was:  '␊␍␈␀␉x'`n           -----^"
         }
 
         It "The arrow points to the correct position when non-printable characters are replaced before the difference" {
-            ShouldBeFailureMessage "123`n456" "123`n789" | Verify-Equal "Expected strings to be the same, but they were different.`nString lengths are both 7.`nStrings differ at index 4.`nExpected: '123$(([char]0x240A))789'`nBut was:  '123$(([char]0x240A))456'`n           ----^"
+            ShouldBeFailureMessage "123`n456" "123`n789" | Verify-Equal "Expected strings to be the same, but they were different.`nString lengths are both 7.`nStrings differ at index 4.`nExpected: '123␊789'`nBut was:  '123␊456'`n           ----^"
         }
 
         It "The arrow points to the correct position when non-printable characters are replaced after the difference" {
-            ShouldBeFailureMessage "abcd`n123" "abc!`n123" | Verify-Equal "Expected strings to be the same, but they were different.`nString lengths are both 8.`nStrings differ at index 3.`nExpected: 'abc!$(([char]0x240A))123'`nBut was:  'abcd$(([char]0x240A))123'`n           ---^"
+            ShouldBeFailureMessage "abcd`n123" "abc!`n123" | Verify-Equal "Expected strings to be the same, but they were different.`nString lengths are both 8.`nStrings differ at index 3.`nExpected: 'abc!␊123'`nBut was:  'abcd␊123'`n           ---^"
         }
     }
 }

--- a/tst/functions/assertions/Be.Tests.ps1
+++ b/tst/functions/assertions/Be.Tests.ps1
@@ -151,15 +151,15 @@ InPesterModuleScope {
         }
 
         It "Replaces non-printable characters correctly" {
-            ShouldBeFailureMessage "`n`r`b`0`tx" "`n`r`b`0`ty" | Verify-Equal "Expected strings to be the same, but they were different.`nString lengths are both 6.`nStrings differ at index 5.`nExpected: '\n\r\b\0\ty'`nBut was:  '\n\r\b\0\tx'`n           ----------^"
+            ShouldBeFailureMessage "`n`r`b`0`tx" "`n`r`b`0`ty" | Verify-Equal "Expected strings to be the same, but they were different.`nString lengths are both 6.`nStrings differ at index 5.`nExpected: '$(([char]0x240A))$(([char]0x240D))$(([char]0x2408))$(([char]0x2400))$(([char]0x2409))y'`nBut was:  '$(([char]0x240A))$(([char]0x240D))$(([char]0x2408))$(([char]0x2400))$(([char]0x2409))x'`n           -----^"
         }
 
         It "The arrow points to the correct position when non-printable characters are replaced before the difference" {
-            ShouldBeFailureMessage "123`n456" "123`n789" | Verify-Equal "Expected strings to be the same, but they were different.`nString lengths are both 7.`nStrings differ at index 4.`nExpected: '123\n789'`nBut was:  '123\n456'`n           -----^"
+            ShouldBeFailureMessage "123`n456" "123`n789" | Verify-Equal "Expected strings to be the same, but they were different.`nString lengths are both 7.`nStrings differ at index 4.`nExpected: '123$(([char]0x240A))789'`nBut was:  '123$(([char]0x240A))456'`n           ----^"
         }
 
         It "The arrow points to the correct position when non-printable characters are replaced after the difference" {
-            ShouldBeFailureMessage "abcd`n123" "abc!`n123" | Verify-Equal "Expected strings to be the same, but they were different.`nString lengths are both 8.`nStrings differ at index 3.`nExpected: 'abc!\n123'`nBut was:  'abcd\n123'`n           ---^"
+            ShouldBeFailureMessage "abcd`n123" "abc!`n123" | Verify-Equal "Expected strings to be the same, but they were different.`nString lengths are both 8.`nStrings differ at index 3.`nExpected: 'abc!$(([char]0x240A))123'`nBut was:  'abcd$(([char]0x240A))123'`n           ---^"
         }
     }
 }


### PR DESCRIPTION
Fixes #2732

Replace `\n`, `\r`, `\t`, `\0`, `\b` escape sequences in assertion error messages with visible Unicode Control Pictures (U+2400 block): `␊`, `␍`, `␉`, `␀`, `␈`.

This reuses the existing `[Pester.Formatter]::EscapeControlChars()` C# implementation (added for #2561) instead of the PowerShell regex chain. The glyphs are single characters, making arrow markers in diff output align correctly without doubling positions.