### PR TITLE
Correct <...> name-template description in 6.0.0 release notes

### DIFF
--- a/docs/6.0.0.md
+++ b/docs/6.0.0.md
@@ -429,11 +429,18 @@ targets **Windows PowerShell 5.1** and **PowerShell 7.2+**.
   now repo-root-relative, so use `JaCoCo` (the default) or `Cobertura`.
 - **`-ForEach $null`/`@()` throws by default** (`Run.FailOnNullOrEmptyForEach`).
 - **Duplicate setup/teardown blocks throw** instead of being silently allowed.
-- **Test and block names expand data templates only.** `<...>` tokens in `Describe`/`Context`/`It`
-  names (and in `-ForEach`/`-TestCases` data) now interpolate only the current data item and its
-  properties — not arbitrary PowerShell expressions. This closes a code-injection vector where an
-  expression embedded in a name could execute during discovery. If you relied on full expression
-  expansion in a name, compute the value into a `-ForEach` property and reference that instead.
+- **Test and block names: only `<...>` templates are expanded, everything else stays literal.**
+  Names used to be expanded by re-parsing the whole name as a double-quoted string, so a literal
+  backtick, `$`, `$(...)` or quote could break the name (`` It 'has `backticks`' `` threw a parse
+  error) or be used to run code. Now only the `<...>` tokens become sub-expressions and every other
+  character is kept inert, which closes that parse-break / code-injection vector
+  ([#2044](https://github.com/pester/Pester/issues/2044)). Inside `<...>` the content is still
+  evaluated as a PowerShell expression at run time — the current `-ForEach`/`-TestCases` item and its
+  properties, any in-scope variable, and full expressions such as arithmetic or method calls — and the
+  result is rendered through Pester's formatter. This is broader than v5, which substituted only simple
+  data/variable/property references inside `<...>` and left anything more complex verbatim, so a name
+  like `'adds up to <($a + $b)>'` now renders `adds up to 3` instead of the literal text. If you want
+  the literal text, escape the leading bracket: `` `<($a + $b)> ``.
 - The deprecated **Legacy parameter set** and other long-deprecated functions were removed from
   `Invoke-Pester`.
 - Mock **fall-through to the real command** was removed.


### PR DESCRIPTION
## Summary

The 6.0.0 release notes (`docs/6.0.0.md`) described `<...>` test/block-name expansion as **data-only**:

> **Test and block names expand data templates only.** `<...>` tokens … now interpolate only the current data item and its properties — not arbitrary PowerShell expressions.

That is inaccurate. The change in #2740 made the text **outside** `<...>` inert (the actual #2044 fix), but the content **inside** `<...>` is still evaluated as a full PowerShell expression at run time and rendered through the formatter — a superset of v5.

Verified against a build of `main` (PowerShell 7.5.5):

| Name source | Renders as |
|---|---|
| `adds up to <($a + $b)>` | `adds up to 3` |
| `<($a.ToString("000"))>` | `007` |
| `` <a> `$($global:x = $true)` `` | literal — does **not** execute |

This rewrites the breaking-change bullet to describe what actually changed: only `<...>` tokens are expanded (everything else kept literal, closing the parse-break / injection vector from #2044), `<...>` still evaluates expressions rendered via the formatter, this is broader than v5, and you escape a literal bracket with `` `< ``.

The companion docs fix (the stale "Internals" mechanism description) is pester/docs#380.

Fix #2808