### PR TITLE
Skip remaining tests when a block setup or teardown fails

### DIFF
--- a/src/functions/Get-SkipRemainingOnFailurePlugin.ps1
+++ b/src/functions/Get-SkipRemainingOnFailurePlugin.ps1
@@ -8,8 +8,8 @@ function Resolve-SkipRemainingOnFailureConfiguration {
 function Set-RemainingAsSkipped {
     param(
         [Parameter(Mandatory)]
-        [Pester.Test]
-        $FailedTest,
+        [string]
+        $FailedPath,
 
         [Parameter(Mandatory)]
         [Pester.Block]
@@ -18,7 +18,7 @@ function Set-RemainingAsSkipped {
 
     $errorRecord = [Pester.Factory]::CreateErrorRecord(
         'PesterTestSkipped',
-        "Skipped due to previous failure at '$($FailedTest.ExpandedPath)' and Run.SkipRemainingOnFailure set to '$($PesterPreference.Run.SkipRemainingOnFailure.Value)'",
+        "Skipped due to previous failure at '$FailedPath' and Run.SkipRemainingOnFailure set to '$($PesterPreference.Run.SkipRemainingOnFailure.Value)'",
         $null,
         $null,
         $null,
@@ -58,6 +58,11 @@ function Get-SkipRemainingOnFailurePlugin {
         $Context.Configuration.SkipRemainingOnFailureCount = 0
     }
 
+    # A failing *test* is handled in EachTestTeardownEnd. A failing *block* (its BeforeAll or
+    # AfterAll threw) never runs a test teardown, so without an EachBlockTeardownEnd hook the
+    # remaining tests/blocks keep running (#2454). Block.OwnPassed is $false only when the block's
+    # own setup/teardown failed - a failing child test leaves it $true - so the two hooks never
+    # double-fire for the same failure.
     if ($PesterPreference.Run.SkipRemainingOnFailure.Value -eq 'Block') {
         $p.EachTestTeardownEnd = {
             param($Context)
@@ -65,7 +70,17 @@ function Get-SkipRemainingOnFailurePlugin {
             # If test was not skipped and failed
             if (-not $Context.Test.Skipped -and -not $Context.Test.Passed) {
                 # Skip all remaining tests in the block recursively
-                Set-RemainingAsSkipped -FailedTest $Context.Test -Block $Context.Block
+                Set-RemainingAsSkipped -FailedPath $Context.Test.ExpandedPath -Block $Context.Block
+            }
+        }
+
+        $p.EachBlockTeardownEnd = {
+            param($Context)
+
+            # If the block's own setup/teardown failed and it was not skipped
+            if (-not $Context.Block.OwnPassed -and -not $Context.Block.Skip) {
+                # Skip all remaining tests in the block recursively
+                Set-RemainingAsSkipped -FailedPath $Context.Block.ExpandedPath -Block $Context.Block
             }
         }
     }
@@ -77,7 +92,17 @@ function Get-SkipRemainingOnFailurePlugin {
             # If test was not skipped and failed
             if (-not $Context.Test.Skipped -and -not $Context.Test.Passed) {
                 # Skip all remaining tests in the container recursively
-                Set-RemainingAsSkipped -FailedTest $Context.Test -Block $Context.Block.Root
+                Set-RemainingAsSkipped -FailedPath $Context.Test.ExpandedPath -Block $Context.Block.Root
+            }
+        }
+
+        $p.EachBlockTeardownEnd = {
+            param($Context)
+
+            # If the block's own setup/teardown failed and it was not skipped
+            if (-not $Context.Block.OwnPassed -and -not $Context.Block.Skip) {
+                # Skip all remaining tests in the container recursively
+                Set-RemainingAsSkipped -FailedPath $Context.Block.ExpandedPath -Block $Context.Block.Root
             }
         }
     }
@@ -86,12 +111,12 @@ function Get-SkipRemainingOnFailurePlugin {
         $p.ContainerRunStart = {
             param($Context)
 
-            # If a test failed in a previous container, skip all tests
-            if ($Context.Configuration.SkipRemainingFailedTest) {
+            # If a failure happened in a previous container, skip all tests
+            if ($Context.Configuration.SkipRemainingFailedPath) {
                 # Skip container root block to avoid root-level BeforeAll/AfterAll from running. Only applicable in this mode
                 $Context.Block.Root.Skip = $true
                 # Skip all remaining tests in current container
-                Set-RemainingAsSkipped -FailedTest $Context.Configuration.SkipRemainingFailedTest -Block $Context.Block
+                Set-RemainingAsSkipped -FailedPath $Context.Configuration.SkipRemainingFailedPath -Block $Context.Block
             }
         }
 
@@ -101,11 +126,24 @@ function Get-SkipRemainingOnFailurePlugin {
             # If test was not skipped but failed
             if (-not $Context.Test.Skipped -and -not $Context.Test.Passed) {
                 # Skip all remaining tests in current container
-                Set-RemainingAsSkipped -FailedTest $Context.Test -Block $Context.Block.Root
+                Set-RemainingAsSkipped -FailedPath $Context.Test.ExpandedPath -Block $Context.Block.Root
 
-                # Store failed test so we can skip remaining containers in ContainerRunStart-step
-                # TODO: Use $Context.GlobalPluginData.SkipRemainingOnFailure.FailedTest when exposed in $Context
-                $Context.Configuration.SkipRemainingFailedTest = $Context.Test
+                # Store failed path so we can skip remaining containers in ContainerRunStart-step
+                # TODO: Use $Context.GlobalPluginData.SkipRemainingOnFailure.FailedPath when exposed in $Context
+                $Context.Configuration.SkipRemainingFailedPath = $Context.Test.ExpandedPath
+            }
+        }
+
+        $p.EachBlockTeardownEnd = {
+            param($Context)
+
+            # If the block's own setup/teardown failed and it was not skipped
+            if (-not $Context.Block.OwnPassed -and -not $Context.Block.Skip) {
+                # Skip all remaining tests in current container
+                Set-RemainingAsSkipped -FailedPath $Context.Block.ExpandedPath -Block $Context.Block.Root
+
+                # Store failed path so we can skip remaining containers in ContainerRunStart-step
+                $Context.Configuration.SkipRemainingFailedPath = $Context.Block.ExpandedPath
             }
         }
     }

--- a/tst/Pester.RSpec.ts.ps1
+++ b/tst/Pester.RSpec.ts.ps1
@@ -2968,6 +2968,110 @@ i -PassThru:$PassThru {
                 }
             }
         }
+
+        foreach ($mode in 'Block', 'Container', 'Run') {
+            t "Remaining tests are skipped when a block setup fails in mode '$mode' (#2454)" {
+                $container = [ordered]@{
+                    RootBeforeAll  = 0
+                    RootAfterAll   = 0
+                    BlockBeforeAll = 0
+                    BlockAfterAll  = 0
+                }
+
+                $sb1 = {
+                    BeforeAll { $container.RootBeforeAll++ }
+                    AfterAll { $container.RootAfterAll++ }
+
+                    Describe 'd1' {
+                        # The block's own setup fails. No test runs in this block, so the
+                        # EachTestTeardownEnd hook never fires - skipping the remaining tests has
+                        # to be triggered from block teardown instead (#2454).
+                        BeforeAll { $container.BlockBeforeAll++; throw 'BeforeAll failure' }
+                        AfterAll { $container.BlockAfterAll++ }
+
+                        It 'Test in failed block' { $true | Should -BeTrue }
+                    }
+                    Describe 'd2' {
+                        BeforeAll { $container.BlockBeforeAll++ }
+                        AfterAll { $container.BlockAfterAll++ }
+
+                        It 'Sibling test' { $true | Should -BeTrue }
+                    }
+                }
+
+                $sb2 = {
+                    BeforeAll { $container.RootBeforeAll++ }
+                    AfterAll { $container.RootAfterAll++ }
+
+                    Describe 'd1' {
+                        BeforeAll { $container.BlockBeforeAll++ }
+                        AfterAll { $container.BlockAfterAll++ }
+
+                        It 'Other container test' { $true | Should -BeTrue }
+                    }
+                }
+
+                $c = [PesterConfiguration] @{
+                    Run    = @{
+                        ScriptBlock            = $sb1, $sb2
+                        PassThru               = $true
+                        SkipRemainingOnFailure = $mode
+                    }
+                    Output = @{
+                        CIFormat = 'None'
+                    }
+                }
+
+                $r = Invoke-Pester -Configuration $c
+
+                # The block whose BeforeAll threw is Failed, and its own test keeps the Failed
+                # result - it is not turned into a Skipped one.
+                $r.Containers[0].Blocks[0].Result | Verify-Equal 'Failed'
+                $r.Containers[0].Blocks[0].Tests[0].Result | Verify-Equal 'Failed'
+
+                # AfterAll always executes for the failed block; BeforeAll and AfterAll must not run
+                # for blocks that end up skipped.
+                switch ($mode) {
+                    'Block' {
+                        # Only the failed block is affected; the sibling and the next container run
+                        $r.Containers[0].Blocks[1].Result | Verify-Equal 'Passed'
+                        $r.Containers[1].Result | Verify-Equal 'Passed'
+                        $r.Containers[1].Blocks[0].Result | Verify-Equal 'Passed'
+
+                        $container.RootBeforeAll | Verify-Equal 2
+                        $container.RootAfterAll | Verify-Equal 2
+                        $container.BlockBeforeAll | Verify-Equal 3
+                        $container.BlockAfterAll | Verify-Equal 3
+                    }
+                    'Container' {
+                        # The sibling in the same container is skipped; the next container still runs
+                        $r.Containers[0].Blocks[1].Result | Verify-Equal 'Skipped'
+                        $r.Containers[1].Result | Verify-Equal 'Passed'
+                        $r.Containers[1].Blocks[0].Result | Verify-Equal 'Passed'
+
+                        # The skip points at the block that failed, not at a test
+                        $r.Containers[0].Blocks[1].Tests[0].ErrorRecord.TargetObject.Message |
+                            Verify-Equal "Skipped due to previous failure at 'd1' and Run.SkipRemainingOnFailure set to 'Container'"
+
+                        $container.RootBeforeAll | Verify-Equal 2
+                        $container.RootAfterAll | Verify-Equal 2
+                        $container.BlockBeforeAll | Verify-Equal 2
+                        $container.BlockAfterAll | Verify-Equal 2
+                    }
+                    'Run' {
+                        # Everything after the failure is skipped, including the next container
+                        $r.Containers[0].Blocks[1].Result | Verify-Equal 'Skipped'
+                        $r.Containers[1].Result | Verify-Equal 'Skipped'
+                        $r.Containers[1].Blocks[0].Result | Verify-Equal 'Skipped'
+
+                        $container.RootBeforeAll | Verify-Equal 1
+                        $container.RootAfterAll | Verify-Equal 1
+                        $container.BlockBeforeAll | Verify-Equal 1
+                        $container.BlockAfterAll | Verify-Equal 1
+                    }
+                }
+            }
+        }
     }
 
     b 'Changes to CWD are reverted on exit' {


### PR DESCRIPTION
Fix #2454

`Run.SkipRemainingOnFailure` only reacted to a failing test (the `EachTestTeardownEnd` plugin step), so when a block's `BeforeAll` or `AfterAll` threw, no test teardown ran and the remaining tests and sibling blocks kept executing.

Adds an `EachBlockTeardownEnd` hook for each mode. It triggers on `Block.OwnPassed -eq $false`, which is only `$false` when the block's own setup/teardown failed - a failing child test leaves it `$true` - so the block hook never double-fires with the test hook. `Set-RemainingAsSkipped` now takes the failed item's path so the skip message can point at either a failed test or a failed block.

Verified: all existing `SkipRemainingOnFailure` tests still pass, plus new tests covering a failing block setup in `Block`/`Container`/`Run` (sibling skipped in Container/Run, left alone in Block, and BeforeAll/AfterAll not run for the skipped blocks).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
