### PR TITLE
Improve comment-based help examples for new Should-* assertions

### DIFF
--- a/src/functions/assert/Mock/Should-Invoke.ps1
+++ b/src/functions/assert/Mock/Should-Invoke.ps1
@@ -57,85 +57,89 @@
 
     .EXAMPLE
     ```powershell
-    Mock Set-Content {}
+    function Save-Report ($Path, $Content) {
+        Set-Content -Path $Path -Value $Content
+    }
 
-    {... Some Code ...}
+    Describe 'Save-Report' {
+        It 'writes the report to disk' {
+            Mock Set-Content
 
-    Should-Invoke Set-Content
-    ```
+            Save-Report -Path 'report.txt' -Content 'All systems green'
 
-    This will throw an exception and cause the test to fail if Set-Content is not called in Some Code.
-
-    .EXAMPLE
-    ```powershell
-    Mock Set-Content -parameterFilter {$path.StartsWith("$env:temp\")}
-
-    {... Some Code ...}
-
-    Should-Invoke Set-Content 2 { $path -eq "$env:temp\test.txt" }
-    ```
-
-    This will throw an exception if some code calls Set-Content on $path=$env:temp\test.txt less than 2 times
-
-    .EXAMPLE
-    ```powershell
-    Mock Set-Content {}
-
-    {... Some Code ...}
-
-    Should-Invoke Set-Content 0
-    ```
-
-    This will throw an exception if some code calls Set-Content at all
-
-    .EXAMPLE
-    Mock Set-Content {}
-
-    {... Some Code ...}
-
-    Should-Invoke Set-Content -Exactly 2
-
-    This will throw an exception if some code does not call Set-Content Exactly two times.
-
-    .EXAMPLE
-    ```powershell
-    Describe 'Should-Invoke Scope behavior' {
-        Mock Set-Content { }
-
-        It 'Calls Set-Content at least once in the It block' {
-            {... Some Code ...}
-
-            Should-Invoke Set-Content -Exactly 0 -Scope It
+            Should-Invoke Set-Content -Times 1 -Exactly
         }
     }
     ```
 
-    Checks for calls only within the current It block.
+    Asserts that `Save-Report` wrote to disk by calling the mocked `Set-Content` exactly once. The test fails if `Set-Content` was not called, or was called more than once.
 
     .EXAMPLE
     ```powershell
-    Describe 'Describe' {
-        Mock -ModuleName SomeModule Set-Content { }
+    Mock Set-Content
 
-        {... Some Code ...}
+    Save-Report -Path 'report.txt' -Content 'All systems green'
 
-        It 'Calls Set-Content at least once in the Describe block' {
-            Should-Invoke -ModuleName SomeModule Set-Content
+    Should-Invoke Set-Content -ParameterFilter { $Path -eq 'report.txt' }
+    ```
+
+    Only the calls where `-Path` was `report.txt` are counted. The assertion passes, because `Save-Report` wrote to that path.
+
+    .EXAMPLE
+    ```powershell
+    function Get-Weather ($City) {
+        Invoke-RestMethod -Uri "https://api.example.com/weather?city=$City"
+    }
+
+    Mock Invoke-RestMethod
+
+    Get-Weather -City 'Oslo'
+
+    Should-Invoke Invoke-RestMethod -Times 1 -Exactly -ParameterFilter { $Uri -match 'city=Oslo' }
+    ```
+
+    Asserts that the weather API was queried exactly once, and that the request was made for the city of Oslo.
+
+    .EXAMPLE
+    ```powershell
+    Describe 'Save-Report' {
+        BeforeAll { Mock Set-Content }
+
+        It 'writes exactly once per call' {
+            Save-Report -Path 'a.txt' -Content 'x'
+
+            Should-Invoke Set-Content -Times 1 -Exactly -Scope It
         }
     }
     ```
 
-    Checks for calls to the mock within the SomeModule module.  Note that both the Mock
-    and Should-Invoke commands use the same module name.
+    `-Scope It` counts only the calls made in the current `It` block, even though the mock is shared by the whole `Describe`.
 
     .EXAMPLE
     ```powershell
-    Should-Invoke Get-ChildItem -ExclusiveFilter { $Path -eq 'C:\' }
+    Describe 'Publish-Thing' {
+        It 'writes from inside the module' {
+            Mock -ModuleName Toolbox Set-Content
+
+            Publish-Thing
+
+            Should-Invoke -ModuleName Toolbox Set-Content -Times 1 -Exactly
+        }
+    }
     ```
 
