### PR TITLE
Fix Should-All and Should-Any crash on empty pipeline input

### DIFF
--- a/src/functions/assert/Collection/Should-All.ps1
+++ b/src/functions/assert/Collection/Should-All.ps1
@@ -55,7 +55,7 @@
     $Actual = $collectedInput.Actual
 
     if ($null -eq $Actual -or 0 -eq @($Actual).Count) {
-        $Message = Get-AssertionMessage -Expected $Expected -Actual $Actual -Data $data -Because $Because -DefaultMessage "Expected all items in collection to pass filter <expected>, but <actualType> <actual> contains no items to compare."
+        $Message = Get-AssertionMessage -Expected $Expected -Actual $Actual -Because $Because -DefaultMessage "Expected all items in collection to pass filter <expected>, but <actualType> <actual> contains no items to compare."
         Invoke-AssertionFailed -Message $Message -CallerCmdlet $PSCmdlet
     }
 

--- a/src/functions/assert/Collection/Should-Any.ps1
+++ b/src/functions/assert/Collection/Should-Any.ps1
@@ -55,7 +55,7 @@
     $Actual = $collectedInput.Actual
 
     if ($null -eq $Actual -or 0 -eq @($Actual).Count) {
-        $Message = Get-AssertionMessage -Expected $Expected -Actual $Actual -Data $data -Because $Because -DefaultMessage "Expected at least one item in collection to pass filter <expected>, but <actualType> <actual> contains no items to compare."
+        $Message = Get-AssertionMessage -Expected $Expected -Actual $Actual -Because $Because -DefaultMessage "Expected at least one item in collection to pass filter <expected>, but <actualType> <actual> contains no items to compare."
         Invoke-AssertionFailed -Message $Message -CallerCmdlet $PSCmdlet
     }
 

--- a/tst/functions/assert/Collection/Should-All.Tests.ps1
+++ b/tst/functions/assert/Collection/Should-All.Tests.ps1
@@ -38,6 +38,30 @@ Expected [int] 2, but got [int] 1." -replace "`r`n", "`n")
         { Should-All -FilterScript { $_ -eq 1 } } | Verify-AssertionFailed
     }
 
+    It "Reports the empty-collection failure when called outside Invoke-Pester (regression)" {
+        # The empty-collection branch must not depend on a `$data` variable. It previously
+        # read an undefined `$data` and passed it to Get-AssertionMessage, which threw
+        # "You cannot call a method on a null-valued expression". A live Invoke-Pester run
+        # masks the bug because the framework keeps a `$data` variable in scope
+        # (Invoke-InNewScriptScope), so we run in a clean runspace with no active run to
+        # reproduce the real-world call, e.g. invoking the assertion from the console.
+        $modulePath = (Get-Module Pester | Select-Object -First 1).Path
+        $ps = [PowerShell]::Create()
+        try {
+            $null = $ps.AddScript(@"
+Import-Module '$modulePath' -Force
+try { @() | Should-All -FilterScript { `$_ -eq 1 }; 'NO-FAILURE' }
+catch { `$_.FullyQualifiedErrorId + '||' + (`$_.Exception.Message -split [Environment]::NewLine)[0] }
+"@)
+            $result = @($ps.Invoke())
+        }
+        finally {
+            $ps.Dispose()
+        }
+
+        ($result -join '') | Verify-Equal "PesterAssertionFailed||Expected all items in collection to pass filter { `$_ -eq 1 }, but [Object[]] @() contains no items to compare."
+    }
+
     It "Validate messages" -TestCases @(
         @{ Actual = @(3, 4, 5); Message = "Expected all items in collection @(3, 4, 5) to pass filter { `$_ -eq 1 }, but 3 of them @(3, 4, 5) did not pass the filter." }
     ) {

--- a/tst/functions/assert/Collection/Should-Any.Tests.ps1
+++ b/tst/functions/assert/Collection/Should-Any.Tests.ps1
@@ -44,6 +44,30 @@ Expected [int] 2, but got [int] 1." -replace "`r`n", "`n")
         { Should-Any -FilterScript { $_ -eq 1 } } | Verify-AssertionFailed
     }
 
+    It "Reports the empty-collection failure when called outside Invoke-Pester (regression)" {
+        # The empty-collection branch must not depend on a `$data` variable. It previously
+        # read an undefined `$data` and passed it to Get-AssertionMessage, which threw
+        # "You cannot call a method on a null-valued expression". A live Invoke-Pester run
+        # masks the bug because the framework keeps a `$data` variable in scope
+        # (Invoke-InNewScriptScope), so we run in a clean runspace with no active run to
+        # reproduce the real-world call, e.g. invoking the assertion from the console.
+        $modulePath = (Get-Module Pester | Select-Object -First 1).Path
+        $ps = [PowerShell]::Create()
+        try {
+            $null = $ps.AddScript(@"
+Import-Module '$modulePath' -Force
+try { @() | Should-Any -FilterScript { `$_ -eq 1 }; 'NO-FAILURE' }
+catch { `$_.FullyQualifiedErrorId + '||' + (`$_.Exception.Message -split [Environment]::NewLine)[0] }
+"@)
+            $result = @($ps.Invoke())
+        }
+        finally {
+            $ps.Dispose()
+        }
+
+        ($result -join '') | Verify-Equal "PesterAssertionFailed||Expected at least one item in collection to pass filter { `$_ -eq 1 }, but [Object[]] @() contains no items to compare."
+    }
+
     It "Can filter using variables from the sorrounding context" {
         $f = 1
         2, 4 | Should-Any { $_ / $f }


### PR DESCRIPTION
`@() | Should-All { ... }` and `@() | Should-Any { ... }` crash with "You cannot call a method on a null-valued expression" instead of failing with the normal "contains no items to compare" message.

The empty-collection branch passes `-Data $data` to `Get-AssertionMessage`, but `$data` is undefined there: `Should-All` only defines it further down, `Should-Any` never. `Get-AssertionMessage` then calls `.GetEnumerator()` on `$null` and throws.

It hides during a normal run because the undefined `$data` resolves case-insensitively to `Invoke-InNewScriptScope`'s `$Data` hashtable in the module scope, so the message renders fine. Outside `Invoke-Pester`, calling the assertion straight from the console, there is no such variable and it crashes. That is also why the existing empty-collection tests didn't catch it.

Fix drops the stray `-Data $data` (those messages have no data tokens). The regression tests run the assertion in a clean runspace so the masking variable isn't present.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
