### PR TITLE
Don't crash the run on stray output during a test run

### DIFF
--- a/src/Main.ps1
+++ b/src/Main.ps1
@@ -607,7 +607,19 @@ function Invoke-Pester {
 
             $r = Invoke-Test -BlockContainer $containers -Plugin $plugins -PluginConfiguration $pluginConfiguration -PluginData $pluginData -SessionState $sessionState -Filter $filter -Configuration $PesterPreference
 
-            foreach ($c in $r) {
+            # Invoke-Test should only return [Pester.Container] objects, but stray output produced during the
+            # run - most often a native command writing to the success stream in a setup block (e.g. BeforeAll)
+            # without being redirected to $null - can leak into the pipeline. Adding it to the strongly-typed
+            # Run.Containers list throws an opaque "Cannot find an overload for Add" error that fails the whole
+            # run. Separate it out and warn instead of crashing. (#2655)
+            $rspecResult = Split-RSpecResult -Result $r
+            $rspecContainers = $rspecResult.Containers
+            if (0 -lt $rspecResult.StrayOutput.Count) {
+                $strayDescription = @(foreach ($strayItem in $rspecResult.StrayOutput) { "'$strayItem'" }) -join ', '
+                & $SafeCommands['Write-Warning'] "Pester received unexpected output while running tests and ignored it: $strayDescription. This is usually caused by a native command writing to the success stream in a setup block such as BeforeAll. Redirect the output to `$null, for example: `$null = my-command 2>`&1."
+            }
+
+            foreach ($c in $rspecContainers) {
                 Fold-Container -Container $c  -OnTest { param($t) Add-RSpecTestObjectProperties $t }
             }
 
@@ -628,7 +640,7 @@ function Invoke-Pester {
             }
 
             $run.PSVersion = $PSVersionTable.PSVersion
-            foreach ($i in @($r)) {
+            foreach ($i in $rspecContainers) {
                 $run.Containers.Add($i)
             }
 
@@ -772,6 +784,32 @@ function Convert-PesterSimpleParameterSet ($BoundParameters) {
     }
 
     return $Configuration
+}
+
+function Split-RSpecResult {
+    # Invoke-Test should only return [Pester.Container] objects. Stray output produced during the run - most
+    # commonly a native command writing to the success stream in a setup block (e.g. BeforeAll) that was not
+    # redirected to $null - can leak into the pipeline. Adding it to the strongly-typed Run.Containers list
+    # throws an opaque "Cannot find an overload for Add" error and fails the whole run. Separate the containers
+    # from any stray output so the caller can keep the results and warn instead of crashing. (#2655)
+    param ($Result)
+
+    $containers = [System.Collections.Generic.List[Pester.Container]]@()
+    $strayOutput = [System.Collections.Generic.List[object]]@()
+
+    foreach ($i in $Result) {
+        if ($i -is [Pester.Container]) {
+            $containers.Add($i)
+        }
+        elseif ($null -ne $i) {
+            $strayOutput.Add($i)
+        }
+    }
+
+    return [PSCustomObject]@{
+        Containers  = $containers
+        StrayOutput = $strayOutput
+    }
 }
 
 function Resolve-AutoEnabledConfiguration {

--- a/tst/Pester.RSpec.ts.ps1
+++ b/tst/Pester.RSpec.ts.ps1
@@ -3250,4 +3250,47 @@ i -PassThru:$PassThru {
             $r.Containers[0].Result | Verify-Equal 'Passed'
         }
     }
+
+    b 'Stray output during the run does not crash Pester (#2655)' {
+        t 'Split-RSpecResult keeps containers and collects stray output separately' {
+            # Get a real [Pester.Container] to mix with stray output
+            $real = Invoke-Pester -Configuration ([PesterConfiguration]@{
+                    Run    = @{ ScriptBlock = { Describe 'd' { It 'i' { $true | Should -Be $true } } }; PassThru = $true }
+                    Output = @{ Verbosity = 'None' }
+                })
+            $container = $real.Containers[0]
+
+            $split = & (Get-Module Pester) {
+                param($c)
+                # Native command output that leaks into the run pipeline (e.g. an unredirected
+                # winrm/net command in BeforeAll) arrives here as plain strings next to the container.
+                Split-RSpecResult -Result (@($c, 'WinRM service is already running on this machine.', $null))
+            } $container
+
+            $split.Containers.Count | Verify-Equal 1
+            ($split.Containers[0] -is [Pester.Container]) | Verify-True
+            $split.StrayOutput.Count | Verify-Equal 1
+            $split.StrayOutput[0] | Verify-Equal 'WinRM service is already running on this machine.'
+        }
+
+        t 'Run.Containers only receives containers after splitting, so the run does not crash' {
+            $real = Invoke-Pester -Configuration ([PesterConfiguration]@{
+                    Run    = @{ ScriptBlock = { Describe 'd' { It 'i' { $true | Should -Be $true } } }; PassThru = $true }
+                    Output = @{ Verbosity = 'None' }
+                })
+            $container = $real.Containers[0]
+
+            # Adding stray output straight to the strongly-typed list is what used to throw
+            # "Cannot find an overload for Add" and fail the whole run.
+            $threw = $false
+            try { ([Pester.Run]::Create()).Containers.Add('stray native output') } catch { $threw = $true }
+            $threw | Verify-True
+
+            # After splitting, only the container is added and the run is built without error.
+            $run = [Pester.Run]::Create()
+            $split = & (Get-Module Pester) { param($c) Split-RSpecResult -Result (@($c, 'stray native output')) } $container
+            foreach ($i in $split.Containers) { $run.Containers.Add($i) }
+            $run.Containers.Count | Verify-Equal 1
+        }
+    }
 }


### PR DESCRIPTION
Fix #2655

Same problem #2656 tried to fix, and like there I can't repro the actual leak. `winrm quickconfig` and `pwsh -help` in a `BeforeAll` don't reproduce it for me, on PowerShell 7 or Windows PowerShell, file or scriptblock container.

The crash itself is easy to pin down though. When something other than a `[Pester.Container]` ends up in `Invoke-Test`'s output - e.g. a native command writing to the success stream in a setup block that wasn't redirected to `$null` - the `$run.Containers.Add($i)` loop throws `Cannot find an overload for "Add"` and the whole run dies with that opaque error.

So instead of chasing the leak this stops feeding stray output into the typed list. `Split-RSpecResult` separates the containers from anything else, the containers go into the run as before, and the rest is dropped with a warning that points at the likely cause. Worst case you lose some stray output you didn't want anyway, instead of losing the whole run.

The alternative is to find and fix the leak at the source, but neither of us could pin it down. LMK if you'd rather preserve the stray output somewhere instead of just warning.
