### PR TITLE
Extend input-shape hint to the other collection assertions

### DIFF
--- a/src/functions/assert/Collection/Should-All.ps1
+++ b/src/functions/assert/Collection/Should-All.ps1
@@ -54,9 +54,20 @@
     $collectedInput = Collect-Input -ParameterInput $Actual -PipelineInput $local:Input -IsPipelineInput $MyInvocation.ExpectingInput
     $Actual = $collectedInput.Actual
 
+    # Captured up-front (cheap reference grabs); the diagnostic hint itself is only computed inside
+    # a failure branch, via & $reportFailure, so there is no cost on the passing path.
+    $pipelineBuffer = $local:Input
+    $isPipelineInput = $collectedInput.IsPipelineInput
+    $reportFailure = {
+        param($Message)
+        $hint = Get-AssertionGotcha -Cmdlet $PSCmdlet -Buffer $pipelineBuffer -CollectedActual $Actual -IsPipelineInput $isPipelineInput -Expecting CollectionItems
+        if ($hint) { $Message = "$Message`n`nHint: $hint" }
+        Invoke-AssertionFailed -Message $Message -CallerCmdlet $PSCmdlet
+    }
+
     if ($null -eq $Actual -or 0 -eq @($Actual).Count) {
         $Message = Get-AssertionMessage -Expected $Expected -Actual $Actual -Because $Because -DefaultMessage "Expected all items in collection to pass filter <expected>, but <actualType> <actual> contains no items to compare."
-        Invoke-AssertionFailed -Message $Message -CallerCmdlet $PSCmdlet
+        & $reportFailure $Message
     }
 
     $failReasons = $null
@@ -108,7 +119,7 @@
             }
             $Message += "`nReasons :`n$failReasons"
         }
-        Invoke-AssertionFailed -Message $Message -CallerCmdlet $PSCmdlet
+        & $reportFailure $Message
     }
     Set-AssertionPassResult
 }

--- a/src/functions/assert/Collection/Should-Any.ps1
+++ b/src/functions/assert/Collection/Should-Any.ps1
@@ -54,9 +54,20 @@
     $collectedInput = Collect-Input -ParameterInput $Actual -PipelineInput $local:Input -IsPipelineInput $MyInvocation.ExpectingInput
     $Actual = $collectedInput.Actual
 
+    # Captured up-front (cheap reference grabs); the diagnostic hint itself is only computed inside
+    # a failure branch, via & $reportFailure, so there is no cost on the passing path.
+    $pipelineBuffer = $local:Input
+    $isPipelineInput = $collectedInput.IsPipelineInput
+    $reportFailure = {
+        param($Message)
+        $hint = Get-AssertionGotcha -Cmdlet $PSCmdlet -Buffer $pipelineBuffer -CollectedActual $Actual -IsPipelineInput $isPipelineInput -Expecting CollectionItems
+        if ($hint) { $Message = "$Message`n`nHint: $hint" }
+        Invoke-AssertionFailed -Message $Message -CallerCmdlet $PSCmdlet
+    }
+
     if ($null -eq $Actual -or 0 -eq @($Actual).Count) {
         $Message = Get-AssertionMessage -Expected $Expected -Actual $Actual -Because $Because -DefaultMessage "Expected at least one item in collection to pass filter <expected>, but <actualType> <actual> contains no items to compare."
-        Invoke-AssertionFailed -Message $Message -CallerCmdlet $PSCmdlet
+        & $reportFailure $Message
     }
 
     $failReasons = $null
@@ -100,7 +111,7 @@
             }
             $Message += "`nReasons :`n$failReasons"
         }
-        Invoke-AssertionFailed -Message $Message -CallerCmdlet $PSCmdlet
+        & $reportFailure $Message
     }
     Set-AssertionPassResult
 }

