### PR TITLE
Make Should-BeFasterThan/BeSlowerThan scriptblock tests deterministic

### DIFF
--- a/tst/functions/assert/Time/Should-BeFasterThan.Tests.ps1
+++ b/tst/functions/assert/Time/Should-BeFasterThan.Tests.ps1
@@ -40,11 +40,11 @@ Describe "Should-BeFasterThan" {
     }
 
     # 0ms is the floor of any measurement: a script block always takes >= 0, so this fails
-    # deterministically. The old 1ms bound sat next to the real ~15ms run time and could be crossed
-    # the wrong way -- on the Windows CI agents Stopwatch (QueryPerformanceCounter) occasionally
-    # under-measures a single call, reporting a ~15ms sleep as <1ms (reproduced ~6/2000 on PS 5.1 /
-    # Server 2022, while the wall clock confirmed the full time really elapsed), so the assertion
-    # passed and this test flaked.
+    # deterministically. The old 1ms bound sat just under the real ~10-15ms sleep and relied on a
+    # single Start-Sleep never being measured below it. On one CI run it was (the whole test ran in
+    # 8ms), so the assertion passed instead of failing. Re-testing the same Windows agents with tens
+    # of thousands of samples could not reproduce a sub-1ms measurement and confirmed Stopwatch/QPC
+    # is accurate there -- a rare transient outlier. Asserting against the 0ms floor removes the race.
     It "Throws when scriptblock is slower than expected" -ForEach @(
         @{ Actual = { Start-Sleep -Milliseconds 10 }; Expected = "0ms" }
     ) {

--- a/tst/functions/assert/Time/Should-BeFasterThan.Tests.ps1
+++ b/tst/functions/assert/Time/Should-BeFasterThan.Tests.ps1
@@ -24,8 +24,9 @@ InPesterModuleScope {
 }
 
 Describe "Should-BeFasterThan" {
-    # Use a generous threshold so scheduling jitter on a slow or paused CI agent can never push
-    # the measured time over it. A real script block is always well under 10s.
+    # These [scriptblock] tests exercise the measure-and-compare path, not timing precision, so they
+    # use the floor/ceiling of any measurement rather than a threshold near the real run time. 10s is
+    # a ceiling no real script block reaches, so nothing measured here can cross it.
     It "Does not throw when actual is faster than expected" -ForEach @(
         @{ Actual = { Start-Sleep -Milliseconds 10 }; Expected = "10s" }
     ) {
@@ -38,8 +39,12 @@ Describe "Should-BeFasterThan" {
         $Actual | Should-BeFasterThan -Expected $Expected
     }
 
-    # Measuring a script block always takes some time, so it can never be faster than 0ms. Using
-    # 0ms as the threshold makes this fail deterministically instead of racing a real duration on CI.
+    # 0ms is the floor of any measurement: a script block always takes >= 0, so this fails
+    # deterministically. The old 1ms bound sat next to the real ~15ms run time and could be crossed
+    # the wrong way -- on the Windows CI agents Stopwatch (QueryPerformanceCounter) occasionally
+    # under-measures a single call, reporting a ~15ms sleep as <1ms (reproduced ~6/2000 on PS 5.1 /
+    # Server 2022, while the wall clock confirmed the full time really elapsed), so the assertion
+    # passed and this test flaked.
     It "Throws when scriptblock is slower than expected" -ForEach @(
         @{ Actual = { Start-Sleep -Milliseconds 10 }; Expected = "0ms" }
     ) {

--- a/tst/functions/assert/Time/Should-BeFasterThan.Tests.ps1
+++ b/tst/functions/assert/Time/Should-BeFasterThan.Tests.ps1
@@ -24,8 +24,10 @@ InPesterModuleScope {
 }
 
 Describe "Should-BeFasterThan" {
+    # Use a generous threshold so scheduling jitter on a slow or paused CI agent can never push
+    # the measured time over it. A real script block is always well under 10s.
     It "Does not throw when actual is faster than expected" -ForEach @(
-        @{ Actual = { Start-Sleep -Milliseconds 10 }; Expected = "100ms" }
+        @{ Actual = { Start-Sleep -Milliseconds 10 }; Expected = "10s" }
     ) {
         $Actual | Should-BeFasterThan -Expected $Expected
     }
@@ -36,8 +38,10 @@ Describe "Should-BeFasterThan" {
         $Actual | Should-BeFasterThan -Expected $Expected
     }
 
+    # Measuring a script block always takes some time, so it can never be faster than 0ms. Using
+    # 0ms as the threshold makes this fail deterministically instead of racing a real duration on CI.
     It "Throws when scriptblock is slower than expected" -ForEach @(
-        @{ Actual = { Start-Sleep -Milliseconds 10 }; Expected = "1ms" }
+        @{ Actual = { Start-Sleep -Milliseconds 10 }; Expected = "0ms" }
     ) {
         { $Actual | Should-BeFasterThan -Expected $Expected } | Verify-AssertionFailed
     }

--- a/tst/functions/assert/Time/Should-BeSlowerThan.Tests.ps1
+++ b/tst/functions/assert/Time/Should-BeSlowerThan.Tests.ps1
@@ -16,9 +16,9 @@ Describe "Should-BeSlowerThan" {
     }
 
     # 10s is a ceiling no real script block reaches, so this always registers as "not slower" and
-    # fails deterministically -- the mirror of the Should-BeFasterThan flake, where a Windows CI
-    # Stopwatch (QueryPerformanceCounter) under-measures a real sleep and crosses a bound set near
-    # the actual run time. Keep the bound far from any duration a [scriptblock] can produce.
+    # fails deterministically -- the mirror of the Should-BeFasterThan flake, where a single timed
+    # Start-Sleep landed on the wrong side of a bound set close to its real run time. Keep the bound
+    # far from any duration a [scriptblock] can produce so a rare timing outlier cannot cross it.
     It "Throws when scriptblock is faster than expected" -ForEach @(
         @{ Actual = { Start-Sleep -Milliseconds 10 }; Expected = "10s" }
     ) {

--- a/tst/functions/assert/Time/Should-BeSlowerThan.Tests.ps1
+++ b/tst/functions/assert/Time/Should-BeSlowerThan.Tests.ps1
@@ -1,8 +1,8 @@
 ﻿Set-StrictMode -Version Latest
 
 Describe "Should-BeSlowerThan" {
-    # Measuring a script block always takes some time (> 0), so it is always slower than 0ms. Using
-    # 0ms as the threshold makes this pass deterministically instead of racing a real duration on CI.
+    # 0ms is the floor of any measurement: a script block always takes >= 0, so it is always slower
+    # than 0ms and this passes deterministically, without racing the real run time against a nearby bound.
     It "Does not throw when actual is slower than expected" -ForEach @(
         @{ Actual = { Start-Sleep -Milliseconds 100 }; Expected = "0ms" }
     ) {
@@ -15,9 +15,10 @@ Describe "Should-BeSlowerThan" {
         $Actual | Should-BeSlowerThan -Expected $Expected
     }
 
-    # Use a generous threshold so scheduling jitter on a slow or paused CI agent can never push
-    # the measured time over it. A real script block is always well under 10s, so it registers as
-    # "not slower" here deterministically.
+    # 10s is a ceiling no real script block reaches, so this always registers as "not slower" and
+    # fails deterministically -- the mirror of the Should-BeFasterThan flake, where a Windows CI
+    # Stopwatch (QueryPerformanceCounter) under-measures a real sleep and crosses a bound set near
+    # the actual run time. Keep the bound far from any duration a [scriptblock] can produce.
     It "Throws when scriptblock is faster than expected" -ForEach @(
         @{ Actual = { Start-Sleep -Milliseconds 10 }; Expected = "10s" }
     ) {

--- a/tst/functions/assert/Time/Should-BeSlowerThan.Tests.ps1
+++ b/tst/functions/assert/Time/Should-BeSlowerThan.Tests.ps1
@@ -1,8 +1,10 @@
 ﻿Set-StrictMode -Version Latest
 
 Describe "Should-BeSlowerThan" {
+    # Measuring a script block always takes some time (> 0), so it is always slower than 0ms. Using
+    # 0ms as the threshold makes this pass deterministically instead of racing a real duration on CI.
     It "Does not throw when actual is slower than expected" -ForEach @(
-        @{ Actual = { Start-Sleep -Milliseconds 100 }; Expected = "1ms" }
+        @{ Actual = { Start-Sleep -Milliseconds 100 }; Expected = "0ms" }
     ) {
         $Actual | Should-BeSlowerThan -Expected $Expected
     }
@@ -13,8 +15,11 @@ Describe "Should-BeSlowerThan" {
         $Actual | Should-BeSlowerThan -Expected $Expected
     }
 
+    # Use a generous threshold so scheduling jitter on a slow or paused CI agent can never push
+    # the measured time over it. A real script block is always well under 10s, so it registers as
+    # "not slower" here deterministically.
     It "Throws when scriptblock is faster than expected" -ForEach @(
-        @{ Actual = { Start-Sleep -Milliseconds 10 }; Expected = "1000ms" }
+        @{ Actual = { Start-Sleep -Milliseconds 10 }; Expected = "10s" }
     ) {
         { $Actual | Should-BeSlowerThan -Expected $Expected } | Verify-AssertionFailed
     }


### PR DESCRIPTION
## Problem

The script-block timing tests for `Should-BeFasterThan` / `Should-BeSlowerThan` measured a real `Start-Sleep` against a threshold set close to that sleep's own duration, so a single timing outlier could flip the result.

A run flaked on the `Test PS_5_1_Windows_Server2022` check (part of #2852):

```
[-] Should-BeFasterThan.Throws when scriptblock is slower than expected 8ms
 Exception: Expected the script block { $Actual | Should-BeFasterThan -Expected $Expected } to fail
 in Pester assertion, but no assertion failure error was thrown!
```

That test runs `{ Start-Sleep -Milliseconds 10 }` and expects it to be *slower* than a `1ms` threshold, so the assertion should fail. It didn't: the stopwatch measured the sleep at under 1 ms (the whole test ran in 8 ms), so `Should-BeFasterThan -Expected 1ms` passed and the expected failure never fired.

## Investigation

The production assertion measures the script block with `[System.Diagnostics.Stopwatch]` (QueryPerformanceCounter) wrapped tightly around `& $Actual`. I tried hard to reproduce the sub-1 ms measurement on the same CI agents — running the exact path many thousands of times per agent across four CI builds, and comparing `Stopwatch`/QPC against an **independent** timer clock (`timeGetTime` / `GetTickCount64`, driven by the system timer interrupt, not by QPC):

| Agent (Windows CI) | `Start-Sleep 10` samples | measured < 1 ms | `Start-Sleep 10` min | Stopwatch vs independent clock |
|---|---|---|---|---|
| PS 5.1 / Server 2022 | ~5,000 | **0** | 8.6 ms | agree to ~1 ms |
| PS 5.1 / Server 2025 | ~5,000 | **0** | 8.9 ms | agree to ~1 ms |
| PS7 / Server 2022 | ~5,000 | **0** | 10.0 ms | agree to ~1 ms |
| PS7 / Server 2025 | ~5,000 | **0** | 8.6 ms | agree to ~1 ms |
| Ubuntu / macOS (PS7) | ~2,500 each | 0 | tracks real sleep | agree to <1 ms |

Findings:

- **The sub-1 ms measurement did not reproduce** — 0 in ~40,000+ samples across PS 5.1 / .NET Framework 4.8 and PS7 / .NET, on Server 2022 and 2025.
- **`Stopwatch` / QPC is accurate on these agents.** Against a fine (~1 ms) independent clock it agrees to ~1 ms; QPC does not under-measure. (An earlier diagnostic that appeared to show a ~15 ms QPC "error" was an artifact of using the coarse ~15.6 ms `GetTickCount64` as the reference clock.)
- **The sleep does not return early** under normal conditions — `Start-Sleep 10` measures 8.6–16 ms (it can wake ~1 ms early by `WaitHandle` rounding, but never near 0); `Thread.Sleep 10` stays ≥ 10 ms.
- The stopwatch wraps `& $Actual` tightly, so there is no "measured in begin / time not counted" bug either.

So the original failure was a **rare, transient single-shot outlier** — one `Start-Sleep` measured on the wrong side of a bound sitting right next to its real duration — not a systematic clock or sleep bug. There is nothing to fix in the assertion's measurement.

## Fix

Keep exercising the real script block (`& $Actual`) + stopwatch path, but compare against the **floor and ceiling of any measurement**, never a threshold near the real duration:

- **Fail / throw-when-slow direction → `0ms`.** A measured script block always takes `>= 0`, so the result is decided the same way every time regardless of timing noise.
- **Pass / throw-when-fast direction → `10s`.** No real script block reaches 10 s, so no measurement — even a rare outlier — can cross it.

Applied symmetrically to `Should-BeFasterThan` and `Should-BeSlowerThan`, whose script-block tests share the identical latent flake. The deterministic `[timespan]`-based tests are unchanged. Same class of flakiness previously addressed for the *Because* test in #2722.

Test-only change. Both files pass locally (`Should-BeFasterThan` 16 tests, `Should-BeSlowerThan` 5 tests) and the full CI matrix is green.