### PR TITLE
Document -ErrorAction soft-assertion behavior on Should-* commands

### DIFF
--- a/src/functions/assert/Boolean/Should-BeFalse.ps1
+++ b/src/functions/assert/Boolean/Should-BeFalse.ps1
@@ -34,6 +34,10 @@
     .NOTES
     The `Should-BeFalse` assertion is the opposite of the `Should-BeTrue` assertion.
 
+    Use the `-ErrorAction` parameter to control soft-assertion behavior for this assertion. `-ErrorAction Continue` records the failure and lets the rest of the test run (a soft assertion), while `-ErrorAction Stop` fails the test immediately, for example to guard a precondition before continuing.
+
+    When `-ErrorAction` is not specified, the behavior comes from `Should.ErrorAction` in the configuration, which defaults to `Stop`. See https://pester.dev/docs/assertions/soft-assertions for more about soft assertions.
+
     .LINK
     https://pester.dev/docs/commands/Should-BeFalse
 

--- a/src/functions/assert/Boolean/Should-BeFalsy.ps1
+++ b/src/functions/assert/Boolean/Should-BeFalsy.ps1
@@ -34,6 +34,10 @@
     .NOTES
     The `Should-BeFalsy` assertion is the opposite of the `Should-BeTruthy` assertion.
 
+    Use the `-ErrorAction` parameter to control soft-assertion behavior for this assertion. `-ErrorAction Continue` records the failure and lets the rest of the test run (a soft assertion), while `-ErrorAction Stop` fails the test immediately, for example to guard a precondition before continuing.
+
+    When `-ErrorAction` is not specified, the behavior comes from `Should.ErrorAction` in the configuration, which defaults to `Stop`. See https://pester.dev/docs/assertions/soft-assertions for more about soft assertions.
+
     .LINK
     https://pester.dev/docs/commands/Should-BeFalsy
 

--- a/src/functions/assert/Boolean/Should-BeTrue.ps1
+++ b/src/functions/assert/Boolean/Should-BeTrue.ps1
@@ -34,6 +34,10 @@
     .NOTES
     The `Should-BeTrue` assertion is the opposite of the `Should-BeFalse` assertion.
 
+    Use the `-ErrorAction` parameter to control soft-assertion behavior for this assertion. `-ErrorAction Continue` records the failure and lets the rest of the test run (a soft assertion), while `-ErrorAction Stop` fails the test immediately, for example to guard a precondition before continuing.
+
+    When `-ErrorAction` is not specified, the behavior comes from `Should.ErrorAction` in the configuration, which defaults to `Stop`. See https://pester.dev/docs/assertions/soft-assertions for more about soft assertions.
+
     .LINK
     https://pester.dev/docs/commands/Should-BeTrue
 

--- a/src/functions/assert/Boolean/Should-BeTruthy.ps1
+++ b/src/functions/assert/Boolean/Should-BeTruthy.ps1
@@ -35,6 +35,10 @@
     .NOTES
     The `Should-BeTruthy` assertion is the opposite of the `Should-BeFalsy` assertion.
 
+    Use the `-ErrorAction` parameter to control soft-assertion behavior for this assertion. `-ErrorAction Continue` records the failure and lets the rest of the test run (a soft assertion), while `-ErrorAction Stop` fails the test immediately, for example to guard a precondition before continuing.
+
+    When `-ErrorAction` is not specified, the behavior comes from `Should.ErrorAction` in the configuration, which defaults to `Stop`. See https://pester.dev/docs/assertions/soft-assertions for more about soft assertions.
+
     .LINK
     https://pester.dev/docs/commands/Should-BeTruthy
 

--- a/src/functions/assert/Collection/Should-All.ps1
+++ b/src/functions/assert/Collection/Should-All.ps1
@@ -31,6 +31,11 @@
 
     The assertions will fail because not all items in the array are greater than 1.
 
+    .NOTES
+    Use the `-ErrorAction` parameter to control soft-assertion behavior for this assertion. `-ErrorAction Continue` records the failure and lets the rest of the test run (a soft assertion), while `-ErrorAction Stop` fails the test immediately, for example to guard a precondition before continuing.
+
+    When `-ErrorAction` is not specified, the behavior comes from `Should.ErrorAction` in the configuration, which defaults to `Stop`. See https://pester.dev/docs/assertions/soft-assertions for more about soft assertions.
+
     .LINK
     https://pester.dev/docs/commands/Should-All
 

--- a/src/functions/assert/Collection/Should-Any.ps1
+++ b/src/functions/assert/Collection/Should-Any.ps1
@@ -31,6 +31,11 @@
 
     The assertions will fail because none of theitems in the array are greater than 4.
 