--- a/src/functions/assert/Collection/Should-ContainCollection.ps1
+++ b/src/functions/assert/Collection/Should-ContainCollection.ps1
@@ -51,9 +51,21 @@
 
     $collectedInput = Collect-Input -ParameterInput $Actual -PipelineInput $local:Input -IsPipelineInput $MyInvocation.ExpectingInput
     $Actual = $collectedInput.Actual
+
+    # Captured up-front (cheap reference grabs); the diagnostic hint itself is only computed inside
+    # a failure branch, via & $reportFailure, so there is no cost on the passing path.
+    $pipelineBuffer = $local:Input
+    $isPipelineInput = $collectedInput.IsPipelineInput
+    $reportFailure = {
+        param($Message)
+        $hint = Get-AssertionGotcha -Cmdlet $PSCmdlet -Buffer $pipelineBuffer -CollectedActual $Actual -IsPipelineInput $isPipelineInput -Expecting CollectionItems
+        if ($hint) { $Message = "$Message`n`nHint: $hint" }
+        Invoke-AssertionFailed -Message $Message -CallerCmdlet $PSCmdlet
+    }
+
     if ($Actual -notcontains $Expected) {
         $Message = Get-AssertionMessage -Expected $Expected -Actual $Actual -Because $Because -DefaultMessage "Expected <expectedType> <expected> to be present in <actualType> <actual>,<because> but it was not there."
-        Invoke-AssertionFailed -Message $Message -CallerCmdlet $PSCmdlet
+        & $reportFailure $Message
     }
     Set-AssertionPassResult
 }

--- a/src/functions/assert/Collection/Should-NotContainCollection.ps1
+++ b/src/functions/assert/Collection/Should-NotContainCollection.ps1
@@ -51,9 +51,21 @@
 
     $collectedInput = Collect-Input -ParameterInput $Actual -PipelineInput $local:Input -IsPipelineInput $MyInvocation.ExpectingInput
     $Actual = $collectedInput.Actual
+
+    # Captured up-front (cheap reference grabs); the diagnostic hint itself is only computed inside
+    # a failure branch, via & $reportFailure, so there is no cost on the passing path.
+    $pipelineBuffer = $local:Input
+    $isPipelineInput = $collectedInput.IsPipelineInput
+    $reportFailure = {
+        param($Message)
+        $hint = Get-AssertionGotcha -Cmdlet $PSCmdlet -Buffer $pipelineBuffer -CollectedActual $Actual -IsPipelineInput $isPipelineInput -Expecting CollectionItems
+        if ($hint) { $Message = "$Message`n`nHint: $hint" }
+        Invoke-AssertionFailed -Message $Message -CallerCmdlet $PSCmdlet
+    }
+
     if ($Actual -contains $Expected) {
         $Message = Get-AssertionMessage -Expected $Expected -Actual $Actual -Because $Because -DefaultMessage "Expected <expectedType> <expected> to not be present in <actualType> <actual>,<because> but it was there."
-        Invoke-AssertionFailed -Message $Message -CallerCmdlet $PSCmdlet
+        & $reportFailure $Message
     }
     Set-AssertionPassResult
 }

--- a/src/functions/assert/Common/Get-AssertionGotcha.ps1
+++ b/src/functions/assert/Common/Get-AssertionGotcha.ps1
@@ -15,12 +15,19 @@ function Get-AssertionGotcha {
         $CollectedActual,
         # $collectedInput.IsPipelineInput.
         [bool] $IsPipelineInput,
-        # What the failing assertion wanted the input to be.
-        [ValidateSet('Collection')]
+        # What the failing assertion wanted the input to be. This selects the wording, because the
+        # same wrong shape is a problem for different reasons depending on the assertion:
+        #   Collection      - the whole input is compared as one collection (e.g. Should-BeCollection).
+        #                     A lone scalar, $null, or dictionary is the wrong container, so all three
+        #                     are worth a hint.
+        #   CollectionItems - the input is iterated or searched item by item (e.g. Should-All,
+        #                     Should-Any, Should-ContainCollection, Should-NotContainCollection). A
+        #                     lone scalar or $null is a perfectly valid one-item collection here, so
+        #                     only a dictionary -- which PowerShell silently passes through as a
+        #                     single, non-iterated object -- is a genuine gotcha.
+        [ValidateSet('Collection', 'CollectionItems')]
         [string] $Expecting = 'Collection'
     )
