### PR TITLE
Detect collections with PowerShell's enumeration primitive

### DIFF
--- a/src/TypeClass.ps1
+++ b/src/TypeClass.ps1
@@ -4,15 +4,12 @@
 }
 
 function Is-Collection ($Value) {
-    # check for value types and strings explicitly
-    # because otherwise it does not work for decimal
-    # so let's skip all values we definitely know
-    # are not collections
-    if ($Value -is [ValueType] -or $Value -is [string]) {
-        return $false
-    }
-
-    -not [object]::ReferenceEquals($Value, $($Value))
+    # Use PowerShell's own enumeration logic to decide whether a value is a collection.
+    # This is the same check the pipeline and foreach use, so strings and dictionaries
+    # are correctly treated as single items and not collections. Unlike comparing $Value
+    # to $($Value), it does not copy the collection, does not consume lazy enumerators,
+    # and needs no special-casing for value types such as decimal.
+    $null -ne [System.Management.Automation.LanguagePrimitives]::GetEnumerator($Value)
 }
 
 function Is-ScriptBlock ($Value) {


### PR DESCRIPTION
`Is-Collection` decided whether a value was a collection by comparing `$Value` to `$($Value)` and seeing if the reference changed. That works, but it copies the whole collection on every check, consumes lazy enumerators, and needs an explicit `ValueType`/`string` guard to avoid a boxing false positive on `decimal`.

Swap it for `[System.Management.Automation.LanguagePrimitives]::GetEnumerator($Value)` - the same call the pipeline and `foreach` use to decide what enumerates. Strings and dictionaries stay single items, nothing is copied or consumed, and the value-type guard is no longer needed. Same result for every existing case.

Suggested by @SeeminglyScience and @vexx32 in #1200.

Checked the whole blast radius (`Is-Collection` feeds the formatters), green across TypeClass, Format/Format2, Should-BeCollection and Should-BeEquivalent, and the full suite.
