### PR TITLE
Add Should-BeHashtable shape assertion

### DIFF
--- a/docs/assertion-types.md
+++ b/docs/assertion-types.md
@@ -111,4 +111,22 @@ The `$Expected` accepts input that has the same type as the assertion type. E.g.
 
 
 
+## Hashtable and dictionary assertions
+
+`Should-BeHashtable` asserts on the *shape* of a hashtable or dictionary. It checks that the value is a dictionary (a `[hashtable]`, an `[ordered]@{}`, or any `System.Collections.IDictionary`), and optionally that it has a given number of entries (`-Count`), that it is ordered (`-Ordered`), or that it contains specific keys (`-Key`):
+
+```powershell
+# Asserts the value is a hashtable / dictionary:
+@{ Name = 'Jakub'; Age = 30 } | Should-BeHashtable
+
+# Optional shape checks:
+@{ Name = 'Jakub'; Age = 30 } | Should-BeHashtable -Count 2
+@{ Name = 'Jakub'; Age = 30 } | Should-BeHashtable -Key Name, Age
+[ordered]@{ a = 1; b = 2 } | Should-BeHashtable -Ordered -Key a, b
+```
+
+A dictionary is received as a single object, so it is piped in directly without being unwrapped, the same way a value assertion receives its input.
+
+`Should-BeHashtable` deliberately does not compare the *values* of the entries. To compare the keys and values of a dictionary against an expected dictionary, use `Should-BeEquivalent`, which performs a deep, order-insensitive comparison.
+
 These assertions are exported from the module as Assert-* functions and aliased to Should-*, this is because of PowerShell restricting multi word functions to a list of predefined approved verbs.

--- a/src/Module.ps1
+++ b/src/Module.ps1
@@ -72,6 +72,9 @@ $script:SafeCommands['Set-DynamicParameterVariable'] = $ExecutionContext.Session
     'Should-BeSame'
     'Should-HaveType'
 
+    # hashtable
+    'Should-BeHashtable'
+
     # string
     'Should-BeString'
     'Should-NotBeString'

--- a/src/Pester.psd1
+++ b/src/Pester.psd1
@@ -94,6 +94,9 @@
         'Should-BeSame'
         'Should-HaveType'
 
+        # hashtable
+        'Should-BeHashtable'
+
         # string
         'Should-BeString'
         'Should-NotBeString'

