### PR TITLE
Update devcontainer to latest .NET 8 image

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,7 @@
 // For format details, see https://aka.ms/vscode-remote/devcontainer.json
 {
 	"name": "Pester",
-	"image": "mcr.microsoft.com/devcontainers/dotnet:1-8.0-jammy",
+	"image": "mcr.microsoft.com/devcontainers/dotnet:2-8.0-noble",
 	"remoteUser": "vscode",
 	"customizations": {
 		"codespaces": {


### PR DESCRIPTION
## PR Summary

Current devcontainer failed tests with `Start-Job`because bundled pwsh 7.4.12 is broken for non-root users (missing execute permission). Updated to latet .NET 8 devcontainer which includes a fixed pwsh 7.4.16 

## PR Checklist

- [x] PR has meaningful title
- [x] Summary describes changes
- [x] PR is ready to be merged
  - If not, use the arrow next to `Create Pull Request` to mark it as a draft. PR can be marked `Ready for review` when it's ready.
- [ ] Tests are added/update *(if required)*
- [ ] Documentation is updated/added *(if required)*