### PR TITLE
Mirror publish-pipeline artifact capture and add skip-tests option to rel/5.x.x

### DIFF
--- a/azure-pipelines-publish.yml
+++ b/azure-pipelines-publish.yml
@@ -1,5 +1,11 @@
 trigger: none
 
+parameters:
+  - name: skipTests
+    displayName: Skip tests
+    type: boolean
+    default: false
+
 variables:
   - group: signing
   - group: publishing
@@ -19,7 +25,7 @@ jobs:
           scriptType: ps
           scriptLocation: inlineScript
           inlineScript: |
-            .\publish\release.ps1 -PsGalleryApiKey '$(PsGalleryApiKey)' -NugetApiKey '$(NugetApiKey)' -ChocolateyApiKey '$(ChocolateyApiKey)' -TenantId '$(TenantId)' -VaultUrl '$(SigningVaultURL)' -CertificateName '$(SigningCertName)'
+            .\publish\release.ps1 -PsGalleryApiKey '$(PsGalleryApiKey)' -NugetApiKey '$(NugetApiKey)' -ChocolateyApiKey '$(ChocolateyApiKey)' -TenantId '$(TenantId)' -VaultUrl '$(SigningVaultURL)' -CertificateName '$(SigningCertName)' -SkipTests:$${{ parameters.skipTests }}
 
       - task: PublishPipelineArtifact@1
         displayName: Publish built packages

--- a/azure-pipelines-publish.yml
+++ b/azure-pipelines-publish.yml
@@ -2,6 +2,7 @@ trigger: none
 
 variables:
   - group: signing
+  - group: publishing
 
 jobs:
   - job: build
@@ -19,3 +20,10 @@ jobs:
           scriptLocation: inlineScript
           inlineScript: |
             .\publish\release.ps1 -PsGalleryApiKey '$(PsGalleryApiKey)' -NugetApiKey '$(NugetApiKey)' -ChocolateyApiKey '$(ChocolateyApiKey)' -TenantId '$(TenantId)' -VaultUrl '$(SigningVaultURL)' -CertificateName '$(SigningCertName)'
+
+      - task: PublishPipelineArtifact@1
+        displayName: Publish built packages
+        condition: succeededOrFailed()
+        inputs:
+          targetPath: '$(Build.SourcesDirectory)/tmp'
+          artifact: pester-packages

--- a/publish/release.ps1
+++ b/publish/release.ps1
@@ -132,6 +132,31 @@ if (0 -ne $LASTEXITCODE) {
     throw "Failed to verify nupkg"
 }
 
+# Pack the PowerShell Gallery module into a .nupkg under tmp/ so the exact package we publish
+# is captured as a build artifact. Publish-Module otherwise packs into a random system temp
+# folder and discards it, so a failed gallery push leaves us with no package to inspect or
+# publish manually. Do this before the gallery push, because that push aborts the script on
+# failure (ErrorActionPreference = 'Stop').
+$psGalleryPackageDir = "$PSScriptRoot/../tmp/PSGallery-package"
+if (Test-Path $psGalleryPackageDir) {
+    Remove-Item -Recurse -Force $psGalleryPackageDir
+}
+$null = New-Item -ItemType Directory -Path $psGalleryPackageDir
+
+$localRepository = 'PesterLocalPublish'
+try {
+    Get-PSRepository -Name $localRepository -ErrorAction SilentlyContinue | Unregister-PSRepository
+    Register-PSRepository -Name $localRepository -SourceLocation $psGalleryPackageDir -PublishLocation $psGalleryPackageDir -InstallationPolicy Trusted
+    Publish-Module -Path $psGalleryDir -Repository $localRepository -NuGetApiKey 'local' -Verbose -Force
+    Write-Host "Saved PowerShell Gallery package to $psGalleryPackageDir"
+}
+catch {
+    Write-Warning "Failed to capture local PowerShell Gallery package: $_"
+}
+finally {
+    Get-PSRepository -Name $localRepository -ErrorAction SilentlyContinue | Unregister-PSRepository
+}
+
 Publish-Module -Path $psGalleryDir -NuGetApiKey $PsGalleryApiKey -Verbose -Force
 
 if (-not $isPreRelease -or $Force) {

--- a/publish/release.ps1
+++ b/publish/release.ps1
@@ -7,7 +7,8 @@ param (
     [String] $TenantId,
     [String] $VaultUrl,
     [String] $CertificateName,
-    [Switch] $Force
+    [Switch] $Force,
+    [Switch] $SkipTests
 )
 
 $ErrorActionPreference = 'Stop'
@@ -44,9 +45,14 @@ if (-not $isPreRelease -or $Force) {
     }
 }
 
-pwsh -noprofile -c "$PSSCriptRoot/../test.ps1 -nobuild"
-if ($LASTEXITCODE -ne 0) {
-    throw "test failed!"
+if ($SkipTests) {
+    Write-Host "Skipping tests because -SkipTests was specified."
+}
+else {
+    pwsh -noprofile -c "$PSSCriptRoot/../test.ps1 -nobuild"
+    if ($LASTEXITCODE -ne 0) {
+        throw "test failed!"
+    }
 }
 
 pwsh -noprofile -c "$PSScriptRoot/../build.ps1 -Inline"


### PR DESCRIPTION
Brings the `rel/5.x.x` publish pipeline in line with `main` so 5.x releases (e.g. 5.8.0) can be published with the same tooling, and adds the skip-tests option.

### Mirror publish-pipeline artifact capture (from main #2777–#2784)
- Add the `publishing` variable group.
- Publish the `tmp` output folder as the `pester-packages` pipeline artifact (`succeededOrFailed`).
- Save the exact PowerShell Gallery package under `tmp/PSGallery-package` before the gallery push, so a failed push still leaves an inspectable/publishable package.

### Add option to skip tests
- New `skipTests` boolean parameter on `azure-pipelines-publish.yml`.
- New `-SkipTests` switch on `publish/release.ps1` that skips the `test.ps1 -nobuild` step.

After this PR the publish pipeline files are byte-identical to `main` (which gets the skip-tests option in #2787). Default behaviour is unchanged (tests run unless skipped).