### PR TITLE
Add experimental global mocks

### DIFF
--- a/src/Main.ps1
+++ b/src/Main.ps1
@@ -460,14 +460,34 @@ function Invoke-Pester {
         # this will inherit to child scopes and allow Describe / Context to run directly from a file or command line
         $invokedViaInvokePester = $true
 
+        # global mock hook state carried from begin to the finally in the end block (nested runs only)
+        $runningPesterInPester = $false
+        $savedGlobalMockState = $null
+
+        # Give this run a unique identity used to isolate global mocks between (possibly nested) runs. A
+        # mock's bootstrap records the run that created it; a leaked bootstrap whose id does not match the
+        # currently executing run defers to the original command instead of applying (see Invoke-Mock).
+        # The previous id is restored when this run ends so nested runs each get their own identity.
+        $pesterRunId = [Guid]::NewGuid().Guid
+        $previousPesterRunId = [Pester.GlobalMockHook]::SetCurrentRun($pesterRunId)
+
         if ($null -eq $state) {
             # Cleanup any leftover mocks from previous runs, but only if we are not running in a nested Pester-run
             # todo: move mock cleanup to BeforeAllBlockContainer when there is any?
             Remove-MockFunctionsAndAliases -SessionState $PSCmdlet.SessionState
+            # The global mock hook is runspace-wide state that a normal mock cleanup does not touch, so an
+            # interrupted previous run (e.g. Ctrl+C during a global mock) can leave it armed. Reset it here
+            # so a fresh top-level run always starts with no global mocks and no lookup handler installed.
+            Reset-GlobalMockHook
         }
         else {
             # this will inherit to child scopes and affect behavior of ex. TestDrive/TestRegistry
             $runningPesterInPester = $true
+            # This is a nested run. The global mock hook is shared across the whole runspace, so give this
+            # run its own clean slate and protect the outer run: snapshot the outer run's global mocks, then
+            # clear the shared state. It is restored once this run ends (see the finally in the end block).
+            $savedGlobalMockState = Get-GlobalMockHookState
+            Reset-GlobalMockHook
         }
 
         # this will inherit to child scopes and allow Pester to run in Pester, not checking if this is
@@ -906,6 +926,17 @@ function Invoke-Pester {
             if ($PesterPreference.Run.Exit.Value) {
                 exit -1
             }
+        }
+        finally {
+            # If this was a nested run, restore the outer run's global mocks that we snapshotted and
+            # cleared in the begin block. Runs on success and on failure so a nested run can never leave
+            # the outer run's global mock hook clobbered or detached.
+            if ($runningPesterInPester) {
+                Restore-GlobalMockHookState -State $savedGlobalMockState
+            }
+            # Restore the run id that was active before this run (null for a top-level run) so the nonce
+            # used to isolate global mocks is correct for whatever run resumes.
+            $null = [Pester.GlobalMockHook]::SetCurrentRun($previousPesterRunId)
         }
 
         # go back to original CWD

--- a/src/csharp/Pester/GlobalMockHook.cs
+++ b/src/csharp/Pester/GlobalMockHook.cs
@@ -63,6 +63,27 @@ namespace Pester
             _suppressedName = null;
         }
 
+        // Identity of the Pester run whose mocks are currently effective on this thread. A mock's bootstrap
+        // records the run that created it (see Create-MockHook) and compares it to this value; when they
+        // differ the bootstrap belongs to another run that leaked in via its script-scope alias, so it
+        // defers to the original command instead of applying the mock. Invoke-Pester sets this in its begin
+        // block and restores the previous value when it ends, so nested runs each get their own id.
+        [ThreadStatic]
+        private static string _currentRunId;
+
+        public static string CurrentRunId
+        {
+            get { return _currentRunId; }
+        }
+
+        // Set the current run id, returning the previous value so a nested run can restore it on exit.
+        public static string SetCurrentRun(string runId)
+        {
+            var previous = _currentRunId;
+            _currentRunId = runId;
+            return previous;
+        }
+
         public static void Register(string name, object command)
         {
             if (string.IsNullOrEmpty(name) || command == null)
@@ -91,6 +112,13 @@ namespace Pester
         public static void Clear()
         {
             _registry.Clear();
+        }
+
+        // Copy of the current registrations. Used to save the outer run's global mocks before a nested
+        // Pester run clears the shared state for itself, so they can be restored when the nested run ends.
+        public static Hashtable GetSnapshot()
+        {
+            return (Hashtable)_registry.Clone();
         }
 
         private static void OnCommandLookup(object sender, CommandLookupEventArgs e)

--- a/src/csharp/Pester/GlobalMockHook.cs
+++ b/src/csharp/Pester/GlobalMockHook.cs
@@ -28,6 +28,13 @@ namespace Pester
     {
         private static readonly Hashtable _registry = new Hashtable(StringComparer.OrdinalIgnoreCase);
 
+        // Name for which the redirect is temporarily suppressed on the current thread. Used while
+        // Pester resolves the *original* command to discover its dynamic parameters: that resolution
+        // looks the command up by name (InvokeCommand.GetCommand), which would otherwise be redirected
+        // back to the mock's bootstrap function and hide the real command's dynamic parameters.
+        [ThreadStatic]
+        private static string _suppressedName;
+
         private static readonly EventHandler<CommandLookupEventArgs> _handler =
             new EventHandler<CommandLookupEventArgs>(OnCommandLookup);
 
@@ -41,6 +48,19 @@ namespace Pester
         public static int Count
         {
             get { return _registry.Count; }
+        }
+
+        // Temporarily stop redirecting lookups of 'name' on the current thread. Pair with EndSuppress
+        // in a finally block. Only one name is suppressed at a time, which is all the dynamic-parameter
+        // resolution needs (it resolves a single command).
+        public static void BeginSuppress(string name)
+        {
+            _suppressedName = name;
+        }
+
+        public static void EndSuppress()
+        {
+            _suppressedName = null;
         }
 
         public static void Register(string name, object command)
@@ -75,6 +95,11 @@ namespace Pester
 
         private static void OnCommandLookup(object sender, CommandLookupEventArgs e)
         {
+            if (_suppressedName != null && string.Equals(_suppressedName, e.CommandName, StringComparison.OrdinalIgnoreCase))
+            {
+                return;
+            }
+
             var command = _registry[e.CommandName];
             if (command == null)
             {

--- a/src/csharp/Pester/GlobalMockHook.cs
+++ b/src/csharp/Pester/GlobalMockHook.cs
@@ -1,0 +1,98 @@
+using System;
+using System.Collections;
+using System.Management.Automation;
+
+namespace Pester
+{
+    // Engine-level hook that makes a Pester mock apply across the whole runspace ("global" mock).
+    //
+    // A normal Pester mock defines a bootstrap function + alias in a single session state (the test's,
+    // or the -ModuleName target's). Code in another module resolves the command in its own session
+    // state and never sees that alias, which is why -ModuleName exists. This hook uses
+    // InvokeCommand.PreCommandLookupAction - a runspace-global callback fired on every parser-driven
+    // command lookup - to redirect the lookup to the mock's bootstrap function no matter which module
+    // the call comes from.
+    //
+    // The callback does NOT fire for '& $capturedCommandInfo' (Get-Command / Pester's $SafeCommands
+    // dispatch), so Pester's own internals are unaffected.
+    //
+    // Correctness note: we store the *base* CommandInfo (unwrapping any PSObject) both on register and
+    // on lookup. Returning a PSObject-wrapped command from a compiled handler throws inside the engine,
+    // which then silently falls through to the real command. The '.Mock' note property attached to the
+    // bootstrap function resurrects off the base object, so it survives this round-trip.
+    //
+    // Threading: the registry is written only during mock setup/teardown (single writer on the Pester
+    // thread) and read during command lookup. That matches Hashtable's documented "one writer, many
+    // readers" thread-safety guarantee.
+    public static class GlobalMockHook
+    {
+        private static readonly Hashtable _registry = new Hashtable(StringComparer.OrdinalIgnoreCase);
+
+        private static readonly EventHandler<CommandLookupEventArgs> _handler =
+            new EventHandler<CommandLookupEventArgs>(OnCommandLookup);
+
+        // A single cached delegate instance so the PowerShell side can install it once and remove
+        // exactly that instance via [Delegate]::Remove.
+        public static EventHandler<CommandLookupEventArgs> Handler
+        {
+            get { return _handler; }
+        }
+
+        public static int Count
+        {
+            get { return _registry.Count; }
+        }
+
+        public static void Register(string name, object command)
+        {
+            if (string.IsNullOrEmpty(name) || command == null)
+            {
+                return;
+            }
+
+            _registry[name] = Unwrap(command);
+        }
+
+        public static void Unregister(string name)
+        {
+            if (string.IsNullOrEmpty(name))
+            {
+                return;
+            }
+
+            _registry.Remove(name);
+        }
+
+        public static bool IsRegistered(string name)
+        {
+            return !string.IsNullOrEmpty(name) && _registry.ContainsKey(name);
+        }
+
+        public static void Clear()
+        {
+            _registry.Clear();
+        }
+
+        private static void OnCommandLookup(object sender, CommandLookupEventArgs e)
+        {
+            var command = _registry[e.CommandName];
+            if (command == null)
+            {
+                return;
+            }
+
+            var commandInfo = Unwrap(command) as CommandInfo;
+            if (commandInfo != null)
+            {
+                e.Command = commandInfo;
+                e.StopSearch = true;
+            }
+        }
+
+        private static object Unwrap(object command)
+        {
+            var pso = command as PSObject;
+            return pso != null ? pso.BaseObject : command;
+        }
+    }
+}

--- a/src/csharp/Pester/MockConfiguration.cs
+++ b/src/csharp/Pester/MockConfiguration.cs
@@ -1,0 +1,42 @@
+using System.Collections;
+
+namespace Pester
+{
+    public class MockConfiguration : ConfigurationSection
+    {
+        private BoolOption _global;
+
+        public static MockConfiguration Default { get { return new MockConfiguration(); } }
+
+        public static MockConfiguration ShallowClone(MockConfiguration configuration)
+        {
+            return Cloner.ShallowClone(configuration);
+        }
+
+        public MockConfiguration() : base("Mock configuration for Pester.")
+        {
+            Global = new BoolOption("EXPERIMENTAL: Make every mock a global mock, so it is applied to calls from any module or script, and the ModuleName parameter is ignored. This is the same as passing -Global to every Mock. Use at your own risk!", false);
+        }
+
+        public MockConfiguration(IDictionary configuration) : this()
+        {
+            configuration?.AssignValueIfNotNull<bool>(nameof(Global), v => Global = v);
+        }
+
+        public BoolOption Global
+        {
+            get { return _global; }
+            set
+            {
+                if (_global == null)
+                {
+                    _global = value;
+                }
+                else
+                {
+                    _global = new BoolOption(_global, value.Value);
+                }
+            }
+        }
+    }
+}

--- a/src/csharp/Pester/MockConfiguration.cs
+++ b/src/csharp/Pester/MockConfiguration.cs
@@ -15,7 +15,7 @@ namespace Pester
 
         public MockConfiguration() : base("Mock configuration for Pester.")
         {
-            Global = new BoolOption("EXPERIMENTAL: Make every mock a global mock, so it is applied to calls from any module or script, and the ModuleName parameter is ignored. This is the same as passing -Global to every Mock. Use at your own risk!", false);
+            Global = new BoolOption("EXPERIMENTAL: Make every mock a global mock, so it is applied to calls of the command from any module or script in the runspace. ModuleName is then used only as a hint to resolve the command, not to scope where the mock applies. Use at your own risk!", false);
         }
 
         public MockConfiguration(IDictionary configuration) : this()

--- a/src/csharp/Pester/PesterConfiguration.cs
+++ b/src/csharp/Pester/PesterConfiguration.cs
@@ -35,6 +35,7 @@ public class PesterConfiguration
         cfg.Output = OutputConfiguration.ShallowClone(configuration.Output);
         cfg.TestDrive = TestDriveConfiguration.ShallowClone(configuration.TestDrive);
         cfg.TestRegistry = TestRegistryConfiguration.ShallowClone(configuration.TestRegistry);
+        cfg.Mock = MockConfiguration.ShallowClone(configuration.Mock);
         return cfg;
     }
 
@@ -50,6 +51,7 @@ public class PesterConfiguration
         cfg.Output = Merger.Merge(configuration.Output, @override.Output);
         cfg.TestDrive = Merger.Merge(configuration.TestDrive, @override.TestDrive);
         cfg.TestRegistry = Merger.Merge(configuration.TestRegistry, @override.TestRegistry);
+        cfg.Mock = Merger.Merge(configuration.Mock, @override.Mock);
         return cfg;
     }
 
@@ -66,6 +68,7 @@ public class PesterConfiguration
             Output = new OutputConfiguration(configuration.GetIDictionaryOrNull(nameof(Output)));
             TestDrive = new TestDriveConfiguration(configuration.GetIDictionaryOrNull(nameof(TestDrive)));
             TestRegistry = new TestRegistryConfiguration(configuration.GetIDictionaryOrNull(nameof(TestRegistry)));
+            Mock = new MockConfiguration(configuration.GetIDictionaryOrNull(nameof(Mock)));
         }
     }
 
