### PR TITLE
Write the code coverage report in the configured encoding and match the xml declaration

### DIFF
--- a/src/Pester.Utility.ps1
+++ b/src/Pester.Utility.ps1
@@ -456,35 +456,3 @@ function View-Flat {
         $tests
     }
 }
-
-function Get-OutputEncodingFromName {
-    # Converts a PowerShell-style encoding name (the values accepted by Out-File -Encoding, e.g. 'UTF8',
-    # 'UTF8BOM', 'Unicode', 'UTF32', 'ASCII') or a .NET web name (e.g. 'utf-16') to a [System.Text.Encoding]
-    # instance for use with XmlWriterSettings.Encoding, so the xml encoding-declaration and the bytes on disk
-    # match. Falls back to UTF-8 (with BOM, the historical default) and warns when the value is empty or not a
-    # recognized encoding. (#2452, #2450)
-    param (
-        [string] $Encoding,
-        [string] $OptionName = 'TestResult.OutputEncoding'
-    )
-
-    switch -Regex ($Encoding) {
-        '^\s*$' { return [System.Text.UTF8Encoding]::new($true) }
-        '(?i)^utf-?8(-?bom)?$' { return [System.Text.UTF8Encoding]::new($true) }
-        '(?i)^utf-?8-?nobom$' { return [System.Text.UTF8Encoding]::new($false) }
-        '(?i)^(unicode|utf-?16(le)?)$' { return [System.Text.UnicodeEncoding]::new($false, $true) }
-        '(?i)^(bigendianunicode|utf-?16be)$' { return [System.Text.UnicodeEncoding]::new($true, $true) }
-        '(?i)^(utf-?32(le)?)$' { return [System.Text.UTF32Encoding]::new($false, $true) }
-        '(?i)^(bigendianutf32|utf-?32be)$' { return [System.Text.UTF32Encoding]::new($true, $true) }
-        '(?i)^ascii$' { return [System.Text.Encoding]::ASCII }
-        default {
-            try {
-                return [System.Text.Encoding]::GetEncoding($Encoding)
-            }
-            catch {
-                & $SafeCommands['Write-Warning'] "$OptionName '$Encoding' is not a valid encoding name, falling back to 'UTF8'. $($_.Exception.Message)"
-                return [System.Text.UTF8Encoding]::new($true)
-            }
-        }
-    }
-}

--- a/src/Pester.Utility.ps1
+++ b/src/Pester.Utility.ps1
@@ -456,3 +456,35 @@ function View-Flat {
         $tests
     }
 }
+
+function Get-OutputEncodingFromName {
+    # Converts a PowerShell-style encoding name (the values accepted by Out-File -Encoding, e.g. 'UTF8',
+    # 'UTF8BOM', 'Unicode', 'UTF32', 'ASCII') or a .NET web name (e.g. 'utf-16') to a [System.Text.Encoding]
+    # instance for use with XmlWriterSettings.Encoding, so the xml encoding-declaration and the bytes on disk
+    # match. Falls back to UTF-8 (with BOM, the historical default) and warns when the value is empty or not a
+    # recognized encoding. (#2452, #2450)
+    param (
+        [string] $Encoding,
+        [string] $OptionName = 'TestResult.OutputEncoding'
+    )
+
+    switch -Regex ($Encoding) {
+        '^\s*$' { return [System.Text.UTF8Encoding]::new($true) }
+        '(?i)^utf-?8(-?bom)?$' { return [System.Text.UTF8Encoding]::new($true) }
+        '(?i)^utf-?8-?nobom$' { return [System.Text.UTF8Encoding]::new($false) }
+        '(?i)^(unicode|utf-?16(le)?)$' { return [System.Text.UnicodeEncoding]::new($false, $true) }
+        '(?i)^(bigendianunicode|utf-?16be)$' { return [System.Text.UnicodeEncoding]::new($true, $true) }
+        '(?i)^(utf-?32(le)?)$' { return [System.Text.UTF32Encoding]::new($false, $true) }
+        '(?i)^(bigendianutf32|utf-?32be)$' { return [System.Text.UTF32Encoding]::new($true, $true) }
+        '(?i)^ascii$' { return [System.Text.Encoding]::ASCII }
+        default {
+            try {
+                return [System.Text.Encoding]::GetEncoding($Encoding)
+            }
+            catch {
+                & $SafeCommands['Write-Warning'] "$OptionName '$Encoding' is not a valid encoding name, falling back to 'UTF8'. $($_.Exception.Message)"
+                return [System.Text.UTF8Encoding]::new($true)
+            }
+        }
+    }
+}

