### PR TITLE
Suggest both local and global option in empty/null ForEach error

### DIFF
--- a/src/functions/Context.ps1
+++ b/src/functions/Context.ps1
@@ -116,7 +116,7 @@
         if ($PSBoundParameters.ContainsKey('ForEach')) {
             if ($null -eq $ForEach -or 0 -eq @($ForEach).Count) {
                 if ($PesterPreference.Run.FailOnNullOrEmptyForEach.Value -and -not $AllowNullOrEmptyForEach) {
-                    throw [System.ArgumentException]::new('Value can not be null or empty array. If this is expected, use -AllowNullOrEmptyForEach', 'ForEach')
+                    throw [System.ArgumentException]::new('Value can not be null or empty array. If this is expected, use -AllowNullOrEmptyForEach on this Context, or set the Run.FailOnNullOrEmptyForEach configuration option to $false to allow it for the whole run.', 'ForEach')
                 }
                 # @() or $null is provided and allowed, do nothing
                 return

--- a/src/functions/Describe.ps1
+++ b/src/functions/Describe.ps1
@@ -124,7 +124,7 @@
         if ($PSBoundParameters.ContainsKey('ForEach')) {
             if ($null -eq $ForEach -or 0 -eq @($ForEach).Count) {
                 if ($PesterPreference.Run.FailOnNullOrEmptyForEach.Value -and -not $AllowNullOrEmptyForEach) {
-                    throw [System.ArgumentException]::new('Value can not be null or empty array. If this is expected, use -AllowNullOrEmptyForEach', 'ForEach')
+                    throw [System.ArgumentException]::new('Value can not be null or empty array. If this is expected, use -AllowNullOrEmptyForEach on this Describe, or set the Run.FailOnNullOrEmptyForEach configuration option to $false to allow it for the whole run.', 'ForEach')
                 }
                 # @() or $null is provided and allowed, do nothing
                 return

--- a/src/functions/It.ps1
+++ b/src/functions/It.ps1
@@ -157,7 +157,7 @@
     if ($PSBoundParameters.ContainsKey('ForEach')) {
         if ($null -eq $ForEach -or 0 -eq @($ForEach).Count) {
             if ($PesterPreference.Run.FailOnNullOrEmptyForEach.Value -and -not $AllowNullOrEmptyForEach) {
-                throw [System.ArgumentException]::new('Value can not be null or empty array. If this is expected, use -AllowNullOrEmptyForEach', 'ForEach')
+                throw [System.ArgumentException]::new('Value can not be null or empty array. If this is expected, use -AllowNullOrEmptyForEach on this It, or set the Run.FailOnNullOrEmptyForEach configuration option to $false to allow it for the whole run.', 'ForEach')
             }
             # @() or $null is provided and allowed, do nothing
             return

--- a/tst/Pester.RSpec.ts.ps1
+++ b/tst/Pester.RSpec.ts.ps1
@@ -1829,6 +1829,8 @@ i -PassThru:$PassThru {
             $r.Result = 'Failed'
             $r.Containers[0].Result = 'Failed'
             $r.Containers[0].ErrorRecord.Exception | Verify-Type ([System.ArgumentException])
+            $r.Containers[0].ErrorRecord.Exception.Message -match 'AllowNullOrEmptyForEach' | Verify-True
+            $r.Containers[0].ErrorRecord.Exception.Message -match 'FailOnNullOrEmptyForEach' | Verify-True
             $r.Containers[1].Result = 'Failed'
             $r.Containers[1].ErrorRecord.Exception | Verify-Type ([System.ArgumentException])
         }
@@ -1950,6 +1952,8 @@ i -PassThru:$PassThru {
             $r.Containers[1].ErrorRecord.Exception | Verify-Type ([System.ArgumentException])
             $r.Containers[2].Result = 'Failed'
             $r.Containers[2].ErrorRecord.Exception | Verify-Type ([System.ArgumentException])
+            $r.Containers[2].ErrorRecord.Exception.Message -match 'AllowNullOrEmptyForEach' | Verify-True
+            $r.Containers[2].ErrorRecord.Exception.Message -match 'FailOnNullOrEmptyForEach' | Verify-True
             $r.Containers[3].Result = 'Failed'
             $r.Containers[3].ErrorRecord.Exception | Verify-Type ([System.ArgumentException])
         }


### PR DESCRIPTION
The throw for an empty/null `-ForEach` only suggested `-AllowNullOrEmptyForEach`. It now also points at `Run.FailOnNullOrEmptyForEach`, so the message offers both the per-block opt-out and the whole-run configuration option. Updated for `It`, `Describe` and `Context`.

Fix #2782