-    Checks to make sure that Get-ChildItem was called at least one time with
-    the -Path parameter set to 'C:\', and that it was not called at all with
-    the -Path parameter set to any other value.
+    When the command under test lives in a module, both `Mock` and `Should-Invoke` must use the same `-ModuleName` so the recorded call is found.
+
+    .EXAMPLE
+    ```powershell
+    Mock Remove-Item
+
+    Remove-TempFile -Path "$env:TEMP/old.log"
+
+    Should-Invoke Remove-Item -ExclusiveFilter { $Path -like "$env:TEMP*" }
+    ```
+
+    `-ExclusiveFilter` passes only if *every* recorded call matches the filter. Here it asserts that `Remove-Item` was called at least once, and only ever for paths inside the temp folder. It is a shorthand for pairing a `Should-Invoke` and a `Should-NotInvoke`.
 
     .NOTES
     The parameter filter passed to Should-Invoke does not necessarily have to match the parameter filter

--- a/src/functions/assert/Mock/Should-NotInvoke.ps1
+++ b/src/functions/assert/Mock/Should-NotInvoke.ps1
@@ -55,74 +55,49 @@
     Makes sure that all verifiable mocks were called.
 
     .EXAMPLE
-    Mock Set-Content {}
-
-    {... Some Code ...}
-
-    Should-NotInvoke Set-Content
-
-    This will throw an exception and cause the test to fail if Set-Content is not called in Some Code.
-
-    .EXAMPLE
-    Mock Set-Content -parameterFilter {$path.StartsWith("$env:temp\")}
-
-    {... Some Code ...}
-
-    Should-NotInvoke Set-Content 2 { $path -eq "$env:temp\test.txt" }
-
-    This will throw an exception if some code calls Set-Content on $path=$env:temp\test.txt less than 2 times
-
-    .EXAMPLE
-    Mock Set-Content {}
-
-    {... Some Code ...}
-
-    Should-NotInvoke Set-Content 0
-
-    This will throw an exception if some code calls Set-Content at all
-
-    .EXAMPLE
-    Mock Set-Content {}
-
-    {... Some Code ...}
-
-    Should-NotInvoke Set-Content -Exactly 2
-
-    This will throw an exception if some code does not call Set-Content Exactly two times.
-
-    .EXAMPLE
-    Describe 'Should-NotInvoke Scope behavior' {
-        Mock Set-Content { }
-
-        It 'Calls Set-Content at least once in the It block' {
-            {... Some Code ...}
-
-            Should-NotInvoke Set-Content -Exactly 0 -Scope It
-        }
+    ```powershell
+    function Remove-TempFile ($Path, [switch] $WhatIf) {
+        if (-not $WhatIf) { Remove-Item -Path $Path }
     }
 
-    Checks for calls only within the current It block.
+    Describe 'Remove-TempFile' {
+        It 'does not delete anything in -WhatIf mode' {
+            Mock Remove-Item
 
-    .EXAMPLE
-    Describe 'Describe' {
-        Mock -ModuleName SomeModule Set-Content { }
+            Remove-TempFile -Path 'temp.txt' -WhatIf
 
-        {... Some Code ...}
-
-        It 'Calls Set-Content at least once in the Describe block' {
-            Should-NotInvoke -ModuleName SomeModule Set-Content
+            Should-NotInvoke Remove-Item
         }
     }
+    ```
 
-    Checks for calls to the mock within the SomeModule module.  Note that both the Mock
-    and Should-NotInvoke commands use the same module name.
+    Because `-WhatIf` was passed, `Remove-TempFile` must not delete anything. The assertion passes when the mocked `Remove-Item` was never called, and throws (failing the test) if it was called.
 
     .EXAMPLE
-    Should-NotInvoke Get-ChildItem -ExclusiveFilter { $Path -eq 'C:\' }
+    ```powershell
+    Mock Remove-Item
 
-    Checks to make sure that Get-ChildItem was called at least one time with
-    the -Path parameter set to 'C:\', and that it was not called at all with
-    the -Path parameter set to any other value.
+    Remove-TempFile -Path "$env:TEMP/old.log"
+
+    Should-NotInvoke Remove-Item -ParameterFilter { $Path -notlike "$env:TEMP*" }
+    ```
+
+    Only the calls whose `-Path` is outside the temp folder are counted. The assertion passes, because `Remove-TempFile` only ever deletes inside `$env:TEMP`.
+
+    .EXAMPLE
+    ```powershell
+    Describe 'Remove-TempFile' {
+        BeforeAll { Mock Remove-Item }
+
+        It 'is a no-op in -WhatIf mode' {
+            Remove-TempFile -Path 'temp.txt' -WhatIf
+
+            Should-NotInvoke Remove-Item -Scope It
+        }
+    }
+    ```
+
+    `-Scope It` limits the check to calls made in the current `It` block, even when the mock is shared across the whole `Describe`.
 
     .NOTES
     The parameter filter passed to Should-NotInvoke does not necessarily have to match the parameter filter

--- a/src/functions/assert/Parameter/Should-HaveParameter.ps1
+++ b/src/functions/assert/Parameter/Should-HaveParameter.ps1
@@ -35,12 +35,47 @@
 
     .EXAMPLE
     ```powershell
-    Get-Command "Invoke-WebRequest" | Should -HaveParameter Uri -Mandatory
+    Get-Command Invoke-WebRequest | Should-HaveParameter Uri -Type ([uri]) -Mandatory
     ```
 
-    This test passes, because it expected the parameter URI to exist and to
-    be mandatory.
+    This assertion passes, because `Invoke-WebRequest` has a mandatory `-Uri` parameter of type `[uri]`.
 
+    .EXAMPLE
+    ```powershell
+    function Get-Cat {
+        [CmdletBinding(DefaultParameterSetName = 'ByName')]
+        param(
+            [Parameter(ParameterSetName = 'ByName', Mandatory)]
+            [Alias('Id')]
+            [string] $Name,
+
+            [Parameter(ParameterSetName = 'ByIndex', Mandatory)]
+            [int] $Index,
+
+            [ValidateSet('Json', 'Xml')]
+            [string] $Format = 'Json'
+        )
+    }
+
+    Describe 'Get-Cat public contract' {
+        It 'requires a Name' {
+            Get-Command Get-Cat | Should-HaveParameter Name -Type ([string]) -Mandatory -Alias 'Id'
+        }
+
+        It 'defaults Format to Json' {
+            Get-Command Get-Cat | Should-HaveParameter Format -Type ([string]) -DefaultValue 'Json'
+        }
+    }
+    ```
+
+    A typical real-life use is locking down the public API of your own command. These assertions pass, because `-Name` is a mandatory `[string]` with the alias `Id`, and `-Format` is an optional `[string]` that defaults to `Json`.
+
+    .EXAMPLE
+    ```powershell
+    Get-Command Get-Cat | Should-HaveParameter Index -InParameterSet 'ByIndex'
+    ```
+
+    This assertion passes, because the `-Index` parameter (from the `Get-Cat` function above) belongs to the `ByIndex` parameter set.
 
     .NOTES
     The attribute [ArgumentCompleter] was added with PSv5. Previously this

--- a/src/functions/assert/Parameter/Should-NotHaveParameter.ps1
+++ b/src/functions/assert/Parameter/Should-NotHaveParameter.ps1
@@ -17,15 +17,21 @@
 
     .EXAMPLE
     ```powershell
-    Get-Command "Invoke-WebRequest" | Should -NotHaveParameter Uri
+    Get-Command Get-Date | Should-NotHaveParameter Uri
     ```
 
-    This test fails, because it expected the parameter URI to not exist.
+    This assertion passes, because `Get-Date` has no `-Uri` parameter.
 
-    .NOTES
-    The attribute [ArgumentCompleter] was added with PSv5. Previously this
-    assertion will not be able to use the -HasArgumentCompleter parameter
-    if the attribute does not exist.
+    .EXAMPLE
+    ```powershell
+    function Get-PublicReport {
+        param([string] $Name)
+    }
+
+    Get-Command Get-PublicReport | Should-NotHaveParameter Credential
+    ```
+
+    This assertion passes, because `Get-PublicReport` does not expose a `-Credential` parameter. This is useful for guarding against accidentally adding parameters you want to keep off a command's public surface.
 
     .LINK
     https://pester.dev/docs/commands/Should-NotHaveParameter

--- a/src/functions/assert/String/Should-MatchString.ps1
+++ b/src/functions/assert/String/Should-MatchString.ps1
@@ -35,17 +35,24 @@ function Should-MatchString {
 
     .EXAMPLE
     ```powershell
-    "hello" | Should-MatchString "h.*o"
+    (New-Guid).Guid | Should-MatchString '^[0-9a-f-]{36}$'
     ```
 
-    This assertion will pass, because the actual value matches the regular expression pattern.
+    This assertion passes, because a GUID is made up of 36 lowercase hexadecimal and dash characters.
 
     .EXAMPLE
     ```powershell
-    "hello" | Should-MatchString "H.*O" -CaseSensitive
+    'user-4f2a' | Should-MatchString '^user-[0-9a-f]{4}$'
     ```
 
-    This assertion will fail, because the actual value does not case-sensitively match the regular expression pattern.
+    This assertion passes, because the generated id matches the expected `user-` prefix followed by four hexadecimal characters. This is handy for checking that a function returns ids, tokens or file names in the format you expect.
+
+    .EXAMPLE
+    ```powershell
+    'Pester 6.0.0' | Should-MatchString 'pester \d+\.\d+\.\d+' -CaseSensitive
+    ```
+
+    This assertion fails, because with `-CaseSensitive` the lowercase `pester` in the pattern does not match the capitalized `Pester` in the actual value.
 
     .LINK
     https://pester.dev/docs/commands/Should-MatchString

--- a/src/functions/assert/String/Should-NotMatchString.ps1
+++ b/src/functions/assert/String/Should-NotMatchString.ps1
@@ -35,17 +35,24 @@ function Should-NotMatchString {
 
     .EXAMPLE
     ```powershell
-    "hello" | Should-NotMatchString "^world$"
+    'Hello Jakub, your order #4821 shipped.' | Should-NotMatchString '\{\{.*?\}\}'
     ```
 
-    This assertion will pass, because the actual value does not match the regular expression pattern.
+    This assertion passes, because the rendered text contains no leftover `{{ ... }}` template placeholders. This is a common check after expanding a template to make sure every token was replaced.
 
     .EXAMPLE
     ```powershell
-    "hello" | Should-NotMatchString "h.*o" -CaseSensitive
+    'level=info msg="started"' | Should-NotMatchString 'password='
     ```
 
-    This assertion will fail, because the actual value case-sensitively matches the regular expression pattern.
+    This assertion passes, because the log line does not leak a `password=` value.
+
+    .EXAMPLE
+    ```powershell
+    'Build failed' | Should-NotMatchString 'failed' -CaseSensitive
+    ```
+
+    This assertion fails, because the actual value case-sensitively contains `failed`.
 
     .LINK
     https://pester.dev/docs/commands/Should-NotMatchString


### PR DESCRIPTION
## What

Improves the `.EXAMPLE` blocks (and a couple of explanations) in the comment-based help for the six newer v6 assertions:

- `Should-Invoke` / `Should-NotInvoke`
- `Should-HaveParameter` / `Should-NotHaveParameter`
- `Should-MatchString` / `Should-NotMatchString`

## Why

The command-reference pages on [pester.dev](https://pester.dev/docs/commands/Should-Invoke) are generated from this comment-based help, and the examples for these commands had several issues:

- **`Should-Invoke` / `Should-NotInvoke`** — carried over `{... Some Code ...}` placeholders from the legacy `Assert-MockCalled` help, and several examples were missing code fences so they render as escaped text on the site. The `Should-NotInvoke` explanations were copy-pasted from `Should-Invoke` and described the **opposite** behavior (e.g. "throws if ... is not called").
- **`Should-HaveParameter` / `Should-NotHaveParameter`** — used the old `Should -HaveParameter` (space) syntax instead of the new `Should-HaveParameter`; `Should-HaveParameter` had only one example (no `-Type`/`-DefaultValue`/`-Alias`/`-InParameterSet`); the `Should-NotHaveParameter` example showed a **failing** test and carried an irrelevant `-HasArgumentCompleter` note.
- **`Should-MatchString` / `Should-NotMatchString`** — only abstract `hello` / `h.*o` samples; replaced with real-life regex checks (GUID, version, secret-leak guard, etc.).

## Notes

- Comment-only change — no functional/code changes, so no test impact.
- All examples were validated against Pester 6.0.0 built from this branch.
- Mirrors the published-side fixes in pester/docs#377 so the inline help and the generated pages stay in sync.
- Relates to #2464.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>