### PR TITLE
Bump module version to 6.0.0-rc1

### DIFF
--- a/src/Pester.psd1
+++ b/src/Pester.psd1
@@ -169,10 +169,10 @@
             LicenseUri   = "https://www.apache.org/licenses/LICENSE-2.0.html"
 
             # Release notes for this particular version of the module
-            ReleaseNotes = 'https://github.com/pester/Pester/releases/tag/6.0.0-alpha5'
+            ReleaseNotes = 'https://github.com/pester/Pester/releases/tag/6.0.0-rc1'
 
             # Prerelease string of this module
-            Prerelease   = 'alpha5'
+            Prerelease   = 'rc1'
         }
 
         # Minimum assembly version required


### PR DESCRIPTION
Bumps the module manifest to the first 6.0.0 release candidate.

- `Prerelease`: `alpha5` → `rc1`
- `ReleaseNotes` URL → `.../releases/tag/6.0.0-rc1`

The full 6.0.0 release notes are published on the GitHub release page (drafted as `6.0.0-rc1`), following the convention since 5.x where release notes are tracked only in GitHub releases (see `docs/CHANGELOG.md`), not in the repo.