### PR TITLE
Add input-shape hint to Should-BeCollection failures

### DIFF
--- a/src/csharp/Pester/PipelineSource.cs
+++ b/src/csharp/Pester/PipelineSource.cs
@@ -1,0 +1,364 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Management.Automation;
+
+namespace Pester
+{
+// Result of recovering the left-hand side of a pipeline from inside an advanced function.
+public sealed class PipelineSourceInfo
+{
+    public string Source;         // collection | scalar | range | stream | empty
+    public string TypeName;       // runtime type of the recovered LHS (or a note)
+    public long Count;
+    public object Value;          // the actual object (same reference) when Reference == true
+    public bool Reference;        // true => Value is the original instance, no copy / no re-run
+    public string[] ElementTypes; // for stream: distinct element type names
+    public object LowerBound;     // for range
+    public object UpperBound;     // for range
+
+    // Diagnostics (for PowerShell-internals analysis).
+    public string EnumeratorType;
+    public string BackingField;
+    public string RuntimeType;
+    public string PipeType;
+}
+
+public static class PipelineSource
+{
+    private const BindingFlags BF =
+        BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public;
+
+    // How the input enumerator relates to a recoverable source container.
+    private enum EnumKind
+    {
+        Collection,
+        Range,
+        None
+    }
+
+    // One cache entry per concrete enumerator type — everything needed, resolved once.
+    private sealed class EnumPlan
+    {
+        public EnumKind Kind;
+        public FieldInfo Backing; // EnumKind.Collection
+        public FieldInfo Lower;   // EnumKind.Range
+        public FieldInfo Upper;   // EnumKind.Range
+    }
+
+    // The internal range-enumerator type, resolved once. Comparing Type references is faster than
+    // (and avoids false positives of) a per-call name string comparison. Null on versions/editions
+    // where the type cannot be found, in which case we fall back to the name comparison.
+    private static readonly Type RangeEnumeratorType =
+        typeof(PSObject).Assembly.GetType("System.Management.Automation.RangeEnumerator");
+
+    // Reflection metadata caches. PowerShell drives the pipeline single-threaded, so plain
+    // dictionaries are safe here and avoid the cost of GetProperty/GetField on every call.
+    private static readonly Dictionary<Type, PropertyInfo> _inputPipeProp =
+        new Dictionary<Type, PropertyInfo>();
+    private static readonly Dictionary<Type, FieldInfo> _enumField =
+        new Dictionary<Type, FieldInfo>();
+    private static readonly Dictionary<Type, EnumPlan> _enumPlan =
+        new Dictionary<Type, EnumPlan>();
+
+    private static readonly string[] PreferredBackingNames =
+    {
+        "_array", "_list", "list", "array", "_collection",
+        "_source", "_items", "m_array", "_set", "_values"
+    };
+
+    private static PropertyInfo FindProp(Type t, string name)
+    {
+        for (Type x = t; x != null; x = x.BaseType)
+        {
+            PropertyInfo p = x.GetProperty(name, BF);
+            if (p != null)
+            {
+                return p;
+            }
+        }
+
+        return null;
+    }
+
+    private static FieldInfo FindField(Type t, string name)
+    {
+        for (Type x = t; x != null; x = x.BaseType)
+        {
+            FieldInfo f = x.GetField(name, BF);
+            if (f != null)
+            {
+                return f;
+            }
+        }
+
+        return null;
+    }
+
+    // cmdlet      : pass $PSCmdlet.
+    // inputBuffer : pass @($input). Only read on the fallback paths (scalar/stream); the common
+    //               "recovered a container" path ignores it.
+    public static PipelineSourceInfo Resolve(PSCmdlet cmdlet, IList inputBuffer)
+    {
+        PipelineSourceInfo r = new PipelineSourceInfo();
+
+        object rt = (cmdlet == null) ? null : cmdlet.CommandRuntime;
+        if (rt != null)
+        {
+            r.RuntimeType = rt.GetType().FullName;
+        }
+
+        object pipe = ReadInputPipe(rt);
+        if (pipe != null)
+        {
+            r.PipeType = pipe.GetType().FullName;
+        }
+
+        object en = ReadEnumerator(pipe);
+        if (en != null)
+        {
+            Type enType = en.GetType();
+            r.EnumeratorType = enType.FullName;
+
+            EnumPlan plan = GetPlan(en, enType);
+
+            if (plan.Kind == EnumKind.Range)
+            {
+                return DescribeRange(r, en, enType, plan, inputBuffer);
+            }
+
+            if (plan.Kind == EnumKind.Collection && plan.Backing != null)
+            {
+                object src = plan.Backing.GetValue(en);
+                if (src != null && (src is IEnumerable) && !(src is string))
+                {
+                    r.BackingField = plan.Backing.Name;
+                    r.Source = "collection";
+                    r.TypeName = src.GetType().FullName;
+                    r.Value = src;
+                    r.Reference = true;
+
+                    ICollection c = src as ICollection;
+                    r.Count = (c != null) ? c.Count : CountEnumerable(src);
+                    return r;
+                }
+            }
+        }
+
+        return DescribeBuffer(r, inputBuffer);
+    }
+
+    // Reads f's own input pipe through the public Cmdlet.CommandRuntime property.
+    private static object ReadInputPipe(object rt)
+    {
+        if (rt == null)
+        {
+            return null;
+        }
+
+        Type rtType = rt.GetType();
+        PropertyInfo pp;
+        if (!_inputPipeProp.TryGetValue(rtType, out pp))
+        {
+            pp = FindProp(rtType, "InputPipe");
+            _inputPipeProp[rtType] = pp;
+        }
+
+        return (pp != null) ? pp.GetValue(rt, null) : null;
+    }
+
+    // Reads Pipe._enumeratorToProcess — the live enumerator over the original left-hand side.
+    private static object ReadEnumerator(object pipe)
+    {
+        if (pipe == null)
+        {
+            return null;
+        }
+
+        Type pType = pipe.GetType();
+        FieldInfo ef;
+        if (!_enumField.TryGetValue(pType, out ef))
+        {
+            ef = FindField(pType, "_enumeratorToProcess");
+            _enumField[pType] = ef;
+        }
+
+        return (ef != null) ? ef.GetValue(pipe) : null;
+    }
+
+    private static EnumPlan GetPlan(object en, Type enType)
+    {
+        EnumPlan plan;
+        if (!_enumPlan.TryGetValue(enType, out plan))
+        {
+            plan = BuildPlan(en, enType);
+            _enumPlan[enType] = plan;
+        }
+
+        return plan;
+    }
+
+    private static EnumPlan BuildPlan(object en, Type enType)
+    {
+        EnumPlan p = new EnumPlan();
+
+        bool isRange = (RangeEnumeratorType != null)
+            ? (enType == RangeEnumeratorType)
+            : (enType.Name == "RangeEnumerator");
+
+        if (isRange)
+        {
+            p.Kind = EnumKind.Range;
+            p.Lower = FindField(enType, "_lowerBound");
+            p.Upper = FindField(enType, "_upperBound");
+            return p;
+        }
+
+        FieldInfo backing = ResolveBackingField(en, enType);
+        if (backing != null)
+        {
+            p.Kind = EnumKind.Collection;
+            p.Backing = backing;
+        }
+        else
+        {
+            p.Kind = EnumKind.None;
+        }
+
+        return p;
+    }
+
+    private static FieldInfo ResolveBackingField(object en, Type enType)
+    {
+        // Prefer well-known source-collection field names.
+        for (int i = 0; i < PreferredBackingNames.Length; i++)
+        {
+            FieldInfo f = FindField(enType, PreferredBackingNames[i]);
+            if (f != null)
+            {
+                object v = f.GetValue(en);
+                if (v != null && (v is IEnumerable) && !(v is string))
+                {
+                    return f;
+                }
+            }
+        }
+
+        // Fallback: the first field (other than the "current" element) holding a non-string
+        // IEnumerable. Best-effort: ambiguous for enumerators with several IEnumerable fields.
+        for (Type x = enType; x != null; x = x.BaseType)
+        {
+            FieldInfo[] fields = x.GetFields(BF);
+            for (int i = 0; i < fields.Length; i++)
+            {
+                if (fields[i].Name.ToLowerInvariant().Contains("current"))
+                {
+                    continue;
+                }
+
+                object v = fields[i].GetValue(en);
+                if (v != null && (v is IEnumerable) && !(v is string))
+                {
+                    return fields[i];
+                }
+            }
+        }
+
+        return null;
+    }
+
+    private static PipelineSourceInfo DescribeRange(
+        PipelineSourceInfo r, object en, Type enType, EnumPlan plan, IList inputBuffer)
+    {
+        r.Source = "range";
+        r.TypeName = "lazy 1..N (" + enType.Name + ")";
+        r.LowerBound = (plan.Lower != null) ? plan.Lower.GetValue(en) : null;
+        r.UpperBound = (plan.Upper != null) ? plan.Upper.GetValue(en) : null;
+        r.Reference = false;
+
+        if (r.LowerBound != null && r.UpperBound != null)
+        {
+            long lo = Convert.ToInt64(r.LowerBound);
+            long hi = Convert.ToInt64(r.UpperBound);
+            r.Count = Math.Abs(hi - lo) + 1;
+        }
+        else
+        {
+            r.Count = (inputBuffer == null) ? 0 : inputBuffer.Count;
+        }
+
+        return r;
+    }
+
+    private static PipelineSourceInfo DescribeBuffer(PipelineSourceInfo r, IList inputBuffer)
+    {
+        // The input arrived as discrete pipeline items (already buffered by the engine in $input).
+        IList buf = (inputBuffer != null) ? inputBuffer : (IList)(new object[0]);
+
+        if (buf.Count == 1)
+        {
+            // Non-enumerated single object (hashtable / dictionary / string / scalar).
+            object v = Unwrap(buf[0]);
+            r.Source = "scalar";
+            r.TypeName = (v == null) ? "<null>" : v.GetType().FullName;
+            r.Value = v;
+            r.Count = 1;
+            r.Reference = true;
+            return r;
+        }
+
+        if (buf.Count == 0)
+        {
+            r.Source = "empty";
+            r.TypeName = "<no input>";
+            r.Count = 0;
+            r.Reference = false;
+            return r;
+        }
+
+        // A genuine stream (a command on the left): no container ever existed.
+        r.Source = "stream";
+        r.TypeName = "<streamed; no container>";
+        r.Count = buf.Count;
+        r.Value = buf;
+        r.Reference = false;
+        r.ElementTypes = ElementTypeNames(buf);
+        return r;
+    }
+
+    private static object Unwrap(object v)
+    {
+        PSObject pso = v as PSObject;
+        return (pso != null) ? pso.BaseObject : v;
+    }
+
+    private static int CountEnumerable(object e)
+    {
+        int n = 0;
+        IEnumerator it = ((IEnumerable)e).GetEnumerator();
+        while (it.MoveNext())
+        {
+            n++;
+        }
+
+        return n;
+    }
+
+    private static string[] ElementTypeNames(IList items)
+    {
+        List<string> names = new List<string>();
+        foreach (object o in items)
+        {
+            object v = Unwrap(o);
+            string n = (v == null) ? "null" : v.GetType().Name;
+            if (!names.Contains(n))
+            {
+                names.Add(n);
+            }
+        }
+
+        return names.ToArray();
+    }
+}
+}

