### PR TITLE
Bump prerelease to alpha2

### DIFF
--- a/src/Pester.psd1
+++ b/src/Pester.psd1
@@ -172,10 +172,10 @@
             LicenseUri   = "https://www.apache.org/licenses/LICENSE-2.0.html"
 
             # Release notes for this particular version of the module
-            ReleaseNotes = 'https://github.com/pester/Pester/releases/tag/6.1.0-alpha1'
+            ReleaseNotes = 'https://github.com/pester/Pester/releases/tag/6.1.0-alpha2'
 
             # Prerelease string of this module
-            Prerelease   = 'alpha1'
+            Prerelease   = 'alpha2'
         }
 
         # Minimum assembly version required


### PR DESCRIPTION
Bumps the Pester module branding to `6.1.0-alpha2`.

- Update `Prerelease` from `alpha1` to `alpha2` in `src/Pester.psd1`.
- Point `ReleaseNotes` at the `6.1.0-alpha2` release tag.