### PR TITLE
Capture the PowerShell Gallery package as a build artifact

### DIFF
--- a/publish/release.ps1
+++ b/publish/release.ps1
@@ -132,6 +132,31 @@ if (0 -ne $LASTEXITCODE) {
     throw "Failed to verify nupkg"
 }
 
+# Pack the PowerShell Gallery module into a .nupkg under tmp/ so the exact package we publish
+# is captured as a build artifact. Publish-Module otherwise packs into a random system temp
+# folder and discards it, so a failed gallery push leaves us with no package to inspect or
+# publish manually. Do this before the gallery push, because that push aborts the script on
+# failure (ErrorActionPreference = 'Stop').
+$psGalleryPackageDir = "$PSScriptRoot/../tmp/PSGallery-package"
+if (Test-Path $psGalleryPackageDir) {
+    Remove-Item -Recurse -Force $psGalleryPackageDir
+}
+$null = New-Item -ItemType Directory -Path $psGalleryPackageDir
+
+$localRepository = 'PesterLocalPublish'
+try {
+    Get-PSRepository -Name $localRepository -ErrorAction SilentlyContinue | Unregister-PSRepository
+    Register-PSRepository -Name $localRepository -SourceLocation $psGalleryPackageDir -PublishLocation $psGalleryPackageDir -InstallationPolicy Trusted
+    Publish-Module -Path $psGalleryDir -Repository $localRepository -NuGetApiKey 'local' -Verbose -Force
+    Write-Host "Saved PowerShell Gallery package to $psGalleryPackageDir"
+}
+catch {
+    Write-Warning "Failed to capture local PowerShell Gallery package: $_"
+}
+finally {
+    Get-PSRepository -Name $localRepository -ErrorAction SilentlyContinue | Unregister-PSRepository
+}
+
 Publish-Module -Path $psGalleryDir -NuGetApiKey $PsGalleryApiKey -Verbose -Force
 
 if (-not $isPreRelease -or $Force) {


### PR DESCRIPTION
## Problem

The publish pipeline artifact only contained the nuget.org/Chocolatey nupkg (`tmp/nuget/Pester.<version>.nupkg`), never the PowerShell Gallery one.

`Publish-Module` packs the gallery module into a **random system temp folder** and discards it after the push:

```
C:\Users\VssAdministrator\AppData\Local\Temp\821736127\Pester\Pester.6.0.0-rc1.nupkg
```

That path is outside `tmp/`, so the artifact upload (which captures `tmp/`) never sees it. When the gallery push fails — as it did with `403 (The specified API key is invalid, has expired, or does not have permission...)` — the agent is torn down and the signed package is gone. Nothing overwrites it; it's simply never written under `tmp/`.

## Fix

Before the gallery push, pack the module into `tmp/PSGallery-package/` via a temporary local `PSRepository`. This produces the **exact** PowerShell Gallery–format `.nupkg` (same packing logic as `Publish-Module`) and saves it where the pipeline artifact already looks, so it's captured **even when the gallery push fails**.

The capture is wrapped in try/catch/finally so its own failure never blocks the real publish, and the temporary repository is always unregistered.

After this, the artifact contains:

```
pester-packages/
  nuget/             Pester.<version>.nupkg   (nuget.org + Chocolatey)
  PSGallery-package/ Pester.<version>.nupkg   (PowerShell Gallery)  ← new
  PSGallery/Pester/  (unpacked module folder)
```

## Note

The `403` means the `PsGalleryApiKey` variable in the AzDO `signing` group is invalid/expired and needs rotating. This PR doesn't fix that — it ensures the signed gallery package is always downloadable so it can be published manually in the meantime.

Pipeline stays `trigger: none` (manual), so this applies on the next publish run.