--- a/src/functions/assert/Collection/Should-BeCollection.ps1
+++ b/src/functions/assert/Collection/Should-BeCollection.ps1
@@ -58,15 +58,26 @@
     $collectedInput = Collect-Input -ParameterInput $Actual -PipelineInput $local:Input -IsPipelineInput $MyInvocation.ExpectingInput
     $Actual = $collectedInput.Actual
 
+    # Captured up-front (cheap reference grabs); the diagnostic hint itself is only computed inside
+    # a failure branch, via & $reportFailure, so there is no cost on the passing path.
+    $pipelineBuffer = $local:Input
+    $isPipelineInput = $collectedInput.IsPipelineInput
+    $reportFailure = {
+        param($Message)
+        $hint = Get-AssertionGotcha -Cmdlet $PSCmdlet -Buffer $pipelineBuffer -CollectedActual $Actual -IsPipelineInput $isPipelineInput -Expecting Collection
+        if ($hint) { $Message = "$Message`n`nHint: $hint" }
+        Invoke-AssertionFailed -Message $Message -CallerCmdlet $PSCmdlet
+    }
+
     if (-not (Is-Collection -Value $Actual)) {
         $Message = Get-AssertionMessage -Expected $Expected -Actual $Actual -Because $Because -DefaultMessage "Actual <actualType> <actual> is not a collection."
-        Invoke-AssertionFailed -Message $Message -CallerCmdlet $PSCmdlet
+        & $reportFailure $Message
     }
 
     if ($PSCmdlet.ParameterSetName -eq 'Count') {
         if ($Count -ne $Actual.Count) {
             $Message = Get-AssertionMessage -Expected $Count -Actual $Actual -Because $Because -Data @{ actualCount = $Actual.Count } -DefaultMessage "Expected <expected> items in <actualType> <actual>,<because> but it has <actualCount> items."
-            Invoke-AssertionFailed -Message $Message -CallerCmdlet $PSCmdlet
+            & $reportFailure $Message
         }
         Set-AssertionPassResult
         return
@@ -79,7 +90,7 @@
 
     if (-not (Is-CollectionSize -Expected $Expected -Actual $Actual)) {
         $Message = Get-AssertionMessage -Expected $Expected -Actual $Actual -Because $Because -DefaultMessage "Expected <expectedType> <expected> to be present in <actualType> <actual>,<because> but they don't have the same number of items."
-        Invoke-AssertionFailed -Message $Message -CallerCmdlet $PSCmdlet
+        & $reportFailure $Message
     }
 
     if (-Not $InOrder) {
@@ -127,7 +138,7 @@
             $expectedDifference = $(for ($e = 0; $e -lt $actualLength; $e++) { if ($same -ne $expectedCopy[$e]) { "$(Format-Nicely2 $expectedCopy[$e]) (index $e)" } }) -join ", "
 
             $Message = Get-AssertionMessage -Expected $Expected -Actual $Actual -Because $Because -Data @{ expectedDifference = $expectedDifference; actualDifference = $actualDifference } -DefaultMessage "Expected <expectedType> <expected> to be present in <actualType> <actual> in any order, but some values were not.`nMissing in actual: <expectedDifference>`nExtra in actual: <actualDifference>"
-            Invoke-AssertionFailed -Message $Message -CallerCmdlet $PSCmdlet
+            & $reportFailure $Message
         }
     }
     Set-AssertionPassResult

