### PR TITLE
Add -FromModule as an alias for -ModuleName on mock commands

### DIFF
--- a/src/Main.ps1
+++ b/src/Main.ps1
@@ -265,6 +265,19 @@ function Add-AssertionDynamicParameterSet {
             $null = $script:AssertionDynamicParams.Add($parameter.Name, $dynamic)
         }
 
+        foreach ($alias in $parameter.Aliases) {
+            $aliasExists = foreach ($existingAttribute in $dynamic.Attributes) {
+                if ($existingAttribute -is [System.Management.Automation.AliasAttribute] -and $existingAttribute.AliasNames -contains $alias) {
+                    $true
+                    break
+                }
+            }
+
+            if (-not $aliasExists) {
+                $null = $dynamic.Attributes.Add([System.Management.Automation.AliasAttribute]::new($alias))
+            }
+        }
+
         $attribute = [Management.Automation.ParameterAttribute]::new()
         $attribute.ParameterSetName = $AssertionEntry.Name
         $attribute.Mandatory = $false

--- a/src/functions/Pester.SessionState.Mock.ps1
+++ b/src/functions/Pester.SessionState.Mock.ps1
@@ -224,6 +224,7 @@ function Mock {
         [ScriptBlock]$MockWith = {},
         [switch]$Verifiable,
         [ScriptBlock]$ParameterFilter,
+        [Alias('FromModule')]
         [string]$ModuleName,
         [string[]]$RemoveParameterType,
         [string[]]$RemoveParameterValidation
@@ -788,6 +789,7 @@ function Should-InvokeAssertion {
         [Parameter(ParameterSetName = 'ExclusiveFilter', Mandatory = $true)]
         [scriptblock] $ExclusiveFilter,
 
+        [Alias('FromModule')]
         [string] $ModuleName,
         [string] $Scope = 0,
         [switch] $Exactly,
@@ -978,6 +980,7 @@ function Invoke-Mock {
         [Parameter(Mandatory = $true)]
         [hashtable] $MockCallState,
 
+        [Alias('FromModule')]
         [string]
         $ModuleName,
 
@@ -1194,6 +1197,5 @@ function Assert-RunInProgress {
         throw "$CommandName can run only during Run, but not during Discovery."
     }
 }
-
 
 

--- a/src/functions/assert/Mock/Should-Invoke.ps1
+++ b/src/functions/assert/Mock/Should-Invoke.ps1
@@ -168,6 +168,7 @@
         [scriptblock] $ExclusiveFilter,
 
         [Parameter(ParameterSetName = 'Default')]
+        [Alias('FromModule')]
         [string] $ModuleName,
         [Parameter(ParameterSetName = 'Default')]
         [string] $Scope = 0,

--- a/src/functions/assert/Mock/Should-NotInvoke.ps1
+++ b/src/functions/assert/Mock/Should-NotInvoke.ps1
@@ -155,6 +155,7 @@
         [scriptblock] $ExclusiveFilter,
 
         [Parameter(ParameterSetName = 'Default')]
+        [Alias('FromModule')]
         [string] $ModuleName,
         [Parameter(ParameterSetName = 'Default')]
         [string] $Scope = 0,

--- a/tst/Pester.Mock.RSpec.ts.ps1
+++ b/tst/Pester.Mock.RSpec.ts.ps1
@@ -593,6 +593,25 @@ i -PassThru:$PassThru {
                 $r.Containers[0].Blocks[0].Tests[0].Result | Verify-Equal "Passed"
                 $r.Containers[0].Blocks[0].Tests[1].Result | Verify-Equal "Passed"
             }
+
+            t "can mock and count calls using FromModule alias" {
+                $sb = {
+                    Describe "a" {
+                        It "it" {
+                            Mock -FromModule Source -CommandName Private -MockWith { "mock" }
+                            Public2 | Should -Be 'mock'
+
+                            Should -Invoke Private -FromModule Source
+                        }
+                    }
+                }
+
+                $r = Invoke-Pester -Configuration ([PesterConfiguration]@{
+                        Run = @{ ScriptBlock = $sb; PassThru = $true }
+                    })
+
+                $r.Containers[0].Blocks[0].Tests[0].Result | Verify-Equal "Passed"
+            }
         }
         finally {
             Get-Module Source, Target | Remove-Module -Force -ErrorAction Ignore


### PR DESCRIPTION
Fix #2035

Adds -FromModule as an alias for -ModuleName on mock commands that take a target module. This is additive, so -ModuleName keeps working. Should -Invoke -FromModule also works by carrying assertion parameter aliases into the dynamic Should parameters. Deprecating -Module is intentionally left for a separate maintainer decision.