### PR TITLE
Don't wrap the actual value when it is passed to Should by parameter

### DIFF
--- a/src/functions/assertions/Should.ps1
+++ b/src/functions/assertions/Should.ps1
@@ -182,7 +182,17 @@ function Should {
             Invoke-Assertion @assertionParams -ValueToTest $null
         }
         elseif ($entry.SupportsArrayInput) {
-            Invoke-Assertion @assertionParams -ValueToTest $inputArray.ToArray()
+            if ($MyInvocation.ExpectingInput) {
+                # Pipeline input is collected item-by-item in the process block, so pass the collected array.
+                Invoke-Assertion @assertionParams -ValueToTest $inputArray.ToArray()
+            }
+            else {
+                # The value was supplied by parameter instead (Should -ActualValue @(1,2,3), which is also what
+                # splatting does). The process block ran once and $inputArray wrapped the whole value into a
+                # single element; enumerate the original $ActualValue with @() so it matches what the pipeline
+                # would have produced, rather than being wrapped one level too deep. (#2314)
+                Invoke-Assertion @assertionParams -ValueToTest @($ActualValue)
+            }
         }
         else {
             foreach ($object in $inputArray) {

--- a/tst/functions/assertions/Should.Tests.ps1
+++ b/tst/functions/assertions/Should.Tests.ps1
@@ -124,4 +124,22 @@ InPesterModuleScope {
             Get-Command Should -Syntax | Should -Not -BeNullOrEmpty
         }
     }
+
+    Describe 'Providing the actual value by parameter instead of the pipeline (#2314)' {
+        It 'compares an array given via -ActualValue / splatting the same as via the pipeline' {
+            # https://github.com/pester/Pester/issues/2314
+            # SupportsArrayInput assertions used to wrap a by-parameter value one level too deep.
+            Should -ActualValue @(1, 2, 3) -Be -ExpectedValue @(1, 2, 3)
+
+            $splat = @{ ActualValue = @(1, 2, 3); Be = $true; ExpectedValue = @(1, 2, 3) }
+            Should @splat
+
+            { Should -ActualValue @(1, 2, 3) -Be -ExpectedValue @(1, 2, 4) } | Verify-AssertionFailed
+        }
+
+        It 'counts an array given via -ActualValue with -HaveCount' {
+            Should -ActualValue @(1, 2, 3) -HaveCount 3
+            { Should -ActualValue @(1, 2, 3) -HaveCount 2 } | Verify-AssertionFailed
+        }
+    }
 }


### PR DESCRIPTION
Fix #2314

`Should -Be`, `Should -HaveCount` and the other SupportsArrayInput assertions wrap the actual value one level too deep when you pass it by parameter instead of through the pipeline - `Should -ActualValue @(1,2,3) -Be -ExpectedValue @(1,2,3)`, which is also what splatting `Should` does. The pipeline collects the items one by one, but the by-parameter call runs the `process` block once and keeps the whole array as a single item in `$inputArray`, so the assertion ends up comparing `@(@(1,2,3))` and the error reads "expected X, got X".

Use the original `$ActualValue` for SupportsArrayInput assertions when there is no pipeline input (`$MyInvocation.ExpectingInput` is false). Pipeline input is unchanged.