--- a/src/functions/assert/Common/Get-AssertionGotcha.ps1
+++ b/src/functions/assert/Common/Get-AssertionGotcha.ps1
@@ -1,0 +1,69 @@
+function Get-AssertionGotcha {
+    # Best-effort diagnostic hint shown when an assertion is *already failing* because the user
+    # most likely piped the wrong shape into it (e.g. a single hashtable into a collection
+    # assertion). It NEVER changes pass/fail and is only ever called from a failure branch, so it
+    # has zero cost on the happy path. Returns a short hint string, or $null when there is nothing
+    # useful to say or the underlying inspection is unavailable.
+    #
+    # This is the single home for input-shape "gotcha" wording. Add new cases here.
+    param (
+        # The calling assertion's $PSCmdlet. Used to recover the real left-hand side of the pipeline.
+        [System.Management.Automation.PSCmdlet] $Cmdlet,
+        # The calling assertion's $local:Input (object[] or $null).
+        $Buffer,
+        # The value the assertion actually compared ($collectedInput.Actual).
+        $CollectedActual,
+        # $collectedInput.IsPipelineInput.
+        [bool] $IsPipelineInput,
+        # What the failing assertion wanted the input to be.
+        [ValidateSet('Collection')]
+        [string] $Expecting = 'Collection'
+    )
+
+    if ($Expecting -ne 'Collection') { return $null }
+
+    try {
+        if ($IsPipelineInput) {
+            # Recover the original left-hand side, undoing the engine's single-item wrapping, so we
+            # can tell "a single hashtable was piped" (scalar) from "a real 1-item collection".
+            $info = [Pester.PipelineSource]::Resolve($Cmdlet, @($Buffer))
+            # A genuine collection/range/stream is exactly what the assertion wants; stay quiet and
+            # let the assertion's own size/content message do the talking. Only a non-collection
+            # left-hand side (scalar) is worth a hint.
+            if ($info.Source -ne 'scalar') { return $null }
+            $value = $info.Value
+            $piped = $true
+        }
+        else {
+            # Parameter syntax (-Actual ...): we already hold the real value, nothing to recover.
+            if (Is-Collection -Value $CollectedActual) { return $null }
+            $value = $CollectedActual
+            $piped = $false
+        }
+
+        if ($null -eq $value) {
+            $what = '$null'
+            $detail = 'It is treated as a single $null item, not an empty collection. Use @() to represent an empty collection.'
+        }
+        elseif ($value -is [System.Collections.IDictionary]) {
+            $what = 'a single ' + (Get-ShortType2 -Value $value)
+            $detail = 'PowerShell treats a dictionary as a single object, not a collection. To check the number of entries use $actual.Count, or compare contents with Should-BeEquivalent.'
+        }
+        else {
+            $what = 'a single ' + (Get-ShortType2 -Value $value)
+            $detail = 'It is treated as a single item. To assert on a one-item collection wrap it as ,$actual, or use Should-Be for a scalar value.'
+        }
+
+        if ($piped) {
+            "You piped $what into a collection assertion. $detail"
+        }
+        else {
+            "-Actual is $what, which is not a collection. $detail"
+        }
+    }
+    catch {
+        # The hint is best-effort. If inspection fails (e.g. PowerShell internals change on a future
+        # version) say nothing, so the assertion behaves exactly as it would without the hint.
+        $null
+    }
+}

