### PR TITLE
Improve Should-BeEquivalent and assert formatting

### DIFF
--- a/src/Format2.ps1
+++ b/src/Format2.ps1
@@ -9,7 +9,10 @@
     $prettyLimit = 50
     if ($Pretty -and ($length + 3) -gt $prettyLimit) {
         # 3 is for the '@()'
-        "@(`n    $($o -join ",`n    ")`n)"
+        # Indent each item's own line breaks as well, so nested collections and
+        # objects are shown at increasing depth instead of all at one level.
+        $indented = foreach ($formatted in $o) { $formatted -replace "`n", "`n    " }
+        "@(`n    $($indented -join ",`n    ")`n)"
     }
     else {
         "@($($o -join ', '))"
@@ -36,7 +39,10 @@ function Format-Object2 ($Value, $Property, [switch]$Pretty) {
         $o = "$valueType{}"
     }
     elseif ($Pretty) {
-        $o = "$valueType{`n    $($items -join ";`n    ");`n}"
+        # Indent each item's own line breaks as well, so nested objects are shown at
+        # increasing depth instead of all at one level.
+        $indented = foreach ($i in $items) { $i -replace "`n", "`n    " }
+        $o = "$valueType{`n    $($indented -join ";`n    ");`n}"
     }
     else {
         $o = "$valueType{$($items -join '; ')}"

--- a/src/csharp/Pester/Formatter.cs
+++ b/src/csharp/Pester/Formatter.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Text;
 
 namespace Pester
 {
@@ -8,19 +9,32 @@ namespace Pester
 
         private static char[] BuildControlChars()
         {
-            var chars = new char[0x20];
-            for (int i = 0; i < 0x20; i++)
+            // C0 controls (0x00..0x1F), DEL (0x7F) and the C1 controls (0x80..0x9F).
+            // C1 includes single-byte ANSI controls such as NEL (0x85) and CSI (0x9B)
+            // that are otherwise invisible in output.
+            var chars = new char[0x20 + 1 + 0x20];
+            int idx = 0;
+            for (int i = 0x00; i <= 0x1F; i++)
             {
-                chars[i] = (char)i;
+                chars[idx++] = (char)i;
+            }
+            chars[idx++] = (char)0x7F;
+            for (int i = 0x80; i <= 0x9F; i++)
+            {
+                chars[idx++] = (char)i;
             }
             return chars;
         }
 
         /// <summary>
-        /// Replaces ASCII control characters (0x00..0x1F) in <paramref name="value"/>
-        /// with the matching Unicode "Control Pictures" code point
-        /// (U+2400..U+241F) so they are visible when printed. See
+        /// Makes invisible control characters in <paramref name="value"/> visible so
+        /// they show up in error messages. See
         /// https://github.com/pester/Pester/issues/2561.
+        ///
+        /// C0 controls (0x00..0x1F) are replaced with the matching Unicode "Control
+        /// Pictures" code point (U+2400..U+241F) and DEL (0x7F) with U+2421. The C1
+        /// controls (0x80..0x9F) have no picture glyph, so they are rendered as an
+        /// explicit "\u00XX" escape.
         ///
         /// Returns <paramref name="value"/> unchanged when it is null, empty, or
         /// contains no control characters — common case, no allocation beyond
@@ -40,20 +54,35 @@ namespace Pester
             }
 
             int len = value.Length;
-            var buf = new char[len];
-            value.CopyTo(0, buf, 0, len);
+            var sb = new StringBuilder(len + 8);
+            // Everything before firstControl is known to be safe; copy it verbatim.
+            sb.Append(value, 0, firstControl);
 
-            // Everything before firstControl is known to be safe; start from there.
             for (int i = firstControl; i < len; i++)
             {
-                char c = buf[i];
-                if (c < 0x20)
+                char c = value[i];
+                if (c <= 0x1F)
                 {
-                    buf[i] = (char)(c + 0x2400);
+                    // C0 controls -> Unicode Control Pictures.
+                    sb.Append((char)(c + 0x2400));
+                }
+                else if (c == 0x7F)
+                {
+                    // DEL -> SYMBOL FOR DELETE.
+                    sb.Append('\u2421');
+                }
+                else if (c >= 0x80 && c <= 0x9F)
+                {
+                    // C1 controls have no picture glyph; show an explicit escape.
+                    sb.Append("\\u").Append(((int)c).ToString("X4"));
+                }
+                else
+                {
+                    sb.Append(c);
                 }
             }
 
-            return new string(buf);
+            return sb.ToString();
         }
     }
 }

