### PR TITLE
Remove vestigial Focus feature

### DIFF
--- a/docs/6.0.0.md
+++ b/docs/6.0.0.md
@@ -481,6 +481,11 @@ both recorded calls:
   running everything. It is invisible for self-contained files, but discovery-time side effects (for
   example a module imported at the top of one file) no longer carry into another file's discovery.
   See [Discovery and run now happen per file](#discovery-and-run-now-happen-per-file).
+- **Test discovery now looks inside hidden folders.** File search uses `Get-ChildItem -Force`,
+  so `*.Tests.ps1` files in hidden or dot-prefixed folders (for example `.config` or `.build`)
+  are now discovered and run; previously they were skipped. Version-control metadata folders
+  (`.git`, `.svn`, `.hg`) are still ignored. Use `Run.ExcludePath` to skip any folder you don't
+  want picked up.
 - **`Assert-MockCalled` and `Assert-VerifiableMock` were removed.** Use `Should -Invoke` /
   `Should -InvokeVerifiable`.
 - **The `Pending` test status was removed.** `Set-ItResult` no longer has a `-Pending` parameter;

--- a/docs/6.0.0.md
+++ b/docs/6.0.0.md
@@ -485,6 +485,7 @@ both recorded calls:
   `Should -InvokeVerifiable`.
 - **The `Pending` test status was removed.** `Set-ItResult` no longer has a `-Pending` parameter;
   use `-Skipped` or `-Inconclusive` instead.
+- **The `-Focus` switch was removed.** `Describe`, `Context`, and `It` no longer accept `-Focus`, and the `Focus` property is gone from the result object's blocks and tests. Use `-Skip`, tags, or the `Filter` configuration to select which tests run.
 - **Profiler-based code coverage is the default.** Set `CodeCoverage.UseBreakpoints = $true` to
   restore breakpoint-based coverage.
 - **The `CodeCoverage.OutputFormat = 'CoverageGutters'` value was removed.** All coverage output is

--- a/src/Main.ps1
+++ b/src/Main.ps1
@@ -727,8 +727,6 @@ function Invoke-Pester {
                         if ((-not $hasNonParallel) -and (-not $discoveryEndFired) -and ($pri -eq ($parallelResults.Count - 1))) {
                             Invoke-PluginStep -Plugins $reportingPlugins -Step DiscoveryEnd -Context @{
                                 BlockContainers = $foldedContainers
-                                AnyFocusedTests = $false
-                                FocusedTests    = $null
                                 Duration        = $totalDiscoveryWatch.Elapsed
                                 Configuration   = $pluginConfiguration
                                 Filter          = $filter
@@ -786,8 +784,6 @@ function Invoke-Pester {
                 if (-not $discoveryEndFired) {
                     Invoke-PluginStep -Plugins $reportingPlugins -Step DiscoveryEnd -Context @{
                         BlockContainers = $foldedContainers
-                        AnyFocusedTests = $false
-                        FocusedTests    = $null
                         Duration        = $totalDiscoveryWatch.Elapsed
                         Configuration   = $pluginConfiguration
                         Filter          = $filter

--- a/src/Pester.Runtime.ps1
+++ b/src/Pester.Runtime.ps1
@@ -171,7 +171,6 @@ function New-ParametrizedBlock {
         [int] $StartColumn = $MyInvocation.OffsetInLine,
         [String[]] $Tag = @(),
         [HashTable] $FrameworkData = @{ },
-        [Switch] $Focus,
         [Switch] $Skip,
         $Data
     )
@@ -183,7 +182,7 @@ function New-ParametrizedBlock {
     foreach ($d in @($Data)) {
         # shallow clone to give every block it's own copy
         $fmwData = $FrameworkData.Clone()
-        New-Block -GroupId $groupId -Name $Name -ScriptBlock $ScriptBlock -StartLine $StartLine -Tag $Tag -FrameworkData $fmwData -Focus:$Focus -Skip:$Skip -Data $d
+        New-Block -GroupId $groupId -Name $Name -ScriptBlock $ScriptBlock -StartLine $StartLine -Tag $Tag -FrameworkData $fmwData -Skip:$Skip -Data $d
     }
 }
 
@@ -198,7 +197,6 @@ function New-Block {
         [int] $StartLine = $MyInvocation.ScriptLineNumber,
         [String[]] $Tag = @(),
         [HashTable] $FrameworkData = @{ },
-        [Switch] $Focus,
         [String] $GroupId,
         [Switch] $Skip,
         $Data
@@ -236,7 +234,6 @@ function New-Block {
     $block.ScriptBlock = $ScriptBlock
     $block.StartLine = $StartLine
     $block.FrameworkData = $FrameworkData
-    $block.Focus = $Focus
     $block.GroupId = $GroupId
     $block.Skip = $Skip
     $block.Data = $Data
@@ -503,7 +500,6 @@ function New-Test {
         [String[]] $Tag = @(),
         $Data,
         [String] $GroupId,
-        [Switch] $Focus,
         [Switch] $Skip
     )
 
@@ -536,7 +532,6 @@ function New-Test {
     $test.ExpandedPath = $path -join '.'
     $test.StartLine = $StartLine
     $test.Tag = $Tag
-    $test.Focus = $Focus
     $test.Skip = $Skip
     $test.Data = $Data
     $test.FrameworkData.Runtime.Phase = 'Discovery'
@@ -1195,8 +1190,6 @@ function Discover-Test {
     if ($null -ne $steps -and 0 -lt @($steps).Count) {
         Invoke-PluginStep -Plugins $state.Plugin -Step DiscoveryEnd -Context @{
             BlockContainers = $found
-            AnyFocusedTests = $false
-            FocusedTests    = $null
             Duration        = $totalDiscoveryDuration.Elapsed
             Configuration   = $state.PluginConfiguration
             Filter          = $Filter
@@ -2063,8 +2056,6 @@ function Invoke-Test {
             if (-not $SkipFrameworkGlobalSteps -and $null -ne $steps -and 0 -lt @($steps).Count) {
                 Invoke-PluginStep -Plugins $state.Plugin -Step DiscoveryEnd -Context @{
                     BlockContainers = $discoveredBlocks
-                    AnyFocusedTests = $false
-                    FocusedTests    = $null
                     Duration        = $totalDiscoveryDuration.Elapsed
                     Configuration   = $state.PluginConfiguration
                     Filter          = $Filter
@@ -2675,7 +2666,6 @@ function New-ParametrizedTest () {
         [String[]] $Tag = @(),
         # do not use [hashtable[]] because that throws away the order if user uses [ordered] hashtable
         [object[]] $Data,
-        [Switch] $Focus,
         [Switch] $Skip
     )
 
@@ -2683,7 +2673,7 @@ function New-ParametrizedTest () {
     # TODO: Id is used by NUnit2.5 and 3 testresults to group. A better way to solve this?
     $groupId = "${StartLine}:${StartColumn}"
     foreach ($d in $Data) {
-        New-Test -GroupId $groupId -Name $Name -Tag $Tag -ScriptBlock $ScriptBlock -StartLine $StartLine -Data $d -Focus:$Focus -Skip:$Skip
+        New-Test -GroupId $groupId -Name $Name -Tag $Tag -ScriptBlock $ScriptBlock -StartLine $StartLine -Data $d -Skip:$Skip
     }
 }
 

--- a/src/csharp/Pester/Block.cs
+++ b/src/csharp/Pester/Block.cs
@@ -44,7 +44,6 @@ namespace Pester
         public string Id { get => GroupId; }
         public string GroupId { get; set; }
         public List<string> Tag { get; set; }
-        public bool Focus { get; set; }
         public bool Skip { get; set; }
 
         public string ItemType { get; } = "Block";

--- a/src/csharp/Pester/Test.cs
+++ b/src/csharp/Pester/Test.cs
@@ -46,7 +46,6 @@ namespace Pester
         public string GroupId { get; set; }
         public ScriptBlock ScriptBlock { get; set; }
         public List<string> Tag { get; set; }
-        public bool Focus { get; set; }
         public bool Skip { get; set; }
         // IDictionary to allow users use [ordered]
 

--- a/src/functions/Context.ps1
+++ b/src/functions/Context.ps1
@@ -87,7 +87,6 @@
         [ValidateNotNull()]
         [ScriptBlock] $Fixture,
 
-        # [Switch] $Focus,
         [Switch] $Skip,
         [Switch] $AllowNullOrEmptyForEach,
 
@@ -95,7 +94,6 @@
         $ForEach
     )
 
-    $Focus = $false
     if ($Fixture -eq $null) {
         if ($Name.Contains("`n")) {
             throw "Test fixture name has multiple lines and no test fixture is provided. (Have you provided a name for the test group?)"
@@ -122,10 +120,10 @@
                 return
             }
 
-            New-ParametrizedBlock -Name $Name -ScriptBlock $Fixture -StartLine $MyInvocation.ScriptLineNumber -StartColumn $MyInvocation.OffsetInLine -Tag $Tag -FrameworkData @{ CommandUsed = 'Context'; WrittenToScreen = $false } -Focus:$Focus -Skip:$Skip -Data $ForEach
+            New-ParametrizedBlock -Name $Name -ScriptBlock $Fixture -StartLine $MyInvocation.ScriptLineNumber -StartColumn $MyInvocation.OffsetInLine -Tag $Tag -FrameworkData @{ CommandUsed = 'Context'; WrittenToScreen = $false } -Skip:$Skip -Data $ForEach
         }
         else {
-            New-Block -Name $Name -ScriptBlock $Fixture -StartLine $MyInvocation.ScriptLineNumber -Tag $Tag -FrameworkData @{ CommandUsed = 'Context'; WrittenToScreen = $false } -Focus:$Focus -Skip:$Skip
+            New-Block -Name $Name -ScriptBlock $Fixture -StartLine $MyInvocation.ScriptLineNumber -Tag $Tag -FrameworkData @{ CommandUsed = 'Context'; WrittenToScreen = $false } -Skip:$Skip
         }
     }
     else {

--- a/src/functions/Describe.ps1
+++ b/src/functions/Describe.ps1
@@ -95,7 +95,6 @@
         [ValidateNotNull()]
         [ScriptBlock] $Fixture,
 
-        # [Switch] $Focus,
         [Switch] $Skip,
         [Switch] $AllowNullOrEmptyForEach,
 
@@ -103,7 +102,6 @@
         $ForEach
     )
 
-    $Focus = $false
     if ($null -eq $Fixture) {
         if ($Name.Contains("`n")) {
             throw "Test fixture name has multiple lines and no test fixture is provided. (Have you provided a name for the test group?)"
@@ -130,10 +128,10 @@
                 return
             }
 
-            New-ParametrizedBlock -Name $Name -ScriptBlock $Fixture -StartLine $MyInvocation.ScriptLineNumber -StartColumn $MyInvocation.OffsetInLine -Tag $Tag -FrameworkData @{ CommandUsed = 'Describe'; WrittenToScreen = $false } -Focus:$Focus -Skip:$Skip -Data $ForEach
+            New-ParametrizedBlock -Name $Name -ScriptBlock $Fixture -StartLine $MyInvocation.ScriptLineNumber -StartColumn $MyInvocation.OffsetInLine -Tag $Tag -FrameworkData @{ CommandUsed = 'Describe'; WrittenToScreen = $false } -Skip:$Skip -Data $ForEach
         }
         else {
-            New-Block -Name $Name -ScriptBlock $Fixture -StartLine $MyInvocation.ScriptLineNumber -Tag $Tag -FrameworkData @{ CommandUsed = 'Describe'; WrittenToScreen = $false } -Focus:$Focus -Skip:$Skip
+            New-Block -Name $Name -ScriptBlock $Fixture -StartLine $MyInvocation.ScriptLineNumber -Tag $Tag -FrameworkData @{ CommandUsed = 'Describe'; WrittenToScreen = $false } -Skip:$Skip
         }
     }
     else {

--- a/src/functions/It.ps1
+++ b/src/functions/It.ps1
@@ -137,11 +137,7 @@
 
         # [Parameter(ParameterSetName = 'Skip')]
         # [String] $SkipBecause,
-
-        # [Switch]$Focus
     )
-
-    $Focus = $false
 
     if ($null -eq $Test) {
         if ($Name.Contains("`n")) {
@@ -163,9 +159,9 @@
             return
         }
 
-        New-ParametrizedTest -Name $Name -ScriptBlock $Test -StartLine $MyInvocation.ScriptLineNumber -StartColumn $MyInvocation.OffsetInLine -Data $ForEach -Tag $Tag -Focus:$Focus -Skip:$Skip
+        New-ParametrizedTest -Name $Name -ScriptBlock $Test -StartLine $MyInvocation.ScriptLineNumber -StartColumn $MyInvocation.OffsetInLine -Data $ForEach -Tag $Tag -Skip:$Skip
     }
     else {
-        New-Test -Name $Name -ScriptBlock $Test -StartLine $MyInvocation.ScriptLineNumber -Tag $Tag -Focus:$Focus -Skip:$Skip
+        New-Test -Name $Name -ScriptBlock $Test -StartLine $MyInvocation.ScriptLineNumber -Tag $Tag -Skip:$Skip
     }
 }

--- a/tst/Pester.Runtime.ts.ps1
+++ b/tst/Pester.Runtime.ts.ps1
@@ -64,7 +64,6 @@ i -PassThru:$PassThru {
             [System.Collections.IDictionary] $Data,
             [ScriptBlock] $ScriptBlock,
             [int] $StartLine,
-            [Switch] $Focus,
             [Switch] $Skip
         )
 
@@ -74,7 +73,6 @@ i -PassThru:$PassThru {
         $t.Path = $Path
         $t.Tag = $Tag
         $t.StartLine = $StartLine
-        $t.Focus = [Bool]$Focus
         $t.Skip = [Bool]$Skip
         $t.Data = $Data
 
@@ -1896,58 +1894,6 @@ i -PassThru:$PassThru {
         }
     }
 
-    # focus is removed and will be replaced by pins
-    # b "focus" {
-    #     t "focusing one test in group will run only it" {
-    #         $actual = Invoke-Test -SessionState $ExecutionContext.SessionState -BlockContainer (
-    #             New-BlockContainerObject -ScriptBlock {
-
-    #                 New-Block -Name "block1" {
-
-    #                     New-Test "test 1" { }
-
-    #                     New-Block -Name "block2" {
-    #                         New-Test "test 2" { }
-    #                     }
-    #                 }
-
-    #                 New-Block -Name "block3" {
-    #                     New-Test -Focus "test 3" { }
-    #                 }
-    #             }
-    #         )
-
-    #         $testsToRun = @($actual | View-Flat | where { $_.ShouldRun })
-    #         $testsToRun.Count | Verify-Equal 1
-    #         $testsToRun[0].Name | Verify-Equal "test 3"
-    #     }
-
-    #     t "focusing one block in group will run only tests in it" {
-    #         $actual = Invoke-Test -SessionState $ExecutionContext.SessionState -BlockContainer (
-    #             New-BlockContainerObject -ScriptBlock {
-
-    #                 New-Block -Focus -Name "block1" {
-
-    #                     New-Test "test 1" { }
-
-    #                     New-Block -Name "block2" {
-    #                         New-Test "test 2" { }
-    #                     }
-    #                 }
-
-    #                 New-Block -Name "block3" {
-    #                     New-Test  "test 3" { }
-    #                 }
-    #             }
-    #         )
-
-    #         $testsToRun = $actual | View-Flat | where { $_.ShouldRun }
-    #         $testsToRun.Count | Verify-Equal 2
-    #         $testsToRun[0].Name | Verify-Equal "test 1"
-    #         $testsToRun[1].Name | Verify-Equal "test 2"
-    #     }
-    # }
-
     b "expandable variables in names" {
         t "can run tests that have expandable variable in their name" {
             # this should cause no problems, the test name is the same during
@@ -2080,8 +2026,8 @@ i -PassThru:$PassThru {
             Write-Host Total difference $totalDifference.TotalMilliseconds
 
             # the difference here is because of the code that is running after all tests have been discovered
-            # such as figuring out if there are focused tests, setting filters and determining which tests to run
-            # this needs to be done over all blocks at the same time because of the focused tests
+            # such as setting filters and determining which tests to run
+            # this needs to be done over all blocks at the same time
             # the difference here is actually <10ms but let's make this less finicky
             $totalDifference.TotalMilliseconds -lt 100 | Verify-True
         }
@@ -2143,8 +2089,8 @@ i -PassThru:$PassThru {
             Write-Host Total difference $totalDifference.TotalMilliseconds
 
             # the difference here is because of the code that is running after all tests have been discovered
-            # such as figuring out if there are focused tests, setting filters and determining which tests to run
-            # this needs to be done over all blocks at the same time because of the focused tests
+            # such as setting filters and determining which tests to run
+            # this needs to be done over all blocks at the same time
             # the difference here is actually <10ms but let's make this less finicky
             $totalDifference.TotalMilliseconds -lt 100 | Verify-True
         }
@@ -2200,8 +2146,8 @@ i -PassThru:$PassThru {
 
 
             # the difference here is because of the code that is running after all tests have been discovered
-            # such as figuring out if there are focused tests, setting filters and determining which tests to run
-            # this needs to be done over all blocks at the same time because of the focused tests
+            # such as setting filters and determining which tests to run
+            # this needs to be done over all blocks at the same time
             # the difference here is actually <10ms but let's make this less finicky
             $totalDifference.TotalMilliseconds -lt 100 | Verify-True
 


### PR DESCRIPTION
## Summary

`Focus` (the v5 `fdescribe`/`fit`-style `-Focus` switch on `Describe`/`Context`/`It`) was already disabled in v6 — the user-facing parameter was commented out and hard-coded to `$false`. This PR removes the remaining vestigial plumbing, which had **zero consumers**: nothing ever read the `Focus` property, the `[Switch] $Focus` parameters, or the `AnyFocusedTests`/`FocusedTests` keys passed into the `DiscoveryEnd` plugin step.

It also adds a second, docs-only breaking-changes note for an already-shipped behavior change (hidden-folder test discovery).

## Changes

- **`src/csharp/Pester/Test.cs`, `src/csharp/Pester/Block.cs`** — removed the unused `public bool Focus` property.
- **`src/Pester.Runtime.ps1`** — removed the `[Switch] $Focus` parameters, the `$block.Focus`/`$test.Focus` assignments and `-Focus:$Focus` call arguments in `New-Block`/`New-ParametrizedBlock`/`New-Test`/`New-ParametrizedTest`, and the dead `AnyFocusedTests`/`FocusedTests` keys from both `DiscoveryEnd` contexts.
- **`src/Main.ps1`** — removed the `AnyFocusedTests`/`FocusedTests` keys from both `DiscoveryEnd` contexts.
- **`src/functions/It.ps1`, `Describe.ps1`, `Context.ps1`** — removed the commented-out `$Focus` param, the `$Focus = $false` line, and `-Focus:$Focus` from the discovery calls.
- **`tst/Pester.Runtime.ts.ps1`** — removed the `Focus` param/assignment from the local `New-TestObject` helper, deleted the already commented-out `b "focus"` test block, and reworded the explanatory comments that referenced focused tests.
- **`docs/6.0.0.md`** — added two breaking-change notes (see below).

## Breaking changes documented

- **The `-Focus` switch was removed** — the `Focus` property is gone from the result object's blocks and tests (a public shape change to the result object).
- **Test discovery now looks inside hidden folders** — docs-only note; the behavior already shipped. File search uses `Get-ChildItem -Force`, so `*.Tests.ps1` files in hidden/dot-prefixed folders (e.g. `.config`, `.build`) are now discovered (VCS metadata folders `.git`/`.svn`/`.hg` are still ignored; use `Run.ExcludePath` to skip others).

## Verification

- `grep` confirms no `Focus`/`Focused`/`AnyFocusedTests`/`FocusedTests` references remain in `src`/`tst`.
- `./build.ps1 -Clean` succeeds (0 warnings, 0 errors) — C# rebuild required since `Test.cs`/`Block.cs` changed.
- `tst/Pester.Runtime.ts.ps1` runtime tests pass (101/101).
- Smoke test: a small inline `Describe`/`Context`/`It` (including a `-ForEach` case) runs green, and the result object's tests/blocks no longer expose a `Focus` property.
- The build analyzer introduces no new violations versus the base.