### PR TITLE
Prepare 6.0.0-rc4

### DIFF
--- a/docs/6.0.0.md
+++ b/docs/6.0.0.md
@@ -68,7 +68,7 @@ The assertions are grouped by how they treat `$Actual` and `$Expected`:
 | --- | --- | --- |
 | **Value – generic** | `Should-Be`, `Should-NotBe`, `Should-BeGreaterThan`, `Should-BeSame`, `Should-BeNull`, `Should-HaveType` | A single value, compared like the PowerShell operators (`Should-Be` ≈ `-eq`). |
 | **Value – type specific** | `Should-BeString`, `Should-MatchString`/`Should-BeLikeString`, `Should-BeTrue`/`Should-BeFalse`, `Should-BeFalsy`/`Should-BeTruthy`, `Should-BeBefore`/`Should-BeAfter`, `Should-BeFasterThan`/`Should-BeSlowerThan` | A value of a known type, with type-specific options. |
-| **Collection – generic** | `Should-BeCollection`, `Should-ContainCollection`, `Should-NotContainCollection` | Comparing whole collections item by item. |
+| **Collection – generic** | `Should-BeCollection`, `Should-ContainCollection`, `Should-NotContainCollection` | Comparing a whole collection item by item, or finding an ordered sub-collection within one. |
 | **Collection – combinator** | `Should-All`, `Should-Any` | Asserting a condition across every / any item. |
 
 There are also dedicated assertions for exceptions (`Should-Throw`), mocks (`Should-Invoke`,
@@ -134,7 +134,7 @@ $result.Error      | Should-BeNull
 1, 2, 3            | Should-BeCollection -Count 3
 1, 2, 3            | Should-All { $_ -gt 0 }
 1, 2, 3            | Should-Any { $_ -gt 2 }
-@('a', 'b', 'c')   | Should-ContainCollection 'b'
+@('a', 'b', 'c')   | Should-ContainCollection @('a', 'c')   # ordered sub-collection, gaps allowed
 
 # Exceptions
 { throw 'kaboom' } | Should-Throw -ExceptionMessage 'kaboom'

--- a/src/Pester.psd1
+++ b/src/Pester.psd1
@@ -169,10 +169,10 @@
             LicenseUri   = "https://www.apache.org/licenses/LICENSE-2.0.html"
 
             # Release notes for this particular version of the module
-            ReleaseNotes = 'https://github.com/pester/Pester/releases/tag/6.0.0-rc3'
+            ReleaseNotes = 'https://github.com/pester/Pester/releases/tag/6.0.0-rc4'
 
             # Prerelease string of this module
-            Prerelease   = 'rc3'
+            Prerelease   = 'rc4'
         }
 
         # Minimum assembly version required


### PR DESCRIPTION
Prepares the `6.0.0-rc4` prerelease.

- **Bump prerelease to `rc4`** in `src/Pester.psd1` and point `ReleaseNotes` at the rc4 tag.
- **Fix the 6.0.0 release notes for `Should-ContainCollection`.** Since #2820 the assertion matches an ordered sub-collection (the expected items appear in order, gaps allowed, each actual item used at most once), but `docs/6.0.0.md` still only showed the single-value case. The example and the assertion-family table now describe the real behaviour.