--- a/src/functions/Coverage.Plugin.ps1
+++ b/src/functions/Coverage.Plugin.ps1
@@ -151,21 +151,38 @@
             default { throw "CodeCoverage.CoverageFormat '$($configuration.OutputFormat)' is not valid, please review your configuration." }
         }
 
+        $resolvedPath = $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($PesterPreference.CodeCoverage.OutputPath.Value)
+        if (-not (& $SafeCommands['Test-Path'] $resolvedPath)) {
+            $dir = & $SafeCommands['Split-Path'] $resolvedPath
+            $null = & $SafeCommands['New-Item'] $dir -Force -ItemType Container
+        }
+
+        # Write the report straight to the file using the configured encoding, and make the xml
+        # encoding-declaration match it. The report templates hard-code encoding="UTF-8", so without this the
+        # declaration does not reflect CodeCoverage.OutputEncoding nor the bytes actually on disk (#2450).
+        # Get-OutputEncodingFromName falls back to utf8 and warns for an invalid encoding, so an unusable value
+        # no longer throws at the very end of the run (#2451).
+        $encoding = Get-OutputEncodingFromName -Encoding $PesterPreference.CodeCoverage.OutputEncoding.Value -OptionName 'CodeCoverage.OutputEncoding'
+        if ($coverageXmlReport.FirstChild -is [System.Xml.XmlDeclaration]) {
+            $coverageXmlReport.FirstChild.Encoding = $encoding.WebName
+        }
+
         $settings = [Xml.XmlWriterSettings] @{
             Indent              = $true
             NewLineOnAttributes = $false
+            Encoding            = $encoding
         }
 
