### PR TITLE
Enumerate non-IList collections (hashtable keys/values) in Should -Be

### DIFF
--- a/src/functions/assertions/Be.ps1
+++ b/src/functions/assertions/Be.ps1
@@ -318,8 +318,8 @@ function Expand-SpecialCharacters {
 
 function ArraysAreEqual {
     param (
-        [object[]] $First,
-        [object[]] $Second,
+        [object] $First,
+        [object] $Second,
         [switch] $CaseSensitive,
         [int] $RecursionDepth = 0,
         [int] $RecursionLimit = 100
@@ -329,6 +329,14 @@ function ArraysAreEqual {
     if ($RecursionDepth -gt $RecursionLimit) {
         throw "Reached the recursion depth limit of $RecursionLimit when comparing arrays $First and $Second. Is one of your arrays cyclic?"
     }
+
+    # Enumerate the inputs ourselves with @(). PowerShell's [object[]] parameter binding wraps a non-IList
+    # enumerable - such as the collection returned by [hashtable].Keys/.Values - into a single element instead
+    # of enumerating it, which made Should -Be report two equal collections as different (#1200). @() uses the
+    # same enumeration the pipeline does (LanguagePrimitives.GetEnumerator), so it expands those collections
+    # while leaving strings, hashtables, scriptblocks and scalars as single values.
+    $First = @($First)
+    $Second = @($Second)
 
     # Do not remove the subexpression @() operators in the following two lines; doing so can cause a
     # silly error in PowerShell v3.  (Null Reference exception from the PowerShell engine in a

--- a/tst/functions/assertions/Be.Tests.ps1
+++ b/tst/functions/assertions/Be.Tests.ps1
@@ -81,8 +81,39 @@ InPesterModuleScope {
             $hashtable.Values | Should -Be $hashtable.Values
             $hashtable.Keys | Should -Not -Be @('One')
 
+            # [Dictionary`2].Keys/.Values are not IList either, and are a common thing to assert on.
+            $dictionary = [System.Collections.Generic.Dictionary[string, int]]::new()
+            $dictionary.Add('One', 1)
+            $dictionary.Add('Two', 2)
+            $dictionary.Keys | Should -Be $dictionary.Keys
+            $dictionary.Values | Should -Be $dictionary.Values
+
             $ordered = [ordered]@{ One = 1; Two = 2 }
             @('One', 'Two') | Should -Be $ordered.Keys
+        }
+
+        It 'Enumerates the non-IList collection <Description> the same way the pipeline does (#1200)' -TestCases @(
+            @{ Description = 'Queue'; Collection = ([System.Collections.Queue]@(1, 2, 3)); Expected = @(1, 2, 3) }
+            @{ Description = 'Stack'; Collection = ([System.Collections.Stack]@(1, 2, 3)); Expected = @(3, 2, 1) }
+            @{ Description = 'SortedSet'; Collection = ([System.Collections.Generic.SortedSet[int]]@(3, 1, 2)); Expected = @(1, 2, 3) }
+        ) {
+            # None of these implement IList, so passing them as the -Be argument used to wrap them as a
+            # single element (#1200). The collection has to be on the right to trigger the bug, because the
+            # piped (actual) side is always enumerated by the pipeline before it reaches the comparison.
+            $Collection -is [System.Collections.IList] | Should -BeFalse
+            $Expected | Should -Be $Collection
+            $Expected | Should -BeExactly $Collection
+            $Collection | Should -Be $Expected
+            @(1, 2) | Should -Not -Be $Collection
+        }
+
+        It 'Still compares IList collections that already worked, such as a generic list (#1200)' {
+            # Guards against regressing the path that bound fine before: arrays and other IList collections.
+            $list = [System.Collections.Generic.List[int]]@(1, 2, 3)
+            $list -is [System.Collections.IList] | Should -BeTrue
+            @(1, 2, 3) | Should -Be $list
+            @(1, 2, 3) | Should -BeExactly $list
+            @(1, 2) | Should -Not -Be $list
         }
 
         It "returns true if the actual value can be cast to the expected value and they are the same value" {

--- a/tst/functions/assertions/Be.Tests.ps1
+++ b/tst/functions/assertions/Be.Tests.ps1
@@ -73,6 +73,18 @@ InPesterModuleScope {
             $array1 | Should -Not -EQ $array3
         }
 
+        It 'Enumerates non-IList collections such as hashtable keys and values (#1200)' {
+            # [hashtable].Keys/.Values are enumerable but not IList, so binding them to an [object[]] parameter
+            # used to wrap them as a single element and report two equal collections as different.
+            $hashtable = @{ One = 1; Two = 2 }
+            $hashtable.Keys | Should -Be $hashtable.Keys
+            $hashtable.Values | Should -Be $hashtable.Values
+            $hashtable.Keys | Should -Not -Be @('One')
+
+            $ordered = [ordered]@{ One = 1; Two = 2 }
+            @('One', 'Two') | Should -Be $ordered.Keys
+        }
+
         It "returns true if the actual value can be cast to the expected value and they are the same value" {
             { abc } | Should -Be " aBc "
             { abc } | Should -EQ " aBc "


### PR DESCRIPTION
Fix #1200

`Should -Be` reported two equal collections as different when they were a non-IList enumerable such as the one returned by `[hashtable].Keys` / `.Values`. `ArraysAreEqual` takes its arguments as `[object[]]`, and binding such a collection to an `[object[]]` parameter wraps it as a single element instead of enumerating it - so the actual value had two items and the expected value had one, and the counts never matched.

Take the arguments as `[object]` and enumerate them with `@()` inside the function, which expands these collections correctly while still leaving strings and hashtables as single values. Arrays, scalars and nested arrays compare exactly as before.
