### PR TITLE
Support -Mandatory:$false in Should-HaveParameter

### DIFF
--- a/src/functions/assertions/HaveParameter.ps1
+++ b/src/functions/assertions/HaveParameter.ps1
@@ -262,15 +262,26 @@
     if ($buts.Count -eq 0) {
         # Parameter exists (in set if specified), assert remaining requirements
 
-        if ($Mandatory) {
+        if ($PSBoundParameters.ContainsKey('Mandatory')) {
             $testMandatory = $parameterAttributes | & $SafeCommands['Where-Object'] { $_.Mandatory }
-            $filters += "which is$(if ($Negate) {' not'}) mandatory"
 
-            if (-not $Negate -and -not $testMandatory) {
-                $buts += "it wasn't mandatory"
+            if ($Mandatory) {
+                $filters += "which is$(if ($Negate) {' not'}) mandatory"
+
+                if (-not $Negate -and -not $testMandatory) {
+                    $buts += "it wasn't mandatory"
+                }
+                elseif ($Negate -and $testMandatory) {
+                    $buts += 'it was mandatory'
+                }
             }
-            elseif ($Negate -and $testMandatory) {
-                $buts += 'it was mandatory'
+            else {
+                # Explicit -Mandatory:$false means "parameter must NOT be mandatory"
+                $filters += "which is not mandatory"
+
+                if ($testMandatory) {
+                    $buts += 'it was mandatory'
+                }
             }
         }
 

--- a/src/functions/assertions/HaveParameter.ps1
+++ b/src/functions/assertions/HaveParameter.ps1
@@ -329,19 +329,35 @@
             }
         }
 
-        if ($HasArgumentCompleter) {
+        if ($PSBoundParameters.ContainsKey('HasArgumentCompleter')) {
             $testArgumentCompleter = $attributes | & $SafeCommands['Where-Object'] { $_ -is [ArgumentCompleter] }
 
             if (-not $testArgumentCompleter) {
-                $testArgumentCompleter = Get-ArgumentCompleter -CommandName $ActualValue.Name -ParameterName $ParameterName
+                try {
+                    $testArgumentCompleter = Get-ArgumentCompleter -CommandName $ActualValue.Name -ParameterName $ParameterName
+                }
+                catch {
+                    # Get-ArgumentCompleter uses reflection that may fail on some PS versions
+                }
             }
-            $filters += 'has ArgumentCompletion'
 
-            if (-not $Negate -and -not $testArgumentCompleter) {
-                $buts += 'has no ArgumentCompletion'
+            if ($HasArgumentCompleter) {
+                $filters += 'has ArgumentCompletion'
+
+                if (-not $Negate -and -not $testArgumentCompleter) {
+                    $buts += 'has no ArgumentCompletion'
+                }
+                elseif ($Negate -and $testArgumentCompleter) {
+                    $buts += 'has ArgumentCompletion'
+                }
             }
-            elseif ($Negate -and $testArgumentCompleter) {
-                $buts += 'has ArgumentCompletion'
+            else {
+                # Explicit -HasArgumentCompleter:$false means "parameter must NOT have argument completer"
+                $filters += 'has no ArgumentCompletion'
+
+                if ($testArgumentCompleter) {
+                    $buts += 'has ArgumentCompletion'
+                }
             }
         }
 

--- a/tst/functions/assert/Parameter/Should-HaveParameter.Tests.ps1
+++ b/tst/functions/assert/Parameter/Should-HaveParameter.Tests.ps1
@@ -60,4 +60,52 @@ Describe "Should-HaveParameter" {
             Get-Command f | Should-HaveParameter a -Mandatory:$false
         }
     }
+
+    Context "HasArgumentCompleter" {
+        It "Fails when parameter does not exist and -HasArgumentCompleter is specified" {
+            function f () { }
+
+            { Get-Command f | Should-HaveParameter a -HasArgumentCompleter } | Verify-Throw
+        }
+
+        It "Fails when parameter exists but has no argument completer" {
+            function f ($a) { }
+
+            { Get-Command f | Should-HaveParameter a -HasArgumentCompleter } | Verify-Throw
+        }
+
+        It "Passes when parameter exists and has argument completer" {
+            function f {
+                param(
+                    [ArgumentCompleter({ @('one', 'two') })]
+                    $a
+                )
+            }
+
+            Get-Command f | Should-HaveParameter a -HasArgumentCompleter
+        }
+
+        It "Fails when parameter does not exist and -HasArgumentCompleter:`$false is specified" {
+            function f () { }
+
+            { Get-Command f | Should-HaveParameter a -HasArgumentCompleter:$false } | Verify-Throw
+        }
+
+        It "Fails when parameter has argument completer but -HasArgumentCompleter:`$false is specified" {
+            function f {
+                param(
+                    [ArgumentCompleter({ @('one', 'two') })]
+                    $a
+                )
+            }
+
+            { Get-Command f | Should-HaveParameter a -HasArgumentCompleter:$false } | Verify-Throw
+        }
+
+        It "Passes when parameter exists and has no argument completer with -HasArgumentCompleter:`$false" {
+            function f ($a) { }
+
+            Get-Command f | Should-HaveParameter a -HasArgumentCompleter:$false
+        }
+    }
 }

--- a/tst/functions/assert/Parameter/Should-HaveParameter.Tests.ps1
+++ b/tst/functions/assert/Parameter/Should-HaveParameter.Tests.ps1
@@ -12,4 +12,52 @@ Describe "Should-HaveParameter" {
 
         { Get-Command f | Should-HaveParameter a } | Verify-Throw
     }
+
+    Context "Mandatory" {
+        It "Fails when parameter does not exist and -Mandatory is specified" {
+            function f () { }
+
+            { Get-Command f | Should-HaveParameter a -Mandatory } | Verify-Throw
+        }
+
+        It "Fails when parameter exists but is not mandatory" {
+            function f ($a) { }
+
+            { Get-Command f | Should-HaveParameter a -Mandatory } | Verify-Throw
+        }
+
+        It "Passes when parameter exists and is mandatory" {
+            function f {
+                param(
+                    [Parameter(Mandatory)]
+                    $a
+                )
+            }
+
+            Get-Command f | Should-HaveParameter a -Mandatory
+        }
+
+        It "Fails when parameter does not exist and -Mandatory:`$false is specified" {
+            function f () { }
+
+            { Get-Command f | Should-HaveParameter a -Mandatory:$false } | Verify-Throw
+        }
+
+        It "Fails when parameter exists and is mandatory but -Mandatory:`$false is specified" {
+            function f {
+                param(
+                    [Parameter(Mandatory)]
+                    $a
+                )
+            }
+
+            { Get-Command f | Should-HaveParameter a -Mandatory:$false } | Verify-Throw
+        }
+
+        It "Passes when parameter exists and is not mandatory with -Mandatory:`$false" {
+            function f ($a) { }
+
+            Get-Command f | Should-HaveParameter a -Mandatory:$false
+        }
+    }
 }


### PR DESCRIPTION
The new `Should-HaveParameter` had no way to assert that a parameter exists but is *not* mandatory. `-Mandatory:$false` now covers that — the parameter must exist and must not be mandatory. `-HasArgumentCompleter:$false` works the same way.

- `Should-HaveParameter X` — must exist
- `Should-HaveParameter X -Mandatory` — must exist and be mandatory
- `Should-HaveParameter X -Mandatory:$false` — must exist and not be mandatory

`-Not` is unchanged: `Should -Not -HaveParameter X` asserts the parameter isn't there at all, so `-Not -Mandatory` does **not** mean "exists but not mandatory" — use `-Mandatory:$false` for that.

Fixes #2105
