### PR TITLE
Fix command name in Should-Invoke not-found error

### DIFF
--- a/src/functions/Pester.SessionState.Mock.ps1
+++ b/src/functions/Pester.SessionState.Mock.ps1
@@ -930,7 +930,7 @@ function Should-InvokeAssertion {
     # no history.
     $contextInfo = Resolve-Command $CommandName $ModuleName -SessionState $SessionState
     if ($null -eq $contextInfo.Hook) {
-        throw "Should -Invoke: Could not find Mock for command $CommandName in $(if ([string]::IsNullOrEmpty($ModuleName)){ "script scope" } else { "module $ModuleName" }). Was the mock defined? Did you use the same -ModuleName as on the Mock? When using InModuleScope are InModuleScope, Mock and Should -Invoke using the same -ModuleName?"
+        throw "Should-Invoke: Could not find Mock for command $CommandName in $(if ([string]::IsNullOrEmpty($ModuleName)){ "script scope" } else { "module $ModuleName" }). Was the mock defined? Did you use the same -ModuleName as on the Mock? When using InModuleScope are InModuleScope, Mock and Should-Invoke using the same -ModuleName?"
     }
     $resolvedModule = $contextInfo.TargetModule
     $resolvedCommand = $contextInfo.Command.Name

--- a/src/functions/Pester.SessionState.Mock.ps1
+++ b/src/functions/Pester.SessionState.Mock.ps1
@@ -796,11 +796,25 @@ function Should-InvokeAssertion {
         [object] $ActualValue,
         [switch] $Negate,
         [string] $Because,
-        [Management.Automation.SessionState] $CallerSessionState
+        [Management.Automation.SessionState] $CallerSessionState,
+        # The Should-Invoke / Should-NotInvoke commands pass their own name here so the error
+        # messages name the command the user actually called. The legacy Should -Invoke operator
+        # does not set it, so we fall back to the operator syntax based on -Negate below.
+        [string] $CommandDisplayName
     )
 
+    $assertionName = if (-not [string]::IsNullOrEmpty($CommandDisplayName)) {
+        $CommandDisplayName
+    }
+    elseif ($Negate) {
+        'Should -Not -Invoke'
+    }
+    else {
+        'Should -Invoke'
+    }
+
     if ($null -ne $ActualValue) {
-        throw "Should -Invoke does not take pipeline input or ActualValue."
+        throw "$assertionName does not take pipeline input or ActualValue."
     }
 
     # Assert-DescribeInProgress -CommandName Should -Invoke
@@ -930,7 +944,7 @@ function Should-InvokeAssertion {
     # no history.
     $contextInfo = Resolve-Command $CommandName $ModuleName -SessionState $SessionState
     if ($null -eq $contextInfo.Hook) {
-        throw "Should-Invoke: Could not find Mock for command $CommandName in $(if ([string]::IsNullOrEmpty($ModuleName)){ "script scope" } else { "module $ModuleName" }). Was the mock defined? Did you use the same -ModuleName as on the Mock? When using InModuleScope are InModuleScope, Mock and Should-Invoke using the same -ModuleName?"
+        throw "${assertionName}: Could not find Mock for command $CommandName in $(if ([string]::IsNullOrEmpty($ModuleName)){ "script scope" } else { "module $ModuleName" }). Was the mock defined? Did you use the same -ModuleName as on the Mock? When using InModuleScope are InModuleScope, Mock and $assertionName using the same -ModuleName?"
     }
     $resolvedModule = $contextInfo.TargetModule
     $resolvedCommand = $contextInfo.Command.Name
@@ -951,6 +965,9 @@ function Should-InvokeAssertion {
     }
     if ($PSBoundParameters.ContainsKey('CallerSessionState')) {
         $PSBoundParameters.Remove('CallerSessionState')
+    }
+    if ($PSBoundParameters.ContainsKey('CommandDisplayName')) {
+        $PSBoundParameters.Remove('CommandDisplayName')
     }
 
     $result = Should-InvokeInternal @PSBoundParameters `

--- a/src/functions/assert/Mock/Should-Invoke.ps1
+++ b/src/functions/assert/Mock/Should-Invoke.ps1
@@ -194,6 +194,7 @@
     $PSBoundParameters["ActualValue"] = $null
     $PSBoundParameters["Negate"] = $false
     $PSBoundParameters["CallerSessionState"] = $PSCmdlet.SessionState
+    $PSBoundParameters["CommandDisplayName"] = 'Should-Invoke'
     $testResult = Should-InvokeAssertion @PSBoundParameters
 
     Test-AssertionResult $testResult

--- a/src/functions/assert/Mock/Should-NotInvoke.ps1
+++ b/src/functions/assert/Mock/Should-NotInvoke.ps1
@@ -182,6 +182,7 @@
     # possible to register as Should operator.
     $PSBoundParameters["ActualValue"] = $null
     $PSBoundParameters["CallerSessionState"] = $PSCmdlet.SessionState
+    $PSBoundParameters["CommandDisplayName"] = 'Should-NotInvoke'
     $testResult = Should-InvokeAssertion @PSBoundParameters
 
     Test-AssertionResult $testResult

--- a/tst/Pester.Mock.RSpec.ts.ps1
+++ b/tst/Pester.Mock.RSpec.ts.ps1
@@ -1033,37 +1033,58 @@ i -PassThru:$PassThru {
     }
 
     b "Mock not found throws" {
-        t "Resolving to function that is not a mock in Should -Invoke throws helpful message" {
+        t "Resolving to a command that is not a mock names the command the user called" {
             # https://github.com/pester/Pester/issues/1878
-            $sb = {
-                BeforeAll {
-                    Get-Module m | Remove-Module
-                    New-Module m -ScriptBlock { } | Import-Module
-                }
-
-                Describe "d" {
-                    It "i" {
-                        Mock Start-Job -ModuleName m
-
-                        # trying to assert on command that is not mocked in script scope
-                        Should-Invoke Start-Job
+            # Should-Invoke, Should-NotInvoke and the legacy Should -Invoke / Should -Not -Invoke
+            # operators all share one assertion. The not-found error must name the command the
+            # user actually called, not a single hard-coded name.
+            $cases = @(
+                @{
+                    Name = 'Should-Invoke'
+                    Sb   = {
+                        BeforeAll { Get-Module m | Remove-Module; New-Module m -ScriptBlock { } | Import-Module }
+                        Describe "d" { It "i" { Mock Start-Job -ModuleName m; Should-Invoke Start-Job } }
                     }
                 }
+                @{
+                    Name = 'Should-NotInvoke'
+                    Sb   = {
+                        BeforeAll { Get-Module m | Remove-Module; New-Module m -ScriptBlock { } | Import-Module }
+                        Describe "d" { It "i" { Mock Start-Job -ModuleName m; Should-NotInvoke Start-Job } }
+                    }
+                }
+                @{
+                    Name = 'Should -Invoke'
+                    Sb   = {
+                        BeforeAll { Get-Module m | Remove-Module; New-Module m -ScriptBlock { } | Import-Module }
+                        Describe "d" { It "i" { Mock Start-Job -ModuleName m; Should -Invoke Start-Job } }
+                    }
+                }
+                @{
+                    Name = 'Should -Not -Invoke'
+                    Sb   = {
+                        BeforeAll { Get-Module m | Remove-Module; New-Module m -ScriptBlock { } | Import-Module }
+                        Describe "d" { It "i" { Mock Start-Job -ModuleName m; Should -Not -Invoke Start-Job } }
+                    }
+                }
+            )
+
+            foreach ($case in $cases) {
+                $r = Invoke-Pester -Configuration ([PesterConfiguration]@{
+                        Run    = @{
+                            ScriptBlock = $case.Sb
+                            PassThru    = $true
+                        }
+                        Output = @{
+                            CIFormat = 'None'
+                        }
+                    })
+
+                $t = $r.Containers[0].Blocks[0].Tests[0]
+                $t.Result | Verify-Equal "Failed"
+                $expected = "$($case.Name): Could not find Mock for command Start-Job in script scope. Was the mock defined? Did you use the same -ModuleName as on the Mock? When using InModuleScope are InModuleScope, Mock and $($case.Name) using the same -ModuleName?"
+                $t.ErrorRecord[0] | Verify-Equal $expected
             }
-
-            $r = Invoke-Pester -Configuration ([PesterConfiguration]@{
-                    Run    = @{
-                        ScriptBlock = $sb
-                        PassThru    = $true
-                    }
-                    Output = @{
-                        CIFormat = 'None'
-                    }
-                })
-
-            $t = $r.Containers[0].Blocks[0].Tests[0]
-            $t.Result | Verify-Equal "Failed"
-            $t.ErrorRecord[0] | Verify-Equal 'Should-Invoke: Could not find Mock for command Start-Job in script scope. Was the mock defined? Did you use the same -ModuleName as on the Mock? When using InModuleScope are InModuleScope, Mock and Should-Invoke using the same -ModuleName?'
         }
     }
 

--- a/tst/Pester.Mock.RSpec.ts.ps1
+++ b/tst/Pester.Mock.RSpec.ts.ps1
@@ -1046,7 +1046,7 @@ i -PassThru:$PassThru {
                         Mock Start-Job -ModuleName m
 
                         # trying to assert on command that is not mocked in script scope
-                        Should -Invoke Start-Job
+                        Should-Invoke Start-Job
                     }
                 }
             }
@@ -1063,7 +1063,7 @@ i -PassThru:$PassThru {
 
             $t = $r.Containers[0].Blocks[0].Tests[0]
             $t.Result | Verify-Equal "Failed"
-            $t.ErrorRecord[0] | Verify-Equal 'Should -Invoke: Could not find Mock for command Start-Job in script scope. Was the mock defined? Did you use the same -ModuleName as on the Mock? When using InModuleScope are InModuleScope, Mock and Should -Invoke using the same -ModuleName?'
+            $t.ErrorRecord[0] | Verify-Equal 'Should-Invoke: Could not find Mock for command Start-Job in script scope. Was the mock defined? Did you use the same -ModuleName as on the Mock? When using InModuleScope are InModuleScope, Mock and Should-Invoke using the same -ModuleName?'
         }
     }
 


### PR DESCRIPTION
The "could not find mock" message said `Should -Invoke`. Now it says `Should-Invoke`, matching the command being used.

Fix #2792