### PR TITLE
Throw on duplicate BeforeAll/BeforeEach/AfterAll/AfterEach

### DIFF
--- a/src/Pester.Runtime.ps1
+++ b/src/Pester.Runtime.ps1
@@ -755,6 +755,9 @@ function New-EachTestSetup {
     )
 
     if (Is-Discovery) {
+        if ($null -ne $state.CurrentBlock.EachTestSetup) {
+            throw "BeforeEach is already defined in this block. Each block can only have one BeforeEach. Combine the code into a single BeforeEach block."
+        }
         $state.CurrentBlock.EachTestSetup = $ScriptBlock
     }
 }
@@ -767,6 +770,9 @@ function New-EachTestTeardown {
     )
 
     if (Is-Discovery) {
+        if ($null -ne $state.CurrentBlock.EachTestTeardown) {
+            throw "AfterEach is already defined in this block. Each block can only have one AfterEach. Combine the code into a single AfterEach block."
+        }
         $state.CurrentBlock.EachTestTeardown = $ScriptBlock
     }
 }
@@ -780,6 +786,9 @@ function New-OneTimeTestSetup {
     )
 
     if (Is-Discovery) {
+        if ($null -ne $state.CurrentBlock.OneTimeTestSetup) {
+            throw "BeforeAll is already defined in this block. Each block can only have one BeforeAll. Combine the code into a single BeforeAll block."
+        }
         $state.CurrentBlock.OneTimeTestSetup = $ScriptBlock
     }
 }
@@ -792,6 +801,9 @@ function New-OneTimeTestTeardown {
         [ScriptBlock] $ScriptBlock
     )
     if (Is-Discovery) {
+        if ($null -ne $state.CurrentBlock.OneTimeTestTeardown) {
+            throw "AfterAll is already defined in this block. Each block can only have one AfterAll. Combine the code into a single AfterAll block."
+        }
         $state.CurrentBlock.OneTimeTestTeardown = $ScriptBlock
     }
 }

--- a/tst/functions/Output.Tests.ps1
+++ b/tst/functions/Output.Tests.ps1
@@ -2,9 +2,6 @@
 
 BeforeAll {
     $PSDefaultParameterValues = @{ 'Should:ErrorAction' = 'Stop' }
-}
-
-BeforeAll {
     $thisScriptRegex = [regex]::Escape((Get-Item $PSCommandPath).FullName)
 }
 
@@ -264,7 +261,7 @@ InModuleScope -ModuleName Pester -ScriptBlock {
                         $r.Trace[0] | Should -be "at f1, ${testPath}:2"
                         $r.Trace[1] | Should -be "at f2, ${testPath}:5"
                         $r.Trace[2] | Should -be "at <ScriptBlock>, ${testPath}:7"
-                        $r.Trace[3] | Should -be "at <ScriptBlock>, ${PSCommandPath}:247"
+                        $r.Trace[3] | Should -be "at <ScriptBlock>, ${PSCommandPath}:244"
                         $r.Trace.Count | Should -be 4
                     }
                 }
@@ -275,7 +272,7 @@ InModuleScope -ModuleName Pester -ScriptBlock {
                         $r.Trace[0] | Should -be "at f1, ${testPath}:2"
                         $r.Trace[1] | Should -be "at f2, ${testPath}:5"
                         $r.Trace[2] | Should -be "at <ScriptBlock>, ${testPath}:7"
-                        $r.Trace[3] | Should -be "at <ScriptBlock>, ${PSCommandPath}:247"
+                        $r.Trace[3] | Should -be "at <ScriptBlock>, ${PSCommandPath}:244"
                         $r.Trace.Count | Should -be 4
                     }
                 }
