### PR TITLE
Bump to 5.8.0

### DIFF
--- a/src/Pester.psd1
+++ b/src/Pester.psd1
@@ -4,7 +4,7 @@
     RootModule        = 'Pester.psm1'
 
     # Version number of this module.
-    ModuleVersion     = '5.7.1'
+    ModuleVersion     = '5.8.0'
 
     # ID used to uniquely identify this module
     GUID              = 'a699dea5-2c73-4616-a270-1f7abb777e71'
@@ -16,7 +16,7 @@
     CompanyName       = 'Pester'
 
     # Copyright statement for this module
-    Copyright         = 'Copyright (c) 2025 by Pester Team, licensed under Apache 2.0 License.'
+    Copyright         = 'Copyright (c) 2026 by Pester Team, licensed under Apache 2.0 License.'
 
     # Description of the functionality provided by this module
     Description       = 'Pester provides a framework for running BDD style Tests to execute and validate PowerShell commands inside of PowerShell and offers a powerful set of Mocking Functions that allow tests to mimic and mock the functionality of any command inside of a piece of PowerShell code being tested. Pester tests can execute any command or script that is accessible to a pester test file. This can include functions, Cmdlets, Modules and scripts. Pester can be run in ad hoc style in a console or it can be integrated into the Build scripts of a Continuous Integration system.'
@@ -116,7 +116,7 @@
             LicenseUri   = "https://www.apache.org/licenses/LICENSE-2.0.html"
 
             # Release notes for this particular version of the module
-            ReleaseNotes = 'https://github.com/pester/Pester/releases/tag/5.7.1'
+            ReleaseNotes = 'https://github.com/pester/Pester/releases/tag/5.8.0'
 
             # Prerelease string of this module
             Prerelease   = ''


### PR DESCRIPTION
Branding bump for the 5.8.0 release on `rel/5.x.x`. Updates `src/Pester.psd1`:

- `ModuleVersion` 5.7.1 → **5.8.0**
- `Copyright` year 2025 → **2026**
- `ReleaseNotes` URL → `releases/tag/5.8.0`

5.8.0 is a minor bump because it adds a new configuration option (`Debug.ShowStartMarkers`, #2619), consistent with past practice (e.g. `CodeCoverage.ExcludeTests` shipped in 5.7.0). Release notes are staged as a draft release.