+    .NOTES
+    Use the `-ErrorAction` parameter to control soft-assertion behavior for this assertion. `-ErrorAction Continue` records the failure and lets the rest of the test run (a soft assertion), while `-ErrorAction Stop` fails the test immediately, for example to guard a precondition before continuing.
+
+    When `-ErrorAction` is not specified, the behavior comes from `Should.ErrorAction` in the configuration, which defaults to `Stop`. See https://pester.dev/docs/assertions/soft-assertions for more about soft assertions.
+
     .LINK
     https://pester.dev/docs/commands/Should-Any
 

--- a/src/functions/assert/Collection/Should-BeCollection.ps1
+++ b/src/functions/assert/Collection/Should-BeCollection.ps1
@@ -37,6 +37,11 @@
 
     The assertions will fail because the collections are not equal.
 
+    .NOTES
+    Use the `-ErrorAction` parameter to control soft-assertion behavior for this assertion. `-ErrorAction Continue` records the failure and lets the rest of the test run (a soft assertion), while `-ErrorAction Stop` fails the test immediately, for example to guard a precondition before continuing.
+
+    When `-ErrorAction` is not specified, the behavior comes from `Should.ErrorAction` in the configuration, which defaults to `Stop`. See https://pester.dev/docs/assertions/soft-assertions for more about soft assertions.
+
     .LINK
     https://pester.dev/docs/commands/Should-BeCollection
 

--- a/src/functions/assert/Collection/Should-ContainCollection.ps1
+++ b/src/functions/assert/Collection/Should-ContainCollection.ps1
@@ -35,6 +35,11 @@
 
     These assertions fail, because an expected item is missing (`@(3, 4)`), the items are not in the right order (`@(3, 2, 1)`), or the actual collection does not have enough matching items (`@(1, 1)` needs two 1s).
 
+    .NOTES
+    Use the `-ErrorAction` parameter to control soft-assertion behavior for this assertion. `-ErrorAction Continue` records the failure and lets the rest of the test run (a soft assertion), while `-ErrorAction Stop` fails the test immediately, for example to guard a precondition before continuing.
+
+    When `-ErrorAction` is not specified, the behavior comes from `Should.ErrorAction` in the configuration, which defaults to `Stop`. See https://pester.dev/docs/assertions/soft-assertions for more about soft assertions.
+
     .LINK
     https://pester.dev/docs/commands/Should-ContainCollection
 

--- a/src/functions/assert/Collection/Should-NotContainCollection.ps1
+++ b/src/functions/assert/Collection/Should-NotContainCollection.ps1
@@ -33,6 +33,11 @@
 
     These assertions fail, because the expected items are present in the same order. Gaps between them, as in `@(1, 3)`, are allowed.
 
+    .NOTES
+    Use the `-ErrorAction` parameter to control soft-assertion behavior for this assertion. `-ErrorAction Continue` records the failure and lets the rest of the test run (a soft assertion), while `-ErrorAction Stop` fails the test immediately, for example to guard a precondition before continuing.
+
+    When `-ErrorAction` is not specified, the behavior comes from `Should.ErrorAction` in the configuration, which defaults to `Stop`. See https://pester.dev/docs/assertions/soft-assertions for more about soft assertions.
+
     .LINK
     https://pester.dev/docs/commands/Should-NotContainCollection
 