-
-    if ($Expecting -ne 'Collection') { return $null }
 
     try {
         if ($IsPipelineInput) {
@@ -41,18 +48,38 @@ function Get-AssertionGotcha {
             $piped = $false
         }
 
+        # Classify the wrong shape once, then pick wording that fits the failing assertion.
         if ($null -eq $value) {
-            $what = '$null'
-            $detail = 'It is treated as a single $null item, not an empty collection. Use @() to represent an empty collection.'
+            $shape = 'null'
         }
         elseif ($value -is [System.Collections.IDictionary]) {
-            $what = 'a single ' + (Get-ShortType2 -Value $value)
-            $detail = 'PowerShell treats a dictionary as a single object, not a collection. To check the number of entries use $actual.Count, or compare contents with Should-BeEquivalent.'
+            $shape = 'dictionary'
         }
         else {
-            $what = 'a single ' + (Get-ShortType2 -Value $value)
-            $detail = 'It is treated as a single item. To assert on a one-item collection wrap it as ,$actual, or use Should-Be for a scalar value.'
+            $shape = 'scalar'
         }
+
+        $detail = switch ($Expecting) {
+            'Collection' {
+                switch ($shape) {
+                    'null' { 'It is treated as a single $null item, not an empty collection. Use @() to represent an empty collection.' }
+                    'dictionary' { 'PowerShell treats a dictionary as a single object, not a collection. To check the number of entries use $actual.Count, or compare contents with Should-BeEquivalent.' }
+                    'scalar' { 'It is treated as a single item. To assert on a one-item collection wrap it as ,$actual, or use Should-Be for a scalar value.' }
+                }
+            }
+            'CollectionItems' {
+                switch ($shape) {
+                    # A lone scalar or $null is a valid one-item collection for an item-wise
+                    # assertion, so there is nothing surprising to point out. Only a dictionary is.
+                    'dictionary' { 'PowerShell treats a dictionary as a single object, so it is passed through as one item instead of being iterated. Enumerate it first, e.g. with $actual.GetEnumerator(), or its .Keys or .Values.' }
+                    default { $null }
+                }
+            }
+        }
+
+        if (-not $detail) { return $null }
+
+        $what = if ($shape -eq 'null') { '$null' } else { 'a single ' + (Get-ShortType2 -Value $value) }
 
         if ($piped) {
             "You piped $what into a collection assertion. $detail"

--- a/tst/functions/assert/Collection/Should-All.Tests.ps1
+++ b/tst/functions/assert/Collection/Should-All.Tests.ps1
@@ -88,3 +88,30 @@ catch { `$_.FullyQualifiedErrorId + '||' + (`$_.Exception.Message -split [Enviro
         $ex.Exception.Message | Verify-Like 'Unbound scriptblock*'
     }
 }
+
+Describe "Should-All input hint" {
+    It 'Hints when a single hashtable is piped' {
+        $err = { @{ Name = 'Jakub' } | Should-All { $_ -eq 1 } } | Verify-AssertionFailed
+        $err.Exception.Message | Verify-Like '*Hint: You piped a single*PowerShell treats a dictionary as a single object*GetEnumerator*'
+    }
+
+    It 'Hints when a hashtable is passed via -Actual' {
+        $err = { Should-All -Actual @{ Name = 'Jakub' } -FilterScript { $_ -eq 1 } } | Verify-AssertionFailed
+        $err.Exception.Message | Verify-Like '*Hint: -Actual is a single*which is not a collection*'
+    }
+
+    It 'Does not hint for a genuine collection that fails the filter' {
+        $err = { @(3, 4, 5) | Should-All { $_ -eq 1 } } | Verify-AssertionFailed
+        ($err.Exception.Message -notlike '*Hint:*') | Verify-True
+    }
+
+    It 'Does not hint for a piped scalar, which is a valid one-item collection' {
+        $err = { 2 | Should-All { $_ -eq 1 } } | Verify-AssertionFailed
+        ($err.Exception.Message -notlike '*Hint:*') | Verify-True
+    }
+
+    It 'Does not hint for piped $null, which is a valid one-item collection' {
+        $err = { $null | Should-All { $_ -eq 1 } } | Verify-AssertionFailed
+        ($err.Exception.Message -notlike '*Hint:*') | Verify-True
+    }
+}

--- a/tst/functions/assert/Collection/Should-Any.Tests.ps1
+++ b/tst/functions/assert/Collection/Should-Any.Tests.ps1
@@ -92,3 +92,30 @@ catch { `$_.FullyQualifiedErrorId + '||' + (`$_.Exception.Message -split [Enviro
         $ex.Exception.Message | Verify-Like 'Unbound scriptblock*'
     }
 }
+
+Describe "Should-Any input hint" {
+    It 'Hints when a single hashtable is piped' {
+        $err = { @{ Name = 'Jakub' } | Should-Any { $_ -eq 1 } } | Verify-AssertionFailed
+        $err.Exception.Message | Verify-Like '*Hint: You piped a single*PowerShell treats a dictionary as a single object*GetEnumerator*'
+    }
+
+    It 'Hints when a hashtable is passed via -Actual' {
+        $err = { Should-Any -Actual @{ Name = 'Jakub' } -FilterScript { $_ -eq 1 } } | Verify-AssertionFailed
+        $err.Exception.Message | Verify-Like '*Hint: -Actual is a single*which is not a collection*'
+    }
+
+    It 'Does not hint for a genuine collection where none pass the filter' {
+        $err = { @(1, 2, 3) | Should-Any { $_ -eq 0 } } | Verify-AssertionFailed
+        ($err.Exception.Message -notlike '*Hint:*') | Verify-True
+    }
+
+    It 'Does not hint for a piped scalar, which is a valid one-item collection' {
+        $err = { 3 | Should-Any { $_ -eq 0 } } | Verify-AssertionFailed
+        ($err.Exception.Message -notlike '*Hint:*') | Verify-True
+    }
+
+    It 'Does not hint for piped $null, which is a valid one-item collection' {
+        $err = { $null | Should-Any { $_ -eq 1 } } | Verify-AssertionFailed
+        ($err.Exception.Message -notlike '*Hint:*') | Verify-True
+    }
+}

--- a/tst/functions/assert/Collection/Should-ContainCollection.Tests.ps1
+++ b/tst/functions/assert/Collection/Should-ContainCollection.Tests.ps1
@@ -25,3 +25,25 @@ InPesterModuleScope {
         }
     }
 }
+
+Describe "Should-ContainCollection input hint" {
+    It 'Hints when a single hashtable is piped' {
+        $err = { @{ Name = 'Jakub' } | Should-ContainCollection 1 } | Verify-AssertionFailed
+        $err.Exception.Message | Verify-Like '*Hint: You piped a single*PowerShell treats a dictionary as a single object*GetEnumerator*'
+    }
+
+    It 'Hints when a hashtable is passed via -Actual' {
+        $err = { Should-ContainCollection -Actual @{ Name = 'Jakub' } -Expected 1 } | Verify-AssertionFailed
+        $err.Exception.Message | Verify-Like '*Hint: -Actual is a single*which is not a collection*'
+    }
+
+    It 'Does not hint for a genuine collection that lacks the item' {
+        $err = { @(5, 6, 7) | Should-ContainCollection 1 } | Verify-AssertionFailed
+        ($err.Exception.Message -notlike '*Hint:*') | Verify-True
+    }
+
+    It 'Does not hint for a piped scalar, which is a valid one-item collection' {
+        $err = { 5 | Should-ContainCollection 1 } | Verify-AssertionFailed
+        ($err.Exception.Message -notlike '*Hint:*') | Verify-True
+    }
+}

--- a/tst/functions/assert/Collection/Should-NotContainCollection.Tests.ps1
+++ b/tst/functions/assert/Collection/Should-NotContainCollection.Tests.ps1
@@ -25,3 +25,21 @@ InPesterModuleScope {
         }
     }
 }
