### PR TITLE
Publish built package as a pipeline artifact

### DIFF
--- a/azure-pipelines-publish.yml
+++ b/azure-pipelines-publish.yml
@@ -19,3 +19,19 @@ jobs:
           scriptLocation: inlineScript
           inlineScript: |
             .\publish\release.ps1 -PsGalleryApiKey '$(PsGalleryApiKey)' -NugetApiKey '$(NugetApiKey)' -ChocolateyApiKey '$(ChocolateyApiKey)' -TenantId '$(TenantId)' -VaultUrl '$(SigningVaultURL)' -CertificateName '$(SigningCertName)'
+
+      - task: CopyFiles@2
+        displayName: Stage built package
+        condition: succeededOrFailed()
+        continueOnError: true
+        inputs:
+          sourceFolder: '$(Build.SourcesDirectory)/tmp/nuget'
+          contents: '*.nupkg'
+          targetFolder: '$(Build.ArtifactStagingDirectory)'
+
+      - task: PublishPipelineArtifact@1
+        displayName: Publish built package
+        condition: succeededOrFailed()
+        inputs:
+          targetPath: '$(Build.ArtifactStagingDirectory)'
+          artifact: pester-package


### PR DESCRIPTION
The publish pipeline (`azure-pipelines-publish.yml`) signs and pushes the module but never retained the built package, so there was no way to inspect or re-upload exactly what shipped.

This stages the signed `Pester.<version>.nupkg` that `publish/release.ps1` produces in `tmp/nuget` and publishes it as the **`pester-package`** pipeline artifact.

- `condition: succeededOrFailed()` so the signed package is captured even if the PSGallery/NuGet push fails (the package is built and signed before the push).
- `continueOnError` on the staging copy so an early build failure doesn't mask the real error.