### PR TITLE
Fall back to utf8 when CodeCoverage.OutputEncoding is invalid

### DIFF
--- a/src/functions/Coverage.Plugin.ps1
+++ b/src/functions/Coverage.Plugin.ps1
@@ -190,7 +190,16 @@
             $null = & $SafeCommands['New-Item'] $dir -Force -ItemType Container
         }
 
-        $stringWriter.ToString() | & $SafeCommands['Out-File'] $resolvedPath -Encoding $PesterPreference.CodeCoverage.OutputEncoding.Value -Force
+        $outputEncoding = $PesterPreference.CodeCoverage.OutputEncoding.Value
+        try {
+            $stringWriter.ToString() | & $SafeCommands['Out-File'] $resolvedPath -Encoding $outputEncoding -Force -ErrorAction Stop
+        }
+        catch {
+            # An invalid CodeCoverage.OutputEncoding would otherwise throw here, at the very end of the
+            # run, discarding the results and breaking -PassThru. Fall back to utf8 and warn instead (#2451).
+            & $SafeCommands['Write-Warning'] "Could not write the code coverage report using CodeCoverage.OutputEncoding '$outputEncoding', falling back to 'utf8'. $($_.Exception.Message)"
+            $stringWriter.ToString() | & $SafeCommands['Out-File'] $resolvedPath -Encoding 'utf8' -Force
+        }
         if ($PesterPreference.Output.Verbosity.Value -in 'Detailed', 'Diagnostic') {
             Write-PesterHostMessage -ForegroundColor Magenta "Code Coverage result processed in $($sw.ElapsedMilliseconds) ms."
         }
@@ -218,24 +227,5 @@ function Resolve-CodeCoverageConfiguration {
     $supportedFormats = 'JaCoCo', 'Cobertura'
     if ($PesterPreference.CodeCoverage.OutputFormat.Value -notin $supportedFormats) {
         throw (Get-StringOptionErrorMessage -OptionPath 'CodeCoverage.OutputFormat' -SupportedValues $supportedFormats -Value $PesterPreference.CodeCoverage.OutputFormat.Value)
-    }
-
-    # Validate the output encoding up front. Out-File accepts only a fixed set of encodings and the
-    # set differs between PowerShell versions, so probe it with the same command used to write the
-    # report. Without this an invalid encoding throws while writing the report at the very end of
-    # the run, which discards the results and breaks -PassThru (#2451).
-    $outputEncoding = $PesterPreference.CodeCoverage.OutputEncoding.Value
-    $encodingProbe = $null
-    try {
-        $encodingProbe = [System.IO.Path]::GetTempFileName()
-        & $SafeCommands['Out-File'] -InputObject '' -LiteralPath $encodingProbe -Encoding $outputEncoding -ErrorAction Stop
-    }
-    catch {
-        throw "Cannot use CodeCoverage.OutputEncoding '$outputEncoding'. $($_.Exception.Message)"
-    }
-    finally {
-        if ($null -ne $encodingProbe) {
-            [System.IO.File]::Delete($encodingProbe)
-        }
     }
 }

--- a/src/functions/Coverage.Plugin.ps1
+++ b/src/functions/Coverage.Plugin.ps1
@@ -219,4 +219,23 @@ function Resolve-CodeCoverageConfiguration {
     if ($PesterPreference.CodeCoverage.OutputFormat.Value -notin $supportedFormats) {
         throw (Get-StringOptionErrorMessage -OptionPath 'CodeCoverage.OutputFormat' -SupportedValues $supportedFormats -Value $PesterPreference.CodeCoverage.OutputFormat.Value)
     }
+
+    # Validate the output encoding up front. Out-File accepts only a fixed set of encodings and the
+    # set differs between PowerShell versions, so probe it with the same command used to write the
+    # report. Without this an invalid encoding throws while writing the report at the very end of
+    # the run, which discards the results and breaks -PassThru (#2451).
+    $outputEncoding = $PesterPreference.CodeCoverage.OutputEncoding.Value
+    $encodingProbe = $null
+    try {
+        $encodingProbe = [System.IO.Path]::GetTempFileName()
+        & $SafeCommands['Out-File'] -InputObject '' -LiteralPath $encodingProbe -Encoding $outputEncoding -ErrorAction Stop
+    }
+    catch {
+        throw "Cannot use CodeCoverage.OutputEncoding '$outputEncoding'. $($_.Exception.Message)"
+    }
+    finally {
+        if ($null -ne $encodingProbe) {
+            [System.IO.File]::Delete($encodingProbe)
+        }
+    }
 }

--- a/tst/Pester.RSpec.Coverage.ts.ps1
+++ b/tst/Pester.RSpec.Coverage.ts.ps1
@@ -1,4 +1,4 @@
-param ([switch] $PassThru, [switch] $NoBuild)
+﻿param ([switch] $PassThru, [switch] $NoBuild)
 
 Get-Module P, PTestHelpers, Pester, Axiom | Remove-Module
 
@@ -320,26 +320,61 @@ i -PassThru:$PassThru {
         }
     }
 
