### PR TITLE
Claim PowerShell 7.4+ support instead of 7.2+

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ The example above also has an [annotated and production ready version here](docs
 
 ## Installation
 
-Pester runs on Windows, Linux, MacOS and anywhere else thanks to PowerShell. It is compatible with Windows PowerShell 5.1 and PowerShell 7.2 and newer.
+Pester runs on Windows, Linux, MacOS and anywhere else thanks to PowerShell. It is compatible with Windows PowerShell 5.1 and PowerShell 7.4 and newer.
 
 Pester 3 comes pre-installed with Windows 10, but we recommend updating, by running this PowerShell command _as administrator_:
 

--- a/docs/6.0.0.md
+++ b/docs/6.0.0.md
@@ -8,7 +8,7 @@ real-world testing before the final release. Pester 6 builds on the v5 runtime (
 configuration object, the rich result object) and focuses on a brand new assertion syntax, faster
 code coverage, and an experimental parallel runner.
 
-Pester 6 runs on **Windows PowerShell 5.1** and **PowerShell 7.2+**.
+Pester 6 runs on **Windows PowerShell 5.1** and **PowerShell 7.4+**.
 
 - [What's new?](#whats-new)
   - [New `Should-*` assertions](#new-should--assertions)
@@ -369,7 +369,7 @@ still change before it is declared stable.
 Support for **PowerShell 3, 4, 6, and early/unsupported 7** has been removed — all of these are out
 of support from Microsoft. Dropping them let us delete a large amount of compatibility code, move the
 C# to **.NET 8** (with net462 for Windows PowerShell 5.1), and modernize the runtime. Pester 6
-targets **Windows PowerShell 5.1** and **PowerShell 7.2+**.
+targets **Windows PowerShell 5.1** and **PowerShell 7.4+**.
 
 ### Richer failure messages and output
 
@@ -414,7 +414,7 @@ targets **Windows PowerShell 5.1** and **PowerShell 7.2+**.
 ## Breaking changes
 
 - **PowerShell 3, 4, 6, and unsupported 7 are no longer supported.** Minimum is Windows PowerShell
-  5.1 / PowerShell 7.2+.
+  5.1 / PowerShell 7.4+.
 - **Discovery and run now happen per file** instead of discovering every file up front and then
   running everything. It is invisible for self-contained files, but discovery-time side effects (for
   example a module imported at the top of one file) no longer carry into another file's discovery.


### PR DESCRIPTION
## Summary

Pester 6 ships a `net8.0` assembly for PowerShell 7 (plus `net462` for Windows PowerShell 5.1). A `net8.0` assembly **cannot load** on the .NET 6 / .NET 7 runtimes used by PowerShell **7.2** / **7.3**, so claiming support for those versions is inaccurate. They are also both out of support from Microsoft per the [PowerShell support lifecycle](https://learn.microsoft.com/en-us/powershell/scripting/install/powershell-support-lifecycle?view=powershell-7.6) — the oldest supported release is **7.4 (LTS, .NET 8)**.

This already matches what `src/csharp/Pester/Pester.csproj` documents ("PowerShell 7.4.x is the oldest supported PowerShell version"). This PR fixes the user-facing claims to match.

## Changes

- `README.md` — "PowerShell 7.2 and newer" → "PowerShell 7.4 and newer".
- `docs/6.0.0.md` — three "PowerShell 7.2+" support claims → "PowerShell 7.4+".

The `.psd1` manifest floor stays at `5.1` (Windows PowerShell 5.1 is served by the `net462` assembly). The "PowerShell 7+" references for the parallel runner feature are left unchanged, as they describe a feature requirement, not the support floor.

A matching docs-site update is being opened against [pester/docs](https://github.com/pester/docs).