### PR TITLE
Honor TestResult.OutputEncoding when writing the report

### DIFF
--- a/src/functions/TestResults.ps1
+++ b/src/functions/TestResults.ps1
@@ -22,24 +22,53 @@ function Export-PesterResult {
     param (
         [Pester.Run] $Result,
         [string] $Path,
-        [string] $Format
+        [string] $Format,
+        [string] $Encoding = 'UTF8'
     )
 
     switch -Wildcard ($Format) {
         'NUnit2.5' {
-            Export-XmlReport -Result $Result -Path $Path -Format $Format
+            Export-XmlReport -Result $Result -Path $Path -Format $Format -Encoding $Encoding
         }
 
         'NUnit3' {
-            Export-XmlReport -Result $Result -Path $Path -Format $Format
+            Export-XmlReport -Result $Result -Path $Path -Format $Format -Encoding $Encoding
         }
 
         '*Xml' {
-            Export-XmlReport -Result $Result -Path $Path -Format $Format
+            Export-XmlReport -Result $Result -Path $Path -Format $Format -Encoding $Encoding
         }
 
         default {
             throw "'$Format' is not a valid Pester export format."
+        }
+    }
+}
+
+function Get-OutputEncodingFromName {
+    # Converts a PowerShell-style encoding name (the values accepted by Out-File -Encoding, e.g. 'UTF8',
+    # 'UTF8BOM', 'Unicode', 'UTF32', 'ASCII') or a .NET web name (e.g. 'utf-16') to a [System.Text.Encoding]
+    # instance for use with XmlWriterSettings.Encoding. Falls back to UTF-8 (with BOM, the historical default)
+    # when the value is empty or not a recognized encoding (#2452).
+    param ([string] $Encoding)
+
+    switch -Regex ($Encoding) {
+        '^\s*$' { return [System.Text.UTF8Encoding]::new($true) }
+        '(?i)^utf-?8(-?bom)?$' { return [System.Text.UTF8Encoding]::new($true) }
+        '(?i)^utf-?8-?nobom$' { return [System.Text.UTF8Encoding]::new($false) }
+        '(?i)^(unicode|utf-?16(le)?)$' { return [System.Text.UnicodeEncoding]::new($false, $true) }
+        '(?i)^(bigendianunicode|utf-?16be)$' { return [System.Text.UnicodeEncoding]::new($true, $true) }
+        '(?i)^(utf-?32(le)?)$' { return [System.Text.UTF32Encoding]::new($false, $true) }
+        '(?i)^(bigendianutf32|utf-?32be)$' { return [System.Text.UTF32Encoding]::new($true, $true) }
+        '(?i)^ascii$' { return [System.Text.Encoding]::ASCII }
+        default {
+            try {
+                return [System.Text.Encoding]::GetEncoding($Encoding)
+            }
+            catch {
+                & $SafeCommands['Write-Warning'] "TestResult.OutputEncoding '$Encoding' is not a valid encoding name, falling back to 'UTF8'. $($_.Exception.Message)"
+                return [System.Text.UTF8Encoding]::new($true)
+            }
         }
     }
 }
