### PR TITLE
Publish PSGallery module variant as a pipeline artifact

### DIFF
--- a/azure-pipelines-publish.yml
+++ b/azure-pipelines-publish.yml
@@ -21,17 +21,26 @@ jobs:
             .\publish\release.ps1 -PsGalleryApiKey '$(PsGalleryApiKey)' -NugetApiKey '$(NugetApiKey)' -ChocolateyApiKey '$(ChocolateyApiKey)' -TenantId '$(TenantId)' -VaultUrl '$(SigningVaultURL)' -CertificateName '$(SigningCertName)'
 
       - task: CopyFiles@2
-        displayName: Stage built package
+        displayName: Stage NuGet and Chocolatey package
         condition: succeededOrFailed()
         continueOnError: true
         inputs:
           sourceFolder: '$(Build.SourcesDirectory)/tmp/nuget'
           contents: '*.nupkg'
-          targetFolder: '$(Build.ArtifactStagingDirectory)'
+          targetFolder: '$(Build.ArtifactStagingDirectory)/nuget'
+
+      - task: CopyFiles@2
+        displayName: Stage PSGallery module
+        condition: succeededOrFailed()
+        continueOnError: true
+        inputs:
+          sourceFolder: '$(Build.SourcesDirectory)/tmp/PSGallery'
+          contents: '**'
+          targetFolder: '$(Build.ArtifactStagingDirectory)/psgallery'
 
       - task: PublishPipelineArtifact@1
-        displayName: Publish built package
+        displayName: Publish built packages
         condition: succeededOrFailed()
         inputs:
           targetPath: '$(Build.ArtifactStagingDirectory)'
-          artifact: pester-package
+          artifact: pester-packages


### PR DESCRIPTION
Follow-up to #2777.

`publish/release.ps1` produces **two** package variants in separate folders, but only one was captured as an artifact:

- `tmp/nuget/Pester.<version>.nupkg` — the signed package pushed to **nuget.org + Chocolatey** (already captured by #2777).
- `tmp/PSGallery/Pester/` — the module folder published to the **PowerShell Gallery** via `Publish-Module` (was **not** captured).

This stages both variants and publishes them under a single `pester-packages` artifact, each in its own subfolder:

```
pester-packages/
  nuget/      # Pester.<version>.nupkg (nuget.org + Chocolatey)
  psgallery/  # Pester/ module folder (PSGallery)
```

Both staging steps keep `condition: succeededOrFailed()` so the signed packages are retained even if a push fails, and `continueOnError: true` so a missing folder from an early failure doesn't mask the original error.

The pipeline remains `trigger: none` (manual), so this takes effect on the next publish run.