### PR TITLE
Publish the whole tmp output folder as a pipeline artifact

### DIFF
--- a/azure-pipelines-publish.yml
+++ b/azure-pipelines-publish.yml
@@ -20,27 +20,9 @@ jobs:
           inlineScript: |
             .\publish\release.ps1 -PsGalleryApiKey '$(PsGalleryApiKey)' -NugetApiKey '$(NugetApiKey)' -ChocolateyApiKey '$(ChocolateyApiKey)' -TenantId '$(TenantId)' -VaultUrl '$(SigningVaultURL)' -CertificateName '$(SigningCertName)'
 
-      - task: CopyFiles@2
-        displayName: Stage NuGet and Chocolatey package
-        condition: succeededOrFailed()
-        continueOnError: true
-        inputs:
-          sourceFolder: '$(Build.SourcesDirectory)/tmp/nuget'
-          contents: '*.nupkg'
-          targetFolder: '$(Build.ArtifactStagingDirectory)/nuget'
-
-      - task: CopyFiles@2
-        displayName: Stage PSGallery module
-        condition: succeededOrFailed()
-        continueOnError: true
-        inputs:
-          sourceFolder: '$(Build.SourcesDirectory)/tmp/PSGallery'
-          contents: '**'
-          targetFolder: '$(Build.ArtifactStagingDirectory)/psgallery'
-
       - task: PublishPipelineArtifact@1
         displayName: Publish built packages
         condition: succeededOrFailed()
         inputs:
-          targetPath: '$(Build.ArtifactStagingDirectory)'
+          targetPath: '$(Build.SourcesDirectory)/tmp'
           artifact: pester-packages


### PR DESCRIPTION
Follow-up to #2777 and #2778.

Filtering individual files kept only one nupkg visible in the artifact. `publish/release.ps1` puts every package variant under `tmp/`:

- `tmp/nuget/Pester.<version>.nupkg` — signed package for **nuget.org + Chocolatey**
- `tmp/PSGallery/Pester/` — module folder published to the **PowerShell Gallery**

Instead of cherry-picking files, this publishes the **entire `tmp/` folder** as the `pester-packages` artifact, so the signed nupkg and every variant are captured. `condition: succeededOrFailed()` keeps the output even if a push fails.

The signed nupkg lands at `pester-packages/nuget/Pester.<version>.nupkg`.

Still `trigger: none` (manual), so it applies on the next publish run.