### PR TITLE
Add option to skip tests in publish pipeline

### DIFF
--- a/azure-pipelines-publish.yml
+++ b/azure-pipelines-publish.yml
@@ -1,5 +1,11 @@
 trigger: none
 
+parameters:
+  - name: skipTests
+    displayName: Skip tests
+    type: boolean
+    default: false
+
 variables:
   - group: signing
   - group: publishing
@@ -19,7 +25,7 @@ jobs:
           scriptType: ps
           scriptLocation: inlineScript
           inlineScript: |
-            .\publish\release.ps1 -PsGalleryApiKey '$(PsGalleryApiKey)' -NugetApiKey '$(NugetApiKey)' -ChocolateyApiKey '$(ChocolateyApiKey)' -TenantId '$(TenantId)' -VaultUrl '$(SigningVaultURL)' -CertificateName '$(SigningCertName)'
+            .\publish\release.ps1 -PsGalleryApiKey '$(PsGalleryApiKey)' -NugetApiKey '$(NugetApiKey)' -ChocolateyApiKey '$(ChocolateyApiKey)' -TenantId '$(TenantId)' -VaultUrl '$(SigningVaultURL)' -CertificateName '$(SigningCertName)' -SkipTests:$${{ parameters.skipTests }}
 
       - task: PublishPipelineArtifact@1
         displayName: Publish built packages

--- a/publish/release.ps1
+++ b/publish/release.ps1
@@ -7,7 +7,8 @@ param (
     [String] $TenantId,
     [String] $VaultUrl,
     [String] $CertificateName,
-    [Switch] $Force
+    [Switch] $Force,
+    [Switch] $SkipTests
 )
 
 $ErrorActionPreference = 'Stop'
@@ -44,9 +45,14 @@ if (-not $isPreRelease -or $Force) {
     }
 }
 
-pwsh -noprofile -c "$PSSCriptRoot/../test.ps1 -nobuild"
-if ($LASTEXITCODE -ne 0) {
-    throw "test failed!"
+if ($SkipTests) {
+    Write-Host "Skipping tests because -SkipTests was specified."
+}
+else {
+    pwsh -noprofile -c "$PSSCriptRoot/../test.ps1 -nobuild"
+    if ($LASTEXITCODE -ne 0) {
+        throw "test failed!"
+    }
 }
 
 pwsh -noprofile -c "$PSScriptRoot/../build.ps1 -Inline"


### PR DESCRIPTION
Adds a way to publish a release without re-running the full test suite from the publish pipeline.

- New `skipTests` boolean parameter on `azure-pipelines-publish.yml` (shown as a checkbox when manually running the publish pipeline, default **false** so normal runs still test).
- New `-SkipTests` switch on `publish/release.ps1` that skips the `test.ps1 -nobuild` step when set.

The pipeline passes `-SkipTests:$${{ parameters.skipTests }}` so the switch follows the checkbox. Default behaviour is unchanged.

The same change is applied to `rel/5.x.x` in a separate PR.