--- a/tst/functions/assert/Collection/Should-BeCollection.Tests.ps1
+++ b/tst/functions/assert/Collection/Should-BeCollection.Tests.ps1
@@ -47,3 +47,50 @@ Describe "Should-BeCollection" {
         }
     }
 }
+
+Describe "Should-BeCollection input hint" {
+    It 'Hints when a single hashtable is piped' {
+        $err = { @{ Name = 'Jakub' } | Should-BeCollection -Count 2 } | Verify-AssertionFailed
+        $err.Exception.Message | Verify-Like '*Hint: You piped a single*PowerShell treats a dictionary as a single object*$actual.Count*'
+    }
+
+    It 'Hints when a single hashtable is piped against an expected collection' {
+        $err = { @{ Name = 'Jakub' } | Should-BeCollection @(1, 2) } | Verify-AssertionFailed
+        $err.Exception.Message | Verify-Like '*Hint: You piped a single*PowerShell treats a dictionary as a single object*'
+    }
+
+    It 'Hints when a hashtable is passed via -Actual' {
+        $err = { Should-BeCollection -Actual @{ Name = 'Jakub' } -Count 2 } | Verify-AssertionFailed
+        $err.Exception.Message | Verify-Like '*Hint: -Actual is a single*which is not a collection*Should-BeEquivalent*'
+    }
+
+    It 'Hints to wrap a scalar that was piped' {
+        $err = { 1 | Should-BeCollection -Count 2 } | Verify-AssertionFailed
+        $err.Exception.Message | Verify-Like '*Hint: You piped a single*wrap it as ,$actual*'
+    }
+
+    It 'Hints that piped $null is a single item, not an empty collection' {
+        $err = { $null | Should-BeCollection -Count 2 } | Verify-AssertionFailed
+        $err.Exception.Message | Verify-Like '*Hint: You piped $null*Use @() to represent an empty collection*'
+    }
+
+    It 'Hints on size mismatch when $null is piped against @()' {
+        $err = { $null | Should-BeCollection @() } | Verify-AssertionFailed
+        $err.Exception.Message | Verify-Like '*Hint: You piped $null*Use @() to represent an empty collection*'
+    }
+
+    It 'Does not hint for a genuine collection of the wrong count' {
+        $err = { @(1, 2) | Should-BeCollection -Count 3 } | Verify-AssertionFailed
+        ($err.Exception.Message -notlike '*Hint:*') | Verify-True
+    }
+
+    It 'Does not hint for an explicit one-item collection @($null)' {
+        $err = { @($null) | Should-BeCollection -Count 2 } | Verify-AssertionFailed
+        ($err.Exception.Message -notlike '*Hint:*') | Verify-True
+    }
+
+    It 'Does not hint for a genuine collection with the wrong contents' {
+        $err = { @(1, 2, 3) | Should-BeCollection @(4, 5, 6) } | Verify-AssertionFailed
+        ($err.Exception.Message -notlike '*Hint:*') | Verify-True
+    }
+}


