### PR TITLE
Bump prerelease to rc3

### DIFF
--- a/src/Pester.psd1
+++ b/src/Pester.psd1
@@ -169,10 +169,10 @@
             LicenseUri   = "https://www.apache.org/licenses/LICENSE-2.0.html"
 
             # Release notes for this particular version of the module
-            ReleaseNotes = 'https://github.com/pester/Pester/releases/tag/6.0.0-rc2'
+            ReleaseNotes = 'https://github.com/pester/Pester/releases/tag/6.0.0-rc3'
 
             # Prerelease string of this module
-            Prerelease   = 'rc2'
+            Prerelease   = 'rc3'
         }
 
         # Minimum assembly version required


### PR DESCRIPTION
Bumps the module branding from `6.0.0-rc2` to `6.0.0-rc3` in `src/Pester.psd1` (both the `Prerelease` string and the `ReleaseNotes` tag URL), in preparation for the next release.

Mirrors the previous bump in #2785.