-        $stringWriter = $null
+        $xmlFile = $null
         $xmlWriter = $null
         try {
-            $stringWriter = [Pester.Factory]::CreateStringWriter()
-            $xmlWriter = [Xml.XmlWriter]::Create($stringWriter, $settings)
+            $xmlFile = [IO.File]::Create($resolvedPath)
+            $xmlWriter = [Xml.XmlWriter]::Create($xmlFile, $settings)
 
             $coverageXmlReport.WriteContentTo($xmlWriter)
 
             $xmlWriter.Flush()
-            $stringWriter.Flush()
+            $xmlFile.Flush()
         }
         finally {
             if ($null -ne $xmlWriter) {
@@ -175,30 +192,13 @@
                 catch {
                 }
             }
-            if ($null -ne $stringWriter) {
+            if ($null -ne $xmlFile) {
                 try {
-                    $stringWriter.Close()
+                    $xmlFile.Close()
                 }
                 catch {
                 }
             }
-        }
-
-        $resolvedPath = $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($PesterPreference.CodeCoverage.OutputPath.Value)
-        if (-not (& $SafeCommands['Test-Path'] $resolvedPath)) {
-            $dir = & $SafeCommands['Split-Path'] $resolvedPath
-            $null = & $SafeCommands['New-Item'] $dir -Force -ItemType Container
-        }
-
-        $outputEncoding = $PesterPreference.CodeCoverage.OutputEncoding.Value
-        try {
-            $stringWriter.ToString() | & $SafeCommands['Out-File'] $resolvedPath -Encoding $outputEncoding -Force -ErrorAction Stop
-        }
-        catch {
-            # An invalid CodeCoverage.OutputEncoding would otherwise throw here, at the very end of the
-            # run, discarding the results and breaking -PassThru. Fall back to utf8 and warn instead (#2451).
-            & $SafeCommands['Write-Warning'] "Could not write the code coverage report using CodeCoverage.OutputEncoding '$outputEncoding', falling back to 'utf8'. $($_.Exception.Message)"
-            $stringWriter.ToString() | & $SafeCommands['Out-File'] $resolvedPath -Encoding 'utf8' -Force
         }
         if ($PesterPreference.Output.Verbosity.Value -in 'Detailed', 'Diagnostic') {
             Write-PesterHostMessage -ForegroundColor Magenta "Code Coverage result processed in $($sw.ElapsedMilliseconds) ms."

--- a/src/functions/TestResults.ps1
+++ b/src/functions/TestResults.ps1
@@ -45,34 +45,6 @@ function Export-PesterResult {
     }
 }
 
-function Get-OutputEncodingFromName {
-    # Converts a PowerShell-style encoding name (the values accepted by Out-File -Encoding, e.g. 'UTF8',
-    # 'UTF8BOM', 'Unicode', 'UTF32', 'ASCII') or a .NET web name (e.g. 'utf-16') to a [System.Text.Encoding]
-    # instance for use with XmlWriterSettings.Encoding. Falls back to UTF-8 (with BOM, the historical default)
-    # when the value is empty or not a recognized encoding (#2452).
-    param ([string] $Encoding)
-
-    switch -Regex ($Encoding) {
-        '^\s*$' { return [System.Text.UTF8Encoding]::new($true) }
-        '(?i)^utf-?8(-?bom)?$' { return [System.Text.UTF8Encoding]::new($true) }
-        '(?i)^utf-?8-?nobom$' { return [System.Text.UTF8Encoding]::new($false) }
-        '(?i)^(unicode|utf-?16(le)?)$' { return [System.Text.UnicodeEncoding]::new($false, $true) }
-        '(?i)^(bigendianunicode|utf-?16be)$' { return [System.Text.UnicodeEncoding]::new($true, $true) }
-        '(?i)^(utf-?32(le)?)$' { return [System.Text.UTF32Encoding]::new($false, $true) }
-        '(?i)^(bigendianutf32|utf-?32be)$' { return [System.Text.UTF32Encoding]::new($true, $true) }
-        '(?i)^ascii$' { return [System.Text.Encoding]::ASCII }
-        default {
-            try {
-                return [System.Text.Encoding]::GetEncoding($Encoding)
-            }
-            catch {
-                & $SafeCommands['Write-Warning'] "TestResult.OutputEncoding '$Encoding' is not a valid encoding name, falling back to 'UTF8'. $($_.Exception.Message)"
-                return [System.Text.UTF8Encoding]::new($true)
-            }
-        }
-    }
-}
-
 function Export-NUnitReport {
     <#
     .SYNOPSIS

--- a/src/functions/TestResults.ps1
+++ b/src/functions/TestResults.ps1
@@ -45,6 +45,38 @@ function Export-PesterResult {
     }
 }
 
+function Get-OutputEncodingFromName {
+    # Converts a PowerShell-style encoding name (the values accepted by Out-File -Encoding, e.g. 'UTF8',
+    # 'UTF8BOM', 'Unicode', 'UTF32', 'ASCII') or a .NET web name (e.g. 'utf-16') to a [System.Text.Encoding]
+    # instance for use with XmlWriterSettings.Encoding, so the xml encoding-declaration and the bytes on disk
+    # match. Falls back to UTF-8 (with BOM, the historical default) and warns when the value is empty or not a
+    # recognized encoding. (#2452, #2450)
+    param (
+        [string] $Encoding,
+        [string] $OptionName = 'TestResult.OutputEncoding'
+    )
+
+    switch -Regex ($Encoding) {
+        '^\s*$' { return [System.Text.UTF8Encoding]::new($true) }
+        '(?i)^utf-?8(-?bom)?$' { return [System.Text.UTF8Encoding]::new($true) }
+        '(?i)^utf-?8-?nobom$' { return [System.Text.UTF8Encoding]::new($false) }
+        '(?i)^(unicode|utf-?16(le)?)$' { return [System.Text.UnicodeEncoding]::new($false, $true) }
+        '(?i)^(bigendianunicode|utf-?16be)$' { return [System.Text.UnicodeEncoding]::new($true, $true) }
+        '(?i)^(utf-?32(le)?)$' { return [System.Text.UTF32Encoding]::new($false, $true) }
+        '(?i)^(bigendianutf32|utf-?32be)$' { return [System.Text.UTF32Encoding]::new($true, $true) }
+        '(?i)^ascii$' { return [System.Text.Encoding]::ASCII }
+        default {
+            try {
+                return [System.Text.Encoding]::GetEncoding($Encoding)
+            }
+            catch {
+                & $SafeCommands['Write-Warning'] "$OptionName '$Encoding' is not a valid encoding name, falling back to 'UTF8'. $($_.Exception.Message)"
+                return [System.Text.UTF8Encoding]::new($true)
+            }
+        }
+    }
+}
+
 function Export-NUnitReport {
     <#
     .SYNOPSIS

--- a/tst/Pester.RSpec.Coverage.ts.ps1
+++ b/tst/Pester.RSpec.Coverage.ts.ps1
@@ -376,5 +376,33 @@ i -PassThru:$PassThru {
                 if (Test-Path $dir) { Remove-Item $dir -Force -Recurse }
             }
         }
+
+        t 'Writes the report in CodeCoverage.OutputEncoding and matches the xml encoding-declaration (#2450)' {
+            $sb = { Describe 'd' { It 'i' { 1 | Should -Be 1 } } }
+            $dir = Join-Path ([IO.Path]::GetTempPath()) ("cc_" + [Guid]::NewGuid())
+
+            $c = New-PesterConfiguration
+            $c.Run.Container = New-PesterContainer -ScriptBlock $sb
+            $c.Run.PassThru = $true
+            $c.Output.Verbosity = 'None'
+            $c.CodeCoverage.Enabled = $true
+            $c.CodeCoverage.Path = "$PSScriptRoot/CoverageTestFile.ps1"
+            $c.CodeCoverage.OutputPath = "$dir/coverage.xml"
+            $c.CodeCoverage.OutputEncoding = 'utf-16'
+
+            try {
+                $null = Invoke-Pester -Configuration $c 3> $null
+
+                $bytes = [IO.File]::ReadAllBytes("$dir/coverage.xml")
+                # utf-16 LE BOM
+                $bytes[0] | Verify-Equal 0xFF
+                $bytes[1] | Verify-Equal 0xFE
+                # the declaration must match the bytes, not the hard-coded utf-8 from the report template
+                ([Text.Encoding]::Unicode.GetString($bytes)) -match 'encoding="utf-16"' | Verify-True
+            }
+            finally {
+                if (Test-Path $dir) { Remove-Item $dir -Force -Recurse }
+            }
+        }
     }
 }


### PR DESCRIPTION
Fix #2450

The code coverage report is built by casting the JaCoCo/Cobertura string to `[xml]`, which carries a hard-coded `encoding="UTF-8"` declaration, and then written through a `StringWriter` and `Out-File -Encoding`. So the bytes on disk used `CodeCoverage.OutputEncoding` but the declaration always said utf-8 - they didn't match.

Write the report straight to the file in the configured encoding and set the declaration to match, the same way `TestResult.OutputEncoding` now works (#2452). The encoding-name to `[Text.Encoding]` mapping moved to `Get-OutputEncodingFromName` in `Pester.Utility` so both report writers share it; an invalid encoding still falls back to utf8 and warns (#2451), now up front instead of after a failed write.