@@ -80,6 +83,7 @@ public class PesterConfiguration
         Output = new OutputConfiguration();
         TestDrive = new TestDriveConfiguration();
         TestRegistry = new TestRegistryConfiguration();
+        Mock = new MockConfiguration();
     }
 
     public RunConfiguration Run { get; set; }
@@ -91,4 +95,5 @@ public class PesterConfiguration
     public OutputConfiguration Output { get; set; }
     public TestDriveConfiguration TestDrive { get; set; }
     public TestRegistryConfiguration TestRegistry { get; set; }
+    public MockConfiguration Mock { get; set; }
 }

--- a/src/csharp/PesterTests/PesterConfigurationTests.cs
+++ b/src/csharp/PesterTests/PesterConfigurationTests.cs
@@ -24,6 +24,7 @@ namespace PesterTests
             Assert.IsNotNull(config.Output);
             Assert.IsNotNull(config.TestDrive);
             Assert.IsNotNull(config.TestRegistry);
+            Assert.IsNotNull(config.Mock);
         }
 
         [TestMethod]

--- a/src/en-US/about_PesterConfiguration.help.txt
+++ b/src/en-US/about_PesterConfiguration.help.txt
@@ -241,6 +241,11 @@ SECTIONS AND OPTIONS
         Type: bool
         Default value: $true
 
+    Mock:
+        Global: EXPERIMENTAL: Make every mock a global mock, so it is applied to calls from any module or script, and the ModuleName parameter is ignored. This is the same as passing -Global to every Mock. Use at your own risk!
+        Type: bool
+        Default value: $false
+
 SEE ALSO
     Pester website: https://pester.dev
     New-PesterConfiguration

--- a/src/en-US/about_PesterConfiguration.help.txt
+++ b/src/en-US/about_PesterConfiguration.help.txt
@@ -242,7 +242,7 @@ SECTIONS AND OPTIONS
         Default value: $true
 
     Mock:
-        Global: EXPERIMENTAL: Make every mock a global mock, so it is applied to calls from any module or script, and the ModuleName parameter is ignored. This is the same as passing -Global to every Mock. Use at your own risk!
+        Global: EXPERIMENTAL: Make every mock a global mock, so it is applied to calls of the command from any module or script in the runspace. ModuleName is then used only as a hint to resolve the command, not to scope where the mock applies. Use at your own risk!
         Type: bool
         Default value: $false
 

--- a/src/functions/Mock.ps1
+++ b/src/functions/Mock.ps1
@@ -222,6 +222,10 @@ function Create-MockHook ($contextInfo, $InvokeMockCallback) {
         Aliases                 = [Collections.Generic.List[object]]@($commandName)
         BootstrapFunctionName   = $mockName
         IsGlobal                = $false
+        # The run that created this mock. A global mock installs a script-scope bootstrap alias in this
+        # run; if that alias leaks into a nested Invoke-Pester run, the bootstrap compares this id to the
+        # currently executing run and defers to the original command when they differ (see Invoke-Mock).
+        OwnerRunId              = [Pester.GlobalMockHook]::CurrentRunId
         BootstrapFunctionInfo   = $null
     }
 
@@ -367,6 +371,61 @@ function Unregister-GlobalMockHook {
         if ($PesterPreference.Debug.WriteDebugMessages.Value) {
             Write-PesterDebugMessage -Scope Mock -Message "Removed the global mock hook from the runspace, no global mocks remain."
         }
+    }
+}
+
+function Reset-GlobalMockHook {
+    # Detach our command-lookup handler and drop every global mock registration. The registry and the
+    # handler are runspace-wide state that outlives a single test, so an interrupted run (for example a
+    # Ctrl+C during a global mock) can leave them armed. Invoke-Pester calls this at the start of a
+    # top-level run to clear anything a previous run left behind, and around a nested run to give it a
+    # clean slate. Removes only our own handler instance, so other PreCommandLookupAction consumers are
+    # preserved.
+    $invokeCommand = $ExecutionContext.SessionState.InvokeCommand
+    $handler = [Pester.GlobalMockHook]::Handler
+    $existing = $invokeCommand.PreCommandLookupAction
+    if ($null -ne $existing) {
+        $invokeCommand.PreCommandLookupAction = [Delegate]::Remove($existing, $handler)
+    }
+
+    [Pester.GlobalMockHook]::Clear()
+}
+
+function Get-GlobalMockHookState {
+    # Snapshot the current global mock registrations so a nested Pester run can clear the shared state for
+    # itself and restore the outer run's global mocks afterwards (see Restore-GlobalMockHookState).
+    [Pester.GlobalMockHook]::GetSnapshot()
+}
+
+function Restore-GlobalMockHookState {
+    # Restore a snapshot taken by Get-GlobalMockHookState. Clears whatever the nested run left behind,
+    # re-registers the saved entries, and installs or removes our command-lookup handler so its presence
+    # matches whether any global mocks remain.
+    param (
+        $State
+    )
+
+    [Pester.GlobalMockHook]::Clear()
+
+    if ($null -ne $State) {
+        foreach ($name in $State.Keys) {
+            [Pester.GlobalMockHook]::Register($name, $State[$name])
+        }
+    }
+
+    $invokeCommand = $ExecutionContext.SessionState.InvokeCommand
+    $handler = [Pester.GlobalMockHook]::Handler
+    $existing = $invokeCommand.PreCommandLookupAction
+    if ($null -ne $existing) {
+        # remove any current instance of our handler first, so we never end up with a duplicate
+        $existing = [Delegate]::Remove($existing, $handler)
+    }
+
+    if (0 -lt [Pester.GlobalMockHook]::Count) {
+        $invokeCommand.PreCommandLookupAction = [Delegate]::Combine($existing, $handler)
+    }
+    else {
+        $invokeCommand.PreCommandLookupAction = $existing
     }
 }
 
