### PR TITLE
Fix #1557: let -RemoveParameterValidation reach dynamic parameters

### DIFF
--- a/src/functions/Mock.ps1
+++ b/src/functions/Mock.ps1
@@ -89,8 +89,19 @@ function Create-MockHook ($contextInfo, $InvokeMockCallback) {
         $paramBlock = [Management.Automation.ProxyCommand]::GetParamBlock($metadata)
         $paramBlock = Repair-EnumParameters -ParamBlock $paramBlock -Metadata $metadata
 
+        # Repair-ConflictingParameters above strips validation from the static parameters, but it skips
+        # dynamic parameters because they are not part of the static param block. To make
+        # -RemoveParameterValidation reach a dynamic parameter (e.g. a dynamic -Name with a ValidateSet)
+        # we forward the names to Get-MockDynamicParameter, which removes the validation attributes from
+        # the dynamic parameters as they are produced for each call. (#1557)
+        $removeValidationArg = ''
+        if ($RemoveParameterValidation) {
+            $escapedValidationNames = foreach ($n in $RemoveParameterValidation) { "'$(EscapeSingleQuotedStringContent $n)'" }
+            $removeValidationArg = " -RemoveParameterValidation @($($escapedValidationNames -join ','))"
+        }
+
         if ($contextInfo.Command.CommandType -eq 'Cmdlet') {
-            $dynamicParamBlock = "dynamicparam { & `$MyInvocation.MyCommand.Mock.Get_MockDynamicParameter -CmdletName '$($contextInfo.Command.Name)' -Parameters `$PSBoundParameters }"
+            $dynamicParamBlock = "dynamicparam { & `$MyInvocation.MyCommand.Mock.Get_MockDynamicParameter -CmdletName '$($contextInfo.Command.Name)' -Parameters `$PSBoundParameters$removeValidationArg }"
         }
         else {
             $dynamicParamStatements = Get-DynamicParamBlock -ScriptBlock $contextInfo.Command.ScriptBlock
@@ -108,7 +119,7 @@ function Create-MockHook ($contextInfo, $InvokeMockCallback) {
                 else {
                     ''
                 }
-                $dynamicParamBlock = "dynamicparam { & `$MyInvocation.MyCommand.Mock.Get_MockDynamicParameter -ModuleName '$moduleName' -FunctionName '$commandName' -Parameters `$PSBoundParameters -Cmdlet `$PSCmdlet -DynamicParamScriptBlock `$MyInvocation.MyCommand.Mock.Hook.DynamicParamScriptBlock }"
+                $dynamicParamBlock = "dynamicparam { & `$MyInvocation.MyCommand.Mock.Get_MockDynamicParameter -ModuleName '$moduleName' -FunctionName '$commandName' -Parameters `$PSBoundParameters -Cmdlet `$PSCmdlet -DynamicParamScriptBlock `$MyInvocation.MyCommand.Mock.Hook.DynamicParamScriptBlock$removeValidationArg }"
 
                 $code = @"
                     $cmdletBinding
@@ -1436,7 +1447,9 @@ function Get-MockDynamicParameter {
         [object] $Cmdlet,
 
         [Parameter(ParameterSetName = "Function")]
-        $DynamicParamScriptBlock
+        $DynamicParamScriptBlock,
+
+        [string[]] $RemoveParameterValidation
     )
 
     switch ($PSCmdlet.ParameterSetName) {
@@ -1453,7 +1466,47 @@ function Get-MockDynamicParameter {
         return
     }
 
+    if ($RemoveParameterValidation) {
+        Remove-DynamicParameterValidation -DynamicParams $dynamicParams -ParameterName $RemoveParameterValidation
+    }
+
     Repair-ConflictingDynamicParameters -DynamicParams $dynamicParams
+}
+
+function Remove-DynamicParameterValidation {
+    [OutputType([void])]
+    param (
+        [Parameter(Mandatory = $true)]
+        [System.Management.Automation.RuntimeDefinedParameterDictionary]
+        $DynamicParams,
+
+        [Parameter(Mandatory = $true)]
+        [string[]]
+        $ParameterName
+    )
+
+    # Mirror the static-parameter handling in Repair-ConflictingParameters: a validation attribute is any
+    # ValidateArgumentsAttribute (ValidateSet, ValidateRange, ValidatePattern, ValidateScript, ...), so
+    # removing those from the dynamic parameter disables the validation while keeping the parameter itself.
+    foreach ($name in $ParameterName) {
+        if (-not $DynamicParams.ContainsKey($name)) {
+            continue
+        }
+
+        $dynamicParam = $DynamicParams[$name]
+        $attrIndexesToRemove = [System.Collections.Generic.List[int]]@()
+        for ($i = 0; $i -lt $dynamicParam.Attributes.Count; $i++) {
+            if ($dynamicParam.Attributes[$i] -is [System.Management.Automation.ValidateArgumentsAttribute]) {
+                $null = $attrIndexesToRemove.Add($i)
+            }
+        }
+
+        # remove attributes in reverse order to avoid index shifting
+        $attrIndexesToRemove.Reverse()
+        foreach ($index in $attrIndexesToRemove) {
+            $null = $dynamicParam.Attributes.RemoveAt($index)
+        }
+    }
 }
 
 function Repair-ConflictingDynamicParameters {

--- a/tst/functions/Mock.Tests.ps1
+++ b/tst/functions/Mock.Tests.ps1
@@ -2763,6 +2763,49 @@ Describe 'RemoveParameterValidation' {
 
         Test-Validation -Count -1 | Should -Be "mock"
     }
+
+    Context 'When the validated parameter is a dynamic parameter (#1557)' {
+        BeforeAll {
+            # Mimics commands such as Get-AzContext, whose -Name parameter is a dynamic parameter
+            # carrying a (dynamic) ValidateSet. Repair-ConflictingParameters skips dynamic parameters,
+            # so -RemoveParameterValidation has to reach them through Get-MockDynamicParameter.
+            function Test-DynamicValidation {
+                [CmdletBinding()]
+                param ()
+
+                dynamicparam {
+                    $dictionary = [System.Management.Automation.RuntimeDefinedParameterDictionary]::new()
+
+                    foreach ($paramName in 'Name', 'Color') {
+                        $attributes = [System.Collections.ObjectModel.Collection[System.Attribute]]::new()
+                        $attributes.Add([System.Management.Automation.ParameterAttribute]::new())
+                        $attributes.Add([System.Management.Automation.ValidateSetAttribute]::new(@('a', 'b')))
+                        $dictionary.Add($paramName, [System.Management.Automation.RuntimeDefinedParameter]::new($paramName, [string], $attributes))
+                    }
+
+                    $dictionary
+                }
+
+                end { 'real' }
+            }
+        }
+
+        It 'still validates the dynamic parameter when validation is not removed' {
+            Mock Test-DynamicValidation { 'mock' }
+            { Test-DynamicValidation -Name 'zzz' } | Should -Throw -ErrorId '*ParameterArgumentValidationError*'
+        }
+
+        It 'passes when mock removes the validation from the dynamic parameter' {
+            Mock Test-DynamicValidation { 'mock' } -RemoveParameterValidation Name
+            Test-DynamicValidation -Name 'zzz' | Should -Be 'mock'
+        }
+
+        It 'only removes validation from the named dynamic parameter' {
+            Mock Test-DynamicValidation { 'mock' } -RemoveParameterValidation Name
+            Test-DynamicValidation -Name 'zzz' | Should -Be 'mock'
+            { Test-DynamicValidation -Color 'zzz' } | Should -Throw -ErrorId '*ParameterArgumentValidationError*'
+        }
+    }
 }
 
 Describe 'Removing multiple attributes for same parameter' {


### PR DESCRIPTION
Fixes #1557.

`Mock -RemoveParameterValidation` is documented to relax validation for the named parameters so strict commands can be mocked more easily. It worked for **static** parameters but silently did nothing for **dynamic** ones — which is exactly the reported case (`Get-AzContext`/`Get-AzureRmContext`, whose `-Name` is a dynamic parameter carrying a dynamic `ValidateSet`).

The reason: static parameters have their validation stripped by `Repair-ConflictingParameters`, but that helper explicitly skips dynamic parameters (they aren't part of the static param block). Pester re-builds the dynamic parameters as-is for every call via `Get-MockDynamicParameter`, so the original `ValidateSet` kept validating.

### Change

- `Create-MockHook` now forwards the `-RemoveParameterValidation` names into the generated `dynamicparam` block (for both the cmdlet and function paths).
- `Get-MockDynamicParameter` strips the `ValidateArgumentsAttribute` attributes (`ValidateSet`, `ValidateRange`, `ValidatePattern`, `ValidateScript`, …) from the matching dynamic parameters via a new `Remove-DynamicParameterValidation` helper — mirroring the static-parameter logic.

The generated `dynamicparam` block is byte-for-byte unchanged when `-RemoveParameterValidation` is not used, so existing mocks are unaffected.

### Tests

Added a `Context` under the existing `RemoveParameterValidation` describe covering a function with dynamic `-Name`/`-Color` parameters (each with a `ValidateSet`):

- still validates the dynamic parameter when validation is **not** removed (no regression),
- passes an out-of-set value when the validation **is** removed,
- only removes validation from the **named** dynamic parameter (no over-stripping).

Verified in both dot-sourced and inline builds. Full `Mock.Tests.ps1` (235 tests) and the Mock RSpec P-tests (37) pass.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
