### PR TITLE
Fix #1137: test that mocked Copy-Item exposes its dynamic parameters

### DIFF
--- a/src/functions/Mock.ps1
+++ b/src/functions/Mock.ps1
@@ -74,7 +74,7 @@ function Create-MockHook ($contextInfo, $InvokeMockCallback) {
         $dynamicParams = foreach ($m in $metadata.Parameters.Values) { if ($m.IsDynamic) { $m } }
         if ($null -ne $dynamicParams) {
             foreach ($p in $dynamicParams) {
-                $null = $metadata.Parameters.Remove($d.name)
+                $null = $metadata.Parameters.Remove($p.Name)
             }
         }
         $cmdletBinding = [Management.Automation.ProxyCommand]::GetCmdletBindingAttribute($metadata)

--- a/tst/functions/Mock.Tests.ps1
+++ b/tst/functions/Mock.Tests.ps1
@@ -1343,6 +1343,30 @@ Describe 'Mocking Cmdlets with dynamic parameters' {
     }
 }
 
+Describe 'Mocking Cmdlets with typed provider dynamic parameters' {
+    # Copy-Item gets the ToSession and FromSession dynamic parameters from the FileSystem provider,
+    # and those only exist on Windows. Mocking Copy-Item used to drop them, so calling the mock with
+    # -ToSession / -FromSession failed with "A parameter cannot be found that matches parameter name".
+    # https://github.com/pester/Pester/issues/1137
+    if ((InPesterModuleScope { GetPesterOs }) -eq 'Windows') {
+        BeforeAll {
+            Mock Copy-Item { 'mocked' }
+        }
+
+        It 'Exposes the <Name> dynamic parameter on the mocked cmdlet' -ForEach @(
+            @{ Name = 'ToSession' }
+            @{ Name = 'FromSession' }
+        ) {
+            # Bind a value of the wrong type to the dynamic parameter. When the parameter is present on
+            # the mock we get a type-conversion binding error; when it is missing (the #1137 bug) we get
+            # a NamedParameterNotFound error instead. We assert the former to prove the parameter exists.
+            $splat = @{ Path = 'TestDrive:\a'; Destination = 'TestDrive:\b'; $Name = 'not-a-session' }
+            $err = { Copy-Item @splat } | Should -Throw -PassThru
+            $err.FullyQualifiedErrorId | Should -Not -BeLike 'NamedParameterNotFound*' -Because "the $Name dynamic parameter should be available on the mocked Copy-Item (#1137)"
+        }
+    }
+}
+
 Describe 'Mocking functions with dynamic parameters' {
     Context 'Dynamicparam block that uses the variables of static parameters in its logic' {
         # Get-Greeting sample function borrowed and modified from Bartek Bielawski's


### PR DESCRIPTION
Fix #1137

`Copy-Item` gets `ToSession` and `FromSession` as dynamic parameters from the FileSystem provider, and they only exist on Windows. The report was that mocking `Copy-Item` dropped them, so calling the mock with `-ToSession`/`-FromSession` failed with "a parameter cannot be found that matches parameter name".

They resolve correctly now: `CopyItemCommand` implements `IDynamicParameters` and `Get-DynamicParametersForCmdlet` picks them up. Nothing tested it though, so this adds a Windows-only test that mocks `Copy-Item` and checks both parameters are recognized on the mock. Binding a wrong-typed value gives a type-conversion error instead of `NamedParameterNotFound`, which proves the parameter is there without needing a real remoting session (we can't create one in CI).

While in there, fix a typo in `Create-MockHook`: the loop that strips dynamic parameters out of the static param block removed `$d.name` (undefined) instead of `$p.Name`, so it never removed anything. It is dead code on current PowerShell because `[CommandMetadata]` doesn't surface dynamic parameters, but it's wrong and defeats what the comment above it describes.

Verified on Windows PowerShell 5.1 and PowerShell 7.6: the full `Mock.Tests.ps1` passes on both.