### PR DESCRIPTION
Draft / RFC — I'd like a sanity check on the approach before I wire it into the other collection assertions.

## Problem

When you pipe a single scalar, `$null`, or a hashtable into `Should-BeCollection`, PowerShell wraps it into a one-item array before the assertion ever sees it. So this:

```powershell
@{ Name = 'Jakub' } | Should-BeCollection -Count 2
```

fails with "expected 2 items ... but it has 1 items" — technically true (the wrapper has one item), but it doesn't tell you that you piped a hashtable, which PowerShell treats as a single object. Same story for `$null` (a single `$null` item, not an empty collection) and bare scalars.

## Change

On failure only, the assertion appends a `Hint:` line that says what was actually piped and how to express what you most likely meant:

```
Expected 2 items in [hashtable] @{ Name = Jakub }, but it has 1 items.

Hint: You piped a single [hashtable] into a collection assertion. PowerShell
treats a dictionary as a single object, not a collection. To check the number
of entries use $actual.Count, or compare contents with Should-BeEquivalent.
```

To do that it has to tell a *piped scalar* (`$null`, `1`, `@{}`) from a *genuine one-item collection* (`@($null)`, `@(1)`). That distinction is already gone by the time `Collect-Input` runs — the engine has unwrapped the container — so I added a small reflection helper, `Pester.PipelineSource`, that recovers the real left-hand side of the pipeline without re-enumerating it. The enumeration trick is based on prior art by @SeeminglyScience and @vexx32 (#1200).

Guardrails:
- Computed only inside failure branches, so the passing path pays nothing.
- Wrapped in try/catch with a buffered fallback — it can never change pass/fail. If the internals it reflects on ever change, it just goes quiet.
- Stays silent for a genuine collection of the wrong size/contents; that already has a good message.
- Wording lives in one place (`Get-AssertionGotcha`) so the other collection assertions can reuse it.

## Verification

23/23 in `Should-BeCollection.Tests.ps1` (14 existing + 9 new) green on pwsh 7. New tests cover: hint fires for piped hashtable / scalar / `$null` and for `-Actual @{}`; stays absent for `@(1, 2)`, `@($null)`, a content mismatch, and on pass.

## Open questions
- [ ] Worth extending to the other collection assertions (`Should-BeEquivalent` especially), or keep it scoped to `Should-BeCollection` for now?
- [ ] `PipelineSource.cs` still carries the full diagnostic surface from the prototype — happy to trim it to just what the hint needs before this leaves draft.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