+
+Describe "Should-NotContainCollection input hint" {
+    It 'Hints when a single hashtable is piped and found by reference' {
+        $h = @{ Name = 'Jakub' }
+        $err = { $h | Should-NotContainCollection $h } | Verify-AssertionFailed
+        $err.Exception.Message | Verify-Like '*Hint: You piped a single*PowerShell treats a dictionary as a single object*GetEnumerator*'
+    }
+
+    It 'Does not hint for a genuine collection that contains the item' {
+        $err = { @(1, 2, 3) | Should-NotContainCollection 1 } | Verify-AssertionFailed
+        ($err.Exception.Message -notlike '*Hint:*') | Verify-True
+    }
+
+    It 'Does not hint for a piped scalar, which is a valid one-item collection' {
+        $err = { 5 | Should-NotContainCollection 5 } | Verify-AssertionFailed
+        ($err.Exception.Message -notlike '*Hint:*') | Verify-True
+    }
+}


### PR DESCRIPTION
## What

Follow-up to #2758, which added the input-shape "gotcha" hint to `Should-BeCollection` and put the wording in one reusable place (`Get-AssertionGotcha`) so the other collection assertions could adopt it. This wires it into the remaining four:

- `Should-All`
- `Should-Any`
- `Should-ContainCollection`
- `Should-NotContainCollection`

