### PR TITLE
Expand only template items in test and block names (fix code injection in names)

### DIFF
--- a/src/Pester.Runtime.ps1
+++ b/src/Pester.Runtime.ps1
@@ -388,7 +388,19 @@ function Invoke-Block ($previousBlock) {
                                 # avoid using variables so we don't run into conflicts
                                 $sb = {
 
-                                    $____Pester.CurrentBlock.ExpandedName = if ($____Pester.CurrentBlock.Name -like "*<*") { & ([ScriptBlock]::Create(('"' + ($____Pester.CurrentBlock.Name -replace '\$', '`$' -replace '"', '`"' -replace '(?<!`)<([^>^`]+)>', '$$($$$1)') + '"'))) } else { $____Pester.CurrentBlock.Name }
+                                    $____Pester.CurrentBlock.ExpandedName = if ($____Pester.CurrentBlock.Name -like "*<*") {
+                                        $____PesterExpandedName = [System.Text.StringBuilder]::new($____Pester.CurrentBlock.Name.Length)
+                                        $____PesterExpandedPos = 0
+                                        foreach ($____PesterExpandedMatch in [regex]::Matches($____Pester.CurrentBlock.Name, '(?<!`)<([^>`]+)>|`([<>])|([`"$])')) {
+                                            $null = $____PesterExpandedName.Append($____Pester.CurrentBlock.Name.Substring($____PesterExpandedPos, $____PesterExpandedMatch.Index - $____PesterExpandedPos))
+                                            if ($____PesterExpandedMatch.Groups[1].Success) { $null = $____PesterExpandedName.Append('$($').Append($____PesterExpandedMatch.Groups[1].Value).Append(')') }
+                                            elseif ($____PesterExpandedMatch.Groups[2].Success) { $null = $____PesterExpandedName.Append($____PesterExpandedMatch.Groups[2].Value) }
+                                            else { $null = $____PesterExpandedName.Append('`').Append($____PesterExpandedMatch.Groups[3].Value) }
+                                            $____PesterExpandedPos = $____PesterExpandedMatch.Index + $____PesterExpandedMatch.Length
+                                        }
+                                        $null = $____PesterExpandedName.Append($____Pester.CurrentBlock.Name.Substring($____PesterExpandedPos))
+                                        & ([ScriptBlock]::Create('"' + $____PesterExpandedName.ToString() + '"'))
+                                    } else { $____Pester.CurrentBlock.Name }
 
                                     $____Pester.CurrentBlock.ExpandedPath = if ($____Pester.CurrentBlock.Parent.IsRoot) {
                                         # to avoid including Root name in the path
@@ -648,7 +660,21 @@ function Invoke-TestItem {
                         $sb = {
 
                             $____Pester.CurrentTest.ExpandedName = if ($____Pester.CurrentTest.Name -like "*<*") {
-                                & ([ScriptBlock]::Create(('"' + ($____Pester.CurrentTest.Name -replace '\$', '`$' -replace '"', '`"' -replace '(?<!`)<([^>^`]+)>', '$$($$$1)') + '"')))
+                                # Expand only the <template> items; escape every other character so literal
+                                # backticks, $ and " stay inert and cannot break parsing or inject code (#2044).
+                                # `< and `> escape a literal angle bracket. Locals are $____Pester-prefixed so a
+                                # <template> that references a user variable is not shadowed.
+                                $____PesterExpandedName = [System.Text.StringBuilder]::new($____Pester.CurrentTest.Name.Length)
+                                $____PesterExpandedPos = 0
+                                foreach ($____PesterExpandedMatch in [regex]::Matches($____Pester.CurrentTest.Name, '(?<!`)<([^>`]+)>|`([<>])|([`"$])')) {
+                                    $null = $____PesterExpandedName.Append($____Pester.CurrentTest.Name.Substring($____PesterExpandedPos, $____PesterExpandedMatch.Index - $____PesterExpandedPos))
+                                    if ($____PesterExpandedMatch.Groups[1].Success) { $null = $____PesterExpandedName.Append('$($').Append($____PesterExpandedMatch.Groups[1].Value).Append(')') }
+                                    elseif ($____PesterExpandedMatch.Groups[2].Success) { $null = $____PesterExpandedName.Append($____PesterExpandedMatch.Groups[2].Value) }
+                                    else { $null = $____PesterExpandedName.Append('`').Append($____PesterExpandedMatch.Groups[3].Value) }
+                                    $____PesterExpandedPos = $____PesterExpandedMatch.Index + $____PesterExpandedMatch.Length
+                                }
+                                $null = $____PesterExpandedName.Append($____Pester.CurrentTest.Name.Substring($____PesterExpandedPos))
+                                & ([ScriptBlock]::Create('"' + $____PesterExpandedName.ToString() + '"'))
                             }
                             else {
                                 $____Pester.CurrentTest.Name

--- a/src/Pester.Runtime.ps1
+++ b/src/Pester.Runtime.ps1
@@ -385,21 +385,21 @@ function Invoke-Block ($previousBlock) {
                             })
                         $(if (-not $Block.IsRoot) {
                                 # expand block name by evaluating the <> templates, only match templates that have at least 1 character and are not escaped by `<abc`>
-                                # avoid using variables so we don't run into conflicts
+                                # the $private:____PesterExpanded* locals below neither leak into nor inherit from the user scope
                                 $sb = {
 
                                     $____Pester.CurrentBlock.ExpandedName = if ($____Pester.CurrentBlock.Name -like "*<*") {
-                                        $____PesterExpandedName = [System.Text.StringBuilder]::new($____Pester.CurrentBlock.Name.Length)
-                                        $____PesterExpandedPos = 0
-                                        foreach ($____PesterExpandedMatch in [regex]::Matches($____Pester.CurrentBlock.Name, '(?<!`)<([^>`]+)>|`([<>])|([`"$])')) {
-                                            $null = $____PesterExpandedName.Append($____Pester.CurrentBlock.Name.Substring($____PesterExpandedPos, $____PesterExpandedMatch.Index - $____PesterExpandedPos))
-                                            if ($____PesterExpandedMatch.Groups[1].Success) { $null = $____PesterExpandedName.Append('$($').Append($____PesterExpandedMatch.Groups[1].Value).Append(')') }
-                                            elseif ($____PesterExpandedMatch.Groups[2].Success) { $null = $____PesterExpandedName.Append($____PesterExpandedMatch.Groups[2].Value) }
-                                            else { $null = $____PesterExpandedName.Append('`').Append($____PesterExpandedMatch.Groups[3].Value) }
-                                            $____PesterExpandedPos = $____PesterExpandedMatch.Index + $____PesterExpandedMatch.Length
+                                        $private:____PesterExpandedName = [System.Text.StringBuilder]::new($____Pester.CurrentBlock.Name.Length)
+                                        $private:____PesterExpandedPos = 0
+                                        foreach ($private:____PesterExpandedMatch in [regex]::Matches($____Pester.CurrentBlock.Name, '(?<!`)<([^>`]+)>|`([<>])|([`"$])')) {
+                                            $null = $private:____PesterExpandedName.Append($____Pester.CurrentBlock.Name.Substring($private:____PesterExpandedPos, $private:____PesterExpandedMatch.Index - $private:____PesterExpandedPos))
+                                            if ($private:____PesterExpandedMatch.Groups[1].Success) { $null = $private:____PesterExpandedName.Append('$($').Append($private:____PesterExpandedMatch.Groups[1].Value).Append(')') }
+                                            elseif ($private:____PesterExpandedMatch.Groups[2].Success) { $null = $private:____PesterExpandedName.Append($private:____PesterExpandedMatch.Groups[2].Value) }
+                                            else { $null = $private:____PesterExpandedName.Append('`').Append($private:____PesterExpandedMatch.Groups[3].Value) }
+                                            $private:____PesterExpandedPos = $private:____PesterExpandedMatch.Index + $private:____PesterExpandedMatch.Length
                                         }
-                                        $null = $____PesterExpandedName.Append($____Pester.CurrentBlock.Name.Substring($____PesterExpandedPos))
-                                        & ([ScriptBlock]::Create('"' + $____PesterExpandedName.ToString() + '"'))
+                                        $null = $private:____PesterExpandedName.Append($____Pester.CurrentBlock.Name.Substring($private:____PesterExpandedPos))
+                                        & ([ScriptBlock]::Create('"' + $private:____PesterExpandedName.ToString() + '"'))
                                     } else { $____Pester.CurrentBlock.Name }
 
                                     $____Pester.CurrentBlock.ExpandedPath = if ($____Pester.CurrentBlock.Parent.IsRoot) {
@@ -654,7 +654,7 @@ function Invoke-TestItem {
                     }
                     $(
                         # expand block name by evaluating the <> templates, only match templates that have at least 1 character and are not escaped by `<abc`>
-                        # avoid using any variables to avoid running into conflict with user variables
+                        # the $private:____PesterExpanded* locals below neither leak into nor inherit from the user scope
                         # $ExecutionContext.SessionState.InvokeCommand.ExpandString() has some weird bug in PowerShell 4 and 3, that makes hashtable resolve to null
                         # instead I create a expandable string in a scriptblock and evaluate
                         $sb = {
@@ -662,19 +662,19 @@ function Invoke-TestItem {
                             $____Pester.CurrentTest.ExpandedName = if ($____Pester.CurrentTest.Name -like "*<*") {
                                 # Expand only the <template> items; escape every other character so literal
                                 # backticks, $ and " stay inert and cannot break parsing or inject code (#2044).
-                                # `< and `> escape a literal angle bracket. Locals are $____Pester-prefixed so a
-                                # <template> that references a user variable is not shadowed.
-                                $____PesterExpandedName = [System.Text.StringBuilder]::new($____Pester.CurrentTest.Name.Length)
-                                $____PesterExpandedPos = 0
-                                foreach ($____PesterExpandedMatch in [regex]::Matches($____Pester.CurrentTest.Name, '(?<!`)<([^>`]+)>|`([<>])|([`"$])')) {
-                                    $null = $____PesterExpandedName.Append($____Pester.CurrentTest.Name.Substring($____PesterExpandedPos, $____PesterExpandedMatch.Index - $____PesterExpandedPos))
-                                    if ($____PesterExpandedMatch.Groups[1].Success) { $null = $____PesterExpandedName.Append('$($').Append($____PesterExpandedMatch.Groups[1].Value).Append(')') }
-                                    elseif ($____PesterExpandedMatch.Groups[2].Success) { $null = $____PesterExpandedName.Append($____PesterExpandedMatch.Groups[2].Value) }
-                                    else { $null = $____PesterExpandedName.Append('`').Append($____PesterExpandedMatch.Groups[3].Value) }
-                                    $____PesterExpandedPos = $____PesterExpandedMatch.Index + $____PesterExpandedMatch.Length
+                                # `< and `> escape a literal angle bracket. Locals are $private: and $____Pester-prefixed
+                                # so they don't leak into the user scope and a <template> referencing a user variable is not shadowed.
+                                $private:____PesterExpandedName = [System.Text.StringBuilder]::new($____Pester.CurrentTest.Name.Length)
+                                $private:____PesterExpandedPos = 0
+                                foreach ($private:____PesterExpandedMatch in [regex]::Matches($____Pester.CurrentTest.Name, '(?<!`)<([^>`]+)>|`([<>])|([`"$])')) {
+                                    $null = $private:____PesterExpandedName.Append($____Pester.CurrentTest.Name.Substring($private:____PesterExpandedPos, $private:____PesterExpandedMatch.Index - $private:____PesterExpandedPos))
+                                    if ($private:____PesterExpandedMatch.Groups[1].Success) { $null = $private:____PesterExpandedName.Append('$($').Append($private:____PesterExpandedMatch.Groups[1].Value).Append(')') }
+                                    elseif ($private:____PesterExpandedMatch.Groups[2].Success) { $null = $private:____PesterExpandedName.Append($private:____PesterExpandedMatch.Groups[2].Value) }
+                                    else { $null = $private:____PesterExpandedName.Append('`').Append($private:____PesterExpandedMatch.Groups[3].Value) }
+                                    $private:____PesterExpandedPos = $private:____PesterExpandedMatch.Index + $private:____PesterExpandedMatch.Length
                                 }
-                                $null = $____PesterExpandedName.Append($____Pester.CurrentTest.Name.Substring($____PesterExpandedPos))
-                                & ([ScriptBlock]::Create('"' + $____PesterExpandedName.ToString() + '"'))
+                                $null = $private:____PesterExpandedName.Append($____Pester.CurrentTest.Name.Substring($private:____PesterExpandedPos))
+                                & ([ScriptBlock]::Create('"' + $private:____PesterExpandedName.ToString() + '"'))
                             }
                             else {
                                 $____Pester.CurrentTest.Name

--- a/tst/Pester.RSpec.ts.ps1
+++ b/tst/Pester.RSpec.ts.ps1
@@ -2244,6 +2244,36 @@ i -PassThru:$PassThru {
                 Remove-Variable -Scope Global -Name ____pesterInjected -ErrorAction Ignore
             }
         }
+
+        t 'template-expansion locals do not leak into child scopes (#2044)' {
+            # The name-expansion builder locals are $private: so user code that opens a child
+            # scope (a called function, & { }, a script block) does not inherit Pester internals.
+            # Without $private: these would be inherited by every child scope spawned from a test.
+            $sb = {
+                Describe 'd <user.name>' {
+                    It 'i <user.name>' {
+                        $global:____pesterLeaked = @(
+                            & {
+                                foreach ($n in '____PesterExpandedName', '____PesterExpandedPos', '____PesterExpandedMatch') {
+                                    if (Get-Variable -Name $n -ErrorAction SilentlyContinue) { $n }
+                                }
+                            }
+                        ) -join ','
+                    }
+                } -ForEach @(@{ User = @{ Name = 'Jakub' } })
+            }
+
+            try {
+                $container = New-PesterContainer -ScriptBlock $sb
+                $r = Invoke-Pester -Container $container -PassThru
+                $r.Containers[0].Blocks[0].Tests[0].Result | Verify-Equal "Passed"
+                $r.Containers[0].Blocks[0].Tests[0].ExpandedName | Verify-Equal "i Jakub"
+                $global:____pesterLeaked | Verify-Equal ''
+            }
+            finally {
+                Remove-Variable -Scope Global -Name ____pesterLeaked -ErrorAction Ignore
+            }
+        }
     }
 
     b "Running Pester in Pester" {

--- a/tst/Pester.RSpec.ts.ps1
+++ b/tst/Pester.RSpec.ts.ps1
@@ -2210,6 +2210,40 @@ i -PassThru:$PassThru {
             $r.Containers[0].Blocks[0].Tests[0].Result | Verify-Equal "Passed"
             $r.Containers[0].Blocks[0].Tests[0].ExpandedName | Verify-Equal "i Jakub is string"
         }
+
+        t 'literal backticks in a name are kept and do not break expansion (#2044)' {
+            $sb = {
+                Describe 'd <user.name> `tick`' {
+                    It 'i <user.name> `tick`' { }
+                } -ForEach @(@{User = @{ Name = "Jakub" } })
+            }
+
+            $container = New-PesterContainer -ScriptBlock $sb
+            $r = Invoke-Pester -Container $container -PassThru
+            $r.Containers[0].Blocks[0].Tests[0].Result | Verify-Equal "Passed"
+            $r.Containers[0].Blocks[0].Tests[0].ExpandedName | Verify-Equal 'i Jakub `tick`'
+            $r.Containers[0].Blocks[0].ExpandedName | Verify-Equal 'd Jakub `tick`'
+        }
+
+        t 'a template name cannot inject code through backticks (#2044)' {
+            $global:____pesterInjected = $false
+            try {
+                $sb = {
+                    Describe 'd' {
+                        It 'i <x> `$($global:____pesterInjected = $true)`' -ForEach @(@{ x = 1 }) { }
+                    }
+                }
+
+                $container = New-PesterContainer -ScriptBlock $sb
+                $r = Invoke-Pester -Container $container -PassThru
+                $r.Containers[0].Blocks[0].Tests[0].Result | Verify-Equal "Passed"
+                $r.Containers[0].Blocks[0].Tests[0].ExpandedName | Verify-Equal 'i 1 `$($global:____pesterInjected = $true)`'
+                $global:____pesterInjected | Verify-Equal $false
+            }
+            finally {
+                Remove-Variable -Scope Global -Name ____pesterInjected -ErrorAction Ignore
+            }
+        }
     }
 
     b "Running Pester in Pester" {

--- a/tst/Pester.RSpec.ts.ps1
+++ b/tst/Pester.RSpec.ts.ps1
@@ -2248,31 +2248,25 @@ i -PassThru:$PassThru {
         t 'template-expansion locals do not leak into child scopes (#2044)' {
             # The name-expansion builder locals are $private: so user code that opens a child
             # scope (a called function, & { }, a script block) does not inherit Pester internals.
-            # Without $private: these would be inherited by every child scope spawned from a test.
+            # Without $private: the child scope below would see them and throw, failing the test.
             $sb = {
                 Describe 'd <user.name>' {
                     It 'i <user.name>' {
-                        $global:____pesterLeaked = @(
-                            & {
-                                foreach ($n in '____PesterExpandedName', '____PesterExpandedPos', '____PesterExpandedMatch') {
-                                    if (Get-Variable -Name $n -ErrorAction SilentlyContinue) { $n }
+                        & {
+                            foreach ($n in '____PesterExpandedName', '____PesterExpandedPos', '____PesterExpandedMatch') {
+                                if (Get-Variable -Name $n -ErrorAction SilentlyContinue) {
+                                    throw "Pester internal '$n' leaked into a child scope"
                                 }
                             }
-                        ) -join ','
+                        }
                     }
                 } -ForEach @(@{ User = @{ Name = 'Jakub' } })
             }
 
-            try {
-                $container = New-PesterContainer -ScriptBlock $sb
-                $r = Invoke-Pester -Container $container -PassThru
-                $r.Containers[0].Blocks[0].Tests[0].Result | Verify-Equal "Passed"
-                $r.Containers[0].Blocks[0].Tests[0].ExpandedName | Verify-Equal "i Jakub"
-                $global:____pesterLeaked | Verify-Equal ''
-            }
-            finally {
-                Remove-Variable -Scope Global -Name ____pesterLeaked -ErrorAction Ignore
-            }
+            $container = New-PesterContainer -ScriptBlock $sb
+            $r = Invoke-Pester -Container $container -PassThru
+            $r.Containers[0].Blocks[0].Tests[0].Result | Verify-Equal "Passed"
+            $r.Containers[0].Blocks[0].Tests[0].ExpandedName | Verify-Equal "i Jakub"
         }
     }
 


### PR DESCRIPTION
Test and block names are expanded by turning `<template>` items into subexpressions. The old code did this by re-parsing the whole name as a double-quoted string, so a literal backtick, `$` or `"` in a name could break parsing (``It 'has `backticks`'`` threw a `ParseException`) or be used to bypass the escaping and inject code.

Now only the `<template>` items become `$(subexpressions)` and every other character is escaped so the literal text stays inert. `` `< `` and `` `> `` still escape a literal angle bracket. Applied at both the block and test expansion sites.

Per-name expansion is ~0.07 ms vs ~0.02 ms for the old whole-string parse, well under the `ExpandString` cost noted on the issue. The Runtime and RSpec suites pass, plus new tests for the backtick break and an injection attempt.

Fixes #2044