@@ -824,6 +883,18 @@ function Resolve-Command {
         throw ([System.Management.Automation.CommandNotFoundException] "Could not find Command $CommandName")
     }
 
+
+    if ($Global -and $command.Name -like 'PesterMock_*' -and $command.Mock.Hook.OwnerRunId -ne [Pester.GlobalMockHook]::CurrentRunId) {
+        # The resolved command is a mock bootstrap, but it belongs to a different (outer) Pester run whose
+        # script-scope alias leaked into this run. Do not reuse it - unwrap to the original command so this
+        # run creates and owns its own hook, and the outer run's mock stays intact.
+        if ($PesterPreference.Debug.WriteDebugMessages.Value) {
+            Write-PesterDebugMessage -Scope MockCore "Resolved a global mock bootstrap owned by another run; unwrapping to the original command $($command.Mock.Hook.OriginalCommand.Name) so this run gets its own hook."
+        }
+        $commandMetadata = $command.Mock.Hook.OriginalMetadata
+        $commandMetadata2 = $command.Mock.Hook.OriginalMetadata2
+        $command = $command.Mock.Hook.OriginalCommand
+    }
 
     if ($command.Name -like 'PesterMock_*') {
         if ($PesterPreference.Debug.WriteDebugMessages.Value) {

--- a/src/functions/Mock.ps1
+++ b/src/functions/Mock.ps1
@@ -673,7 +673,8 @@ function Resolve-Command {
         [string] $CommandName,
         [string] $ModuleName,
         [Parameter(Mandatory)]
-        [Management.Automation.SessionState] $SessionState
+        [Management.Automation.SessionState] $SessionState,
+        [switch] $Global
     )
 
     # saving the caller session state here, below the command is looked up and
@@ -722,7 +723,35 @@ function Resolve-Command {
         Write-PesterDebugMessage -Scope Mock "Resolving command $CommandName."
     }
 
-    if ($ModuleName) {
+    if ($Global) {
+        # Global mock: ModuleName is not the destination (the engine hook makes the mock effective
+        # everywhere), it is only a hint to find the command. Resolve from the caller/script scope
+        # first, which also finds the bootstrap of an existing global mock so re-mocking reuses its
+        # hook. If the command is not visible there (a module-private command), fall back to the
+        # module named by the hint to find and resolve it. Either way the mock is installed in the
+        # caller scope and has no target module.
+        if ($PesterPreference.Debug.WriteDebugMessages.Value) {
+            Write-PesterDebugMessage -Scope Mock "Resolving command $CommandName for a global mock, searching the caller scope$(if ($ModuleName) { " and using module $ModuleName as a hint" })."
+        }
+
+        Set-ScriptBlockScope -ScriptBlock $findAndResolveCommand -SessionState $callerSessionState
+        $command, $commandMetadata, $commandMetadata2 = & $findAndResolveCommand -Name $CommandName
+
+        if ($null -eq $command -and $ModuleName) {
+            $module = Get-CompatibleModule -ModuleName $ModuleName -ErrorAction SilentlyContinue
+            if ($null -ne $module) {
+                if ($PesterPreference.Debug.WriteDebugMessages.Value) {
+                    Write-PesterDebugMessage -Scope Mock "Command $CommandName not found in the caller scope, searching module $($module.Name) version $($module.Version)."
+                }
+                $command, $commandMetadata, $commandMetadata2 = & $module $findAndResolveCommand -Name $CommandName
+            }
+        }
+
+        # the mock is installed in the caller (script) scope and has no target module
+        $SessionState = $callerSessionState
+        $ModuleName = ''
+    }
+    elseif ($ModuleName) {
         if ($PesterPreference.Debug.WriteDebugMessages.Value) {
             Write-PesterDebugMessage -Scope Mock "ModuleName was specified searching for the command in module $ModuleName."
         }
@@ -1696,36 +1725,46 @@ function Get-DynamicParametersForCmdlet {
         [System.Collections.IDictionary] $Parameters
     )
 
+    # When a global mock is active, its bootstrap function shadows $CmdletName in every scope via the
+    # engine command-lookup hook. Resolving the *original* cmdlet here (by name) to discover its
+    # dynamic parameters would be redirected back to the mock and the real dynamic parameters (e.g.
+    # Get-ChildItem -Hidden) would be lost. Suppress the redirect for this name while we resolve it.
+    [Pester.GlobalMockHook]::BeginSuppress($CmdletName)
     try {
-        $command = & $SafeCommands['Get-Command'] -Name $CmdletName -CommandType Cmdlet -ErrorAction Stop
+        try {
+            $command = & $SafeCommands['Get-Command'] -Name $CmdletName -CommandType Cmdlet -ErrorAction Stop
 
-        if (@($command).Count -gt 1) {
-            throw "Name '$CmdletName' resolved to multiple Cmdlets"
+            if (@($command).Count -gt 1) {
+                throw "Name '$CmdletName' resolved to multiple Cmdlets"
+            }
+        }
+        catch {
+            $PSCmdlet.ThrowTerminatingError($_)
+        }
+
+        if ($null -eq $command.ImplementingType.GetInterface('IDynamicParameters', $true)) {
+            return
+        }
+
+        if ($null -eq $Parameters) {
+            $paramsArg = @()
+        }
+        else {
+            $paramsArg = @($Parameters)
+        }
+
+        try {
+            $command = $ExecutionContext.InvokeCommand.GetCommand($CmdletName, [System.Management.Automation.CommandTypes]::Cmdlet, $paramsArg)
+        }
+        catch {
+            # Resolving a cmdlet's dynamic parameters can fail when they are built from external state that isn't
+            # available while the command is mocked - e.g. Set-PSRepository's -Location comes from the package
+            # provider and validates while resolving. Fall back to no dynamic parameters instead of failing. (#619)
+            return
         }
     }
-    catch {
-        $PSCmdlet.ThrowTerminatingError($_)
-    }
-
-    if ($null -eq $command.ImplementingType.GetInterface('IDynamicParameters', $true)) {
-        return
-    }
-
-    if ($null -eq $Parameters) {
-        $paramsArg = @()
-    }
-    else {
-        $paramsArg = @($Parameters)
-    }
-
-    try {
-        $command = $ExecutionContext.InvokeCommand.GetCommand($CmdletName, [System.Management.Automation.CommandTypes]::Cmdlet, $paramsArg)
-    }
-    catch {
-        # Resolving a cmdlet's dynamic parameters can fail when they are built from external state that isn't
-        # available while the command is mocked - e.g. Set-PSRepository's -Location comes from the package
-        # provider and validates while resolving. Fall back to no dynamic parameters instead of failing. (#619)
-        return
+    finally {
+        [Pester.GlobalMockHook]::EndSuppress()
     }
     $paramDictionary = [System.Management.Automation.RuntimeDefinedParameterDictionary]::new()
 

--- a/src/functions/Mock.ps1
+++ b/src/functions/Mock.ps1
@@ -221,6 +221,8 @@ function Create-MockHook ($contextInfo, $InvokeMockCallback) {
         DynamicParamScriptBlock = $dynamicParamScriptBlock
         Aliases                 = [Collections.Generic.List[object]]@($commandName)
         BootstrapFunctionName   = $mockName
+        IsGlobal                = $false
+        BootstrapFunctionInfo   = $null
     }
 
     if ($mock.OriginalCommand.ModuleName) {
@@ -302,7 +304,70 @@ function Create-MockHook ($contextInfo, $InvokeMockCallback) {
 
     $definedFunction.psobject.properties.Add([Pester.Factory]::CreateNoteProperty('Mock', $functionLocalData))
 
+    # keep a reference to the bootstrap function so a global mock can register it with the
+    # engine-level command-lookup hook (see Register-GlobalMockHook). We store it on the hook
+    # instead of registering here, so both freshly created and reused hooks go through the same path.
+    $mock.BootstrapFunctionInfo = $definedFunction
+
     $mock
+}
+
+function Register-GlobalMockHook {
+    # Makes a mock global by pointing the runspace-wide command-lookup hook at the mock's bootstrap
+    # function. After this, a call to the mocked command from any module or script in the runspace is
+    # redirected to the mock, not just calls from the session state where the mock was defined.
+    param (
+        [Parameter(Mandatory)]
+        $Hook
+    )
+
+    $Hook.IsGlobal = $true
+
+    foreach ($alias in $Hook.Aliases) {
+        [Pester.GlobalMockHook]::Register($alias, $Hook.BootstrapFunctionInfo)
+    }
+
+    # Install our handler into the current runspace. This is idempotent: we remove any existing instance
+    # of our handler first, so repeated runs in the same process don't stack duplicates, and so the
+    # handler we later remove in teardown is the exact same delegate instance. Other consumers of
+    # PreCommandLookupAction are preserved via Delegate.Combine.
+    $invokeCommand = $ExecutionContext.SessionState.InvokeCommand
+    $handler = [Pester.GlobalMockHook]::Handler
+    $existing = $invokeCommand.PreCommandLookupAction
+    if ($null -ne $existing) {
+        $existing = [Delegate]::Remove($existing, $handler)
+    }
+    $invokeCommand.PreCommandLookupAction = [Delegate]::Combine($existing, $handler)
+
+    if ($PesterPreference.Debug.WriteDebugMessages.Value) {
+        Write-PesterDebugMessage -Scope Mock -Message "Registered global mock hook for aliases $($Hook.Aliases -join ', ')."
+    }
+}
+
+function Unregister-GlobalMockHook {
+    # Undoes Register-GlobalMockHook for a single hook. When the last global mock is removed we also
+    # detach our handler from the runspace, so there is zero lookup overhead once no global mocks exist.
+    param (
+        [Parameter(Mandatory)]
+        $Hook
+    )
+
+    foreach ($alias in $Hook.Aliases) {
+        [Pester.GlobalMockHook]::Unregister($alias)
+    }
+
+    if (0 -eq [Pester.GlobalMockHook]::Count) {
+        $invokeCommand = $ExecutionContext.SessionState.InvokeCommand
+        $handler = [Pester.GlobalMockHook]::Handler
+        $existing = $invokeCommand.PreCommandLookupAction
+        if ($null -ne $existing) {
+            $invokeCommand.PreCommandLookupAction = [Delegate]::Remove($existing, $handler)
+        }
+
+        if ($PesterPreference.Debug.WriteDebugMessages.Value) {
+            Write-PesterDebugMessage -Scope Mock -Message "Removed the global mock hook from the runspace, no global mocks remain."
+        }
+    }
 }
 
 function Should-InvokeVerifiableInternal {
@@ -593,6 +658,10 @@ function Remove-MockHook {
     foreach ($h in $Hooks) {
         if ($PesterPreference.Debug.WriteDebugMessages.Value) {
             Write-PesterDebugMessage -Scope Mock -Message "Removing function $($h.BootstrapFunctionName)$(if($h.Aliases) { " and aliases $($h.Aliases -join ", ")" }) for$(if($h.ModuleName) { " $($h.ModuleName) -" }) $($h.CommandName)."
+        }
+
+        if ($h.IsGlobal) {
+            Unregister-GlobalMockHook -Hook $h
         }
 
         $null = Invoke-InMockScope -SessionState $h.SessionState -ScriptBlock $removeMockStub -Arguments $h.BootstrapFunctionName, $h.Aliases, $Write_Debug_Enabled, $Write_Debug

--- a/src/functions/Pester.SessionState.Mock.ps1
+++ b/src/functions/Pester.SessionState.Mock.ps1
@@ -293,13 +293,13 @@ function Mock {
 
     $SessionState = $PSCmdlet.SessionState
 
-    # a global mock ignores ModuleName, it is defined in the caller scope and the engine-level hook
-    # routes calls from every module to it, so there is no single target module.
-    if ($isGlobalMock) {
-        $ModuleName = ''
-    }
-    # use the caller module name as ModuleName, so calling the mock in InModuleScope uses the ModuleName as target module
-    elseif (-not $PSBoundParameters.ContainsKey('ModuleName') -and $null -ne $SessionState.Module) {
+    # A global mock is not scoped to a single module, it is defined in the caller scope and the
+    # engine-level hook routes calls from every module to it. ModuleName is therefore not the
+    # destination of the mock. It is still used as a hint to resolve the command though (see the
+    # -Global path in Resolve-Command), so a module-private command can be found and mocked. So we
+    # keep whatever ModuleName the caller passed and let Resolve-Command use it only for lookup.
+    if (-not $isGlobalMock -and -not $PSBoundParameters.ContainsKey('ModuleName') -and $null -ne $SessionState.Module) {
+        # use the caller module name as ModuleName, so calling the mock in InModuleScope uses the ModuleName as target module
         $ModuleName = $SessionState.Module.Name
     }
 
@@ -317,7 +317,7 @@ function Mock {
     $invokeMockCallBack = $ExecutionContext.SessionState.InvokeCommand.GetCommand('Invoke-Mock', 'function')
 
     $mockData = Get-MockDataForCurrentScope
-    $contextInfo = Resolve-Command $CommandName $ModuleName -SessionState $SessionState
+    $contextInfo = Resolve-Command $CommandName $ModuleName -SessionState $SessionState -Global:$isGlobalMock
 
     if ($contextInfo.IsMockBootstrapFunction) {
         if ($PesterPreference.Debug.WriteDebugMessages.Value) {
@@ -895,6 +895,15 @@ function Should-InvokeAssertion {
         # user did not specify the target module, using the caller session state module name
         # to ensure we bind to the current module when running in InModuleScope
         $ModuleName = if ($CallerSessionState.Module) { $CallerSessionState.Module.Name } else { $null }
+    }
+
+    # A global mock is installed in the caller (script) scope and records its calls there, with no
+    # target module, no matter which module the call came from. So when a global mock exists for the
+    # command, ignore -ModuleName and resolve from the script scope, mirroring how the mock was set
+    # up. This lets `Should -Invoke -ModuleName X Command` still find the calls that a `Mock
+    # -ModuleName X Command` recorded as a global mock.
+    if ([Pester.GlobalMockHook]::IsRegistered($CommandName)) {
+        $ModuleName = ''
     }
 
     if ($PSCmdlet.ParameterSetName -eq 'ExclusiveFilter' -and $Negate) {

--- a/src/functions/Pester.SessionState.Mock.ps1
+++ b/src/functions/Pester.SessionState.Mock.ps1
@@ -109,7 +109,26 @@ function Mock {
     Optional string specifying the name of the module where this command
     is to be mocked.  This should be a module that _calls_ the mocked
     command; it doesn't necessarily have to be the same module which
-    originally implemented the command.
+    originally implemented the command. This parameter is ignored when the
+    mock is global (see -Global and -Throw).
+
+    .PARAMETER Global
+    EXPERIMENTAL: Makes the mock global. A global mock is applied to calls of
+    the command from any module or script in the runspace, not just from the
+    scope where the mock is defined. This removes the need for -ModuleName, and
+    -ModuleName is ignored when this switch is used. The mock is removed when
+    the test or block where it was defined ends, like any other mock. You can
+    make every mock global without this switch by setting the experimental
+    configuration option Mock.Global to $true.
+
+    .PARAMETER Throw
+    EXPERIMENTAL: Defines a global mock (implies -Global) whose default behavior
+    is to throw when the command is called. Use it to make sure a command cannot
+    run from any code, for example to block Invoke-WebRequest or Remove-Item in a
+    test. The call is still recorded, so Should -Invoke works. Combine it with
+    -ParameterFilter to throw only for calls that match the filter and let the
+    rest fall through to the original command. -Throw and -MockWith cannot be used
+    together; use -Global with a throwing -MockWith if you need a custom message.
 
     .PARAMETER RemoveParameterType
     Optional list of parameter names that should use Object as the parameter
@@ -212,6 +231,27 @@ function Mock {
     This example shows how calls to commands made from inside a module can be
     mocked by using the -ModuleName parameter.
 
+    .EXAMPLE
+    Mock Invoke-WebRequest { '<html />' } -Global
+
+    Defines a global mock. Any code that calls Invoke-WebRequest, in the test
+    script or in any module it loads, gets the mock instead of the real command.
+    No -ModuleName is needed.
+
+    .EXAMPLE
+    Mock Invoke-WebRequest -Throw
+
+    Blocks Invoke-WebRequest everywhere for the duration of the test. Any call to
+    it, from any module or script, throws. The call is still recorded, so you can
+    assert it with Should -Invoke Invoke-WebRequest.
+
+    .EXAMPLE
+    Mock Remove-Item -Throw -ParameterFilter { $Path -notlike "$TestDrive*" }
+
+    Blocks Remove-Item for any path outside TestDrive, from any module or script.
+    Calls that target TestDrive are not matched by the filter and run the real
+    Remove-Item.
+
     .LINK
     https://pester.dev/docs/commands/Mock
 
@@ -226,7 +266,9 @@ function Mock {
         [ScriptBlock]$ParameterFilter,
         [string]$ModuleName,
         [string[]]$RemoveParameterType,
-        [string[]]$RemoveParameterValidation
+        [string[]]$RemoveParameterValidation,
+        [switch]$Global,
+        [switch]$Throw
     )
     if (Is-Discovery) {
         # this is to allow mocks in between Describe and It which is discouraged but common
@@ -234,10 +276,30 @@ function Mock {
         return
     }
 
+    # -Throw defines a mock whose default behavior is to throw, and it is global by default so the
+    # command is blocked no matter which module or script calls it. It cannot be combined with a
+    # custom -MockWith, use -Global with a throwing -MockWith for that.
+    if ($Throw -and $PSBoundParameters.ContainsKey('MockWith')) {
+        throw [System.Management.Automation.ParameterBindingException] 'The -Throw and -MockWith parameters cannot be used together. Use -Global with a throwing -MockWith if you need a custom message.'
+    }
+
+    # a mock is global when -Global or -Throw is used, or when the experimental Mock.Global option is on.
+    $isGlobalMock = [bool]$Global -or [bool]$Throw -or $PesterPreference.Mock.Global.Value
+
+    if ($Throw) {
+        $safeCommandName = $CommandName -replace "'", "''"
+        $MockWith = [ScriptBlock]::Create("throw [System.InvalidOperationException] 'Command ''$safeCommandName'' is blocked by a global Pester mock that was defined with -Throw.'")
+    }
+
     $SessionState = $PSCmdlet.SessionState
 
+    # a global mock ignores ModuleName, it is defined in the caller scope and the engine-level hook
+    # routes calls from every module to it, so there is no single target module.
+    if ($isGlobalMock) {
+        $ModuleName = ''
+    }
     # use the caller module name as ModuleName, so calling the mock in InModuleScope uses the ModuleName as target module
-    if (-not $PSBoundParameters.ContainsKey('ModuleName') -and $null -ne $SessionState.Module) {
+    elseif (-not $PSBoundParameters.ContainsKey('ModuleName') -and $null -ne $SessionState.Module) {
         $ModuleName = $SessionState.Module.Name
     }
 
@@ -269,6 +331,13 @@ function Mock {
         }
         $hook = Create-MockHook -ContextInfo $contextInfo -InvokeMockCallback $invokeMockCallBack
         $mockData.Hooks.Add($hook)
+    }
+
+    # register the hook with the runspace-wide command-lookup hook so calls from any module or script
+    # are routed to it. This is idempotent, so re-mocking a command that already has a global hook, or
+    # promoting an existing non-global hook to global, both work.
+    if ($isGlobalMock -and -not $hook.IsGlobal) {
+        Register-GlobalMockHook -Hook $hook
     }
 
     if ($mockData.Behaviors.ContainsKey($contextInfo.Command.Name)) {

--- a/src/functions/Pester.SessionState.Mock.ps1
+++ b/src/functions/Pester.SessionState.Mock.ps1
@@ -1044,6 +1044,29 @@ function Invoke-Mock {
         $Hook
     )
 
+    # A global mock is registered runspace-wide but still installs its bootstrap alias in the run that
+    # created it. When a nested Invoke-Pester run resolves that leaked alias, this dispatcher runs with the
+    # outer run's hook even though the mock does not belong to the nested run. Detect that by comparing the
+    # run that created the mock with the run that is currently executing, and defer to the original command
+    # so a global mock has no effect outside its own run (full isolation between nested runs).
+    if ($Hook.IsGlobal -and $Hook.OwnerRunId -ne [Pester.GlobalMockHook]::CurrentRunId) {
+        if ('Process' -eq $FromBlock) {
+            if ($PesterPreference.Debug.WriteDebugMessages.Value) {
+                Write-PesterDebugMessage -Scope MockCore "Global mock for $CommandName belongs to another Pester run (leaked into a nested run via its script-scope alias); calling the original command instead."
+            }
+            if ($null -ne $InputObject -and @($InputObject).Count -gt 0) {
+                # reproduce the original pipeline input; piping an empty collection would suppress the
+                # output of commands that do not take pipeline input (e.g. Get-Date), so only pipe when
+                # there is something to pipe.
+                $InputObject | & $Hook.OriginalCommand @BoundParameters @ArgumentList
+            }
+            else {
+                & $Hook.OriginalCommand @BoundParameters @ArgumentList
+            }
+        }
+        return
+    }
+
     if ('End' -eq $FromBlock) {
         if (-not $MockCallState.MatchedNoBehavior) {
             if ($PesterPreference.Debug.WriteDebugMessages.Value) {

--- a/src/functions/Pester.SessionState.Mock.ps1
+++ b/src/functions/Pester.SessionState.Mock.ps1
@@ -109,26 +109,10 @@ function Mock {
     Optional string specifying the name of the module where this command
     is to be mocked.  This should be a module that _calls_ the mocked
     command; it doesn't necessarily have to be the same module which
-    originally implemented the command. This parameter is ignored when the
-    mock is global (see -Global and -Throw).
-
-    .PARAMETER Global
-    EXPERIMENTAL: Makes the mock global. A global mock is applied to calls of
-    the command from any module or script in the runspace, not just from the
-    scope where the mock is defined. This removes the need for -ModuleName, and
-    -ModuleName is ignored when this switch is used. The mock is removed when
-    the test or block where it was defined ends, like any other mock. You can
-    make every mock global without this switch by setting the experimental
-    configuration option Mock.Global to $true.
-
-    .PARAMETER Throw
-    EXPERIMENTAL: Defines a global mock (implies -Global) whose default behavior
-    is to throw when the command is called. Use it to make sure a command cannot
-    run from any code, for example to block Invoke-WebRequest or Remove-Item in a
-    test. The call is still recorded, so Should -Invoke works. Combine it with
-    -ParameterFilter to throw only for calls that match the filter and let the
-    rest fall through to the original command. -Throw and -MockWith cannot be used
-    together; use -Global with a throwing -MockWith if you need a custom message.
+    originally implemented the command. When the experimental Mock.Global
+    configuration option is enabled this parameter is used only as a hint to
+    resolve the command (for example to find a module-private command), not
+    to scope where the mock applies.
 
     .PARAMETER RemoveParameterType
     Optional list of parameter names that should use Object as the parameter
@@ -231,27 +215,6 @@ function Mock {
     This example shows how calls to commands made from inside a module can be
     mocked by using the -ModuleName parameter.
 
-    .EXAMPLE
-    Mock Invoke-WebRequest { '<html />' } -Global
-
-    Defines a global mock. Any code that calls Invoke-WebRequest, in the test
-    script or in any module it loads, gets the mock instead of the real command.
-    No -ModuleName is needed.
-
-    .EXAMPLE
-    Mock Invoke-WebRequest -Throw
-
-    Blocks Invoke-WebRequest everywhere for the duration of the test. Any call to
-    it, from any module or script, throws. The call is still recorded, so you can
-    assert it with Should -Invoke Invoke-WebRequest.
-
-    .EXAMPLE
-    Mock Remove-Item -Throw -ParameterFilter { $Path -notlike "$TestDrive*" }
-
-    Blocks Remove-Item for any path outside TestDrive, from any module or script.
-    Calls that target TestDrive are not matched by the filter and run the real
-    Remove-Item.
-
     .LINK
     https://pester.dev/docs/commands/Mock
 
@@ -266,9 +229,7 @@ function Mock {
         [ScriptBlock]$ParameterFilter,
         [string]$ModuleName,
         [string[]]$RemoveParameterType,
-        [string[]]$RemoveParameterValidation,
-        [switch]$Global,
-        [switch]$Throw
+        [string[]]$RemoveParameterValidation
     )
     if (Is-Discovery) {
         # this is to allow mocks in between Describe and It which is discouraged but common
@@ -276,20 +237,9 @@ function Mock {
         return
     }
 
-    # -Throw defines a mock whose default behavior is to throw, and it is global by default so the
-    # command is blocked no matter which module or script calls it. It cannot be combined with a
-    # custom -MockWith, use -Global with a throwing -MockWith for that.
-    if ($Throw -and $PSBoundParameters.ContainsKey('MockWith')) {
-        throw [System.Management.Automation.ParameterBindingException] 'The -Throw and -MockWith parameters cannot be used together. Use -Global with a throwing -MockWith if you need a custom message.'
-    }
-
-    # a mock is global when -Global or -Throw is used, or when the experimental Mock.Global option is on.
-    $isGlobalMock = [bool]$Global -or [bool]$Throw -or $PesterPreference.Mock.Global.Value
-
-    if ($Throw) {
-        $safeCommandName = $CommandName -replace "'", "''"
-        $MockWith = [ScriptBlock]::Create("throw [System.InvalidOperationException] 'Command ''$safeCommandName'' is blocked by a global Pester mock that was defined with -Throw.'")
-    }
+    # a mock is global when the experimental Mock.Global option is on, which makes every mock reach
+    # calls of the command from any module or script in the runspace.
+    $isGlobalMock = [bool]$PesterPreference.Mock.Global.Value
 
     $SessionState = $PSCmdlet.SessionState
 

--- a/tst/Pester.RSpec.Configuration.ts.ps1
+++ b/tst/Pester.RSpec.Configuration.ts.ps1
@@ -171,6 +171,10 @@ i -PassThru:$PassThru {
         t "TestRegistry.Enabled is `$true" {
             [PesterConfiguration]::Default.TestRegistry.Enabled.Value | Verify-True
         }
+
+        t "Mock.Global is `$false" {
+            [PesterConfiguration]::Default.Mock.Global.Value | Verify-False
+        }
     }
 
     b "Assignment" {

--- a/tst/functions/Mock.Global.Tests.ps1
+++ b/tst/functions/Mock.Global.Tests.ps1
@@ -4,128 +4,103 @@ BeforeAll {
     $PSDefaultParameterValues = @{ 'Should:ErrorAction' = 'Stop' }
 }
 
-Describe 'Mock -Global' {
-    BeforeAll {
-        # A module that calls commands from its own session state. A normal mock defined in the test
-        # script scope does not reach these calls, which is what -Global changes.
-        $null = New-Module -Name GlobalMockConsumer -ScriptBlock {
-            function Get-YearFromModule { (Get-Date).Year }
-            function Get-QualifiedYearFromModule { (Microsoft.PowerShell.Utility\Get-Date).Year }
-            Export-ModuleMember -Function Get-YearFromModule, Get-QualifiedYearFromModule
-        } | Import-Module -PassThru -Force
-    }
-
-    AfterAll {
-        Remove-Module GlobalMockConsumer -Force -ErrorAction SilentlyContinue
-    }
-
-    It 'a normal mock does not reach calls made from inside another module' {
-        Mock Get-Date { [pscustomobject]@{ Year = 1999 } }
-        Get-YearFromModule | Should -Not -Be 1999
-    }
-
-    It 'a -Global mock reaches calls made from inside another module' {
-        Mock Get-Date { [pscustomobject]@{ Year = 1999 } } -Global
-        Get-YearFromModule | Should -Be 1999
-    }
-
-    It 'a -Global mock reaches module-qualified calls' {
-        Mock Get-Date { [pscustomobject]@{ Year = 1999 } } -Global
-        Get-QualifiedYearFromModule | Should -Be 1999
-    }
-
-    It 'records the calls, so Should -Invoke works without -ModuleName' {
-        Mock Get-Date { [pscustomobject]@{ Year = 1999 } } -Global
-        $null = Get-YearFromModule
-        $null = Get-YearFromModule
-        Should -Invoke Get-Date -Exactly -Times 2
-    }
-
-    It 'ignores -ModuleName when -Global is used' {
-        Mock Get-Date { [pscustomobject]@{ Year = 1999 } } -Global -ModuleName 'ThisModuleDoesNotExist'
-        Get-YearFromModule | Should -Be 1999
-    }
-}
-
-Describe 'Mock -Global cleanup' {
-    # This block runs after the -Global block above. If a global mock leaked past its defining test,
-    # Get-Date would still be mocked here and the year would be 1999.
-    BeforeAll {
-        $null = New-Module -Name GlobalMockConsumerCleanup -ScriptBlock {
-            function Get-YearAfterCleanup { (Get-Date).Year }
-            Export-ModuleMember -Function Get-YearAfterCleanup
-        } | Import-Module -PassThru -Force
-    }
-
-    AfterAll {
-        Remove-Module GlobalMockConsumerCleanup -Force -ErrorAction SilentlyContinue
-    }
-
-    It 'removes the global mock once the defining test ends' {
-        Get-YearAfterCleanup | Should -BeGreaterThan 2000
-    }
-}
-
-Describe 'Mock -Throw' {
-    BeforeAll {
-        $null = New-Module -Name ThrowMockConsumer -ScriptBlock {
-            function Invoke-BlockedRequest { Invoke-WebRequest -Uri 'http://example.com' }
-            function Read-Path { param($Path) Get-Content -Path $Path }
-            Export-ModuleMember -Function Invoke-BlockedRequest, Read-Path
-        } | Import-Module -PassThru -Force
-    }
-
-    AfterAll {
-        Remove-Module ThrowMockConsumer -Force -ErrorAction SilentlyContinue
-    }
-
-    It 'blocks the command when it is called from another module' {
-        Mock Invoke-WebRequest -Throw
-        { Invoke-BlockedRequest } | Should -Throw '*blocked by a global Pester mock*'
-    }
-
-    It 'records the blocked call, so Should -Invoke works' {
-        Mock Invoke-WebRequest -Throw
-        { Invoke-BlockedRequest } | Should -Throw
-        Should -Invoke Invoke-WebRequest -Exactly -Times 1
-    }
-
-    It 'throws only for calls that match the parameter filter, others fall through' {
-        Mock Get-Content { 'allowed-content' } -Global -ParameterFilter { $Path -like '*allowed*' }
-        Mock Get-Content -Throw -ParameterFilter { $Path -notlike '*allowed*' }
-
-        Read-Path -Path 'C:\allowed\file.txt' | Should -Be 'allowed-content'
-        { Read-Path -Path 'C:\secret\file.txt' } | Should -Throw '*blocked by a global Pester mock*'
-    }
-
-    It 'cannot be combined with -MockWith' {
-        { Mock Get-Date -Throw -MockWith { 1 } } | Should -Throw '*-Throw and -MockWith*'
-    }
-}
-
 Describe 'Mock.Global configuration option' {
     It 'defaults to $false' {
         (New-PesterConfiguration).Mock.Global.Value | Should -BeFalse
     }
 
-    It 'makes every mock global and ignores -ModuleName' {
+    It 'makes every mock reach calls from any module or script' {
+        # The behavior of global mocks can only be observed from inside a run that has the option
+        # enabled, so we drive a nested Pester run with Mock.Global = $true and assert that all of its
+        # tests pass. Each 'It' below documents one behavior of a global mock.
         $container = New-PesterContainer -ScriptBlock {
-            Describe 'forced global' {
+            Describe 'global mocks' {
                 BeforeAll {
-                    $null = New-Module -Name ConfigForcedConsumer -ScriptBlock {
-                        function Get-ForcedYear { (Get-Date).Year }
-                        Export-ModuleMember -Function Get-ForcedYear
+                    # A module that calls commands from its own session state. A normal mock defined in
+                    # the test script scope does not reach these calls; a global mock does.
+                    $null = New-Module -Name GlobalMockConsumer -ScriptBlock {
+                        function Get-YearFromModule { (Get-Date).Year }
+                        function Get-QualifiedYearFromModule { (Microsoft.PowerShell.Utility\Get-Date).Year }
+                        function Invoke-BlockedRequest { Invoke-WebRequest -Uri 'http://example.com' }
+                        function Read-Path { param($Path) Get-Content -Path $Path }
+                        function Get-HiddenItems { Get-ChildItem -Hidden }
+                        Export-ModuleMember -Function Get-YearFromModule, Get-QualifiedYearFromModule, Invoke-BlockedRequest, Read-Path, Get-HiddenItems
                     } | Import-Module -PassThru -Force
                 }
 
                 AfterAll {
-                    Remove-Module ConfigForcedConsumer -Force -ErrorAction SilentlyContinue
+                    Remove-Module GlobalMockConsumer -Force -ErrorAction SilentlyContinue
                 }
 
-                It 'a plain mock reaches another module because the option is on' {
-                    # note: no -Global and a bogus -ModuleName, the option forces it global anyway
-                    Mock Get-Date { [pscustomobject]@{ Year = 1234 } } -ModuleName 'Nope'
-                    Get-ForcedYear | Should -Be 1234
+                It 'reaches calls made from inside another module' {
+                    Mock Get-Date { [pscustomobject]@{ Year = 1999 } }
+                    Get-YearFromModule | Should -Be 1999
+                }
+
+                It 'reaches module-qualified calls' {
+                    Mock Get-Date { [pscustomobject]@{ Year = 1999 } }
+                    Get-QualifiedYearFromModule | Should -Be 1999
+                }
+
+                It 'records the calls, so Should -Invoke works without -ModuleName' {
+                    Mock Get-Date { [pscustomobject]@{ Year = 1999 } }
+                    $null = Get-YearFromModule
+                    $null = Get-YearFromModule
+                    Should -Invoke Get-Date -Exactly -Times 2
+                }
+
+                It 'uses -ModuleName only as a resolve hint, not to scope the mock' {
+                    # a bogus module name is ignored, the command resolves in the caller scope anyway
+                    Mock Get-Date { [pscustomobject]@{ Year = 1999 } } -ModuleName 'ThisModuleDoesNotExist'
+                    Get-YearFromModule | Should -Be 1999
+                }
+
+                It 'a throwing mock blocks the command everywhere and still records the call' {
+                    Mock Invoke-WebRequest { throw 'blocked' }
+                    { Invoke-BlockedRequest } | Should -Throw '*blocked*'
+                    Should -Invoke Invoke-WebRequest -Exactly -Times 1
+                }
+
+                It 'a parameter filter blocks only matching calls, others fall through' {
+                    Mock Get-Content { 'allowed-content' } -ParameterFilter { $Path -like '*allowed*' }
+                    Mock Get-Content { throw 'blocked' } -ParameterFilter { $Path -notlike '*allowed*' }
+
+                    Read-Path -Path 'C:\allowed\file.txt' | Should -Be 'allowed-content'
+                    { Read-Path -Path 'C:\secret\file.txt' } | Should -Throw '*blocked*'
+                }
+
+                It 'preserves the original cmdlet dynamic parameters' {
+                    # Get-ChildItem -Hidden relies on the FileSystem provider's dynamic parameters. The
+                    # global hook must not hide them when resolving the command to build the mock.
+                    Mock Get-ChildItem { 'mocked' }
+                    Get-HiddenItems | Should -Be 'mocked'
+                }
+
+                It 'does not affect commands Pester calls internally through SafeCommands' {
+                    # Pester dispatches its internal commands through $SafeCommands (captured CommandInfo
+                    # invoked with the call operator), which does not go through command lookup. A global
+                    # mock of a command Pester uses internally must not break Pester itself.
+                    Mock Get-Command { throw 'blocked' }
+                    { Get-Command Get-Date } | Should -Throw '*blocked*'
+                }
+            }
+
+            Describe 'global mock cleanup' {
+                # Runs after the block above. If a global mock leaked past its defining test, Get-Date
+                # would still be mocked here.
+                BeforeAll {
+                    $null = New-Module -Name GlobalMockConsumerCleanup -ScriptBlock {
+                        function Get-YearAfterCleanup { (Get-Date).Year }
+                        Export-ModuleMember -Function Get-YearAfterCleanup
+                    } | Import-Module -PassThru -Force
+                }
+
+                AfterAll {
+                    Remove-Module GlobalMockConsumerCleanup -Force -ErrorAction SilentlyContinue
+                }
+
+                It 'removes the global mock once the defining test ends' {
+                    Get-YearAfterCleanup | Should -BeGreaterThan 2000
                 }
             }
         }
@@ -138,24 +113,7 @@ Describe 'Mock.Global configuration option' {
 
         $result = Invoke-Pester -Configuration $configuration
         $result.Result | Should -Be 'Passed'
-        $result.PassedCount | Should -Be 1
         $result.FailedCount | Should -Be 0
-    }
-}
-
-Describe 'Global mocks and Pester internals' {
-    It 'does not affect commands Pester calls internally through SafeCommands' {
-        # Pester dispatches its internal commands through $SafeCommands, which are captured CommandInfo
-        # objects invoked with the call operator. That path does not go through the engine-level command
-        # lookup, so blocking a command by name globally must not break Pester itself.
-        Mock Get-Command -Throw
-
-        # Setting up this mock makes Pester resolve Get-ChildItem internally (via SafeCommands). If the
-        # global block leaked into Pester internals, this line would throw.
-        Mock Get-ChildItem { 'mocked' } -Global
-        Get-ChildItem | Should -Be 'mocked'
-
-        # A by-name call from the test scope is still blocked.
-        { Get-Command Get-Date } | Should -Throw '*blocked by a global Pester mock*'
+        $result.PassedCount | Should -BeGreaterThan 0
     }
 }

--- a/tst/functions/Mock.Global.Tests.ps1
+++ b/tst/functions/Mock.Global.Tests.ps1
@@ -1,0 +1,161 @@
+Set-StrictMode -Version Latest
+
+BeforeAll {
+    $PSDefaultParameterValues = @{ 'Should:ErrorAction' = 'Stop' }
+}
+
+Describe 'Mock -Global' {
+    BeforeAll {
+        # A module that calls commands from its own session state. A normal mock defined in the test
+        # script scope does not reach these calls, which is what -Global changes.
+        $null = New-Module -Name GlobalMockConsumer -ScriptBlock {
+            function Get-YearFromModule { (Get-Date).Year }
+            function Get-QualifiedYearFromModule { (Microsoft.PowerShell.Utility\Get-Date).Year }
+            Export-ModuleMember -Function Get-YearFromModule, Get-QualifiedYearFromModule
+        } | Import-Module -PassThru -Force
+    }
+
+    AfterAll {
+        Remove-Module GlobalMockConsumer -Force -ErrorAction SilentlyContinue
+    }
+
+    It 'a normal mock does not reach calls made from inside another module' {
+        Mock Get-Date { [pscustomobject]@{ Year = 1999 } }
+        Get-YearFromModule | Should -Not -Be 1999
+    }
+
+    It 'a -Global mock reaches calls made from inside another module' {
+        Mock Get-Date { [pscustomobject]@{ Year = 1999 } } -Global
+        Get-YearFromModule | Should -Be 1999
+    }
+
+    It 'a -Global mock reaches module-qualified calls' {
+        Mock Get-Date { [pscustomobject]@{ Year = 1999 } } -Global
+        Get-QualifiedYearFromModule | Should -Be 1999
+    }
+
+    It 'records the calls, so Should -Invoke works without -ModuleName' {
+        Mock Get-Date { [pscustomobject]@{ Year = 1999 } } -Global
+        $null = Get-YearFromModule
+        $null = Get-YearFromModule
+        Should -Invoke Get-Date -Exactly -Times 2
+    }
+
+    It 'ignores -ModuleName when -Global is used' {
+        Mock Get-Date { [pscustomobject]@{ Year = 1999 } } -Global -ModuleName 'ThisModuleDoesNotExist'
+        Get-YearFromModule | Should -Be 1999
+    }
+}
+
+Describe 'Mock -Global cleanup' {
+    # This block runs after the -Global block above. If a global mock leaked past its defining test,
+    # Get-Date would still be mocked here and the year would be 1999.
+    BeforeAll {
+        $null = New-Module -Name GlobalMockConsumerCleanup -ScriptBlock {
+            function Get-YearAfterCleanup { (Get-Date).Year }
+            Export-ModuleMember -Function Get-YearAfterCleanup
+        } | Import-Module -PassThru -Force
+    }
+
+    AfterAll {
+        Remove-Module GlobalMockConsumerCleanup -Force -ErrorAction SilentlyContinue
+    }
+
+    It 'removes the global mock once the defining test ends' {
+        Get-YearAfterCleanup | Should -BeGreaterThan 2000
+    }
+}
+
+Describe 'Mock -Throw' {
+    BeforeAll {
+        $null = New-Module -Name ThrowMockConsumer -ScriptBlock {
+            function Invoke-BlockedRequest { Invoke-WebRequest -Uri 'http://example.com' }
+            function Read-Path { param($Path) Get-Content -Path $Path }
+            Export-ModuleMember -Function Invoke-BlockedRequest, Read-Path
+        } | Import-Module -PassThru -Force
+    }
+
+    AfterAll {
+        Remove-Module ThrowMockConsumer -Force -ErrorAction SilentlyContinue
+    }
+
+    It 'blocks the command when it is called from another module' {
+        Mock Invoke-WebRequest -Throw
+        { Invoke-BlockedRequest } | Should -Throw '*blocked by a global Pester mock*'
+    }
+
+    It 'records the blocked call, so Should -Invoke works' {
+        Mock Invoke-WebRequest -Throw
+        { Invoke-BlockedRequest } | Should -Throw
+        Should -Invoke Invoke-WebRequest -Exactly -Times 1
+    }
+
+    It 'throws only for calls that match the parameter filter, others fall through' {
+        Mock Get-Content { 'allowed-content' } -Global -ParameterFilter { $Path -like '*allowed*' }
+        Mock Get-Content -Throw -ParameterFilter { $Path -notlike '*allowed*' }
+
+        Read-Path -Path 'C:\allowed\file.txt' | Should -Be 'allowed-content'
+        { Read-Path -Path 'C:\secret\file.txt' } | Should -Throw '*blocked by a global Pester mock*'
+    }
+
+    It 'cannot be combined with -MockWith' {
+        { Mock Get-Date -Throw -MockWith { 1 } } | Should -Throw '*-Throw and -MockWith*'
+    }
+}
+
+Describe 'Mock.Global configuration option' {
+    It 'defaults to $false' {
+        (New-PesterConfiguration).Mock.Global.Value | Should -BeFalse
+    }
+
+    It 'makes every mock global and ignores -ModuleName' {
+        $container = New-PesterContainer -ScriptBlock {
+            Describe 'forced global' {
+                BeforeAll {
+                    $null = New-Module -Name ConfigForcedConsumer -ScriptBlock {
+                        function Get-ForcedYear { (Get-Date).Year }
+                        Export-ModuleMember -Function Get-ForcedYear
+                    } | Import-Module -PassThru -Force
+                }
+
+                AfterAll {
+                    Remove-Module ConfigForcedConsumer -Force -ErrorAction SilentlyContinue
+                }
+
+                It 'a plain mock reaches another module because the option is on' {
+                    # note: no -Global and a bogus -ModuleName, the option forces it global anyway
+                    Mock Get-Date { [pscustomobject]@{ Year = 1234 } } -ModuleName 'Nope'
+                    Get-ForcedYear | Should -Be 1234
+                }
+            }
+        }
+
+        $configuration = New-PesterConfiguration
+        $configuration.Run.Container = $container
+        $configuration.Run.PassThru = $true
+        $configuration.Output.Verbosity = 'None'
+        $configuration.Mock.Global = $true
+
+        $result = Invoke-Pester -Configuration $configuration
+        $result.Result | Should -Be 'Passed'
+        $result.PassedCount | Should -Be 1
+        $result.FailedCount | Should -Be 0
+    }
+}
+
+Describe 'Global mocks and Pester internals' {
+    It 'does not affect commands Pester calls internally through SafeCommands' {
+        # Pester dispatches its internal commands through $SafeCommands, which are captured CommandInfo
+        # objects invoked with the call operator. That path does not go through the engine-level command
+        # lookup, so blocking a command by name globally must not break Pester itself.
+        Mock Get-Command -Throw
+
+        # Setting up this mock makes Pester resolve Get-ChildItem internally (via SafeCommands). If the
+        # global block leaked into Pester internals, this line would throw.
+        Mock Get-ChildItem { 'mocked' } -Global
+        Get-ChildItem | Should -Be 'mocked'
+
+        # A by-name call from the test scope is still blocked.
+        { Get-Command Get-Date } | Should -Throw '*blocked by a global Pester mock*'
+    }
+}

--- a/tst/functions/Mock.Global.Tests.ps1
+++ b/tst/functions/Mock.Global.Tests.ps1
@@ -117,3 +117,140 @@ Describe 'Mock.Global configuration option' {
         $result.PassedCount | Should -BeGreaterThan 0
     }
 }
+
+Describe 'Global mock hook lifecycle' {
+    It 'a nested Pester run does not clobber the outer run''s global mocks' {
+        # The global mock hook is runspace-wide. A nested Invoke-Pester (Pester-in-Pester) must not
+        # overwrite or tear down the outer run's global mocks. The outer run below defines a global mock,
+        # runs an inner Pester run that defines its own global mock for the same command, and then checks
+        # that its own mock is still in effect after the inner run finished.
+        $container = New-PesterContainer -ScriptBlock {
+            Describe 'outer' {
+                It 'keeps its own global mock across a nested run' {
+                    Mock Get-Date { [pscustomobject]@{ Year = 1111 } }
+                    (Get-Date).Year | Should -Be 1111
+
+                    $inner = New-PesterContainer -ScriptBlock {
+                        Describe 'inner' {
+                            It 'has its own global mock' {
+                                Mock Get-Date { [pscustomobject]@{ Year = 2222 } }
+                                (Get-Date).Year | Should -Be 2222
+                            }
+                        }
+                    }
+                    $innerConfig = New-PesterConfiguration
+                    $innerConfig.Run.Container = $inner
+                    $innerConfig.Run.PassThru = $true
+                    $innerConfig.Output.Verbosity = 'None'
+                    $innerConfig.Mock.Global = $true
+                    $innerResult = Invoke-Pester -Configuration $innerConfig
+                    $innerResult.FailedCount | Should -Be 0
+                    $innerResult.PassedCount | Should -Be 1
+
+                    # the outer run's global mock must still be in effect after the nested run
+                    (Get-Date).Year | Should -Be 1111
+                }
+            }
+        }
+
+        $configuration = New-PesterConfiguration
+        $configuration.Run.Container = $container
+        $configuration.Run.PassThru = $true
+        $configuration.Output.Verbosity = 'None'
+        $configuration.Mock.Global = $true
+
+        $result = Invoke-Pester -Configuration $configuration
+        $result.Result | Should -Be 'Passed'
+        $result.FailedCount | Should -Be 0
+    }
+
+    It 'a nested Pester run does not inherit the outer run''s global mocks' {
+        # Full isolation via the per-run nonce: a global mock defined in the outer run must not leak into a
+        # nested run through its script-scope bootstrap alias. The inner run below does not mock Get-Date,
+        # so it must see the real command, not the outer run's fake value.
+        $container = New-PesterContainer -ScriptBlock {
+            Describe 'outer' {
+                It 'runs a nested run that does not mock the command' {
+                    Mock Get-Date { [pscustomobject]@{ Year = 1111 } }
+                    (Get-Date).Year | Should -Be 1111
+
+                    $inner = New-PesterContainer -ScriptBlock {
+                        Describe 'inner' {
+                            It 'sees the real command, not the outer global mock' {
+                                # Get-Date is not mocked in this run; the outer run's global mock must not
+                                # leak in, so we must get a real date (not the fake 1111 the outer set).
+                                (Get-Date).Year | Should -Not -Be 1111
+                            }
+                        }
+                    }
+                    $innerConfig = New-PesterConfiguration
+                    $innerConfig.Run.Container = $inner
+                    $innerConfig.Run.PassThru = $true
+                    $innerConfig.Output.Verbosity = 'None'
+                    $innerConfig.Mock.Global = $true
+                    $innerResult = Invoke-Pester -Configuration $innerConfig
+                    $innerResult.FailedCount | Should -Be 0
+                    $innerResult.PassedCount | Should -Be 1
+
+                    # the outer run's global mock must still be in effect after the nested run
+                    (Get-Date).Year | Should -Be 1111
+                }
+            }
+        }
+
+        $configuration = New-PesterConfiguration
+        $configuration.Run.Container = $container
+        $configuration.Run.PassThru = $true
+        $configuration.Output.Verbosity = 'None'
+        $configuration.Mock.Global = $true
+
+        $result = Invoke-Pester -Configuration $configuration
+        $result.Result | Should -Be 'Passed'
+        $result.FailedCount | Should -Be 0
+    }
+
+    It 'a fresh top-level run clears a global mock hook left armed by a previous run' {
+        # An interrupted run (for example Ctrl+C during a global mock) can leave the runspace-wide hook
+        # armed, because its teardown never ran. A new top-level Invoke-Pester must reset it. This can only
+        # be observed at the top level (a nested run snapshots/restores instead), so we use a child process:
+        # arm the hook by hand, run a trivial top-level Pester run, and confirm the hook was cleared.
+        $modulePath = (Get-Module -Name Pester | Select-Object -First 1).Path
+        $modulePath | Should -Not -BeNullOrEmpty
+
+        $childScript = {
+            Import-Module $env:PESTER_MODULE_PATH_FOR_TEST -Force
+
+            # simulate a global mock left behind by an interrupted run
+            [Pester.GlobalMockHook]::Register('LeftoverGlobalMock', (Get-Command -Name Get-Date))
+            $ec = $ExecutionContext.SessionState.InvokeCommand
+            $ec.PreCommandLookupAction = [Delegate]::Combine($ec.PreCommandLookupAction, [Pester.GlobalMockHook]::Handler)
+            $before = [Pester.GlobalMockHook]::Count
+
+            $container = New-PesterContainer -ScriptBlock {
+                Describe 'trivial' { It 'passes' { 1 | Should -Be 1 } }
+            }
+            $c = New-PesterConfiguration
+            $c.Run.Container = $container
+            $c.Run.PassThru = $true
+            $c.Output.Verbosity = 'None'
+            $r = Invoke-Pester -Configuration $c
+
+            $after = [Pester.GlobalMockHook]::Count
+            "BEFORE=$before AFTER=$after RESULT=$($r.Result)"
+        }
+
+        $env:PESTER_MODULE_PATH_FOR_TEST = $modulePath
+        try {
+            $exe = [System.Diagnostics.Process]::GetCurrentProcess().MainModule.FileName
+            $output = (& $exe -NoProfile -Command $childScript 2>&1) -join "`n"
+        }
+        finally {
+            $env:PESTER_MODULE_PATH_FOR_TEST = $null
+        }
+
+        # the hook was armed before the run (BEFORE=1) and cleared by the fresh top-level run (AFTER=0)
+        $output | Should -Match 'BEFORE=1'
+        $output | Should -Match 'AFTER=0'
+        $output | Should -Match 'RESULT=Passed'
+    }
+}


### PR DESCRIPTION
A normal mock only applies to calls from the scope where it is defined, or from the module you pass with `-ModuleName`. Code in another module looks the command up in its own session state and never sees the mock. So to be sure a command like `Invoke-WebRequest` is never called from any code under test, you have to know every module that might call it and mock it in each one.

Global mocks apply to calls of the mocked command from any module or script in the runspace, so you don't have to. This is experimental.

## `Mock.Global` configuration option

Turn global mocks on for the whole run with the experimental option:

```powershell
$config = New-PesterConfiguration
$config.Mock.Global = $true
```

With it on you write your mocks exactly as you do today and they simply reach the command wherever it is called. One mock covers every module, so you no longer have to name each calling module:

```powershell
Mock Invoke-WebRequest { '<html />' }
Get-Data   # a function in another module that calls Invoke-WebRequest
Should -Invoke Invoke-WebRequest -Times 1
```

To make sure a command never runs, mock it to throw. Combine that with `-ParameterFilter` to block only the calls you care about and let the rest fall through to the real command:

```powershell
# block deleting anything outside TestDrive, from any code under test
Mock Remove-Item { throw 'blocked' } -ParameterFilter { $Path -notlike "$TestDrive*" }
```

The mock is removed when the test or block that defined it ends, like any other mock.

With the option on, `-ModuleName` no longer scopes a mock. It is used only as a hint to resolve the command, so a module-private command can still be found and mocked. You can point it to any place where the command is resolvable - that is to the module where it is defined, or to the module where the function is exported to. If your current mocks use `-ModuleName`, you should not need to change them to use  the new .Global option.

## How it works

A global mock is a normal Pester mock plus a registration in the runspace-wide `InvokeCommand.PreCommandLookupAction` hook. That hook fires on every parser-driven command lookup, in any module, so the lookup is redirected to the mock's bootstrap function no matter where the call comes from. The hook is installed while at least one global mock exists and removed once none remain.

Pester's own internals are not affected. Pester calls its internal commands through `$SafeCommands`, a captured `CommandInfo` invoked with the call operator, which does not go through command lookup. So even mocking a command Pester uses internally (for example `Get-Command`) does not break Pester itself.

### Isolation between runs

Because the hook and its bootstrap alias are runspace-wide, a global mock is tied to the run that created it so it can't leak elsewhere:

- **Each run has its own identity.** Every `Invoke-Pester` run gets a unique id that is baked into each mock it creates. A mock only applies while its own run is executing.
- **Nested Pester-in-Pester runs are fully isolated.** If an outer run's global mock leaks into a nested run through the outer script's scope, the nested run sees the id mismatch and calls the real command instead of applying the leaked mock. The nested run can mock the same command independently, and the outer run's global mocks are snapshotted and restored around the nested run so they are never clobbered.
- **Interrupted runs recover.** The hook is runspace state that outlives a single test, so a `Ctrl+C` during a global mock could leave it armed. A fresh top-level run resets the hook before it starts, so it always begins with a clean slate.

The configuration option is experimental and may change based on feedback.

## What `-ModuleName` does

Without the option, a mock is module-scoped: `Mock -ModuleName A Cmd` affects only calls made from module `A`. This is the default, and it gives you three things a global mock does not:

- **Isolation to a single module.** Only calls from `A` are affected; the same-named command in module `B`, or in the test script, is untouched. A global mock reaches all of them.
- **Disambiguating same-named commands.** Two modules — or two nested copies — that each define `Get-Data` can be mocked independently with `-ModuleName`. One global `Get-Data` mock catches every copy.
- **Module-scoped call history and messages.** `Should -Invoke -ModuleName A` counts only `A`'s calls, and the "verifiable not called" message names the module. A global mock records once with no module, so both the per-module count and that message qualifier go away.

Fix #2705