### PR TITLE
Rename Pester.ps1 script-scope helper to Pester.ScriptScope.ps1

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -206,7 +206,7 @@ function Copy-Content ($Content) {
 
 $content = @(
     , ("$PSScriptRoot/src/en-US/*.txt", "$PSScriptRoot/bin/en-US/")
-    , ("$PSScriptRoot/src/Pester.ps1", "$PSScriptRoot/bin/")
+    , ("$PSScriptRoot/src/Pester.ScriptScope.ps1", "$PSScriptRoot/bin/")
     , ("$PSScriptRoot/src/Pester.psd1", "$PSScriptRoot/bin/")
     , ("$PSScriptRoot/src/Pester.Format.ps1xml", "$PSScriptRoot/bin/")
 )

--- a/publish/filesToPublish.ps1
+++ b/publish/filesToPublish.ps1
@@ -1,5 +1,5 @@
 ﻿@(
-    'Pester.ps1'
+    'Pester.ScriptScope.ps1'
     'Pester.psd1'
     'Pester.psm1'
     'Pester.Format.ps1xml'

--- a/src/Pester.Runtime.ps1
+++ b/src/Pester.Runtime.ps1
@@ -2693,7 +2693,8 @@ function Invoke-InNewScriptScope ([ScriptBlock] $ScriptBlock, $SessionState) {
     # correct session state, and then invoke the file. We can also pass a script block tied
     # to the current module to invoke internal function in the newly pushed script scope.
 
-    $Path = "$PSScriptRoot/Pester.ps1"
+    # Invoked as a standalone script file (not Pester.ps1; see Pester.ScriptScope.ps1 for why).
+    $Path = "$PSScriptRoot/Pester.ScriptScope.ps1"
     $Data = @{ ScriptBlock = $ScriptBlock }
 
     $wrapper = {

--- a/src/Pester.ScriptScope.ps1
+++ b/src/Pester.ScriptScope.ps1
@@ -1,0 +1,10 @@
+﻿# This file is invoked as a real script file by Invoke-InNewScriptScope to push a new
+# script scope into the caller's session state (see src/Pester.Runtime.ps1).
+#
+# Do NOT rename it to Pester.ps1. PSResourceGet treats a '<ModuleName>.ps1' file in the
+# package (i.e. Pester.ps1) as a script and prints a spurious installation-path warning
+# on Install-PSResource Pester. See https://github.com/pester/Pester/issues/2826.
+param ($ScriptBlock)
+
+. $ScriptBlock
+

--- a/src/Pester.ps1
+++ b/src/Pester.ps1
@@ -1,4 +1,0 @@
-﻿param ($ScriptBlock)
-
-. $ScriptBlock
-

--- a/tst/Pester.Tests.ps1
+++ b/tst/Pester.Tests.ps1
@@ -208,6 +208,24 @@ Describe 'Style rules' -Tag StyleRules {
     }
 }
 
+Describe 'Module packaging' -Tag StyleRules {
+    # Issue #2826: PSResourceGet decides a package is a script by looking for a
+    # '<ModuleName>.ps1' file in the package root (i.e. Pester.ps1). When that file is
+    # present it prints a spurious installation-path warning on Install-PSResource Pester.
+    # The script-scope helper is therefore shipped as Pester.ScriptScope.ps1 instead.
+    BeforeAll {
+        $pesterRoot = (Get-Module Pester).ModuleBase
+    }
+
+    It 'does not ship a Pester.ps1 that PSResourceGet would treat as a script' {
+        (Join-Path $pesterRoot 'Pester.ps1') | Should -Not -Exist
+    }
+
+    It 'ships the script-scope helper as Pester.ScriptScope.ps1' {
+        (Join-Path $pesterRoot 'Pester.ScriptScope.ps1') | Should -Exist
+    }
+}
+
 InPesterModuleScope {
     Describe 'Find-File' {
         BeforeAll {


### PR DESCRIPTION
## Problem

Installing Pester with `Install-PSResource Pester` prints a spurious warning:

> WARNING: The installation path for the script does not currently appear in the CurrentUser path environment variable. To make the script discoverable, add the script installation path, `.../Modules`, to the environment PATH variable.

## Root cause

PSResourceGet decides whether an installed package is a *script* by checking for a `<ModuleName>.ps1` file in the package root ([InstallHelper.cs](https://github.com/PowerShell/PSResourceGet/blob/6ecc668473baf37aa3cb84cc54dce7434364d121/src/code/InstallHelper.cs#L1031-L1035)):

```csharp
var scriptPath = Path.Combine(tempDirNameVersion, pkgName + PSScriptFileExt); // Pester.ps1
bool isScript = File.Exists(scriptPath);                                       // true!
```

Pester ships a tiny `Pester.ps1` (used by `Invoke-InNewScriptScope` for script-scope isolation), so `isScript` becomes `true` and the PATH warning at `if (!_savePkg && isScript)` fires. The upstream fix in [PSResourceGet#1043](https://github.com/PowerShell/PSResourceGet/issues/1043) wasn't accepted, so the agreed fallback is to rename the file on Pester's side.

## Fix

Rename `src/Pester.ps1` → `src/Pester.ScriptScope.ps1` so the shipped module no longer contains a file matching the module name, and update its references:

- `src/Pester.Runtime.ps1` — the `Invoke-InNewScriptScope` path
- `build.ps1` — the copy-to-`bin/` step
- `publish/filesToPublish.ps1` — the published-file list

The file must stay a standalone `.ps1` on disk (it is invoked as a real script to push a new script scope; it is **not** inlined into `Pester.psm1`). A comment in the file and at the call site documents why it must not be named `Pester.ps1`.

## Regression test

Added a `StyleRules`-tagged test in `tst/Pester.Tests.ps1` asserting the built module ships `Pester.ScriptScope.ps1` and contains no `Pester.ps1`.

## Verification

- Clean build succeeds; `bin/` ships `Pester.ScriptScope.ps1` and no `Pester.ps1`.
- New regression tests pass.
- Running a real test *file* exercises `Invoke-InNewScriptScope` and passes (script scope pushed, `$PSCommandPath` set).
- RSpec acceptance suite: 116/116 passing.
- Custom build-analyzer rules on `./src`: no new violations (new file is clean).

Fix #2826