### PR TITLE
Update 6.0.0 release notes for parallel data and wall-clock durations

### DIFF
--- a/docs/6.0.0.md
+++ b/docs/6.0.0.md
@@ -306,7 +306,10 @@ $config.Run.ParallelThrottleLimit = 4   # at most 4 files at a time; 0 (default)
 ```
 
 Each file is discovered and run inside its own runspace, and the results are merged back into a
-single `[Pester.Run]` with correct aggregate counts and durations. This builds directly on the
+single `[Pester.Run]` with correct aggregate counts. Because the files overlap in wall-clock time,
+the run's total `Duration` is the orchestrator's measured elapsed time rather than the sum of the
+files, and the per-phase run totals (user, framework, discovery) are left blank — that breakdown is
+still reported on each container. This builds directly on the
 [per-file discovery model](#discovery-and-run-now-happen-per-file) described above: a file is a
 self-contained unit of work, which is exactly what lets workers run in isolation.
 
@@ -336,12 +339,14 @@ Describe 'integration that must not share the box' {
 Files marked this way run in the **parent session** on the normal serial path — with shared session
 state and live output — while the other files run in parallel.
 
-**What's supported, and what falls back.** Parallel execution needs **PowerShell 7+** and a
-**file-based** run (`Run.Path`). When a run can't be parallelized it falls back to a normal sequential
-run **with a warning** so it keeps working unchanged — this happens on Windows PowerShell 5.1, for
-`ScriptBlock`/`Container` inputs, when `CodeCoverage` is enabled (coverage is always collected on the
-sequential path), when `Run.SkipRemainingOnFailure = 'Run'` (a cross-file stop-on-failure can't span
-runspaces), and when every file opts out with `#pester:no-parallel`.
+**What's supported, and what falls back.** Parallel execution needs **PowerShell 7+** and
+**file-based** containers — `Run.Path` as well as `New-PesterContainer -Path`, including
+**parametrized files** built with `-Data` (each file's data is handed to its worker, so its `param()`
+block binds exactly as it does in a serial run). When a run can't be parallelized it falls back to a
+normal sequential run **with a warning** so it keeps working unchanged — this happens on Windows
+PowerShell 5.1, for in-memory **`ScriptBlock`** containers, when `CodeCoverage` is enabled (coverage
+is always collected on the sequential path), when `Run.SkipRemainingOnFailure = 'Run'` (a cross-file
+stop-on-failure can't span runspaces), and when every file opts out with `#pester:no-parallel`.
 
 Within a parallel run each worker runs silently and the parent **replays** every file's output in
 discovery order, emitting the **same plugin-event sequence as a serial run**. Console output, the

--- a/docs/6.0.0.md
+++ b/docs/6.0.0.md
@@ -527,7 +527,7 @@ be aware of is that [discovery and run now happen per file](#discovery-and-run-n
 
 ## Thank you
 
-Pester 6 is the work of many contributors across the 6.0 alphas and release candidate. Special thanks
+Pester 6 is the work of many contributors across the 6.0 alphas and release candidates. Special thanks
 to the new contributors during the 6.0 cycle, including @kborowinski, @WithHolm, @ocalvo, @joeskeen,
 and @johlju, and to everyone who reported issues, tested prereleases, and sponsors Pester.
 


### PR DESCRIPTION
The committed `docs/6.0.0.md` (the 6.0.0 final release notes) still described the rc1 parallel runner. This folds in the two user-facing parallel changes made since then so the notes match shipped behavior:

- **Parametrized file containers now parallelize.** `New-PesterContainer -Path ... -Data @{...}` runs in parallel with its `-Data` handed to each worker (#2803), so the "what falls back" list now correctly names only in-memory `ScriptBlock` containers instead of all `Container` inputs.
- **Wall-clock durations.** A parallel run reports its total `Duration` as the orchestrator's measured elapsed time and leaves the per-phase run totals (user, framework, discovery) blank, since the files overlap; the per-phase breakdown stays on each container (#2807).

Docs-only change. The previously merged 7.4+ claim (#2811), corrected `<...>` description (#2812), and pipeline-unwrap hint (#2806) were already reflected.