### PR TITLE
Count dictionary entries in Should -HaveCount

### DIFF
--- a/src/functions/assertions/HaveCount.ps1
+++ b/src/functions/assertions/HaveCount.ps1
@@ -8,12 +8,38 @@
 
     This test passes, because it expected three objects, and received three.
     This is like running `@(1,2,3).Count` in PowerShell.
+
+    .EXAMPLE
+    @{ Name = 'Jakub'; Age = 30 } | Should -HaveCount 2
+
+    This test passes. A hashtable (or any dictionary) passes through the pipeline as a
+    single object, so HaveCount looks inside it and counts its entries.
     #>
     if ($ExpectedValue -lt 0) {
         throw [ArgumentException]"Expected collection size must be greater than or equal to 0."
     }
     $count = if ($null -eq $ActualValue) {
         0
+    }
+    elseif ($ActualValue.Count -eq 1) {
+        # A single object reached us. The pipeline does not enumerate dictionaries
+        # and hashtables, so they arrive as one item - look inside and count their
+        # entries instead of reporting 1. A lone $null is treated as empty. Every
+        # other single object counts as 1.
+        #
+        # We must not read .Count off the inner item unless it is a real collection.
+        # PowerShell synthesizes .Count on scalars and $null, but that synthesized
+        # member is not available under Set-StrictMode and would throw.
+        $single = $ActualValue[0]
+        if ($null -eq $single) {
+            0
+        }
+        elseif ($single -is [System.Collections.IDictionary]) {
+            $single.Count
+        }
+        else {
+            1
+        }
     }
     else {
         $ActualValue.Count

--- a/tst/functions/assertions/HaveCount.Tests.ps1
+++ b/tst/functions/assertions/HaveCount.Tests.ps1
@@ -44,6 +44,76 @@ InPesterModuleScope {
         }
     }
 
+    Describe "Should -HaveCount with dictionaries" {
+        # The pipeline does not enumerate dictionaries and hashtables, so they arrive
+        # as a single item. HaveCount looks inside and counts their entries. (#1234, #1200)
+
+        It "counts the entries of a hashtable" {
+            @{ Property1 = '1'; Property2 = '3' } | Should -HaveCount 2
+        }
+
+        It "counts an empty hashtable as 0" {
+            @{} | Should -HaveCount 0
+        }
+
+        It "counts the entries of an ordered dictionary" {
+            ([ordered]@{ a = 1; b = 2; c = 3 }) | Should -HaveCount 3
+        }
+
+        It "counts the entries of a generic dictionary" {
+            $dictionary = [System.Collections.Generic.Dictionary[string, string]]::new()
+            $dictionary.Add('a', '1')
+            $dictionary.Add('b', '2')
+            $dictionary | Should -HaveCount 2
+        }
+
+        It "counts an empty generic dictionary as 0" {
+            [System.Collections.Generic.Dictionary[string, string]]::new() | Should -HaveCount 0
+        }
+
+        It "counts the entries of a hashtable passed via -ActualValue" {
+            Should -ActualValue @{ Property1 = '1'; Property2 = '3' } -HaveCount 2
+        }
+
+        It "counts the entries of a single dictionary wrapped in an array" {
+            # The accepted trade-off: an array holding one dictionary counts the
+            # dictionary's entries, not the array's single item.
+            @(@{ a = 1; b = 2 }) | Should -HaveCount 2
+        }
+    }
+
+    Describe "Should -HaveCount with `$null" {
+        # Casting an empty pipeline to [System.Array] yields @($null) - a one-element
+        # array holding $null - which should count as empty. (#1000)
+
+        It "counts a lone `$null as 0" {
+            , $null | Should -HaveCount 0
+        }
+
+        It "counts an array casted from an empty pipeline as 0" {
+            $value = [System.Array] (1..3 | Where-Object { $false })
+            $value | Should -HaveCount 0
+        }
+
+        It "counts an empty result piped without casting as 0" {
+            (1..3 | Where-Object { $false }) | Should -HaveCount 0
+        }
+    }
+
+    Describe "Should -HaveCount with single objects" {
+        It "counts a scalar as 1" {
+            'a' | Should -HaveCount 1
+        }
+
+        It "counts a single object that is not a collection as 1" {
+            (Get-Date) | Should -HaveCount 1
+        }
+
+        It "counts a single PSCustomObject as 1" {
+            ([pscustomobject]@{ a = 1; b = 2 }) | Should -HaveCount 1
+        }
+    }
+
     Describe "Should -Not -HaveCount" {
         It "passes if collection does not have the expected count of items" {
             @(1, 'a', 3, 4) | Should -Not -HaveCount 3


### PR DESCRIPTION
A hashtable or dictionary passes through the pipeline as a single object, so `Should -HaveCount` only ever saw one item and reported size 1. Now a single piped item is inspected: dictionaries report their entry count, a lone `$null` counts as empty, and any other single object stays 1.

Only real `IDictionary` types are looked into. The synthesized `.Count` that PowerShell puts on scalars and `$null` isn't available under `Set-StrictMode` (it throws), so we never read it there - scalars are just 1 and the collected array's own `.Count` covers everything else.

Trade-off, as discussed in #1234: an array holding a single dictionary now counts the dictionary's entries, so `@(@{ a = 1; b = 2 }) | Should -HaveCount 2` rather than `1`.

Closes #1234
Closes #1000
