### PR TITLE
Render Describing/Context headers in parallel Detailed output

### DIFF
--- a/src/functions/Pester.Parallel.ps1
+++ b/src/functions/Pester.Parallel.ps1
@@ -269,7 +269,8 @@ function Invoke-TestInParallel {
         # FrameworkData.CommandUsed (Describe/Context) before the parent replays the tape, and the
         # reporting plugins would then fail to render the "Describing"/"Context" headers in
         # Detailed/Diagnostic output (#2824). The parent runs the same cleanup itself after folding
-        # the worker's containers into its own run, so the user still receives a cleaned result.
+        # the worker's containers into its own run (Remove-RSpecNonPublicProperties in Main.ps1,
+        # after the tape has been replayed), so the user still receives a cleaned result.
         $workerConfig.Debug.ReturnRawResultObject = $true
 
         $pesterModule = Get-Module -Name Pester

--- a/src/functions/Pester.Parallel.ps1
+++ b/src/functions/Pester.Parallel.ps1
@@ -263,6 +263,14 @@ function Invoke-TestInParallel {
         $workerConfig.Run.RepoRoot = ''
         # The worker stays silent; the parent renders all output by replaying the recorded tape.
         $workerConfig.Output.Verbosity = 'None'
+        # Keep the raw result object in the worker. At the end of a run Pester strips internal,
+        # non-public state - including each block's FrameworkData - off the result tree. The tape
+        # holds live references to those same Block/Test objects, so that cleanup would blank out
+        # FrameworkData.CommandUsed (Describe/Context) before the parent replays the tape, and the
+        # reporting plugins would then fail to render the "Describing"/"Context" headers in
+        # Detailed/Diagnostic output (#2824). The parent runs the same cleanup itself after folding
+        # the worker's containers into its own run, so the user still receives a cleaned result.
+        $workerConfig.Debug.ReturnRawResultObject = $true
 
         $pesterModule = Get-Module -Name Pester
 

--- a/tst/Pester.RSpec.Parallel.ts.ps1
+++ b/tst/Pester.RSpec.Parallel.ts.ps1
@@ -527,4 +527,45 @@ Describe 'B' { It 'b1 never runs' { 1 | Should -Be 1 } }
             finally { Remove-Item -Path $folder -Recurse -Force }
         }
     }
+
+    b "Run.Parallel output" {
+        t "renders Describing/Context block headers in Detailed output" {
+            # In parallel each file runs in a silent worker whose result tree is replayed to the
+            # parent's reporting plugins. The worker's end-of-run cleanup used to strip every block's
+            # FrameworkData (which carries the Describe/Context command name), and because the replay
+            # tape holds live references to those same block objects the parent was then left without
+            # a CommandUsed to render - so the "Describing"/"Context" headers silently vanished from
+            # Detailed/Diagnostic output (#2824). Assert they are present in a parallel run.
+            $folder = Join-Path ([IO.Path]::GetTempPath()) ([Guid]::NewGuid().Guid)
+            $null = New-Item -ItemType Directory -Path $folder -Force
+            try {
+                Set-Content -Path (Join-Path $folder 'One.Tests.ps1') -Value @'
+Describe 'OuterOne' {
+    Context 'CtxA' { It 'a1 passes' { 1 | Should -Be 1 } }
+}
+'@
+                Set-Content -Path (Join-Path $folder 'Two.Tests.ps1') -Value @'
+Describe 'OuterTwo' {
+    Context 'CtxB' { It 'b1 passes' { 1 | Should -Be 1 } }
+}
+'@
+                $c = [PesterConfiguration]::Default
+                $c.Run.Path = $folder
+                $c.Run.Parallel = $true
+                $c.Run.PassThru = $true
+                $c.Output.Verbosity = 'Detailed'
+                $c.Output.RenderMode = 'Plaintext'
+
+                # Write-PesterHostMessage uses Write-Host, so console output lands on the
+                # information stream (6) and can be captured in-process.
+                $output = (Invoke-Pester -Configuration $c 6>&1 | Out-String)
+
+                $output | Verify-Like '*Describing OuterOne*'
+                $output | Verify-Like '*Context CtxA*'
+                $output | Verify-Like '*Describing OuterTwo*'
+                $output | Verify-Like '*Context CtxB*'
+            }
+            finally { Remove-Item -Path $folder -Recurse -Force }
+        }
+    }
 }


### PR DESCRIPTION
Fix #2824

## Problem

In a parallel run (`Run.Parallel = $true`) with `Output.Verbosity` set to `Detailed` or `Diagnostic`, the `Describing ...` / `Context ...` block headers were missing from the console output. They render correctly in a sequential run.

## Root cause

Each file in a parallel run is executed by a silent worker (`Output.Verbosity = None`) whose plugin events are recorded onto a "tape" of **live** `Block`/`Test` objects. The parent replays that tape to its reporting plugins to produce console output.

At the end of every run Pester calls `Remove-RSpecNonPublicProperties`, which nulls each block's `FrameworkData`. `FrameworkData.CommandUsed` is what tells the output plugin whether a block is a `Describe` or a `Context`. Because the tape holds live references to the very same block objects, the worker's own end-of-run cleanup blanked out `FrameworkData` **before** the parent replayed the tape. `Write-BlockToScreen` then indexed a report hashtable with a `$null` key, threw, and the error was swallowed by the non-throwing replay path — so the header silently disappeared.

Sequential runs are unaffected because they write output during the run, before that cleanup runs.

## Fix

Set `Debug.ReturnRawResultObject = $true` on the worker configuration so the worker skips the cleanup and leaves `FrameworkData` intact on the live tape objects. The parent performs the same cleanup itself on the merged result tree after replaying the tape, so the object returned to the user is still cleaned exactly as before.

## Tests

Added a test in `tst/Pester.RSpec.Parallel.ts.ps1` asserting that `Describing`/`Context` headers appear in `Detailed` output for a parallel run. Full parallel and output suites pass.