@@ -336,7 +333,7 @@ InModuleScope -ModuleName Pester -ScriptBlock {
                 It 'produces correct trace line.' {
                     if ($hasStackTrace) {
                         $r.Trace[0] | Should -be "at <ScriptBlock>, $testPath`:10"
-                        $r.Trace[1] | Should -be "at <ScriptBlock>, $PSCommandPath`:313"
+                        $r.Trace[1] | Should -be "at <ScriptBlock>, $PSCommandPath`:310"
                         $r.Trace.Count | Should -be 2
                     }
                 }
@@ -345,7 +342,7 @@ InModuleScope -ModuleName Pester -ScriptBlock {
                 It 'produces correct trace line.' {
                     if ($hasStackTrace) {
                         $r.Trace[0] | Should -be "at <ScriptBlock>, $testPath`:10"
-                        $r.Trace[1] | Should -be "at <ScriptBlock>, $PSCommandPath`:313"
+                        $r.Trace[1] | Should -be "at <ScriptBlock>, $PSCommandPath`:310"
                         $r.Trace.Count | Should -be 2
                     }
                 }
@@ -434,7 +431,7 @@ InModuleScope -ModuleName Pester -ScriptBlock {
                 $errorMessage = Format-ErrorMessage -Err $errorRecord -StackTraceVerbosity $_
                 $messages = $errorMessage -split [Environment]::NewLine
                 $messages[0] | Should -BeExactly "System.DivideByZeroException: Attempted to divide by zero."
-                $messages[1] | Should -BeExactly "at <ScriptBlock>, ${PSCommandPath}: line 388"
+                $messages[1] | Should -BeExactly "at <ScriptBlock>, ${PSCommandPath}: line 385"
                 $messages.Count | Should -BeGreaterThan 1
             }
 

--- a/tst/functions/SetupTeardown.Tests.ps1
+++ b/tst/functions/SetupTeardown.Tests.ps1
@@ -63,16 +63,12 @@ Describe 'Multiple Test Case setup blocks' {
     }
 
     Context 'The context' {
-        It 'Executes Describe setup blocks first, then Context blocks in the order they were defined (even if they are defined after the It block.)' {
-            $testVariable | Should -Be 'Set in the second Context BeforeEach'
+        It 'Executes Describe setup blocks first, then Context block' {
+            $testVariable | Should -Be 'Set in Context BeforeEach'
         }
 
         BeforeEach {
-            $testVariable = 'Set in the first Context BeforeEach'
-        }
-
-        BeforeEach {
-            $testVariable = 'Set in the second Context BeforeEach'
+            $testVariable = 'Set in Context BeforeEach'
         }
     }
 
@@ -113,18 +109,14 @@ Describe 'Multiple Test Case teardown blocks' {
 
     Context 'The context' {
         AfterEach {
-            $container.Value = 'Set in the first Context AfterEach'
+            $container.Value = 'Set in the Context AfterEach'
         }
 
         It 'Performs a test in Context' { "some output" }
 
         It 'Executes Describe teardown blocks after Context teardown blocks' {
-            $container.Value | Should -Be 'Set in the second Describe AfterEach'
+            $container.Value | Should -Be 'Set in Describe AfterEach'
         }
-    }
-
-    AfterEach {
-        $container.Value = 'Set in the second Describe AfterEach'
     }
 }
 
@@ -210,7 +202,89 @@ Describe 'Unbound scriptsblocks as input' {
     }
 }
 
-# if ($PSVersionTable.PSVersion.Major -ge 3) {
+Describe 'Duplicate setup and teardown blocks throw' {
+    It 'Throws when two BeforeAll are defined in the same block' {
+        $sb = {
+            Describe 'd' {
+                BeforeAll { }
+                BeforeAll { }
+                It 'i' { }
+            }
+        }
+        $c = New-PesterConfiguration
+        $c.Run.ScriptBlock = $sb
+        $c.Run.PassThru = $true
+        $c.Output.Verbosity = 'None'
+        $r = Invoke-Pester -Configuration $c
+        $r.Containers[0].ErrorRecord[0].Exception.Message | Should -BeLike '*BeforeAll is already defined*'
+    }
+
+    It 'Throws when two AfterAll are defined in the same block' {
+        $sb = {
+            Describe 'd' {
+                AfterAll { }
+                AfterAll { }
+                It 'i' { }
+            }
+        }
+        $c = New-PesterConfiguration
+        $c.Run.ScriptBlock = $sb
+        $c.Run.PassThru = $true
+        $c.Output.Verbosity = 'None'
+        $r = Invoke-Pester -Configuration $c
+        $r.Containers[0].ErrorRecord[0].Exception.Message | Should -BeLike '*AfterAll is already defined*'
+    }
+
+    It 'Throws when two BeforeEach are defined in the same block' {
+        $sb = {
+            Describe 'd' {
+                BeforeEach { }
+                BeforeEach { }
+                It 'i' { }
+            }
+        }
+        $c = New-PesterConfiguration
+        $c.Run.ScriptBlock = $sb
+        $c.Run.PassThru = $true
+        $c.Output.Verbosity = 'None'
+        $r = Invoke-Pester -Configuration $c
+        $r.Containers[0].ErrorRecord[0].Exception.Message | Should -BeLike '*BeforeEach is already defined*'
+    }
+
+    It 'Throws when two AfterEach are defined in the same block' {
+        $sb = {
+            Describe 'd' {
+                AfterEach { }
+                AfterEach { }
+                It 'i' { }
+            }
+        }
+        $c = New-PesterConfiguration
+        $c.Run.ScriptBlock = $sb
+        $c.Run.PassThru = $true
+        $c.Output.Verbosity = 'None'
+        $r = Invoke-Pester -Configuration $c
+        $r.Containers[0].ErrorRecord[0].Exception.Message | Should -BeLike '*AfterEach is already defined*'
+    }
+
+    It 'Allows same hook type in different blocks' {
+        $sb = {
+            Describe 'd' {
+                BeforeAll { $script:x = 1 }
+                Context 'c' {
+                    BeforeAll { $script:y = 2 }
+                    It 'i' { $script:x + $script:y | Should -Be 3 }
+                }
+            }
+        }
+        $c = New-PesterConfiguration
+        $c.Run.ScriptBlock = $sb
+        $c.Run.PassThru = $true
+        $c.Output.Verbosity = 'None'
+        $r = Invoke-Pester -Configuration $c
+        $r.FailedCount | Should -Be 0
+    }
+}
 #     # TODO: this depends on the old pester internals it would be easier to test in P
 #     $thisTestScriptFilePath = $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($PSCommandPath)
 


### PR DESCRIPTION
Each block can only have one of each setup/teardown hook. Using multiple was never supported and could lead to unpredictable behavior since execution order wasn't guaranteed. Now throws a clear error during discovery.

- Added `` checks in `New-EachTestSetup`, `New-EachTestTeardown`, `New-OneTimeTestSetup`, `New-OneTimeTestTeardown`
- Fixed existing tests that had duplicate hooks (SetupTeardown.Tests.ps1, Output.Tests.ps1)
- Added 5 new tests for duplicate detection

Fixes #2706