### PR TITLE
Bind $_ to $null for -ForEach @($null)

### DIFF
--- a/src/Pester.Runtime.ps1
+++ b/src/Pester.Runtime.ps1
@@ -247,7 +247,10 @@ function New-Block {
             Write-PesterDebugMessage -Scope DiscoveryCore "Discovering in body of block $Name"
         }
 
-        if ($null -ne $block.Data) {
+        # Bind the data even when it is $null, as long as this is a data-driven block
+        # (it has a GroupId); otherwise -ForEach @($null) would leave $_ at the parent
+        # value instead of $null (#2320).
+        if ($null -ne $block.Data -or -not [string]::IsNullOrEmpty($block.GroupId)) {
             $context = @{}
             Add-DataToContext -Destination $context -Data $block.Data
 
@@ -370,7 +373,10 @@ function Invoke-Block ($previousBlock) {
                         ____Pester                           = $State
                     }
 
-                    if ($null -ne $block.Data) {
+                    # Bind the data even when it is $null, as long as this is a data-driven block
+                    # (it has a GroupId); otherwise -ForEach @($null) would leave $_ at the parent
+                    # value instead of $null (#2320).
+                    if ($null -ne $block.Data -or -not [string]::IsNullOrEmpty($block.GroupId)) {
                         Add-DataToContext -Destination $context -Data $block.Data
                     }
 
@@ -606,7 +612,10 @@ function Invoke-TestItem {
                     ____Pester = $State
                 }
 
-                if ($null -ne $test.Data) {
+                # Bind the data even when it is $null, as long as this is a data-driven test
+                # (it has a GroupId); otherwise -ForEach @($null) would leave $_ at the parent
+                # value instead of $null (#2320).
+                if ($null -ne $test.Data -or -not [string]::IsNullOrEmpty($test.GroupId)) {
                     Add-DataToContext -Destination $context -Data $test.Data
                 }
 

--- a/tst/Pester.RSpec.ts.ps1
+++ b/tst/Pester.RSpec.ts.ps1
@@ -2114,6 +2114,62 @@ i -PassThru:$PassThru {
             $r.Containers[0].Blocks[0].ExpandedName | Verify-Equal "d 1"
         }
 
+        t "It -ForEach @(`$null) sets `$_ to `$null and does not render the parent data in the name (#2320)" {
+            $sb = {
+                Describe 'd' {
+                    It 'i <_>' -ForEach @($null) {
+                        # $_ must be the $null item from -ForEach, not the parent block's data
+                        Test-Path variable:_ | Should -BeTrue
+                        $null -eq $_ | Should -BeTrue
+                    }
+                }
+            }
+
+            $container = New-PesterContainer -ScriptBlock $sb
+            $r = Invoke-Pester -Container $container -PassThru
+            $r.Containers[0].Blocks[0].Tests[0].Result | Verify-Equal 'Passed'
+            # <_> expands $null to an empty string, not to 'System.Collections.Hashtable'
+            $r.Containers[0].Blocks[0].Tests[0].ExpandedName | Verify-Equal 'i '
+        }
+
+        t "Describe and Context -ForEach @(`$null) set `$_ to `$null (#2320)" {
+            $sb = {
+                Describe 'd <_>' -ForEach @($null) {
+                    It 'i' { $null -eq $_ | Should -BeTrue }
+                }
+                Context 'c <_>' -ForEach @($null) {
+                    It 'i' { $null -eq $_ | Should -BeTrue }
+                }
+            }
+
+            $container = New-PesterContainer -ScriptBlock $sb
+            $r = Invoke-Pester -Container $container -PassThru
+            $r.Containers[0].Blocks[0].Tests[0].Result | Verify-Equal 'Passed'
+            $r.Containers[0].Blocks[0].ExpandedName | Verify-Equal 'd '
+            $r.Containers[0].Blocks[1].Tests[0].Result | Verify-Equal 'Passed'
+            $r.Containers[0].Blocks[1].ExpandedName | Verify-Equal 'c '
+        }
+
+        t "a `$null entry in -ForEach generates its own test with `$_ set to `$null (#2320)" {
+            $sb = {
+                Describe 'd' {
+                    It 'i <_>' -ForEach @(1, $null, 3) {
+                        if ($null -eq $_) { 'null' | Should -Be 'null' } else { $_ | Should -BeIn 1, 3 }
+                    }
+                }
+            }
+
+            $container = New-PesterContainer -ScriptBlock $sb
+            $r = Invoke-Pester -Container $container -PassThru
+            $tests = $r.Containers[0].Blocks[0].Tests
+            @($tests).Count | Verify-Equal 3
+            $tests[0].Result | Verify-Equal 'Passed'
+            $tests[1].Result | Verify-Equal 'Passed'
+            $tests[2].Result | Verify-Equal 'Passed'
+            # the middle entry is the $null one and renders as empty
+            $tests[1].ExpandedName | Verify-Equal 'i '
+        }
+
         t "ExpandedPath is expanded for parent blocks when block setup fails" {
             $sb = {
                 Describe 'd <_>' {


### PR DESCRIPTION
Fix #2320

`It -ForEach @($null)` (and `Describe`/`Context`) generated the test but never set `$_` to the `$null` item, so the body saw the parent block's `$_` and the name rendered as `System.Collections.Hashtable`.

The data binding was guarded by `$null -ne $Data`, which can't tell "no `-ForEach`" apart from "a `$null` item". It now also binds when the test/block is data-driven, detected by a non-empty `GroupId` - only `New-ParametrizedTest`/`New-ParametrizedBlock` set one. That covers the test and both block binding sites, so `It`, `Describe` and `Context` behave the same.

`$_` is now `$null` and `<_>` renders empty (same as `@()`), instead of the hashtable.

Verified: existing parametric tests still pass, plus new tests for `@($null)` on It/Describe/Context and a `$null` entry mixed with real values.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