--- a/src/functions/assert/Equivalence/Should-BeEquivalent.ps1
+++ b/src/functions/assert/Equivalence/Should-BeEquivalent.ps1
@@ -58,7 +58,9 @@ function Compare-CollectionEquivalent ($Expected, $Actual, $Property, $Options) 
     if (-not (Is-Collection -Value $Actual)) {
         Write-EquivalenceResult -Difference "`$Actual is not a collection it is a $(Format-Nicely2 $Actual.GetType()), so they are not equivalent."
         $expectedFormatted = Format-Collection2 -Value $Expected
-        $expectedLength = $expected.Length
+        # Use .Count for collections (List, etc.) that don't expose a scalar .Length,
+        # otherwise .Length enumerates the items and yields a bogus value like "1 1 1".
+        $expectedLength = if ($Expected.Length -is [int]) { $Expected.Length } else { $Expected.Count }
         $actualFormatted = Format-Nicely2 -Value $actual
         return "Expected collection $expectedFormatted with length $expectedLength, but got $actualFormatted."
     }

--- a/tst/Format2.Tests.ps1
+++ b/tst/Format2.Tests.ps1
@@ -166,6 +166,18 @@ InPesterModuleScope {
             Format-Nicely2 -Value $Value | Verify-Equal $Expected
         }
 
+        It "Indents nested objects by depth when -Pretty is used" {
+            $value = [PSCustomObject]@{ a = [PSCustomObject]@{ b = 1 } }
+            $expected = "PSObject{`n    a=PSObject{`n        b=1;`n    };`n}"
+            Format-Nicely2 -Value $value -Pretty | Verify-Equal $expected
+        }
+
+        It "Indents objects nested inside a collection by depth when -Pretty is used" {
+            $value = @(([PSCustomObject]@{ n = 'x'; v = 1 }), ([PSCustomObject]@{ n = 'y'; v = 2 }))
+            $expected = "@(`n    PSObject{`n        n='x';`n        v=1;`n    },`n    PSObject{`n        n='y';`n        v=2;`n    }`n)"
+            Format-Nicely2 -Value $value -Pretty | Verify-Equal $expected
+        }
+
         # Regression test for https://github.com/pester/Pester/issues/2474
         # DirectoryInfo has circular references (Root -> DirectoryInfo) that caused
         # infinite recursion. Verify formatting completes without hanging.
@@ -279,6 +291,22 @@ InPesterModuleScope {
             Format-String2 -Value "$([char]27)" | Verify-Equal "'␛'"
         }
 
+        It "Escapes DEL character to its control picture" {
+            # DEL (0x7F) sits just outside the C0 range; it maps to U+2421 SYMBOL FOR DELETE.
+            Format-String2 -Value "$([char]0x7F)" | Verify-Equal "'␡'"
+        }
+
+        It "Escapes C1 control '<char>' to a visible \u escape '<expected>'" -TestCases @(
+            # C1 controls (0x80..0x9F) have no control-picture glyph, so they are shown as \u00XX.
+            # NEL (0x85) and CSI (0x9B) are single-byte ANSI controls that are otherwise invisible.
+            @{ Char = [char]0x85; Expected = "'\u0085'" }
+            @{ Char = [char]0x9B; Expected = "'\u009B'" }
+            @{ Char = [char]0x80; Expected = "'\u0080'" }
+        ) {
+            param ($Char, $Expected)
+            Format-String2 -Value "$Char" | Verify-Equal $Expected
+        }
+
         It "Leaves normal strings unchanged" {
             Format-String2 -Value "hello" | Verify-Equal "'hello'"
         }
