### PR TITLE
Expand <> templates with Format-Nicely2 so values read nicely

### DIFF
--- a/src/Format2.ps1
+++ b/src/Format2.ps1
@@ -147,6 +147,19 @@ function Format-Nicely2 ($Value, [switch]$Pretty) {
     Format-Object2 -Value $Value -Property (Get-DisplayProperty2 $Value.GetType()) -Pretty:$Pretty
 }
 
+function Format-NicelyForTemplate ($Value) {
+    # Used to render a <> template value into an expanded test or block name (#2744). Everything
+    # goes through Format-Nicely2 so $null, booleans, arrays and hashtables read nicely (e.g.
+    # '$null', '@(1, 2, 3)', "@{Name='x'}") instead of PowerShell's bare interpolation. A top-level
+    # string is passed through unquoted though, so the common '<user.name>' case stays clean ('Jakub'
+    # rather than "'Jakub'"). Nested strings still get their quotes from Format-Nicely2.
+    if ($Value -is [string]) {
+        return $Value
+    }
+
+    Format-Nicely2 -Value $Value
+}
+
 function Get-DisplayProperty2 ([Type]$Type) {
     # rename to Get-DisplayProperty?
 

--- a/src/Pester.Runtime.ps1
+++ b/src/Pester.Runtime.ps1
@@ -80,10 +80,12 @@ function New-PesterState {
 
         Stack               = [Collections.Stack]@()
 
-        # captured here so the <> template expansion (which runs in the user's session state) can
+        # Captured here so the <> template expansion (which runs in the user's session state) can
         # invoke it via "& $____Pester.FormatNicelyForTemplate" while the function itself stays bound
         # to the Pester module session state, where Format-Nicely2 is available (#2744).
-        FormatNicelyForTemplate = ${function:Format-NicelyForTemplate}
+        # Format-NicelyForTemplate lives in Format2.ps1, which is not loaded when the runtime is
+        # tested in isolation (Pester.Runtime.ts.ps1); fall back to plain interpolation there.
+        FormatNicelyForTemplate = $(if ($null -ne ${function:Format-NicelyForTemplate}) { ${function:Format-NicelyForTemplate} } else { { param($____PesterFallbackValue) "$($____PesterFallbackValue)" } })
     }
 
     $o.TotalStopWatch.Restart()

--- a/src/Pester.Runtime.ps1
+++ b/src/Pester.Runtime.ps1
@@ -79,6 +79,11 @@ function New-PesterState {
         FrameworkStopWatch  = [Diagnostics.Stopwatch]::StartNew()
 
         Stack               = [Collections.Stack]@()
+
+        # captured here so the <> template expansion (which runs in the user's session state) can
+        # invoke it via "& $____Pester.FormatNicelyForTemplate" while the function itself stays bound
+        # to the Pester module session state, where Format-Nicely2 is available (#2744).
+        FormatNicelyForTemplate = ${function:Format-NicelyForTemplate}
     }
 
     $o.TotalStopWatch.Restart()
@@ -399,7 +404,7 @@ function Invoke-Block ($previousBlock) {
                                         $private:____PesterExpandedPos = 0
                                         foreach ($private:____PesterExpandedMatch in [regex]::Matches($____Pester.CurrentBlock.Name, '(?<!`)<([^>`]+)>|`([<>])|([`"$])')) {
                                             $null = $private:____PesterExpandedName.Append($____Pester.CurrentBlock.Name.Substring($private:____PesterExpandedPos, $private:____PesterExpandedMatch.Index - $private:____PesterExpandedPos))
-                                            if ($private:____PesterExpandedMatch.Groups[1].Success) { $null = $private:____PesterExpandedName.Append('$($').Append($private:____PesterExpandedMatch.Groups[1].Value).Append(')') }
+                                            if ($private:____PesterExpandedMatch.Groups[1].Success) { $null = $private:____PesterExpandedName.Append('$(& $____Pester.FormatNicelyForTemplate ($').Append($private:____PesterExpandedMatch.Groups[1].Value).Append('))') }
                                             elseif ($private:____PesterExpandedMatch.Groups[2].Success) { $null = $private:____PesterExpandedName.Append($private:____PesterExpandedMatch.Groups[2].Value) }
                                             else { $null = $private:____PesterExpandedName.Append('`').Append($private:____PesterExpandedMatch.Groups[3].Value) }
                                             $private:____PesterExpandedPos = $private:____PesterExpandedMatch.Index + $private:____PesterExpandedMatch.Length
@@ -677,7 +682,7 @@ function Invoke-TestItem {
                                 $private:____PesterExpandedPos = 0
                                 foreach ($private:____PesterExpandedMatch in [regex]::Matches($____Pester.CurrentTest.Name, '(?<!`)<([^>`]+)>|`([<>])|([`"$])')) {
                                     $null = $private:____PesterExpandedName.Append($____Pester.CurrentTest.Name.Substring($private:____PesterExpandedPos, $private:____PesterExpandedMatch.Index - $private:____PesterExpandedPos))
-                                    if ($private:____PesterExpandedMatch.Groups[1].Success) { $null = $private:____PesterExpandedName.Append('$($').Append($private:____PesterExpandedMatch.Groups[1].Value).Append(')') }
+                                    if ($private:____PesterExpandedMatch.Groups[1].Success) { $null = $private:____PesterExpandedName.Append('$(& $____Pester.FormatNicelyForTemplate ($').Append($private:____PesterExpandedMatch.Groups[1].Value).Append('))') }
                                     elseif ($private:____PesterExpandedMatch.Groups[2].Success) { $null = $private:____PesterExpandedName.Append($private:____PesterExpandedMatch.Groups[2].Value) }
                                     else { $null = $private:____PesterExpandedName.Append('`').Append($private:____PesterExpandedMatch.Groups[3].Value) }
                                     $private:____PesterExpandedPos = $private:____PesterExpandedMatch.Index + $private:____PesterExpandedMatch.Length

--- a/tst/Pester.RSpec.ts.ps1
+++ b/tst/Pester.RSpec.ts.ps1
@@ -2128,8 +2128,8 @@ i -PassThru:$PassThru {
             $container = New-PesterContainer -ScriptBlock $sb
             $r = Invoke-Pester -Container $container -PassThru
             $r.Containers[0].Blocks[0].Tests[0].Result | Verify-Equal 'Passed'
-            # <_> expands $null to an empty string, not to 'System.Collections.Hashtable'
-            $r.Containers[0].Blocks[0].Tests[0].ExpandedName | Verify-Equal 'i '
+            # <_> renders the $null item as '$null' (Format-Nicely2), not the parent hashtable
+            $r.Containers[0].Blocks[0].Tests[0].ExpandedName | Verify-Equal 'i $null'
         }
 
         t "Describe and Context -ForEach @(`$null) set `$_ to `$null (#2320)" {
@@ -2145,9 +2145,9 @@ i -PassThru:$PassThru {
             $container = New-PesterContainer -ScriptBlock $sb
             $r = Invoke-Pester -Container $container -PassThru
             $r.Containers[0].Blocks[0].Tests[0].Result | Verify-Equal 'Passed'
-            $r.Containers[0].Blocks[0].ExpandedName | Verify-Equal 'd '
+            $r.Containers[0].Blocks[0].ExpandedName | Verify-Equal 'd $null'
             $r.Containers[0].Blocks[1].Tests[0].Result | Verify-Equal 'Passed'
-            $r.Containers[0].Blocks[1].ExpandedName | Verify-Equal 'c '
+            $r.Containers[0].Blocks[1].ExpandedName | Verify-Equal 'c $null'
         }
 
         t "a `$null entry in -ForEach generates its own test with `$_ set to `$null (#2320)" {
@@ -2166,8 +2166,8 @@ i -PassThru:$PassThru {
             $tests[0].Result | Verify-Equal 'Passed'
             $tests[1].Result | Verify-Equal 'Passed'
             $tests[2].Result | Verify-Equal 'Passed'
-            # the middle entry is the $null one and renders as empty
-            $tests[1].ExpandedName | Verify-Equal 'i '
+            # the middle entry is the $null one and renders as '$null'
+            $tests[1].ExpandedName | Verify-Equal 'i $null'
         }
 
         t "ExpandedPath is expanded for parent blocks when block setup fails" {
@@ -2264,7 +2264,29 @@ i -PassThru:$PassThru {
             $container = New-PesterContainer -ScriptBlock $sb
             $r = Invoke-Pester -Container $container -PassThru -Output Detailed
             $r.Containers[0].Blocks[0].Tests[0].Result | Verify-Equal "Passed"
-            $r.Containers[0].Blocks[0].Tests[0].ExpandedName | Verify-Equal "i Jakub is string"
+            $r.Containers[0].Blocks[0].Tests[0].ExpandedName | Verify-Equal "i Jakub is [string]"
+        }
+
+        t 'template values are formatted with Format-Nicely2 (#2744)' {
+            $sb = {
+                Describe 'd' {
+                    It 'bool <_>'      -ForEach @($true) { }
+                    It 'int <_>'       -ForEach @(42) { }
+                    It 'array <_>'     -ForEach @(, @(1, 2, 3)) { }
+                    It 'hashtable <_>' -ForEach @(@{ Name = 'Jakub' }) { }
+                    It 'string <_>'    -ForEach @('Jakub') { }
+                }
+            }
+
+            $container = New-PesterContainer -ScriptBlock $sb
+            $r = Invoke-Pester -Container $container -PassThru
+            $t = $r.Containers[0].Blocks[0].Tests
+            $t[0].ExpandedName | Verify-Equal 'bool $true'
+            $t[1].ExpandedName | Verify-Equal 'int 42'
+            $t[2].ExpandedName | Verify-Equal 'array @(1, 2, 3)'
+            $t[3].ExpandedName | Verify-Equal "hashtable @{Name='Jakub'}"
+            # a top-level string is rendered without quotes, so the common case stays clean
+            $t[4].ExpandedName | Verify-Equal 'string Jakub'
         }
 
         t 'literal backticks in a name are kept and do not break expansion (#2044)' {


### PR DESCRIPTION
Fix #2744

`<>` templates in test and block names were expanded with plain string interpolation, so non-string `-ForEach` values read poorly: `$null` and `@()` showed as empty, `$true` as `True`, `@(1,2,3)` as `1 2 3`, and a hashtable as `System.Collections.Hashtable`.

Render the values through `Format-Nicely2` instead, so they show as `$null`, `@()`, `$true`, `@(1, 2, 3)`, `@{Name='x'}`. Top-level strings are passed through unquoted (via `Format-NicelyForTemplate`) so the common `<user.name>` case stays `Jakub`, not `'Jakub'`; nested strings keep their quotes.

`Format-Nicely2` is module-internal but the expansion runs in the user session state, so it's captured onto `$State` as a module-bound scriptblock and invoked as `& $____Pester.FormatNicelyForTemplate (<template>)` - the value evaluates in the user scope while the formatting runs in the module.

One existing name changes: `<x.GetType()>` now renders `[string]` instead of `string`.

Verified: existing template tests pass, plus a new test covering bool/int/array/hashtable/string rendering.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
