### PR TITLE
Fall back to no dynamic parameters when a mocked command can't produce them

### DIFF
--- a/src/functions/Mock.ps1
+++ b/src/functions/Mock.ps1
@@ -1526,7 +1526,15 @@ function Get-DynamicParametersForCmdlet {
         $paramsArg = @($Parameters)
     }
 
-    $command = $ExecutionContext.InvokeCommand.GetCommand($CmdletName, [System.Management.Automation.CommandTypes]::Cmdlet, $paramsArg)
+    try {
+        $command = $ExecutionContext.InvokeCommand.GetCommand($CmdletName, [System.Management.Automation.CommandTypes]::Cmdlet, $paramsArg)
+    }
+    catch {
+        # Resolving a cmdlet's dynamic parameters can fail when they are built from external state that isn't
+        # available while the command is mocked - e.g. Set-PSRepository's -Location comes from the package
+        # provider and validates while resolving. Fall back to no dynamic parameters instead of failing. (#619)
+        return
+    }
     $paramDictionary = [System.Management.Automation.RuntimeDefinedParameterDictionary]::new()
 
     foreach ($param in $command.Parameters.Values) {
@@ -1559,7 +1567,15 @@ function Get-DynamicParametersForMockedFunction {
 
     if ($DynamicParamScriptBlock) {
         $splat = @{ 'P S Cmdlet' = $Cmdlet }
-        return & $DynamicParamScriptBlock @Parameters @splat
+        try {
+            return & $DynamicParamScriptBlock @Parameters @splat
+        }
+        catch {
+            # The mocked command's own dynamicparam block failed to produce its dynamic parameters - e.g. it
+            # validates against state that isn't available while it is being mocked. We only need the metadata
+            # to forward the call, so fall back to no dynamic parameters instead of failing the whole mock. (#619)
+            return
+        }
     }
 }
 

--- a/tst/functions/Mock.Tests.ps1
+++ b/tst/functions/Mock.Tests.ps1
@@ -1693,6 +1693,23 @@ Describe 'Mocking functions with dynamic parameters' {
             $hash.Result | Should -Be 'Mocked'
         }
     }
+
+    Context 'When the mocked command''s dynamicparam block cannot produce its dynamic parameters (#619)' {
+        It 'falls back to no dynamic parameters instead of failing the mock' {
+            # Mimics Set-PSRepository, whose -Location dynamic parameter is built (and validated) from the
+            # package provider and throws while resolving when the command is mocked.
+            function Get-ThingWithFailingDynamicParam {
+                [CmdletBinding()]
+                param ()
+                dynamicparam { throw 'dynamic parameters are not available here' }
+                process { 'real' }
+            }
+
+            Mock Get-ThingWithFailingDynamicParam { 'mocked' }
+            { Get-ThingWithFailingDynamicParam } | Should -Not -Throw
+            Get-ThingWithFailingDynamicParam | Should -Be 'mocked'
+        }
+    }
 }
 
 


### PR DESCRIPTION
Fix #619

Mocking a command whose dynamic parameters can't be resolved while it's mocked failed the whole mock with "Cannot retrieve the dynamic parameters for the cmdlet. ...". The reported case is `Set-PSRepository`: its `-Location` parameter is built (and validated) from the package provider, and that validation throws when Pester re-runs the dynamicparam block to copy the parameter metadata onto the mock.

Pester only needs that metadata to forward the call, so when retrieving it fails - either from a cmdlet's `IDynamicParameters` or a function's `dynamicparam` block - fall back to no dynamic parameters instead of failing the mock. The mock then works as long as the call doesn't use one of those parameters (the issue's repro doesn't use `-Location`).
