### PR TITLE
Use supported CI images on rel/5.x.x

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -82,20 +82,23 @@ stages:
             PS7_Ubuntu_24_04:
               vmImage: ubuntu-24.04
               pwsh: true
-            PS7_macOS_13:
-              vmImage: macOS-13
-              pwsh: true
             PS7_macOS_14:
               vmImage: macOS-14
               pwsh: true
-            PS7_Windows_Server2019:
-              vmImage: windows-2019
+            PS7_macOS_15:
+              vmImage: macOS-15
               pwsh: true
             PS7_Windows_Server2022:
               vmImage: windows-2022
               pwsh: true
             PS_5_1_Windows_Server2022:
               vmImage: windows-2022
+              pwsh: false
+            PS7_Windows_Server2025:
+              vmImage: windows-2025
+              pwsh: true
+            PS_5_1_Windows_Server2025:
+              vmImage: windows-2025
               pwsh: false
         pool:
           vmImage: $[ variables['vmImage'] ]


### PR DESCRIPTION
The 5.x.x build fails at the Test stage with:

```
##[error]No image label found to route agent pool Azure Pipelines.
```

This is because the Microsoft-hosted **`windows-2019`** image (used by the `PS7_Windows_Server2019` matrix leg) has been retired, so the pool can no longer route the job. The aging `macOS-13` image is in the same boat.

This aligns the hosted-image matrix with the supported set already used on `main` (#2676):

| | before | after |
|---|---|---|
| macOS | macOS-13, macOS-14 | macOS-14, macOS-15 |
| Windows (PS7) | windows-2019, windows-2022 | windows-2022, windows-2025 |
| Windows (PS 5.1) | windows-2022 | windows-2022, windows-2025 |

Ubuntu legs are unchanged. The self-hosted **PS3 / PS4 / PS6.2** legs run on the `Default` pool (custom agents, not the `Azure Pipelines` hosted pool) and are intentionally left as-is, since Pester 5 still tests those.