### PR TITLE
Bump prerelease to rc2

### DIFF
--- a/src/Pester.psd1
+++ b/src/Pester.psd1
@@ -169,10 +169,10 @@
             LicenseUri   = "https://www.apache.org/licenses/LICENSE-2.0.html"
 
             # Release notes for this particular version of the module
-            ReleaseNotes = 'https://github.com/pester/Pester/releases/tag/6.0.0-rc1'
+            ReleaseNotes = 'https://github.com/pester/Pester/releases/tag/6.0.0-rc2'
 
             # Prerelease string of this module
-            Prerelease   = 'rc1'
+            Prerelease   = 'rc2'
         }
 
         # Minimum assembly version required


### PR DESCRIPTION
## Summary

Bumps the module prerelease from `rc1` to `rc2` so we can run the publish pipeline for `6.0.0-rc2`.

### Changes
- `src/Pester.psd1`:
  - `PrivateData.PSData.Prerelease`: `rc1` → `rc2`
  - `ReleaseNotes` URL: `.../tag/6.0.0-rc1` → `.../tag/6.0.0-rc2`