@@ -154,7 +183,9 @@ function Export-XmlReport {
 
         [parameter(Mandatory = $true)]
         [ValidateSet('NUnitXml', 'NUnit2.5', 'NUnit3', 'JUnitXml')]
-        [string] $Format
+        [string] $Format,
+
+        [string] $Encoding = 'UTF8'
     )
 
     if ('NUnit2.5' -eq $Format) {
@@ -169,6 +200,7 @@ function Export-XmlReport {
     $settings = [Xml.XmlWriterSettings] @{
         Indent              = $true
         NewLineOnAttributes = $false
+        Encoding            = Get-OutputEncodingFromName -Encoding $Encoding
     }
 
     $xmlFile = $null
@@ -528,7 +560,7 @@ function Get-TestResultPlugin {
 
         $run = $Context.TestRun
         $testResultConfig = $PesterPreference.TestResult
-        Export-PesterResult -Result $run -Path $testResultConfig.OutputPath.Value -Format $testResultConfig.OutputFormat.Value
+        Export-PesterResult -Result $run -Path $testResultConfig.OutputPath.Value -Format $testResultConfig.OutputFormat.Value -Encoding $testResultConfig.OutputEncoding.Value
     }
 
     New-PluginObject @p

--- a/tst/Pester.RSpec.TestResults.NUnit3.ts.ps1
+++ b/tst/Pester.RSpec.TestResults.NUnit3.ts.ps1
@@ -928,6 +928,75 @@ i -PassThru:$PassThru {
         }
     }
 
+    b 'TestResult.OutputEncoding' {
+        # https://github.com/pester/Pester/issues/2452
+        t 'Defaults to utf8 with BOM and an utf-8 xml declaration' {
+            try {
+                $xml = [IO.Path]::GetTempFileName()
+                $null = Invoke-Pester -Configuration ([PesterConfiguration]@{
+                        Run        = @{ ScriptBlock = { Describe 'd' { It 'i' { $true | Should -Be $true } } }; PassThru = $true }
+                        Output     = @{ Verbosity = 'None' }
+                        TestResult = @{ Enabled = $true; OutputFormat = 'NUnit3'; OutputPath = $xml }
+                    })
+
+                $bytes = [IO.File]::ReadAllBytes($xml)
+                # utf-8 BOM
+                $bytes[0] | Verify-Equal 0xEF
+                $bytes[1] | Verify-Equal 0xBB
+                $bytes[2] | Verify-Equal 0xBF
+                ([Text.Encoding]::UTF8.GetString($bytes)) -match 'encoding="utf-8"' | Verify-True
+            }
+            finally {
+                if (Test-Path $xml) { Remove-Item $xml -Force -ErrorAction Ignore }
+            }
+        }
+
+        t 'Writes the report using the configured TestResult.OutputEncoding (utf-16)' {
+            try {
+                $xml = [IO.Path]::GetTempFileName()
+                $null = Invoke-Pester -Configuration ([PesterConfiguration]@{
+                        Run        = @{ ScriptBlock = { Describe 'd' { It 'i' { $true | Should -Be $true } } }; PassThru = $true }
+                        Output     = @{ Verbosity = 'None' }
+                        TestResult = @{ Enabled = $true; OutputFormat = 'NUnit3'; OutputPath = $xml; OutputEncoding = 'utf-16' }
+                    })
+
+                $bytes = [IO.File]::ReadAllBytes($xml)
+                # utf-16 LE BOM
+                $bytes[0] | Verify-Equal 0xFF
+                $bytes[1] | Verify-Equal 0xFE
+                # declaration must match the actual encoding, not be hardcoded to utf-8
+                ([Text.Encoding]::Unicode.GetString($bytes)) -match 'encoding="utf-16"' | Verify-True
+            }
+            finally {
+                if (Test-Path $xml) { Remove-Item $xml -Force -ErrorAction Ignore }
+            }
+        }
+
+        t 'Falls back to utf8 and warns when TestResult.OutputEncoding is invalid' {
+            try {
+                $xml = [IO.Path]::GetTempFileName()
+                $c = [PesterConfiguration]@{
+                    Run        = @{ ScriptBlock = { Describe 'd' { It 'i' { $true | Should -Be $true } } }; PassThru = $true }
+                    Output     = @{ Verbosity = 'None' }
+                    TestResult = @{ Enabled = $true; OutputFormat = 'NUnit3'; OutputPath = $xml; OutputEncoding = 'not-a-real-encoding' }
+                }
+
+                $warnings = @()
+                $r = Invoke-Pester -Configuration $c -WarningVariable warnings 3> $null
+
+                $r.Result | Verify-Equal 'Passed'
+                $bytes = [IO.File]::ReadAllBytes($xml)
+                $bytes[0] | Verify-Equal 0xEF
+                $bytes[1] | Verify-Equal 0xBB
+                $bytes[2] | Verify-Equal 0xBF
+                ($warnings -match "TestResult.OutputEncoding 'not-a-real-encoding'") | Verify-NotNull
+            }
+            finally {
+                if (Test-Path $xml) { Remove-Item $xml -Force -ErrorAction Ignore }
+            }
+        }
+    }
+
     b 'Blocks with test and child-blocks' {
         t 'Should validate against the nunit 3 schema' {
             # https://github.com/pester/Pester/issues/2143


### PR DESCRIPTION
Fix #2452

`Export-XmlReport` built the `XmlWriterSettings` without an encoding, so the result file was always utf-8 with a hardcoded `encoding="utf-8"` declaration, no matter what `TestResult.OutputEncoding` was set to.

Map the configured encoding name to a `[Text.Encoding]` and set it on the writer. Unknown names fall back to utf8 with a warning instead of throwing at the end of the run, same as #2741 did for `CodeCoverage.OutputEncoding`. The default `UTF8` still produces utf-8-with-BOM, so existing output is unchanged.

Verified locally: `utf-16`/`Unicode` write the UTF-16 BOM and `encoding="utf-16"`, `ascii`/`bigendianunicode`/`utf32` work, invalid names warn and fall back to utf8. NUnit3, NUnit2.5 and JUnit4 result tests pass.