@@ -298,10 +326,11 @@ InPesterModuleScope {
 
         It "Escaped output contains no actual control characters" {
             # Round-trip: the escaped output should be a clean displayable string
-            $value = "`0`a`b`t`f`r`n$([char]27)"
+            $value = "`0`a`b`t`f`r`n$([char]27)$([char]0x7F)$([char]0x85)$([char]0x9B)"
             $result = Format-String2 -Value $value
             # The result should not contain any of the original control characters
-            $result | Should -Not -Match '[\x00-\x1F]'
+            # (C0 0x00-0x1F, DEL 0x7F, or C1 0x80-0x9F).
+            $result | Should -Not -Match '[\x00-\x1F\x7F-\x9F]'
         }
     }
 }

--- a/tst/functions/assert/Equivalence/Should-BeEquivalent.Tests.ps1
+++ b/tst/functions/assert/Equivalence/Should-BeEquivalent.Tests.ps1
@@ -199,7 +199,10 @@ InPesterModuleScope {
 
         It "Given collection '<expected>' on the expected side and non-collection '<actual>' on the actual side it prints the correct message '<message>'" -TestCases @(
             @{ Actual = 3; Expected = (1, 2, 3, 4); Message = "Expected collection @(1, 2, 3, 4) with length 4, but got 3." },
-            @{ Actual = ([PSCustomObject]@{ Name = 'Jakub' }); Expected = (1, 2, 3, 4); Message = "Expected collection @(1, 2, 3, 4) with length 4, but got PSObject{Name='Jakub'}." }
+            @{ Actual = ([PSCustomObject]@{ Name = 'Jakub' }); Expected = (1, 2, 3, 4); Message = "Expected collection @(1, 2, 3, 4) with length 4, but got PSObject{Name='Jakub'}." },
+            # A collection without a scalar .Length (e.g. List<T>) must still report its
+            # real size via .Count, not enumerate .Length into a bogus value like "1 1 1 1".
+            @{ Actual = 3; Expected = ([System.Collections.Generic.List[int]]@(1, 2, 3, 4)); Message = "Expected collection @(1, 2, 3, 4) with length 4, but got 3." }
         ) {
             param ($Actual, $Expected, $Message)
             Compare-CollectionEquivalent -Actual $Actual -Expected $Expected | Verify-Equal $Message


### PR DESCRIPTION
Following up on the control-character work in #2561, this fixes a few formatting edge cases found while reviewing `Should-BeEquivalent` and the `Format2` helpers, plus one latent bug.

## Changes

- **Escape DEL and C1 controls** (`Formatter.cs`). `EscapeControlChars` previously only covered the C0 range (0x00–0x1F). It now also escapes DEL (0x7F → the control picture `␡`) and the C1 controls (0x80–0x9F → an explicit `\u00XX` escape, since they have no picture glyph). This makes single-byte ANSI controls such as NEL and CSI visible in failure messages.

- **Indent nested `-Pretty` output** (`Format2.ps1`). Nested objects and collections are now indented by depth instead of all rendering at a single indent level.

- **Fix bogus `with length 1 1 1` message** (`Should-BeEquivalent.ps1`). When the expected side is a collection without a scalar `.Length` (e.g. `List<T>`), the length is now read via `.Count` instead of enumerating `.Length` into a garbled value.

## Tests

- `Format2.Tests.ps1`: DEL escaping, parametrized C1 escaping, extended round-trip guard, nested-pretty indentation.
- `Should-BeEquivalent.Tests.ps1`: `List<T>` non-array length case.

All green: Format2 75/75, Should-BeEquivalent 107/107, full assert module 756/756, C# 60/60.