### PR TITLE
Show single duration in output instead of user/framework split

### DIFF
--- a/src/functions/Output.ps1
+++ b/src/functions/Output.ps1
@@ -586,7 +586,9 @@ function Get-WriteScreenPlugin ($Verbosity) {
         }
 
         if ('Normal' -eq $PesterPreference.Output.Verbosity.Value) {
-            $humanTime = "$(Get-HumanTime ($Context.Result.Duration)) ($(Get-HumanTime $Context.Result.UserDuration)|$(Get-HumanTime $Context.Result.FrameworkDuration))"
+            # UserDuration and FrameworkDuration are kept on the result object for profiling,
+            # but we only show the combined Duration here to keep the output easy to read.
+            $humanTime = "$(Get-HumanTime ($Context.Result.Duration))"
 
             if ($Context.Result.Passed) {
                 Write-PesterHostMessage -ForegroundColor $ReportTheme.Pass "[+] $($Context.Result.Name)" -NoNewLine
@@ -654,7 +656,9 @@ function Get-WriteScreenPlugin ($Verbosity) {
             throw "Unsupported level of output '$($PesterPreference.Output.Verbosity.Value)'"
         }
 
-        $humanTime = "$(Get-HumanTime ($_test.Duration)) ($(Get-HumanTime $_test.UserDuration)|$(Get-HumanTime $_test.FrameworkDuration))"
+        # UserDuration and FrameworkDuration are kept on the result object for profiling,
+        # but we only show the combined Duration here to keep the output easy to read.
+        $humanTime = "$(Get-HumanTime ($_test.Duration))"
 
         if ($PesterPreference.Debug.ShowNavigationMarkers.Value) {
             $out += ", $($_test.ScriptBlock.File):$($_Test.StartLine)"

--- a/src/functions/Set-ItResult.ps1
+++ b/src/functions/Set-ItResult.ps1
@@ -35,8 +35,8 @@
 
     ```
     Describing Example
-      [?] Inconclusive test is inconclusive, because we want it to be inconclusive 35ms (32ms|3ms)
-      [!] Skipped test is skipped, because we want it to be skipped 3ms (2ms|1ms)
+      [?] Inconclusive test is inconclusive, because we want it to be inconclusive 35ms
+      [!] Skipped test is skipped, because we want it to be skipped 3ms
     Tests completed in 78ms
     Tests Passed: 0, Failed: 0, Skipped: 1, Inconclusive: 1, NotRun: 0
     ```


### PR DESCRIPTION
## Summary

Pester's console output rendered each test and block duration as the total duration followed by a `(user code time|framework time)` breakdown, e.g.:

```
Describing Calculator
  [+] adds two numbers 84ms (80ms|4ms)
[+] C:\repo\Calculator.Tests.ps1 1.05s (950ms|100ms)
```

The `(user|framework)` split is essentially a profiling aid for Pester maintainers and is noise for everyone else. This folds it into a single duration number:

```
Describing Calculator
  [+] adds two numbers 84ms
[+] C:\repo\Calculator.Tests.ps1 1.05s
```

## What changed

- `src/functions/Output.ps1`: the `$humanTime` string (block line in `Normal` verbosity and the test line used for Passed/Failed/Skipped/Inconclusive) now shows only `Duration`.
- `src/functions/Set-ItResult.ps1`: updated the example output in comment-based help to match.

## Data is preserved

This is purely a console-output change. `UserDuration` and `FrameworkDuration` remain on the result objects (`Test`, `Block`, `Container`, `Run`) so the breakdown is still available for profiling. Verified that `$result.Tests[0].UserDuration` / `.FrameworkDuration` and the run-level equivalents are still populated.

## Testing

- `tst/Pester.RSpec.Output.ts.ps1` — 14/14 pass
- `tst/Pester.RSpec.ResultObject.ts.ps1` — 6/6 pass (still verifies UserDuration/FrameworkDuration aggregation)
- `tst/functions/Output.Tests.ps1` — 55/55 pass

Fix #2765