-    b 'CodeCoverage.OutputEncoding is validated up front' {
-        t 'Invalid CodeCoverage.OutputEncoding is rejected with a clear message before the run (#2451)' {
-            $err = & (Get-Module Pester) {
-                $PesterPreference = [PesterConfiguration]::Default
-                $PesterPreference.CodeCoverage.OutputEncoding = 'not-a-real-encoding'
-                try { Resolve-CodeCoverageConfiguration; $null } catch { $_ }
-            }
+    b 'CodeCoverage.OutputEncoding falls back gracefully when invalid' {
+        t 'Invalid CodeCoverage.OutputEncoding does not crash the run; it falls back to utf8 and warns (#2451)' {
+            $sb = { Describe 'd' { It 'i' { 1 | Should -Be 1 } } }
+            $dir = Join-Path ([IO.Path]::GetTempPath()) ("cc_" + [Guid]::NewGuid())
 
-            $err | Verify-NotNull
-            ($err.Exception.Message -like "*CodeCoverage.OutputEncoding 'not-a-real-encoding'*") | Verify-True
+            $c = New-PesterConfiguration
+            $c.Run.Container = New-PesterContainer -ScriptBlock $sb
+            $c.Run.PassThru = $true
+            $c.Output.Verbosity = 'None'
+            $c.CodeCoverage.Enabled = $true
+            $c.CodeCoverage.Path = "$PSScriptRoot/CoverageTestFile.ps1"
+            $c.CodeCoverage.OutputPath = "$dir/coverage.xml"
+            $c.CodeCoverage.OutputEncoding = 'not-a-real-encoding'
+
+            try {
+                $warnings = @()
+                # Previously an invalid encoding threw while writing the report at the very end of the
+                # run, discarding the results and breaking -PassThru (#2451).
+                $r = Invoke-Pester -Configuration $c -WarningVariable warnings 3> $null
+
+                $r.Result | Verify-Equal 'Passed'
+                $r.CodeCoverage | Verify-NotNull
+                (Test-Path "$dir/coverage.xml") | Verify-True
+                ((Get-Item "$dir/coverage.xml").Length -gt 0) | Verify-True
+                ($warnings -match "CodeCoverage.OutputEncoding 'not-a-real-encoding'") | Verify-NotNull
+            }
+            finally {
+                if (Test-Path $dir) { Remove-Item $dir -Force -Recurse }
+            }
         }
 
-        t 'Valid CodeCoverage.OutputEncoding is accepted' {
-            $err = & (Get-Module Pester) {
-                $PesterPreference = [PesterConfiguration]::Default
-                $PesterPreference.CodeCoverage.OutputEncoding = 'utf8'
-                try { Resolve-CodeCoverageConfiguration; $null } catch { $_ }
-            }
+        t 'Valid CodeCoverage.OutputEncoding writes the report without an encoding warning' {
+            $sb = { Describe 'd' { It 'i' { 1 | Should -Be 1 } } }
+            $dir = Join-Path ([IO.Path]::GetTempPath()) ("cc_" + [Guid]::NewGuid())
 
-            $err | Verify-Null
+            $c = New-PesterConfiguration
+            $c.Run.Container = New-PesterContainer -ScriptBlock $sb
+            $c.Run.PassThru = $true
+            $c.Output.Verbosity = 'None'
+            $c.CodeCoverage.Enabled = $true
+            $c.CodeCoverage.Path = "$PSScriptRoot/CoverageTestFile.ps1"
+            $c.CodeCoverage.OutputPath = "$dir/coverage.xml"
+            $c.CodeCoverage.OutputEncoding = 'utf8'
+
+            try {
+                $warnings = @()
+                $r = Invoke-Pester -Configuration $c -WarningVariable warnings 3> $null
+
+                $r.Result | Verify-Equal 'Passed'
+                (Test-Path "$dir/coverage.xml") | Verify-True
+                ($warnings -match 'CodeCoverage.OutputEncoding') | Verify-Null
+            }
+            finally {
+                if (Test-Path $dir) { Remove-Item $dir -Force -Recurse }
+            }
         }
     }
 }

--- a/tst/Pester.RSpec.Coverage.ts.ps1
+++ b/tst/Pester.RSpec.Coverage.ts.ps1
@@ -319,4 +319,27 @@ i -PassThru:$PassThru {
             @($r.CodeCoverage.FilesAnalyzed) -match '\.Tests.ps1$' | Verify-NotNull
         }
     }
+
+    b 'CodeCoverage.OutputEncoding is validated up front' {
+        t 'Invalid CodeCoverage.OutputEncoding is rejected with a clear message before the run (#2451)' {
+            $err = & (Get-Module Pester) {
+                $PesterPreference = [PesterConfiguration]::Default
+                $PesterPreference.CodeCoverage.OutputEncoding = 'not-a-real-encoding'
+                try { Resolve-CodeCoverageConfiguration; $null } catch { $_ }
+            }
+
+            $err | Verify-NotNull
+            ($err.Exception.Message -like "*CodeCoverage.OutputEncoding 'not-a-real-encoding'*") | Verify-True
+        }
+
+        t 'Valid CodeCoverage.OutputEncoding is accepted' {
+            $err = & (Get-Module Pester) {
+                $PesterPreference = [PesterConfiguration]::Default
+                $PesterPreference.CodeCoverage.OutputEncoding = 'utf8'
+                try { Resolve-CodeCoverageConfiguration; $null } catch { $_ }
+            }
+
+            $err | Verify-Null
+        }
+    }
 }


### PR DESCRIPTION
Fix #2451

An invalid `CodeCoverage.OutputEncoding` threw while writing the report at the very end of the run, which discarded the results and broke `-PassThru`.

Rather than validating up front (which adds IO overhead to every run, including the common valid case, and would mean maintaining a per-version allow-list since `Out-File` accepts an open set of encodings on PowerShell 7), wrap the report write: on failure, write the report as `utf8` and emit a warning explaining the fallback. The run completes and `-PassThru` keeps working.

Verified: new tests for an invalid encoding (run completes, report written, warning emitted) and a valid encoding (no warning).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>