### PR TITLE
Pass data to parallel runs

### DIFF
--- a/src/functions/Pester.Parallel.ps1
+++ b/src/functions/Pester.Parallel.ps1
@@ -169,6 +169,7 @@ function Invoke-TestInParallel {
     $work = @(foreach ($c in $BlockContainer) {
             [PSCustomObject]@{
                 Path = $c.Item.FullName
+                Data = $c.Data
                 Init = $beforeContainerInit
             }
         })
@@ -228,7 +229,17 @@ function Invoke-TestInParallel {
         }
 
         $workerConfig = [PesterConfiguration]::Merge([PesterConfiguration]::Default, $baseConfig)
-        $workerConfig.Run.Path = $item.Path
+        # Pass the file together with its -Data so parametrized containers (New-PesterContainer
+        # -Path ... -Data @{ ... }) bind the file's param() block the same way they do sequentially.
+        # Run them by reference - ForEach-Object -Parallel uses runspaces in the same process, so the
+        # Data values (including live objects) cross unchanged. When there is no Data, point at the
+        # path directly, which behaves identically to a plain file run.
+        if (($item.Data -is [System.Collections.IDictionary]) -and 0 -lt $item.Data.Count) {
+            $workerConfig.Run.Container = New-PesterContainer -Path $item.Path -Data $item.Data
+        }
+        else {
+            $workerConfig.Run.Path = $item.Path
+        }
         $workerConfig.Run.Parallel = $false
         $workerConfig.Run.PassThru = $true
         $workerConfig.Run.Exit = $false

--- a/tst/Pester.RSpec.Parallel.ts.ps1
+++ b/tst/Pester.RSpec.Parallel.ts.ps1
@@ -103,6 +103,33 @@ i -PassThru:$PassThru {
         }
     }
 
+    b "Run.Parallel data passing" {
+        t "passes container -Data to each parallel worker's param() block" {
+            # New-PesterContainer -Path ... -Data must bind the file's param() block under parallel
+            # the same way it does sequentially. (#2793)
+            $folder = Join-Path ([IO.Path]::GetTempPath()) ([Guid]::NewGuid().Guid)
+            $null = New-Item -ItemType Directory -Path $folder -Force
+            foreach ($n in 1..2) {
+                Set-Content -Path (Join-Path $folder "Data$n.Tests.ps1") -Value @'
+param([Parameter(Mandatory)][ValidateNotNullOrEmpty()][string] $Module, $Data)
+Describe 'D' { It 'sees data' { $Module | Should -Be 'hello'; $Data.k | Should -Be 42 } }
+'@
+            }
+            try {
+                $c = [PesterConfiguration]::Default
+                $c.Run.Container = New-PesterContainer -Path $folder -Data @{ Module = 'hello'; Data = @{ k = 42 } }
+                $c.Run.Parallel = $true
+                $c.Run.PassThru = $true
+                $c.Output.Verbosity = 'None'
+                $r = Invoke-Pester -Configuration $c
+
+                $r.PassedCount | Verify-Equal 2
+                $r.FailedCount | Verify-Equal 0
+            }
+            finally { Remove-Item -Path $folder -Recurse -Force }
+        }
+    }
+
     b "Run.BeforeContainer" {
         t "runs the repo-root Pester.BeforeContainer.ps1 before each file in a sequential run" {
             $folder = New-BeforeContainerTestFolder


### PR DESCRIPTION
`Run.Parallel` sent only the file path to each worker, so `New-PesterContainer -Path … -Data @{…}` dropped its data and parametrized files failed discovery on missing mandatory params. Workers now rebuild a data-bearing container when data is present, and run the path directly otherwise.

`ForEach-Object -Parallel` uses runspaces in the same process, so the data values (including live objects) cross unchanged.

Added a parallel data-passing test.

Fix #2793