### PR TITLE
Fix parallel run total durations

### DIFF
--- a/src/Main.ps1
+++ b/src/Main.ps1
@@ -663,7 +663,8 @@ function Invoke-Pester {
             # If every file opted out with #pester:no-parallel, the run is effectively sequential,
             # so fall through to the sequential path - which fires the framework's own global
             # plugin steps at the correct interleaved points.
-            if ($useParallel -and $parallelSupported -and $allFileContainers -and -not $coverageEnabled -and -not $skipRemainingRunScope -and 0 -lt $parallelContainers.Count) {
+            $ranInParallel = $useParallel -and $parallelSupported -and $allFileContainers -and -not $coverageEnabled -and -not $skipRemainingRunScope -and 0 -lt $parallelContainers.Count
+            if ($ranInParallel) {
                 $foldedContainers = [System.Collections.Generic.List[object]]@()
                 $hasNonParallel = 0 -lt $nonParallelContainers.Count
 
@@ -845,6 +846,11 @@ function Invoke-Pester {
                 }
             }
 
+            # Wall-clock end of test execution, captured before building and post-processing the
+            # run object. For parallel runs this is used as Run.Duration, because summing the
+            # overlapping container durations would overstate the actual elapsed time. (#2794)
+            $end = [DateTime]::Now
+
             $run = [Pester.Run]::Create()
             $run.Executed = $true
             $run.ExecutedAt = $start
@@ -866,7 +872,7 @@ function Invoke-Pester {
                 $run.Containers.Add($i)
             }
 
-            PostProcess-RSpecTestRun -TestRun $run
+            PostProcess-RSpecTestRun -TestRun $run -Parallel:$ranInParallel -RunDuration ($end - $start)
 
             $steps = $Plugins.End
             if ($null -ne $steps -and 0 -lt @($steps).Count) {

--- a/src/Pester.RSpec.ps1
+++ b/src/Pester.RSpec.ps1
@@ -178,7 +178,7 @@ function Add-RSpecBlockObjectProperties ($BlockObject) {
     }
 }
 
-function PostProcess-RspecTestRun ($TestRun) {
+function PostProcess-RspecTestRun ($TestRun, [switch] $Parallel, [TimeSpan] $RunDuration) {
     $discoveryOnly = $PesterPreference.Run.SkipRun.Value
 
     Fold-Run $Run -OnTest {
@@ -280,6 +280,19 @@ function PostProcess-RspecTestRun ($TestRun) {
         $TestRun.UserDuration += $b.UserDuration
         $TestRun.FrameworkDuration += $b.FrameworkDuration
         $TestRun.DiscoveryDuration += $b.DiscoveryDuration
+    }
+
+    if ($Parallel) {
+        # In a file-parallel run the containers overlap in wall-clock time, so the summed
+        # container durations above overstate the run. Use the orchestrator's measured
+        # wall-clock as the total instead, and blank the per-phase run totals - a single
+        # wall-clock figure for user, framework or discovery time is not meaningful once the
+        # files overlap. The per-phase breakdown is still available on each container, because
+        # parallelism is file-level. (#2794)
+        $TestRun.Duration = $RunDuration
+        $TestRun.UserDuration = [TimeSpan]::Zero
+        $TestRun.FrameworkDuration = [TimeSpan]::Zero
+        $TestRun.DiscoveryDuration = [TimeSpan]::Zero
     }
 
     $TestRun.PassedCount = $TestRun.Passed.Count

--- a/tst/Pester.RSpec.Parallel.ts.ps1
+++ b/tst/Pester.RSpec.Parallel.ts.ps1
@@ -103,6 +103,69 @@ i -PassThru:$PassThru {
         }
     }
 
+    b "Run.Parallel durations" {
+        t "uses wall-clock for the run total and blanks the per-phase run totals (#2794)" {
+            # Two files that each sleep ~1s would total ~2s if their container durations were summed.
+            # Running them in parallel overlaps that time, so the run's actual wall-clock is closer to
+            # a single file. Summing the container durations therefore overstates Run.Duration; the
+            # run total must instead be the orchestrator's measured wall-clock.
+            $folder = Join-Path ([IO.Path]::GetTempPath()) ([Guid]::NewGuid().Guid)
+            $null = New-Item -ItemType Directory -Path $folder -Force
+            Set-Content -Path (Join-Path $folder 'Slow1.Tests.ps1') -Value @'
+Describe 'Slow1' {
+    BeforeAll { Start-Sleep -Milliseconds 1000 }
+    It 'passes' { 1 | Should -Be 1 }
+}
+'@
+            Set-Content -Path (Join-Path $folder 'Slow2.Tests.ps1') -Value @'
+Describe 'Slow2' {
+    BeforeAll { Start-Sleep -Milliseconds 1000 }
+    It 'passes' { 1 | Should -Be 1 }
+}
+'@
+            try {
+                $c = [PesterConfiguration]::Default
+                $c.Run.Path = $folder
+                $c.Run.Parallel = $true
+                $c.Run.PassThru = $true
+                $c.Output.Verbosity = 'None'
+
+                $sw = [System.Diagnostics.Stopwatch]::StartNew()
+                $r = Invoke-Pester -Configuration $c
+                $sw.Stop()
+
+                if ($PSVersionTable.PSVersion.Major -ge 7) {
+                    # Naive sum of the overlapping container durations - the old (wrong) run total.
+                    $containerSum = [TimeSpan]::Zero
+                    foreach ($container in $r.Containers) { $containerSum += $container.Duration }
+
+                    # Run total is the measured wall-clock: positive, never larger than the elapsed
+                    # time around the whole call, and well below the naive sum because the files overlap.
+                    ($r.Duration -gt [TimeSpan]::Zero) | Verify-True
+                    ($r.Duration -le $sw.Elapsed) | Verify-True
+                    ($r.Duration -lt $containerSum) | Verify-True
+
+                    # The per-phase run totals are blanked - a single wall-clock figure for user,
+                    # framework or discovery time is not meaningful once the files overlap.
+                    ($r.UserDuration -eq [TimeSpan]::Zero) | Verify-True
+                    ($r.FrameworkDuration -eq [TimeSpan]::Zero) | Verify-True
+                    ($r.DiscoveryDuration -eq [TimeSpan]::Zero) | Verify-True
+
+                    # Parallelism is file-level, so each container keeps its full duration breakdown.
+                    foreach ($container in $r.Containers) {
+                        ($container.Duration -gt [TimeSpan]::Zero) | Verify-True
+                        ($container.UserDuration -gt [TimeSpan]::Zero) | Verify-True
+                    }
+                    # Discovery is measured per container too (summed here only to avoid per-file flakiness).
+                    $discoverySum = [TimeSpan]::Zero
+                    foreach ($container in $r.Containers) { $discoverySum += $container.DiscoveryDuration }
+                    ($discoverySum -gt [TimeSpan]::Zero) | Verify-True
+                }
+            }
+            finally { Remove-Item -Path $folder -Recurse -Force }
+        }
+    }
+
     b "Run.Parallel data passing" {
         t "passes container -Data to each parallel worker's param() block" {
             # New-PesterContainer -Path ... -Data must bind the file's param() block under parallel


### PR DESCRIPTION
Summing container durations overstates a parallel run — the files overlap in wall-clock time, so two 1s files don't take 2s. Use the orchestrator's measured wall-clock for `Run.Duration` in parallel instead.

The per-phase run totals (`UserDuration`, `FrameworkDuration`, `DiscoveryDuration`) are blanked in parallel rather than summed. A single wall-clock figure for those isn't meaningful once the files overlap, and the breakdown still lives on each container since parallelism is file-level.

Sequential runs are unchanged — `Run.Duration` there is still the sum of the containers, which a result-object test pins down.

Supersedes #2802.

Fix #2794