## Why the hint set differs from `Should-BeCollection`

`Should-BeCollection` compares the input as **one whole collection**, so a piped scalar, `$null`, or hashtable is all a "wrong container" worth flagging.

These four assertions instead **iterate or search the input item by item**. For them a lone scalar or `$null` is a perfectly valid one-item collection — `1 | Should-All { ... }` is documented, tested usage — so hinting there would be noise (and would contradict their own exact-message tests). The one shape that is *always* a mistake is a **dictionary**: PowerShell passes it through as a single, non-iterated object, so `@{ ... } | Should-All { ... }` runs the filter once over the whole hashtable instead of per entry.

So `Get-AssertionGotcha` now classifies the wrong shape once and picks wording per family via `-Expecting`:

- `Collection` (unchanged): hints scalar, `$null`, and dictionary.
- `CollectionItems` (new): hints **dictionaries only**, pointing at `$actual.GetEnumerator()`, `.Keys`, or `.Values`.

As before, the hint is computed only on the failing path through a buffered `& $reportFailure` helper, wrapped in try/catch so it can never change pass/fail.

### Example

```powershell
@{ Name = 'Jakub' } | Should-All { $_ -eq 1 }
```

```
Expected all items in collection @(@{Name=Jakub}) to pass filter { $_ -eq 1 }, but 1 of them @{Name=Jakub} did not pass the filter.

Hint: You piped a single [hashtable] into a collection assertion. PowerShell treats a dictionary as a single object, so it is passed through as one item instead of being iterated. Enumerate it first, e.g. with $actual.GetEnumerator(), or its .Keys or .Values.
```

## Tests

- +17 hint tests across the four assertions (positive dictionary hint, plus negatives confirming no hint for genuine collections, valid scalars, and `$null`).
- Collection suite: 84 passing. Full assert suite: 755 passing. Normal and inline builds clean; style checks pass.

No behavior change on the passing path, and existing exact-message failures (including piped `$null`/scalar for `Should-All`/`Should-Any`) are unchanged.