--- a/src/functions/assert/Common/Get-AssertionGotcha.ps1
+++ b/src/functions/assert/Common/Get-AssertionGotcha.ps1
@@ -63,7 +63,7 @@ function Get-AssertionGotcha {
             'Collection' {
                 switch ($shape) {
                     'null' { 'It is treated as a single $null item, not an empty collection. Use @() to represent an empty collection.' }
-                    'dictionary' { 'PowerShell treats a dictionary as a single object, not a collection. To check the number of entries use $actual.Count, or compare contents with Should-BeEquivalent.' }
+                    'dictionary' { 'PowerShell treats a dictionary as a single object, not a collection. To assert on it as a hashtable use Should-BeHashtable, or compare its contents with Should-BeEquivalent.' }
                     'scalar' { 'It is treated as a single item. To assert on a one-item collection wrap it as ,$actual, or use Should-Be for a scalar value.' }
                 }
             }
@@ -71,7 +71,7 @@ function Get-AssertionGotcha {
                 switch ($shape) {
                     # A lone scalar or $null is a valid one-item collection for an item-wise
                     # assertion, so there is nothing surprising to point out. Only a dictionary is.
-                    'dictionary' { 'PowerShell treats a dictionary as a single object, so it is passed through as one item instead of being iterated. Enumerate it first, e.g. with $actual.GetEnumerator(), or its .Keys or .Values.' }
+                    'dictionary' { 'PowerShell treats a dictionary as a single object, so it is passed through as one item instead of being iterated. Enumerate it first, e.g. with $actual.GetEnumerator(), or its .Keys or .Values, or assert on it directly with Should-BeHashtable.' }
                     default { $null }
                 }
             }

--- a/src/functions/assert/Hashtable/Should-BeHashtable.ps1
+++ b/src/functions/assert/Hashtable/Should-BeHashtable.ps1
@@ -109,7 +109,7 @@
 
         $missingKeys = @(foreach ($k in $Key) { if (-not $dictionary.Contains($k)) { $k } })
         if ($missingKeys.Count -gt 0) {
-            $missingFormatted = ($missingKeys | & $SafeCommands['ForEach-Object'] { Format-Nicely2 -Value $_ }) -join ', '
+            $missingFormatted = @(foreach ($k in $missingKeys) { Format-Nicely2 -Value $k }) -join ', '
             $keyWord = if ($missingKeys.Count -eq 1) { 'key' } else { 'keys' }
             $Message = Get-AssertionMessage -Expected $Key -Actual $Actual -Because $Because -DefaultMessage "Expected hashtable <actual> to contain $keyWord $missingFormatted,<because> but it does not."
             Invoke-AssertionFailed -Message $Message -CallerCmdlet $PSCmdlet
@@ -134,8 +134,8 @@
             }
 
             if (-not $inOrder) {
-                $keysFormatted = ($Key | & $SafeCommands['ForEach-Object'] { Format-Nicely2 -Value $_ }) -join ', '
-                $actualOrderFormatted = ($actualKeys | & $SafeCommands['ForEach-Object'] { Format-Nicely2 -Value $_ }) -join ', '
+                $keysFormatted = @(foreach ($k in $Key) { Format-Nicely2 -Value $k }) -join ', '
+                $actualOrderFormatted = @(foreach ($k in $actualKeys) { Format-Nicely2 -Value $k }) -join ', '
                 $Message = Get-AssertionMessage -Expected $Key -Actual $Actual -Because $Because -DefaultMessage "Expected keys $keysFormatted to appear in this order in hashtable <actual>,<because> but the actual key order is $actualOrderFormatted."
                 Invoke-AssertionFailed -Message $Message -CallerCmdlet $PSCmdlet
             }

--- a/src/functions/assert/Hashtable/Should-BeHashtable.ps1
+++ b/src/functions/assert/Hashtable/Should-BeHashtable.ps1
@@ -1,0 +1,146 @@
+﻿function Should-BeHashtable {
+    <#
+    .SYNOPSIS
+    Asserts that the input is a hashtable or dictionary, and optionally checks the number of
+    entries, whether it is ordered, and that it contains specific keys.
+
+    .DESCRIPTION
+    `Should-BeHashtable` is a shape assertion. It verifies that `$Actual` is a hashtable or
+    dictionary (anything implementing `System.Collections.IDictionary`, such as `@{}`,
+    `[ordered]@{}` or a generic `Dictionary[,]`).
+
+    It does not compare the contents of the dictionary. Use the optional parameters to assert on
+    the shape of the dictionary:
+
+    - `-Count` checks the number of entries.
+    - `-Ordered` checks that the value is an ordered dictionary (`[ordered]@{}`).
+    - `-Key` checks that the given keys are present, ignoring their values. When combined with
+      `-Ordered`, the keys must also appear in the given relative order.
+
+    To compare the keys *and values* of a dictionary against an expected dictionary use
+    `Should-BeEquivalent` instead, which performs a deep, order-insensitive comparison.
+
+    .PARAMETER Actual
+    The value to test. It is expected to be a hashtable or dictionary.
+
+    .PARAMETER Count
+    Checks that the dictionary has the expected number of entries.
+
+    .PARAMETER Ordered
+    Checks that the dictionary is an ordered dictionary (`System.Collections.Specialized.OrderedDictionary`),
+    as produced by `[ordered]@{}`. A plain `[hashtable]` is unordered and fails this check.
+
+    .PARAMETER Key
+    Checks that the dictionary contains the given keys. Only the presence of the keys is checked,
+    not their values. When `-Ordered` is also specified, the keys must appear in the dictionary in
+    the same relative order as they are listed here.
+
+    .PARAMETER Because
+    The reason why the input should be a hashtable with the expected shape.
+
+    .EXAMPLE
+    ```powershell
+    @{ Name = 'Jakub'; Age = 30 } | Should-BeHashtable
+    [ordered]@{ a = 1; b = 2 } | Should-BeHashtable
+    ```
+
+    These assertions pass, because the actual value is a hashtable or dictionary.
+
+    .EXAMPLE
+    ```powershell
+    @{ Name = 'Jakub'; Age = 30 } | Should-BeHashtable -Count 2
+    @{ Name = 'Jakub'; Age = 30 } | Should-BeHashtable -Key Name, Age
+    [ordered]@{ a = 1; b = 2 } | Should-BeHashtable -Ordered -Key a, b
+    ```
+
+    These assertions pass. The dictionary has two entries, it contains the keys `Name` and `Age`,
+    and the ordered dictionary contains the keys `a` and `b` in that order.
+
+    .EXAMPLE
+    ```powershell
+    @{ Name = 'Jakub' } | Should-BeHashtable -Ordered
+    @(1, 2, 3) | Should-BeHashtable
+    ```
+
+    These assertions fail. The first value is a plain (unordered) hashtable, and the second value
+    is a collection, not a hashtable.
+
+    .NOTES
+    `Should-BeHashtable` only asserts on the shape of the dictionary. To compare its keys and
+    values against an expected dictionary, use `Should-BeEquivalent`.
+
+    .LINK
+    https://pester.dev/docs/commands/Should-BeHashtable
+
+    .LINK
+    https://pester.dev/docs/assertions
+    #>
+    [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseProcessBlockForPipelineCommand', '')]
+    [CmdletBinding()]
+    param (
+        [Parameter(Position = 1, ValueFromPipeline = $true)]
+        $Actual,
+        [int] $Count,
+        [string[]] $Key,
+        [switch] $Ordered,
+        [String] $Because
+    )
+
+    $collectedInput = Collect-Input -ParameterInput $Actual -PipelineInput $local:Input -IsPipelineInput $MyInvocation.ExpectingInput -UnrollInput
+    $Actual = $collectedInput.Actual
+
+    if (-not (Is-Dictionary -Value $Actual)) {
+        $Message = Get-AssertionMessage -Expected $null -Actual $Actual -Because $Because -DefaultMessage "Expected a hashtable,<because> but got <actualType> <actual>."
+        Invoke-AssertionFailed -Message $Message -CallerCmdlet $PSCmdlet
+    }
+
+    if ($Ordered -and ($Actual -isnot [System.Collections.Specialized.OrderedDictionary])) {
+        $Message = Get-AssertionMessage -Expected $null -Actual $Actual -Because $Because -DefaultMessage "Expected an ordered hashtable ([ordered]@{}),<because> but got unordered <actualType> <actual>."
+        Invoke-AssertionFailed -Message $Message -CallerCmdlet $PSCmdlet
+    }
+
+    if ($PSBoundParameters.ContainsKey('Count') -and ($Count -ne $Actual.Count)) {
+        $Message = Get-AssertionMessage -Expected $Count -Actual $Actual -Because $Because -Data @{ actualCount = $Actual.Count } -DefaultMessage "Expected <expected> entries in hashtable <actual>,<because> but it has <actualCount> entries."
+        Invoke-AssertionFailed -Message $Message -CallerCmdlet $PSCmdlet
+    }
+
+    if ($PSBoundParameters.ContainsKey('Key')) {
+        $dictionary = [System.Collections.IDictionary]$Actual
+
+        $missingKeys = @(foreach ($k in $Key) { if (-not $dictionary.Contains($k)) { $k } })
+        if ($missingKeys.Count -gt 0) {
+            $missingFormatted = ($missingKeys | & $SafeCommands['ForEach-Object'] { Format-Nicely2 -Value $_ }) -join ', '
+            $keyWord = if ($missingKeys.Count -eq 1) { 'key' } else { 'keys' }
+            $Message = Get-AssertionMessage -Expected $Key -Actual $Actual -Because $Because -DefaultMessage "Expected hashtable <actual> to contain $keyWord $missingFormatted,<because> but it does not."
+            Invoke-AssertionFailed -Message $Message -CallerCmdlet $PSCmdlet
+        }
+
+        # When the dictionary is asserted to be ordered, the requested keys must also appear in the
+        # given relative order. Only OrderedDictionary reaches this point (the -Ordered check above
+        # rejects anything else), and it compares keys case-insensitively, matching -eq below.
+        if ($Ordered) {
+            $actualKeys = @($Actual.Keys)
+            $positions = foreach ($k in $Key) {
+                $found = -1
+                for ($i = 0; $i -lt $actualKeys.Count; $i++) {
+                    if ($actualKeys[$i] -eq $k) { $found = $i; break }
+                }
+                $found
+            }
+
+            $inOrder = $true
+            for ($i = 1; $i -lt $positions.Count; $i++) {
+                if ($positions[$i] -le $positions[$i - 1]) { $inOrder = $false; break }
+            }
+
+            if (-not $inOrder) {
+                $keysFormatted = ($Key | & $SafeCommands['ForEach-Object'] { Format-Nicely2 -Value $_ }) -join ', '
+                $actualOrderFormatted = ($actualKeys | & $SafeCommands['ForEach-Object'] { Format-Nicely2 -Value $_ }) -join ', '
+                $Message = Get-AssertionMessage -Expected $Key -Actual $Actual -Because $Because -DefaultMessage "Expected keys $keysFormatted to appear in this order in hashtable <actual>,<because> but the actual key order is $actualOrderFormatted."
+                Invoke-AssertionFailed -Message $Message -CallerCmdlet $PSCmdlet
+            }
+        }
+    }
+
+    Set-AssertionPassResult
+}

--- a/tst/functions/assert/Collection/Should-BeCollection.Tests.ps1
+++ b/tst/functions/assert/Collection/Should-BeCollection.Tests.ps1
@@ -51,7 +51,7 @@ Describe "Should-BeCollection" {
 Describe "Should-BeCollection input hint" {
     It 'Hints when a single hashtable is piped' {
         $err = { @{ Name = 'Jakub' } | Should-BeCollection -Count 2 } | Verify-AssertionFailed
-        $err.Exception.Message | Verify-Like '*Hint: You piped a single*PowerShell treats a dictionary as a single object*$actual.Count*'
+        $err.Exception.Message | Verify-Like '*Hint: You piped a single*PowerShell treats a dictionary as a single object*Should-BeHashtable*'
     }
 
     It 'Hints when a single hashtable is piped against an expected collection' {

--- a/tst/functions/assert/Hashtable/Should-BeHashtable.Tests.ps1
+++ b/tst/functions/assert/Hashtable/Should-BeHashtable.Tests.ps1
@@ -1,0 +1,102 @@
+﻿Set-StrictMode -Version Latest
+
+Describe "Should-BeHashtable" {
+    It "Passes when the value is a hashtable or dictionary" -ForEach @(
+        @{ Actual = @{} }
+        @{ Actual = @{ Name = 'Jakub' } }
+        @{ Actual = [ordered]@{ a = 1; b = 2 } }
+        @{ Actual = (& { $d = [System.Collections.Generic.Dictionary[string, int]]::new(); $d['x'] = 1; $d }) }
+    ) {
+        $Actual | Should-BeHashtable
+    }
+
+    It "Fails when the value is not a hashtable" -ForEach @(
+        @{ Actual = @(1, 2, 3) }
+        @{ Actual = 1 }
+        @{ Actual = 'hello' }
+        @{ Actual = $null }
+        @{ Actual = [PSCustomObject]@{ Name = 'Jakub' } }
+    ) {
+        $err = { $Actual | Should-BeHashtable } | Verify-AssertionFailed
+        $err.Exception.Message | Verify-Like 'Expected a hashtable, but got *'
+    }
+
+    It "Can be used with the -Actual parameter" {
+        Should-BeHashtable -Actual @{ Name = 'Jakub' }
+    }
+
+    It "Can be used with positional parameters" {
+        Should-BeHashtable @{ Name = 'Jakub' }
+    }
+
+    Describe "-Count" {
+        It "Passes when the hashtable has the expected number of entries" -ForEach @(
+            @{ Actual = @{}; Count = 0 }
+            @{ Actual = @{ a = 1 }; Count = 1 }
+            @{ Actual = @{ a = 1; b = 2 }; Count = 2 }
+            @{ Actual = [ordered]@{ a = 1; b = 2; c = 3 }; Count = 3 }
+        ) {
+            $Actual | Should-BeHashtable -Count $Count
+        }
+
+        It "Fails when the hashtable does not have the expected number of entries" {
+            $err = { @{ a = 1 } | Should-BeHashtable -Count 2 } | Verify-AssertionFailed
+            $err.Exception.Message | Verify-Like 'Expected 2 entries in hashtable *, but it has 1 entries.'
+        }
+
+        It "Fails the type check before counting when the value is not a hashtable" {
+            $err = { @(1, 2) | Should-BeHashtable -Count 2 } | Verify-AssertionFailed
+            $err.Exception.Message | Verify-Like 'Expected a hashtable, but got *'
+        }
+    }
+
+    Describe "-Ordered" {
+        It "Passes when the value is an ordered dictionary" {
+            [ordered]@{ a = 1; b = 2 } | Should-BeHashtable -Ordered
+        }
+
+        It "Fails when the value is an unordered hashtable" {
+            $err = { @{ a = 1 } | Should-BeHashtable -Ordered } | Verify-AssertionFailed
+            $err.Exception.Message | Verify-Like 'Expected an ordered hashtable (`[ordered`]@{}), but got unordered *'
+        }
+
+        It "Can be combined with -Count" {
+            [ordered]@{ a = 1; b = 2 } | Should-BeHashtable -Ordered -Count 2
+        }
+    }
+
+    Describe "-Key" {
+        It "Passes when all the given keys are present" {
+            @{ Name = 'Jakub'; Age = 30 } | Should-BeHashtable -Key Name, Age
+        }
+
+        It "Matches keys using the dictionary comparer, so hashtable keys are case-insensitive" {
+            @{ Name = 'Jakub' } | Should-BeHashtable -Key 'NAME'
+        }
+
+        It "Ignores the values of the keys" {
+            @{ Name = $null } | Should-BeHashtable -Key Name
+        }
+
+        It "Fails when a single key is missing" {
+            $err = { @{ Name = 'Jakub' } | Should-BeHashtable -Key Age } | Verify-AssertionFailed
+            $err.Exception.Message | Verify-Like "Expected hashtable * to contain key 'Age', but it does not."
+        }
+
+        It "Fails when multiple keys are missing" {
+            $err = { @{ Name = 'Jakub' } | Should-BeHashtable -Key Age, City } | Verify-AssertionFailed
+            $err.Exception.Message | Verify-Like "Expected hashtable * to contain keys 'Age', 'City', but it does not."
+        }
+
+        Describe "with -Ordered" {
+            It "Passes when the keys are present in the given order" {
+                [ordered]@{ a = 1; b = 2; c = 3 } | Should-BeHashtable -Ordered -Key a, c
+            }
+
+            It "Fails when the keys are present but in a different order" {
+                $err = { [ordered]@{ a = 1; b = 2; c = 3 } | Should-BeHashtable -Ordered -Key c, a } | Verify-AssertionFailed
+                $err.Exception.Message | Verify-Like "Expected keys 'c', 'a' to appear in this order in hashtable *, but the actual key order is 'a', 'b', 'c'."
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds a new `Should-BeHashtable` assertion for hashtables and dictionaries to the Pester 6 `Should-*` assertion set.

It is a **shape assertion** — the hashtable analogue of `Should-BeCollection` / `Should-BeString` — and is designed to *complement* `Should-BeEquivalent` rather than duplicate it. Deep content/value comparison stays with `Should-BeEquivalent`; `Should-BeHashtable` focuses on the things `Should-BeEquivalent` can't express.

## What it does

`Should-BeHashtable` verifies the value is an `IDictionary` (`@{}`, `[ordered]@{}`, or any dictionary), with optional, combinable checks:

| Parameter | Checks |
|-----------|--------|
| `-Count <int>` | number of entries (works with `-Count 0` for an empty hashtable) |
| `-Ordered` | the value is an ordered dictionary (`[ordered]@{}` → `System.Collections.Specialized.OrderedDictionary`) |
| `-Key <string[]>` | the given keys are present (value-agnostic, using the dictionary's own comparer). With `-Ordered`, the keys must also appear in that relative order |

```powershell
@{ Name = 'Jakub'; Age = 30 } | Should-BeHashtable
@{ Name = 'Jakub'; Age = 30 } | Should-BeHashtable -Count 2
@{ Name = 'Jakub'; Age = 30 } | Should-BeHashtable -Key Name, Age
[ordered]@{ a = 1; b = 2 }    | Should-BeHashtable -Ordered -Key a, b
```

For comparing keys **and values**, use `Should-BeEquivalent` (deep, order-insensitive). `-Ordered` + `-Key` order checking is the one capability `Should-BeEquivalent` cannot express, since it ignores order.

### Example failure messages
```
Expected a hashtable, but got [Object[]] @(1, 2, 3).
Expected 3 entries in hashtable @{a=1}, but it has 1 entries.
Expected an ordered hashtable ([ordered]@{}), but got unordered [hashtable] @{a=1}.
Expected hashtable @{Name=1} to contain keys 'Age', 'City', but it does not.
Expected keys 'c', 'a' to appear in this order in hashtable Dictionary{a=1; b=2; c=3}, but the actual key order is 'a', 'b', 'c'.
```

## Changes
- **New** `src/functions/assert/Hashtable/Should-BeHashtable.ps1` — implementation + comment-based help.
- **Hints**: `Get-AssertionGotcha` dictionary hints now point at `Should-BeHashtable` (alongside `Should-BeEquivalent`), so piping a dictionary into a collection assertion suggests the right tool.
- **Exports**: registered in `src/Pester.psd1` and `src/Module.ps1`.
- **Docs**: added a "Hashtable and dictionary assertions" section to `docs/assertion-types.md`.
- **Tests**: new `Should-BeHashtable.Tests.ps1` (27 tests) and updated the `Should-BeCollection` hint-wording assertion.

## Validation
- Non-inline and inline builds succeed; function exported in both.
- `Should-BeHashtable` tests: 27 passed.
- Full assert suite: 782 passed. `Help.Tests.ps1`: 390 passed / 1 skipped. Collection + item-wise hint tests: pass.