### PR TITLE
Fix parallel run durations + data passing, Should-Invoke mock error name, and ForEach null suggestion

### DIFF
--- a/src/Main.ps1
+++ b/src/Main.ps1
@@ -663,7 +663,8 @@ function Invoke-Pester {
             # If every file opted out with #pester:no-parallel, the run is effectively sequential,
             # so fall through to the sequential path - which fires the framework's own global
             # plugin steps at the correct interleaved points.
-            if ($useParallel -and $parallelSupported -and $allFileContainers -and -not $coverageEnabled -and -not $skipRemainingRunScope -and 0 -lt $parallelContainers.Count) {
+            $ranInParallel = $useParallel -and $parallelSupported -and $allFileContainers -and -not $coverageEnabled -and -not $skipRemainingRunScope -and 0 -lt $parallelContainers.Count
+            if ($ranInParallel) {
                 $foldedContainers = [System.Collections.Generic.List[object]]@()
                 $hasNonParallel = 0 -lt $nonParallelContainers.Count
 
@@ -866,7 +867,7 @@ function Invoke-Pester {
                 $run.Containers.Add($i)
             }
 
-            PostProcess-RSpecTestRun -TestRun $run
+            PostProcess-RSpecTestRun -TestRun $run -Parallel:$ranInParallel
 
             $steps = $Plugins.End
             if ($null -ne $steps -and 0 -lt @($steps).Count) {

--- a/src/Pester.RSpec.ps1
+++ b/src/Pester.RSpec.ps1
@@ -178,7 +178,7 @@ function Add-RSpecBlockObjectProperties ($BlockObject) {
     }
 }
 
-function PostProcess-RspecTestRun ($TestRun) {
+function PostProcess-RspecTestRun ($TestRun, [switch] $Parallel) {
     $discoveryOnly = $PesterPreference.Run.SkipRun.Value
 
     Fold-Run $Run -OnTest {
@@ -276,10 +276,20 @@ function PostProcess-RspecTestRun ($TestRun) {
             $TestRun.FailedContainers.Add($b)
         }
 
-        $TestRun.Duration += $b.Duration
-        $TestRun.UserDuration += $b.UserDuration
-        $TestRun.FrameworkDuration += $b.FrameworkDuration
-        $TestRun.DiscoveryDuration += $b.DiscoveryDuration
+        # Container durations are summed for a sequential run, where they don't overlap. In a
+        # parallel run the files execute simultaneously, so summing overstates the totals - the
+        # real wall-clock duration (RunEnd - RunStart) is used instead and the per-phase totals
+        # are left blank because they would require excluding overlapping time between containers.
+        if (-not $Parallel) {
+            $TestRun.Duration += $b.Duration
+            $TestRun.UserDuration += $b.UserDuration
+            $TestRun.FrameworkDuration += $b.FrameworkDuration
+            $TestRun.DiscoveryDuration += $b.DiscoveryDuration
+        }
+    }
+
+    if ($Parallel) {
+        $TestRun.Duration = [DateTime]::Now - $TestRun.ExecutedAt
     }
 
     $TestRun.PassedCount = $TestRun.Passed.Count

--- a/src/functions/Context.ps1
+++ b/src/functions/Context.ps1
@@ -116,7 +116,7 @@
         if ($PSBoundParameters.ContainsKey('ForEach')) {
             if ($null -eq $ForEach -or 0 -eq @($ForEach).Count) {
                 if ($PesterPreference.Run.FailOnNullOrEmptyForEach.Value -and -not $AllowNullOrEmptyForEach) {
-                    throw [System.ArgumentException]::new('Value can not be null or empty array. If this is expected, use -AllowNullOrEmptyForEach', 'ForEach')
+                    throw [System.ArgumentException]::new('Value can not be null or empty array. If this is expected, use -AllowNullOrEmptyForEach on this Context, or set the Run.FailOnNullOrEmptyForEach configuration option to $false to allow it for the whole run.', 'ForEach')
                 }
                 # @() or $null is provided and allowed, do nothing
                 return

--- a/src/functions/Describe.ps1
+++ b/src/functions/Describe.ps1
@@ -124,7 +124,7 @@
         if ($PSBoundParameters.ContainsKey('ForEach')) {
             if ($null -eq $ForEach -or 0 -eq @($ForEach).Count) {
                 if ($PesterPreference.Run.FailOnNullOrEmptyForEach.Value -and -not $AllowNullOrEmptyForEach) {
-                    throw [System.ArgumentException]::new('Value can not be null or empty array. If this is expected, use -AllowNullOrEmptyForEach', 'ForEach')
+                    throw [System.ArgumentException]::new('Value can not be null or empty array. If this is expected, use -AllowNullOrEmptyForEach on this Describe, or set the Run.FailOnNullOrEmptyForEach configuration option to $false to allow it for the whole run.', 'ForEach')
                 }
                 # @() or $null is provided and allowed, do nothing
                 return

--- a/src/functions/It.ps1
+++ b/src/functions/It.ps1
@@ -157,7 +157,7 @@
     if ($PSBoundParameters.ContainsKey('ForEach')) {
         if ($null -eq $ForEach -or 0 -eq @($ForEach).Count) {
             if ($PesterPreference.Run.FailOnNullOrEmptyForEach.Value -and -not $AllowNullOrEmptyForEach) {
-                throw [System.ArgumentException]::new('Value can not be null or empty array. If this is expected, use -AllowNullOrEmptyForEach', 'ForEach')
+                throw [System.ArgumentException]::new('Value can not be null or empty array. If this is expected, use -AllowNullOrEmptyForEach on this It, or set the Run.FailOnNullOrEmptyForEach configuration option to $false to allow it for the whole run.', 'ForEach')
             }
             # @() or $null is provided and allowed, do nothing
             return

--- a/src/functions/Pester.Parallel.ps1
+++ b/src/functions/Pester.Parallel.ps1
@@ -169,6 +169,7 @@ function Invoke-TestInParallel {
     $work = @(foreach ($c in $BlockContainer) {
             [PSCustomObject]@{
                 Path = $c.Item.FullName
+                Data = $c.Data
                 Init = $beforeContainerInit
             }
         })
@@ -228,7 +229,17 @@ function Invoke-TestInParallel {
         }
 
         $workerConfig = [PesterConfiguration]::Merge([PesterConfiguration]::Default, $baseConfig)
-        $workerConfig.Run.Path = $item.Path
+        # Pass the file together with its -Data so parametrized containers (New-PesterContainer
+        # -Path ... -Data @{ ... }) bind the file's param() block the same way they do sequentially.
+        # Run them by reference - ForEach-Object -Parallel uses runspaces in the same process, so the
+        # Data values (including live objects) cross unchanged. When there is no Data, point at the
+        # path directly, which behaves identically to a plain file run.
+        if (($item.Data -is [System.Collections.IDictionary]) -and 0 -lt $item.Data.Count) {
+            $workerConfig.Run.Container = New-PesterContainer -Path $item.Path -Data $item.Data
+        }
+        else {
+            $workerConfig.Run.Path = $item.Path
+        }
         $workerConfig.Run.Parallel = $false
         $workerConfig.Run.PassThru = $true
         $workerConfig.Run.Exit = $false

--- a/src/functions/Pester.SessionState.Mock.ps1
+++ b/src/functions/Pester.SessionState.Mock.ps1
@@ -930,7 +930,7 @@ function Should-InvokeAssertion {
     # no history.
     $contextInfo = Resolve-Command $CommandName $ModuleName -SessionState $SessionState
     if ($null -eq $contextInfo.Hook) {
-        throw "Should -Invoke: Could not find Mock for command $CommandName in $(if ([string]::IsNullOrEmpty($ModuleName)){ "script scope" } else { "module $ModuleName" }). Was the mock defined? Did you use the same -ModuleName as on the Mock? When using InModuleScope are InModuleScope, Mock and Should -Invoke using the same -ModuleName?"
+        throw "Should-Invoke: Could not find Mock for command $CommandName in $(if ([string]::IsNullOrEmpty($ModuleName)){ "script scope" } else { "module $ModuleName" }). Was the mock defined? Did you use the same -ModuleName as on the Mock? When using InModuleScope are InModuleScope, Mock and Should-Invoke using the same -ModuleName?"
     }
     $resolvedModule = $contextInfo.TargetModule
     $resolvedCommand = $contextInfo.Command.Name

--- a/tst/Pester.Mock.RSpec.ts.ps1
+++ b/tst/Pester.Mock.RSpec.ts.ps1
@@ -1046,7 +1046,7 @@ i -PassThru:$PassThru {
                         Mock Start-Job -ModuleName m
 
                         # trying to assert on command that is not mocked in script scope
-                        Should -Invoke Start-Job
+                        Should-Invoke Start-Job
                     }
                 }
             }
@@ -1063,7 +1063,7 @@ i -PassThru:$PassThru {
 
             $t = $r.Containers[0].Blocks[0].Tests[0]
             $t.Result | Verify-Equal "Failed"
-            $t.ErrorRecord[0] | Verify-Equal 'Should -Invoke: Could not find Mock for command Start-Job in script scope. Was the mock defined? Did you use the same -ModuleName as on the Mock? When using InModuleScope are InModuleScope, Mock and Should -Invoke using the same -ModuleName?'
+            $t.ErrorRecord[0] | Verify-Equal 'Should-Invoke: Could not find Mock for command Start-Job in script scope. Was the mock defined? Did you use the same -ModuleName as on the Mock? When using InModuleScope are InModuleScope, Mock and Should-Invoke using the same -ModuleName?'
         }
     }
 

--- a/tst/Pester.RSpec.Parallel.ts.ps1
+++ b/tst/Pester.RSpec.Parallel.ts.ps1
@@ -139,6 +139,33 @@ Describe 'Slow2' { BeforeAll { Start-Sleep -Milliseconds 600 }; It 'p' { 1 | Sho
         }
     }
 
+    b "Run.Parallel data passing" {
+        t "passes container -Data to each parallel worker's param() block" {
+            # New-PesterContainer -Path ... -Data must bind the file's param() block under parallel
+            # the same way it does sequentially. (#2793)
+            $folder = Join-Path ([IO.Path]::GetTempPath()) ([Guid]::NewGuid().Guid)
+            $null = New-Item -ItemType Directory -Path $folder -Force
+            foreach ($n in 1..2) {
+                Set-Content -Path (Join-Path $folder "Data$n.Tests.ps1") -Value @'
+param([Parameter(Mandatory)][ValidateNotNullOrEmpty()][string] $Module, $Data)
+Describe 'D' { It 'sees data' { $Module | Should -Be 'hello'; $Data.k | Should -Be 42 } }
+'@
+            }
+            try {
+                $c = [PesterConfiguration]::Default
+                $c.Run.Container = New-PesterContainer -Path $folder -Data @{ Module = 'hello'; Data = @{ k = 42 } }
+                $c.Run.Parallel = $true
+                $c.Run.PassThru = $true
+                $c.Output.Verbosity = 'None'
+                $r = Invoke-Pester -Configuration $c
+
+                $r.PassedCount | Verify-Equal 2
+                $r.FailedCount | Verify-Equal 0
+            }
+            finally { Remove-Item -Path $folder -Recurse -Force }
+        }
+    }
+
     b "Run.BeforeContainer" {
         t "runs the repo-root Pester.BeforeContainer.ps1 before each file in a sequential run" {
             $folder = New-BeforeContainerTestFolder

--- a/tst/Pester.RSpec.Parallel.ts.ps1
+++ b/tst/Pester.RSpec.Parallel.ts.ps1
@@ -103,6 +103,42 @@ i -PassThru:$PassThru {
         }
     }
 
+    b "Run duration in parallel mode" {
+        t "uses wall-clock duration and leaves per-phase totals blank instead of summing containers" {
+            # Two files that each sleep run sequentially would total ~1.2s; in parallel the wall-clock
+            # is closer to a single file, so summing container durations overstates the run. (#2794)
+            $folder = Join-Path ([IO.Path]::GetTempPath()) ([Guid]::NewGuid().Guid)
+            $null = New-Item -ItemType Directory -Path $folder -Force
+            Set-Content -Path (Join-Path $folder 'Slow1.Tests.ps1') -Value @'
+Describe 'Slow1' { BeforeAll { Start-Sleep -Milliseconds 600 }; It 'p' { 1 | Should -Be 1 } }
+'@
+            Set-Content -Path (Join-Path $folder 'Slow2.Tests.ps1') -Value @'
+Describe 'Slow2' { BeforeAll { Start-Sleep -Milliseconds 600 }; It 'p' { 1 | Should -Be 1 } }
+'@
+            try {
+                $c = [PesterConfiguration]::Default
+                $c.Run.Path = $folder
+                $c.Run.Parallel = $true
+                $c.Run.PassThru = $true
+                $c.Output.Verbosity = 'None'
+                $r = Invoke-Pester -Configuration $c
+
+                if ($PSVersionTable.PSVersion.Major -ge 7) {
+                    $containerSum = [TimeSpan]::Zero
+                    foreach ($container in $r.Containers) { $containerSum += $container.Duration }
+                    # Wall-clock run duration is less than the naive sum of the two slow files.
+                    ($r.Duration -lt $containerSum) | Verify-True
+                    ($r.Duration -gt [TimeSpan]::Zero) | Verify-True
+                    # Per-phase totals are left blank because containers overlap.
+                    $r.UserDuration | Verify-Equal ([TimeSpan]::Zero)
+                    $r.FrameworkDuration | Verify-Equal ([TimeSpan]::Zero)
+                    $r.DiscoveryDuration | Verify-Equal ([TimeSpan]::Zero)
+                }
+            }
+            finally { Remove-Item -Path $folder -Recurse -Force }
+        }
+    }
+
     b "Run.BeforeContainer" {
         t "runs the repo-root Pester.BeforeContainer.ps1 before each file in a sequential run" {
             $folder = New-BeforeContainerTestFolder

--- a/tst/Pester.RSpec.ts.ps1
+++ b/tst/Pester.RSpec.ts.ps1
@@ -1829,6 +1829,8 @@ i -PassThru:$PassThru {
             $r.Result = 'Failed'
             $r.Containers[0].Result = 'Failed'
             $r.Containers[0].ErrorRecord.Exception | Verify-Type ([System.ArgumentException])
+            $r.Containers[0].ErrorRecord.Exception.Message -match 'AllowNullOrEmptyForEach' | Verify-True
+            $r.Containers[0].ErrorRecord.Exception.Message -match 'FailOnNullOrEmptyForEach' | Verify-True
             $r.Containers[1].Result = 'Failed'
             $r.Containers[1].ErrorRecord.Exception | Verify-Type ([System.ArgumentException])
         }
@@ -1950,6 +1952,8 @@ i -PassThru:$PassThru {
             $r.Containers[1].ErrorRecord.Exception | Verify-Type ([System.ArgumentException])
             $r.Containers[2].Result = 'Failed'
             $r.Containers[2].ErrorRecord.Exception | Verify-Type ([System.ArgumentException])
+            $r.Containers[2].ErrorRecord.Exception.Message -match 'AllowNullOrEmptyForEach' | Verify-True
+            $r.Containers[2].ErrorRecord.Exception.Message -match 'FailOnNullOrEmptyForEach' | Verify-True
             $r.Containers[3].Result = 'Failed'
             $r.Containers[3].ErrorRecord.Exception | Verify-Type ([System.ArgumentException])
         }


### PR DESCRIPTION
Four recent 6.0.0 reports:

- **Parallel total durations** — container durations were summed, which overstates a parallel run since files overlap. Use the wall-clock duration (RunEnd − RunStart) for `Run.Duration` and leave the per-phase totals blank in parallel mode. Fix #2794
- **Pass data to parallel runs** — `Run.Parallel` sent only the file path to each worker, so `New-PesterContainer -Path … -Data @{…}` dropped its data and parametrized files failed discovery on missing mandatory params. Workers now rebuild a data-bearing container when data is present. Fix #2793
- **Should-Invoke error** — the "could not find mock" message said `Should -Invoke`. Now `Should-Invoke`. Fix #2792
- **Empty/null `-ForEach`** — the throw now also points at `Run.FailOnNullOrEmptyForEach`, not just `-AllowNullOrEmptyForEach`. Fix #2782

Added parallel duration + data tests and tightened the mock/ForEach tests. The 3 unrelated `SkipRemainingOnFailure` test failures are pre-existing on main.