### PR TITLE
Bump prerelease to rc5

### DIFF
--- a/src/Pester.psd1
+++ b/src/Pester.psd1
@@ -169,10 +169,10 @@
             LicenseUri   = "https://www.apache.org/licenses/LICENSE-2.0.html"
 
             # Release notes for this particular version of the module
-            ReleaseNotes = 'https://github.com/pester/Pester/releases/tag/6.0.0-rc4'
+            ReleaseNotes = 'https://github.com/pester/Pester/releases/tag/6.0.0-rc5'
 
             # Prerelease string of this module
-            Prerelease   = 'rc4'
+            Prerelease   = 'rc5'
         }
 
         # Minimum assembly version required


### PR DESCRIPTION
Bumps the prerelease string and release-notes link in `src/Pester.psd1` from `6.0.0-rc4` to `6.0.0-rc5` to prepare the next release candidate.

Follows the same pattern as the previous bumps (#2809 rc3, #2823 rc4). No other files reference the rc version.