--- a/src/functions/assert/Equivalence/Should-BeEquivalent.ps1
+++ b/src/functions/assert/Equivalence/Should-BeEquivalent.ps1
@@ -687,6 +687,11 @@ function Should-BeEquivalent {
 
     This will pass because the actual object has the same properties as the expected object and the Name values are equivalent.
 
+    .NOTES
+    Use the `-ErrorAction` parameter to control soft-assertion behavior for this assertion. `-ErrorAction Continue` records the failure and lets the rest of the test run (a soft assertion), while `-ErrorAction Stop` fails the test immediately, for example to guard a precondition before continuing.
+
+    When `-ErrorAction` is not specified, the behavior comes from `Should.ErrorAction` in the configuration, which defaults to `Stop`. See https://pester.dev/docs/assertions/soft-assertions for more about soft assertions.
+
     .LINK
     https://pester.dev/docs/commands/Should-BeEquivalent
 

--- a/src/functions/assert/Exception/Should-Throw.ps1
+++ b/src/functions/assert/Exception/Should-Throw.ps1
@@ -45,6 +45,11 @@
 
     The error record is returned from the assertion and can be used in further assertions.
 
+    .NOTES
+    Use the `-ErrorAction` parameter to control soft-assertion behavior for this assertion. `-ErrorAction Continue` records the failure and lets the rest of the test run (a soft assertion), while `-ErrorAction Stop` fails the test immediately, for example to guard a precondition before continuing.
+
+    When `-ErrorAction` is not specified, the behavior comes from `Should.ErrorAction` in the configuration, which defaults to `Stop`. See https://pester.dev/docs/assertions/soft-assertions for more about soft assertions.
+
     .LINK
     https://pester.dev/docs/commands/Should-Throw
 

--- a/src/functions/assert/General/Should-Be.ps1
+++ b/src/functions/assert/General/Should-Be.ps1
@@ -23,6 +23,11 @@
 
     These assertions will pass, because the expected value is equal to the actual value.
 
+    .NOTES
+    Use the `-ErrorAction` parameter to control soft-assertion behavior for this assertion. `-ErrorAction Continue` records the failure and lets the rest of the test run (a soft assertion), while `-ErrorAction Stop` fails the test immediately, for example to guard a precondition before continuing.
+
+    When `-ErrorAction` is not specified, the behavior comes from `Should.ErrorAction` in the configuration, which defaults to `Stop`. See https://pester.dev/docs/assertions/soft-assertions for more about soft assertions.
+
     .LINK
     https://pester.dev/docs/commands/Should-Be
 

--- a/src/functions/assert/General/Should-BeGreaterThan.ps1
+++ b/src/functions/assert/General/Should-BeGreaterThan.ps1
@@ -23,6 +23,11 @@
 
     These assertions will pass, because the actual value is greater than the expected value.
 
+    .NOTES
+    Use the `-ErrorAction` parameter to control soft-assertion behavior for this assertion. `-ErrorAction Continue` records the failure and lets the rest of the test run (a soft assertion), while `-ErrorAction Stop` fails the test immediately, for example to guard a precondition before continuing.
+
+    When `-ErrorAction` is not specified, the behavior comes from `Should.ErrorAction` in the configuration, which defaults to `Stop`. See https://pester.dev/docs/assertions/soft-assertions for more about soft assertions.
+
     .LINK
     https://pester.dev/docs/commands/Should-BeGreaterThan
 

--- a/src/functions/assert/General/Should-BeGreaterThanOrEqual.ps1
+++ b/src/functions/assert/General/Should-BeGreaterThanOrEqual.ps1
@@ -23,6 +23,11 @@
 
     These assertions will pass, because the actual value is greater than or equal to the expected value.
 
+    .NOTES
+    Use the `-ErrorAction` parameter to control soft-assertion behavior for this assertion. `-ErrorAction Continue` records the failure and lets the rest of the test run (a soft assertion), while `-ErrorAction Stop` fails the test immediately, for example to guard a precondition before continuing.
+
+    When `-ErrorAction` is not specified, the behavior comes from `Should.ErrorAction` in the configuration, which defaults to `Stop`. See https://pester.dev/docs/assertions/soft-assertions for more about soft assertions.
+
     .LINK
     https://pester.dev/docs/commands/Should-BeGreaterThanOrEqual
 

--- a/src/functions/assert/General/Should-BeLessThan.ps1
+++ b/src/functions/assert/General/Should-BeLessThan.ps1
@@ -23,6 +23,11 @@
 
     These assertions will pass, because the actual value is less than the expected value.
 
+    .NOTES
+    Use the `-ErrorAction` parameter to control soft-assertion behavior for this assertion. `-ErrorAction Continue` records the failure and lets the rest of the test run (a soft assertion), while `-ErrorAction Stop` fails the test immediately, for example to guard a precondition before continuing.
+
+    When `-ErrorAction` is not specified, the behavior comes from `Should.ErrorAction` in the configuration, which defaults to `Stop`. See https://pester.dev/docs/assertions/soft-assertions for more about soft assertions.
+
     .LINK
     https://pester.dev/docs/commands/Should-BeLessThan
 

--- a/src/functions/assert/General/Should-BeLessThanOrEqual.ps1
+++ b/src/functions/assert/General/Should-BeLessThanOrEqual.ps1
@@ -33,6 +33,10 @@
     .NOTES
     The `Should-BeLessThanOrEqual` assertion is the opposite of the `Should-BeGreaterThan` assertion.
 
+    Use the `-ErrorAction` parameter to control soft-assertion behavior for this assertion. `-ErrorAction Continue` records the failure and lets the rest of the test run (a soft assertion), while `-ErrorAction Stop` fails the test immediately, for example to guard a precondition before continuing.
+
+    When `-ErrorAction` is not specified, the behavior comes from `Should.ErrorAction` in the configuration, which defaults to `Stop`. See https://pester.dev/docs/assertions/soft-assertions for more about soft assertions.
+
     .LINK
     https://pester.dev/docs/commands/Should-BeLessThanOrEqual
 

--- a/src/functions/assert/General/Should-BeNull.ps1
+++ b/src/functions/assert/General/Should-BeNull.ps1
@@ -19,6 +19,11 @@
 
     This assertion will pass, because the actual value is `$null`.
 
+    .NOTES
+    Use the `-ErrorAction` parameter to control soft-assertion behavior for this assertion. `-ErrorAction Continue` records the failure and lets the rest of the test run (a soft assertion), while `-ErrorAction Stop` fails the test immediately, for example to guard a precondition before continuing.
+
+    When `-ErrorAction` is not specified, the behavior comes from `Should.ErrorAction` in the configuration, which defaults to `Stop`. See https://pester.dev/docs/assertions/soft-assertions for more about soft assertions.
+
     .LINK
     https://pester.dev/docs/commands/Should-BeNull
 

--- a/src/functions/assert/General/Should-BeSame.ps1
+++ b/src/functions/assert/General/Should-BeSame.ps1
@@ -35,6 +35,10 @@
     .NOTES
     The `Should-BeSame` assertion is the opposite of the `Should-NotBeSame` assertion.
 
+    Use the `-ErrorAction` parameter to control soft-assertion behavior for this assertion. `-ErrorAction Continue` records the failure and lets the rest of the test run (a soft assertion), while `-ErrorAction Stop` fails the test immediately, for example to guard a precondition before continuing.
+
+    When `-ErrorAction` is not specified, the behavior comes from `Should.ErrorAction` in the configuration, which defaults to `Stop`. See https://pester.dev/docs/assertions/soft-assertions for more about soft assertions.
+
     .LINK
     https://pester.dev/docs/commands/Should-BeSame
 

--- a/src/functions/assert/General/Should-HaveType.ps1
+++ b/src/functions/assert/General/Should-HaveType.ps1
@@ -23,6 +23,11 @@
 
     These assertions will pass, because the actual value is of the expected type.
 
+    .NOTES
+    Use the `-ErrorAction` parameter to control soft-assertion behavior for this assertion. `-ErrorAction Continue` records the failure and lets the rest of the test run (a soft assertion), while `-ErrorAction Stop` fails the test immediately, for example to guard a precondition before continuing.
+
+    When `-ErrorAction` is not specified, the behavior comes from `Should.ErrorAction` in the configuration, which defaults to `Stop`. See https://pester.dev/docs/assertions/soft-assertions for more about soft assertions.
+
     .LINK
     https://pester.dev/docs/commands/Should-HaveType
 

--- a/src/functions/assert/General/Should-NotBe.ps1
+++ b/src/functions/assert/General/Should-NotBe.ps1
@@ -23,6 +23,11 @@
 
     These assertions will pass, because the actual value is not equal to the expected value.
 
+    .NOTES
+    Use the `-ErrorAction` parameter to control soft-assertion behavior for this assertion. `-ErrorAction Continue` records the failure and lets the rest of the test run (a soft assertion), while `-ErrorAction Stop` fails the test immediately, for example to guard a precondition before continuing.
+
+    When `-ErrorAction` is not specified, the behavior comes from `Should.ErrorAction` in the configuration, which defaults to `Stop`. See https://pester.dev/docs/assertions/soft-assertions for more about soft assertions.
+
     .LINK
     https://pester.dev/docs/commands/Should-NotBe
 

--- a/src/functions/assert/General/Should-NotBeNull.ps1
+++ b/src/functions/assert/General/Should-NotBeNull.ps1
@@ -20,6 +20,11 @@
 
     These assertions will pass, because the actual value is not `$null.
 
+    .NOTES
+    Use the `-ErrorAction` parameter to control soft-assertion behavior for this assertion. `-ErrorAction Continue` records the failure and lets the rest of the test run (a soft assertion), while `-ErrorAction Stop` fails the test immediately, for example to guard a precondition before continuing.
+
+    When `-ErrorAction` is not specified, the behavior comes from `Should.ErrorAction` in the configuration, which defaults to `Stop`. See https://pester.dev/docs/assertions/soft-assertions for more about soft assertions.
+
     .LINK
     https://pester.dev/docs/commands/Should-NotBeNull
 

--- a/src/functions/assert/General/Should-NotBeSame.ps1
+++ b/src/functions/assert/General/Should-NotBeSame.ps1
@@ -34,6 +34,10 @@
     .NOTES
     The `Should-NotBeSame` assertion is the opposite of the `Should-BeSame` assertion.
 
+    Use the `-ErrorAction` parameter to control soft-assertion behavior for this assertion. `-ErrorAction Continue` records the failure and lets the rest of the test run (a soft assertion), while `-ErrorAction Stop` fails the test immediately, for example to guard a precondition before continuing.
+
+    When `-ErrorAction` is not specified, the behavior comes from `Should.ErrorAction` in the configuration, which defaults to `Stop`. See https://pester.dev/docs/assertions/soft-assertions for more about soft assertions.
+
     .LINK
     https://pester.dev/docs/commands/Should-NotBeSame
 

--- a/src/functions/assert/General/Should-NotHaveType.ps1
+++ b/src/functions/assert/General/Should-NotHaveType.ps1
@@ -26,6 +26,10 @@
     .NOTES
     This assertion is the opposite of `Should-HaveType`.
 
+    Use the `-ErrorAction` parameter to control soft-assertion behavior for this assertion. `-ErrorAction Continue` records the failure and lets the rest of the test run (a soft assertion), while `-ErrorAction Stop` fails the test immediately, for example to guard a precondition before continuing.
+
+    When `-ErrorAction` is not specified, the behavior comes from `Should.ErrorAction` in the configuration, which defaults to `Stop`. See https://pester.dev/docs/assertions/soft-assertions for more about soft assertions.
+
     .LINK
     https://pester.dev/docs/commands/Should-NotHaveType
 

--- a/src/functions/assert/Hashtable/Should-BeHashtable.ps1
+++ b/src/functions/assert/Hashtable/Should-BeHashtable.ps1
@@ -69,6 +69,10 @@
     `Should-BeHashtable` only asserts on the shape of the dictionary. To compare its keys and
     values against an expected dictionary, use `Should-BeEquivalent`.
 
+    Use the `-ErrorAction` parameter to control soft-assertion behavior for this assertion. `-ErrorAction Continue` records the failure and lets the rest of the test run (a soft assertion), while `-ErrorAction Stop` fails the test immediately, for example to guard a precondition before continuing.
+
+    When `-ErrorAction` is not specified, the behavior comes from `Should.ErrorAction` in the configuration, which defaults to `Stop`. See https://pester.dev/docs/assertions/soft-assertions for more about soft assertions.
+
     .LINK
     https://pester.dev/docs/commands/Should-BeHashtable
 

--- a/src/functions/assert/Mock/Should-Invoke.ps1
+++ b/src/functions/assert/Mock/Should-Invoke.ps1
@@ -150,6 +150,10 @@
     In other words, Should-Invoke can only be used to check for calls to the mocked implementation, not
     to the original.
 
+    Use the `-ErrorAction` parameter to control soft-assertion behavior for this assertion. `-ErrorAction Continue` records the failure and lets the rest of the test run (a soft assertion), while `-ErrorAction Stop` fails the test immediately, for example to guard a precondition before continuing.
+
+    When `-ErrorAction` is not specified, the behavior comes from `Should.ErrorAction` in the configuration, which defaults to `Stop`. See https://pester.dev/docs/assertions/soft-assertions for more about soft assertions.
+
     .LINK
     https://pester.dev/docs/commands/Should-Invoke
 

--- a/src/functions/assert/Mock/Should-NotInvoke.ps1
+++ b/src/functions/assert/Mock/Should-NotInvoke.ps1
@@ -108,6 +108,10 @@
     In other words, Should-NotInvoke can only be used to check for calls to the mocked implementation, not
     to the original.
 
+    Use the `-ErrorAction` parameter to control soft-assertion behavior for this assertion. `-ErrorAction Continue` records the failure and lets the rest of the test run (a soft assertion), while `-ErrorAction Stop` fails the test immediately, for example to guard a precondition before continuing.
+
+    When `-ErrorAction` is not specified, the behavior comes from `Should.ErrorAction` in the configuration, which defaults to `Stop`. See https://pester.dev/docs/assertions/soft-assertions for more about soft assertions.
+
     .LINK
     https://pester.dev/docs/commands/Should-NotInvoke
 

--- a/src/functions/assert/Parameter/Should-HaveParameter.ps1
+++ b/src/functions/assert/Parameter/Should-HaveParameter.ps1
@@ -82,6 +82,10 @@
     assertion will not be able to use the -HasArgumentCompleter parameter
     if the attribute does not exist.
 
+    Use the `-ErrorAction` parameter to control soft-assertion behavior for this assertion. `-ErrorAction Continue` records the failure and lets the rest of the test run (a soft assertion), while `-ErrorAction Stop` fails the test immediately, for example to guard a precondition before continuing.
+
+    When `-ErrorAction` is not specified, the behavior comes from `Should.ErrorAction` in the configuration, which defaults to `Stop`. See https://pester.dev/docs/assertions/soft-assertions for more about soft assertions.
+
     .LINK
     https://pester.dev/docs/commands/Should-HaveParameter
 

--- a/src/functions/assert/Parameter/Should-NotHaveParameter.ps1
+++ b/src/functions/assert/Parameter/Should-NotHaveParameter.ps1
@@ -33,6 +33,11 @@
 
     This assertion passes, because `Get-PublicReport` does not expose a `-Credential` parameter. This is useful for guarding against accidentally adding parameters you want to keep off a command's public surface.
 
+    .NOTES
+    Use the `-ErrorAction` parameter to control soft-assertion behavior for this assertion. `-ErrorAction Continue` records the failure and lets the rest of the test run (a soft assertion), while `-ErrorAction Stop` fails the test immediately, for example to guard a precondition before continuing.
+
+    When `-ErrorAction` is not specified, the behavior comes from `Should.ErrorAction` in the configuration, which defaults to `Stop`. See https://pester.dev/docs/assertions/soft-assertions for more about soft assertions.
+
     .LINK
     https://pester.dev/docs/commands/Should-NotHaveParameter
 

--- a/src/functions/assert/String/Should-BeEmptyString.ps1
+++ b/src/functions/assert/String/Should-BeEmptyString.ps1
@@ -38,6 +38,11 @@
 
     All the tests above will fail, the input is not a string.
 
+    .NOTES
+    Use the `-ErrorAction` parameter to control soft-assertion behavior for this assertion. `-ErrorAction Continue` records the failure and lets the rest of the test run (a soft assertion), while `-ErrorAction Stop` fails the test immediately, for example to guard a precondition before continuing.
+
+    When `-ErrorAction` is not specified, the behavior comes from `Should.ErrorAction` in the configuration, which defaults to `Stop`. See https://pester.dev/docs/assertions/soft-assertions for more about soft assertions.
+
     .LINK
     https://pester.dev/docs/commands/Should-BeEmptyString
 

--- a/src/functions/assert/String/Should-BeLikeString.ps1
+++ b/src/functions/assert/String/Should-BeLikeString.ps1
@@ -50,6 +50,10 @@ function Should-BeLikeString {
     .NOTES
     The `Should-BeLikeString` assertion is the opposite of the `Should-NotBeLikeString` assertion.
 
+    Use the `-ErrorAction` parameter to control soft-assertion behavior for this assertion. `-ErrorAction Continue` records the failure and lets the rest of the test run (a soft assertion), while `-ErrorAction Stop` fails the test immediately, for example to guard a precondition before continuing.
+
+    When `-ErrorAction` is not specified, the behavior comes from `Should.ErrorAction` in the configuration, which defaults to `Stop`. See https://pester.dev/docs/assertions/soft-assertions for more about soft assertions.
+
     .LINK
     https://pester.dev/docs/commands/Should-BeLikeString
 

--- a/src/functions/assert/String/Should-BeString.ps1
+++ b/src/functions/assert/String/Should-BeString.ps1
@@ -72,6 +72,10 @@ function Should-BeString {
     .NOTES
     The `Should-BeString` assertion is the opposite of the `Should-NotBeString` assertion.
 
+    Use the `-ErrorAction` parameter to control soft-assertion behavior for this assertion. `-ErrorAction Continue` records the failure and lets the rest of the test run (a soft assertion), while `-ErrorAction Stop` fails the test immediately, for example to guard a precondition before continuing.
+
+    When `-ErrorAction` is not specified, the behavior comes from `Should.ErrorAction` in the configuration, which defaults to `Stop`. See https://pester.dev/docs/assertions/soft-assertions for more about soft assertions.
+
     .LINK
     https://pester.dev/docs/commands/Should-BeString
 

--- a/src/functions/assert/String/Should-MatchString.ps1
+++ b/src/functions/assert/String/Should-MatchString.ps1
@@ -54,6 +54,11 @@ function Should-MatchString {
 
     This assertion fails, because with `-CaseSensitive` the lowercase `pester` in the pattern does not match the capitalized `Pester` in the actual value.
 
+    .NOTES
+    Use the `-ErrorAction` parameter to control soft-assertion behavior for this assertion. `-ErrorAction Continue` records the failure and lets the rest of the test run (a soft assertion), while `-ErrorAction Stop` fails the test immediately, for example to guard a precondition before continuing.
+
+    When `-ErrorAction` is not specified, the behavior comes from `Should.ErrorAction` in the configuration, which defaults to `Stop`. See https://pester.dev/docs/assertions/soft-assertions for more about soft assertions.
+
     .LINK
     https://pester.dev/docs/commands/Should-MatchString
 

--- a/src/functions/assert/String/Should-NotBeEmptyString.ps1
+++ b/src/functions/assert/String/Should-NotBeEmptyString.ps1
@@ -38,6 +38,11 @@
 
     All the tests above will fail, the input is not a string.
 
+    .NOTES
+    Use the `-ErrorAction` parameter to control soft-assertion behavior for this assertion. `-ErrorAction Continue` records the failure and lets the rest of the test run (a soft assertion), while `-ErrorAction Stop` fails the test immediately, for example to guard a precondition before continuing.
+
+    When `-ErrorAction` is not specified, the behavior comes from `Should.ErrorAction` in the configuration, which defaults to `Stop`. See https://pester.dev/docs/assertions/soft-assertions for more about soft assertions.
+
     .LINK
     https://pester.dev/docs/commands/Should-NotBeEmptyString
 

--- a/src/functions/assert/String/Should-NotBeLikeString.ps1
+++ b/src/functions/assert/String/Should-NotBeLikeString.ps1
@@ -58,6 +58,10 @@ function Should-NotBeLikeString {
     .NOTES
     The `Should-NotBeLikeString` assertion is the opposite of the `Should-BeLikeString` assertion.
 
+    Use the `-ErrorAction` parameter to control soft-assertion behavior for this assertion. `-ErrorAction Continue` records the failure and lets the rest of the test run (a soft assertion), while `-ErrorAction Stop` fails the test immediately, for example to guard a precondition before continuing.
+
+    When `-ErrorAction` is not specified, the behavior comes from `Should.ErrorAction` in the configuration, which defaults to `Stop`. See https://pester.dev/docs/assertions/soft-assertions for more about soft assertions.
+
     .LINK
     https://pester.dev/docs/commands/Should-NotBeLikeString
 

--- a/src/functions/assert/String/Should-NotBeString.ps1
+++ b/src/functions/assert/String/Should-NotBeString.ps1
@@ -42,6 +42,10 @@ function Should-NotBeString {
     .NOTES
     The `Should-NotBeString` assertion is the opposite of the `Should-BeString` assertion.
 
+    Use the `-ErrorAction` parameter to control soft-assertion behavior for this assertion. `-ErrorAction Continue` records the failure and lets the rest of the test run (a soft assertion), while `-ErrorAction Stop` fails the test immediately, for example to guard a precondition before continuing.
+
+    When `-ErrorAction` is not specified, the behavior comes from `Should.ErrorAction` in the configuration, which defaults to `Stop`. See https://pester.dev/docs/assertions/soft-assertions for more about soft assertions.
+
     .LINK
     https://pester.dev/docs/commands/Should-NotBeString
 

--- a/src/functions/assert/String/Should-NotBeWhiteSpaceString.ps1
+++ b/src/functions/assert/String/Should-NotBeWhiteSpaceString.ps1
@@ -39,6 +39,11 @@
 
     All the tests above will fail, the input is not a string.
 
+    .NOTES
+    Use the `-ErrorAction` parameter to control soft-assertion behavior for this assertion. `-ErrorAction Continue` records the failure and lets the rest of the test run (a soft assertion), while `-ErrorAction Stop` fails the test immediately, for example to guard a precondition before continuing.
+
+    When `-ErrorAction` is not specified, the behavior comes from `Should.ErrorAction` in the configuration, which defaults to `Stop`. See https://pester.dev/docs/assertions/soft-assertions for more about soft assertions.
+
     .LINK
     https://pester.dev/docs/commands/Should-NotBeWhiteSpaceString
 

--- a/src/functions/assert/String/Should-NotMatchString.ps1
+++ b/src/functions/assert/String/Should-NotMatchString.ps1
@@ -54,6 +54,11 @@ function Should-NotMatchString {
 
     This assertion fails, because the actual value case-sensitively contains `failed`.
 
+    .NOTES
+    Use the `-ErrorAction` parameter to control soft-assertion behavior for this assertion. `-ErrorAction Continue` records the failure and lets the rest of the test run (a soft assertion), while `-ErrorAction Stop` fails the test immediately, for example to guard a precondition before continuing.
+
+    When `-ErrorAction` is not specified, the behavior comes from `Should.ErrorAction` in the configuration, which defaults to `Stop`. See https://pester.dev/docs/assertions/soft-assertions for more about soft assertions.
+
     .LINK
     https://pester.dev/docs/commands/Should-NotMatchString
 

--- a/src/functions/assert/Time/Should-BeAfter.ps1
+++ b/src/functions/assert/Time/Should-BeAfter.ps1
@@ -58,6 +58,10 @@
     .NOTES
     The `Should-BeAfter` assertion is the opposite of the `Should-BeBefore` assertion.
 
+    Use the `-ErrorAction` parameter to control soft-assertion behavior for this assertion. `-ErrorAction Continue` records the failure and lets the rest of the test run (a soft assertion), while `-ErrorAction Stop` fails the test immediately, for example to guard a precondition before continuing.
+
+    When `-ErrorAction` is not specified, the behavior comes from `Should.ErrorAction` in the configuration, which defaults to `Stop`. See https://pester.dev/docs/assertions/soft-assertions for more about soft assertions.
+
     .LINK
     https://pester.dev/docs/commands/Should-BeAfter
 

--- a/src/functions/assert/Time/Should-BeBefore.ps1
+++ b/src/functions/assert/Time/Should-BeBefore.ps1
@@ -58,6 +58,10 @@
     .NOTES
     The `Should-BeBefore` assertion is the opposite of the `Should-BeAfter` assertion.
 
+    Use the `-ErrorAction` parameter to control soft-assertion behavior for this assertion. `-ErrorAction Continue` records the failure and lets the rest of the test run (a soft assertion), while `-ErrorAction Stop` fails the test immediately, for example to guard a precondition before continuing.
+
+    When `-ErrorAction` is not specified, the behavior comes from `Should.ErrorAction` in the configuration, which defaults to `Stop`. See https://pester.dev/docs/assertions/soft-assertions for more about soft assertions.
+
     .LINK
     https://pester.dev/docs/commands/Should-BeBefore
 

--- a/src/functions/assert/Time/Should-BeFasterThan.ps1
+++ b/src/functions/assert/Time/Should-BeFasterThan.ps1
@@ -32,6 +32,10 @@
     .NOTES
     The `Should-BeFasterThan` assertion is the opposite of the `Should-BeSlowerThan` assertion.
 
+    Use the `-ErrorAction` parameter to control soft-assertion behavior for this assertion. `-ErrorAction Continue` records the failure and lets the rest of the test run (a soft assertion), while `-ErrorAction Stop` fails the test immediately, for example to guard a precondition before continuing.
+
+    When `-ErrorAction` is not specified, the behavior comes from `Should.ErrorAction` in the configuration, which defaults to `Stop`. See https://pester.dev/docs/assertions/soft-assertions for more about soft assertions.
+
     .LINK
     https://pester.dev/docs/commands/Should-BeFasterThan
 

--- a/src/functions/assert/Time/Should-BeSlowerThan.ps1
+++ b/src/functions/assert/Time/Should-BeSlowerThan.ps1
@@ -39,6 +39,10 @@
     .NOTES
     The `Should-BeSlowerThan` assertion is the opposite of the `Should-BeFasterThan` assertion.
 
+    Use the `-ErrorAction` parameter to control soft-assertion behavior for this assertion. `-ErrorAction Continue` records the failure and lets the rest of the test run (a soft assertion), while `-ErrorAction Stop` fails the test immediately, for example to guard a precondition before continuing.
+
+    When `-ErrorAction` is not specified, the behavior comes from `Should.ErrorAction` in the configuration, which defaults to `Stop`. See https://pester.dev/docs/assertions/soft-assertions for more about soft assertions.
+
     .LINK
     https://pester.dev/docs/commands/Should-BeSlowerThan
 


### PR DESCRIPTION
## Summary

Surfaces the per-assertion meaning of `-ErrorAction` on the `Should-*` assertions by adding a **NOTES** section to their comment-based help. Today `-ErrorAction` only appears in the generic common-parameters boilerplate on the auto-generated [Command Reference pages](https://pester.dev/docs/commands/Should-Be), with no hint that for assertions it is the knob that controls **soft-assertion** behavior.

Each `Should-*` help now explains:

- `-ErrorAction Continue` — record the failure but keep running the test (soft assertion)
- `-ErrorAction Stop` — fail the test immediately (e.g. to guard a precondition before continuing)
- when `-ErrorAction` is not specified, the behavior comes from `Should.ErrorAction` in the configuration (default `Stop`)

The note links to the dedicated https://pester.dev/docs/assertions/soft-assertions page.

## Why

This is **Part 1** of pester/docs#385. Part 2 (a dedicated, searchable "Soft assertions" page) already shipped in the docs repo (pester/docs#397). Part 1 has to land here because the `Should-*` Command Reference pages are auto-generated from this comment-based help — so the text change can't be made in the docs repo.

## Scope

- Adds a `.NOTES` section to the 21 `Should-*` assertions that didn't have one, and appends the same two paragraphs to the existing `.NOTES` of the other 20. **41 files, additive only** (no logic changes).
- Wording matches the mechanism in `Invoke-AssertionFailed` (`-ErrorAction Stop` → throw; otherwise collected; falls back to `Should.ErrorAction`).

## Verification

- All 41 files parse with no errors.
- `Get-Help` shows the new NOTES on all 41 commands.
- `tst/Help.Tests.ps1 -Tag Help` passes: **390 passed, 0 failed, 1 skipped**.
