### PR TITLE
[DO NOT MERGE] QPC anomaly diagnostic

### DIFF
--- a/tst/functions/assert/Time/zzz-QpcRepro.Tests.ps1
+++ b/tst/functions/assert/Time/zzz-QpcRepro.Tests.ps1
@@ -1,7 +1,7 @@
 Set-StrictMode -Version Latest
 
 Describe 'QPC anomaly diagnostic' {
-    It 'measures QueryPerformanceCounter against an independent tick clock across sleep durations' {
+    It 'measures QueryPerformanceCounter against an independent timer clock across sleep durations' {
         $src = @'
 // QpcAnomalyRepro
 // -----------------------------------------------------------------------------
@@ -13,10 +13,12 @@ Describe 'QPC anomaly diagnostic' {
 //   * QPC          - QueryPerformanceCounter (raw P/Invoke on Windows, the same
 //                    source System.Diagnostics.Stopwatch uses). This is the
 //                    suspected-buggy clock.
-//   * Tick counter - GetTickCount64 (Windows) / Environment.TickCount (other).
-//                    Driven by the periodic system timer interrupt, NOT by
-//                    TSC/QPC, so it is an independent witness that real time
-//                    actually elapsed.
+//   * Independent  - timeGetTime (Windows, ~1ms with timeBeginPeriod(1)) /
+//                    Environment.TickCount (other). Driven by the periodic
+//                    system timer interrupt, NOT by TSC/QPC, so it is an
+//                    independent witness that real time actually elapsed. Its
+//                    ~1ms quantization is far smaller than the multi-ms QPC
+//                    under-measurement it exposes.
 //
 // If a single bracketed measurement reports QPC < 1 ms while the independent
 // tick counter confirms the full sleep elapsed, the sleep did NOT return early:
@@ -54,6 +56,7 @@ public static class QpcAnomalyRepro
     [DllImport("kernel32.dll")] private static extern uint GetCurrentProcessorNumber();
     [DllImport("kernel32.dll")] private static extern bool QueryPerformanceCounter(out long value);
     [DllImport("kernel32.dll")] private static extern bool QueryPerformanceFrequency(out long value);
+    [DllImport("winmm.dll")] private static extern uint timeGetTime();
     [DllImport("winmm.dll")] private static extern uint timeBeginPeriod(uint period);
     [DllImport("winmm.dll")] private static extern uint timeEndPeriod(uint period);
 
@@ -244,7 +247,7 @@ public static class QpcAnomalyRepro
 
     private static ulong ReadTick()
     {
-        if (_isWindows) return GetTickCount64();
+        if (_isWindows) return timeGetTime();
         return (ulong)(uint)Environment.TickCount;
     }
 
@@ -319,7 +322,9 @@ public static class QpcAnomalyRepro
         }
         try { Write-Host ("QPCDIAG:: HOST psVersion=" + $PSVersionTable.PSVersion.ToString() + " psEdition=" + $PSVersionTable.PSEdition) } catch { }
         try { Write-Host ("QPCDIAG:: HOST framework=" + [System.Runtime.InteropServices.RuntimeInformation]::FrameworkDescription) } catch { Write-Host "QPCDIAG:: HOST framework=unknown" }
-        $argv = [string[]]@('--durations','10,20,50,100,200','--iters','100000','--budget-ms','25000','--load','4','--sub-ms','1.0')
+        # No background load: a lone Start-Sleep(10) really takes ~10-16ms, the danger zone where a
+        # bounded QPC under-measurement can drop the measured value below a small threshold.
+        $argv = [string[]]@('--durations','10,15,20,30,50,100','--iters','100000','--budget-ms','30000','--load','0','--sub-ms','1.0')
         [QpcAnomalyRepro]::Main($argv) | Out-Null
         $true | Should -Be $true
     }

--- a/tst/functions/assert/Time/zzz-QpcRepro.Tests.ps1
+++ b/tst/functions/assert/Time/zzz-QpcRepro.Tests.ps1
@@ -1,20 +1,18 @@
 Set-StrictMode -Version Latest
 
-Describe 'Sleep timing diagnostic' {
-    It 'compares Start-Sleep vs Thread.Sleep measured by QPC against an independent timer clock' {
+Describe 'Sleep timing diagnostic (high power, default timer)' {
+    It 'hammers Start-Sleep 10ms vs Thread.Sleep 10ms with QPC vs an independent tick clock' {
         $helper = @'
 using System;
 using System.Runtime.InteropServices;
 
-public static class Clock
+public static class Clock2
 {
     private static readonly bool Win = Environment.OSVersion.Platform == PlatformID.Win32NT;
 
     [DllImport("kernel32.dll")] private static extern bool QueryPerformanceCounter(out long v);
     [DllImport("kernel32.dll")] private static extern bool QueryPerformanceFrequency(out long v);
-    [DllImport("winmm.dll")] private static extern uint timeGetTime();
-    [DllImport("winmm.dll")] private static extern uint timeBeginPeriod(uint p);
-    [DllImport("winmm.dll")] private static extern uint timeEndPeriod(uint p);
+    [DllImport("kernel32.dll")] private static extern ulong GetTickCount64();
 
     public static long Qpc()
     {
@@ -26,61 +24,62 @@ public static class Clock
         if (Win) { long v; QueryPerformanceFrequency(out v); return v; }
         return System.Diagnostics.Stopwatch.Frequency;
     }
-    public static long Indep()
+    // Independent of QPC/TSC: system tick counter (~15.6ms granularity). Coarse, but it
+    // cannot manufacture a sub-1ms QPC reading, so it is a valid witness for the specific
+    // "QPC says <1ms while real time was a full ~15ms tick" anomaly we are hunting.
+    public static long Tick()
     {
-        if (Win) return timeGetTime();
+        if (Win) return (long)GetTickCount64();
         return (long)(uint)Environment.TickCount;
     }
-    public static void BeginPeriod() { if (Win) timeBeginPeriod(1); }
-    public static void EndPeriod() { if (Win) timeEndPeriod(1); }
 }
 '@
-        if (-not ('Clock' -as [type])) { Add-Type -TypeDefinition $helper -Language CSharp -ErrorAction Stop | Out-Null }
+        if (-not ('Clock2' -as [type])) { Add-Type -TypeDefinition $helper -Language CSharp -ErrorAction Stop | Out-Null }
 
         try { Write-Host ("QPCDIAG:: HOST psVersion=" + $PSVersionTable.PSVersion.ToString() + " psEdition=" + $PSVersionTable.PSEdition) } catch { }
         try { Write-Host ("QPCDIAG:: HOST framework=" + [System.Runtime.InteropServices.RuntimeInformation]::FrameworkDescription) } catch { Write-Host "QPCDIAG:: HOST framework=unknown" }
-
-        [Clock]::BeginPeriod()
-        $freq = [Clock]::Freq()
+        # NOTE: deliberately NOT calling timeBeginPeriod, to match the real Pester run where the
+        # timer resolution is the default ~15.6ms and Start-Sleep -Milliseconds 10 takes ~15.6ms.
+        $freq = [Clock2]::Freq()
         Write-Host ("QPCDIAG:: ENV qpcFreq=" + $freq + " cpus=" + [Environment]::ProcessorCount)
 
-        $durations = 10, 15, 20, 30, 50, 100
-        $budgetMs  = 20000
-        $maxIters  = 100000
+        $budgetMs = 80000
+        $maxIters = 500000
 
         function Measure-Op {
             param($Label, $D, $Invoke)
             $subMs = 0; $early = 0; $glitch = 0
-            $minSw = [double]::MaxValue; $minIndep = [double]::MaxValue
+            $minSw = [double]::MaxValue
+            $lt5 = 0; $lt10 = 0
             $n = 0
             $budget = [System.Diagnostics.Stopwatch]::StartNew()
             while ($n -lt $maxIters -and $budget.ElapsedMilliseconds -lt $budgetMs) {
-                $q0 = [Clock]::Qpc(); $t0 = [Clock]::Indep()
+                $q0 = [Clock2]::Qpc(); $k0 = [Clock2]::Tick()
                 & $Invoke
-                $t1 = [Clock]::Indep(); $q1 = [Clock]::Qpc()
+                $k1 = [Clock2]::Tick(); $q1 = [Clock2]::Qpc()
                 $swMs = ($q1 - $q0) * 1000.0 / $freq
-                $indepMs = [double]($t1 - $t0)
+                $tickMs = [double]($k1 - $k0)
                 if ($swMs -lt $minSw) { $minSw = $swMs }
-                if ($indepMs -lt $minIndep) { $minIndep = $indepMs }
+                if ($swMs -lt 5.0) { $lt5++ }
+                if ($swMs -lt 10.0) { $lt10++ }
                 if ($swMs -lt 1.0) {
                     $subMs++
-                    if ($indepMs -lt 2.0) { $early++ }
-                    elseif ($indepMs -ge ($D / 2.0)) { $glitch++ }
+                    if ($tickMs -lt 8.0) { $early++ } else { $glitch++ }
+                    if (($subMs -le 8)) {
+                        Write-Host ("QPCDIAG:: HIT {0} dur={1} i={2} swMs={3} tickMs={4}" -f $Label, $D, $n, [math]::Round($swMs,4), $tickMs)
+                    }
                 }
                 $n++
             }
-            Write-Host ("QPCDIAG:: {0} dur={1} n={2} swMin={3} indepMin={4} subMs(<1)={5} earlyReturn={6} qpcGlitch={7}" -f `
-                $Label, $D, $n, [math]::Round($minSw, 3), $minIndep, $subMs, $early, $glitch)
+            Write-Host ("QPCDIAG:: {0} dur={1} n={2} swMin={3} lt5={4} lt10={5} subMs(<1)={6} earlyReturn={7} qpcGlitch={8}" -f `
+                $Label, $D, $n, [math]::Round($minSw, 4), $lt5, $lt10, $subMs, $early, $glitch)
         }
 
-        foreach ($d in $durations) {
-            $ssb = [scriptblock]::Create("Start-Sleep -Milliseconds $d")
-            $tsb = [scriptblock]::Create("[System.Threading.Thread]::Sleep($d)")
-            Measure-Op -Label 'STARTSLEEP' -D $d -Invoke $ssb
-            Measure-Op -Label 'THREADSLEEP' -D $d -Invoke $tsb
-        }
+        $ssb = [scriptblock]::Create("Start-Sleep -Milliseconds 10")
+        $tsb = [scriptblock]::Create("[System.Threading.Thread]::Sleep(10)")
+        Measure-Op -Label 'STARTSLEEP' -D 10 -Invoke $ssb
+        Measure-Op -Label 'THREADSLEEP' -D 10 -Invoke $tsb
 
-        [Clock]::EndPeriod()
         $true | Should -Be $true
     }
 }

--- a/tst/functions/assert/Time/zzz-QpcRepro.Tests.ps1
+++ b/tst/functions/assert/Time/zzz-QpcRepro.Tests.ps1
@@ -1,0 +1,326 @@
+Set-StrictMode -Version Latest
+
+Describe 'QPC anomaly diagnostic' {
+    It 'measures QueryPerformanceCounter against an independent tick clock across sleep durations' {
+        $src = @'
+// QpcAnomalyRepro
+// -----------------------------------------------------------------------------
+// Standalone, framework-agnostic repro for a per-call QueryPerformanceCounter
+// (QPC / Stopwatch) under-measurement seen on some virtualized Windows hosts.
+//
+// It brackets a real Thread.Sleep(D) with TWO INDEPENDENT clocks:
+//
+//   * QPC          - QueryPerformanceCounter (raw P/Invoke on Windows, the same
+//                    source System.Diagnostics.Stopwatch uses). This is the
+//                    suspected-buggy clock.
+//   * Tick counter - GetTickCount64 (Windows) / Environment.TickCount (other).
+//                    Driven by the periodic system timer interrupt, NOT by
+//                    TSC/QPC, so it is an independent witness that real time
+//                    actually elapsed.
+//
+// If a single bracketed measurement reports QPC < 1 ms while the independent
+// tick counter confirms the full sleep elapsed, the sleep did NOT return early:
+// QPC under-measured a real interval. That is the bug, and it is what makes a
+// "measured time" occasionally read ~0 on CI.
+//
+// The program also sweeps several sleep durations so you can see whether a
+// longer duration is "safe" (i.e. how low the measured value can drop for a
+// real 10 / 20 / 50 / 100 / 200 ms interval) and what the worst downward error
+// is. That answers "what is the shortest duration users can rely on?".
+//
+// Build (portable):   dotnet run -c Release -- [options]
+// Windows PS 5.1:      see Run-Repro.ps1 (compiles this with Add-Type on .NET FW)
+//
+// Options (all optional):
+//   --durations 10,20,50,100,200   sleep targets in ms (csv)
+//   --iters 3000                   max iterations per duration
+//   --budget-ms 20000              wall-time cap per duration (ms)
+//   --load 0                       background CPU-spinner threads (raise to
+//                                  increase core migration / repro rate)
+//   --sub-ms 1.0                   threshold (ms) below which a measurement is
+//                                  considered "impossibly fast"
+// -----------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
+using System.Runtime.InteropServices;
+using System.Threading;
+
+public static class QpcAnomalyRepro
+{
+    [DllImport("kernel32.dll")] private static extern ulong GetTickCount64();
+    [DllImport("kernel32.dll")] private static extern uint GetCurrentProcessorNumber();
+    [DllImport("kernel32.dll")] private static extern bool QueryPerformanceCounter(out long value);
+    [DllImport("kernel32.dll")] private static extern bool QueryPerformanceFrequency(out long value);
+    [DllImport("winmm.dll")] private static extern uint timeBeginPeriod(uint period);
+    [DllImport("winmm.dll")] private static extern uint timeEndPeriod(uint period);
+
+    private static bool _isWindows;
+    private static long _qpcFreq;
+    private static volatile bool _stopLoad;
+
+    public static int Main(string[] args)
+    {
+        _isWindows = Environment.OSVersion.Platform == PlatformID.Win32NT;
+
+        int[] durations = new int[] { 10, 20, 50, 100, 200 };
+        int maxIters = 3000;
+        int budgetMs = 20000;
+        int loadThreads = 0;
+        double subMs = 1.0;
+
+        for (int i = 0; i < args.Length - 1; i++)
+        {
+            string a = args[i];
+            string v = args[i + 1];
+            if (a == "--durations") durations = ParseInts(v);
+            else if (a == "--iters") maxIters = int.Parse(v, CultureInfo.InvariantCulture);
+            else if (a == "--budget-ms") budgetMs = int.Parse(v, CultureInfo.InvariantCulture);
+            else if (a == "--load") loadThreads = int.Parse(v, CultureInfo.InvariantCulture);
+            else if (a == "--sub-ms") subMs = double.Parse(v, CultureInfo.InvariantCulture);
+        }
+
+        if (_isWindows)
+        {
+            timeBeginPeriod(1);
+            long f;
+            _qpcFreq = QueryPerformanceFrequency(out f) ? f : Stopwatch.Frequency;
+        }
+        else
+        {
+            _qpcFreq = Stopwatch.Frequency;
+        }
+
+        Line("ENV os=" + Environment.OSVersion +
+             " bits=" + (IntPtr.Size * 8) +
+             " clr=" + Environment.Version +
+             " cpus=" + Environment.ProcessorCount +
+             " qpcFreq=" + _qpcFreq +
+             " swFreq=" + Stopwatch.Frequency +
+             " swHighRes=" + Stopwatch.IsHighResolution +
+             " load=" + loadThreads);
+
+        List<Thread> load = StartLoad(loadThreads);
+
+        double worstDownErr = 0.0;
+        double lowestMeasuredEver = double.MaxValue;
+        int totalAnomalies = 0;
+
+        try
+        {
+            foreach (int d in durations)
+            {
+                Result r = RunDuration(d, maxIters, budgetMs, subMs);
+                Line(r.Summary());
+                for (int k = 0; k < r.Examples.Count && k < 5; k++) Line(r.Examples[k]);
+                if (r.MaxDownErr > worstDownErr) worstDownErr = r.MaxDownErr;
+                if (r.MinMeasured < lowestMeasuredEver) lowestMeasuredEver = r.MinMeasured;
+                totalAnomalies += r.Anomalies;
+            }
+        }
+        finally
+        {
+            _stopLoad = true;
+            foreach (Thread t in load) t.Join();
+            if (_isWindows) timeEndPeriod(1);
+        }
+
+        Line("RELIABILITY totalAnomalies=" + totalAnomalies +
+             " lowestMeasuredMs=" + F(lowestMeasuredEver) +
+             " worstDownErrMs=" + F(worstDownErr));
+        Line("RELIABILITY note: measured time can drop to ~" + F(lowestMeasuredEver) +
+             " ms regardless of the real duration; keep assertion thresholds at least ~" +
+             F(Math.Ceiling(worstDownErr)) + " ms away from the real run time (a safe rule is a floor/ceiling far from it).");
+        return 0;
+    }
+
+    private static Result RunDuration(int d, int maxIters, int budgetMs, double subMs)
+    {
+        Result r = new Result();
+        r.Duration = d;
+        r.SubMs = subMs;
+        List<double> qpcSamples = new List<double>(maxIters);
+
+        Stopwatch budget = Stopwatch.StartNew();
+        int i = 0;
+        for (; i < maxIters; i++)
+        {
+            if (budget.ElapsedMilliseconds > budgetMs) break;
+
+            uint proc0 = CurrentProcessor();
+            long q0 = ReadQpc();
+            ulong t0 = ReadTick();
+
+            Thread.Sleep(d);
+
+            ulong t1 = ReadTick();
+            long q1 = ReadQpc();
+            uint proc1 = CurrentProcessor();
+
+            long qpcDelta = q1 - q0;
+            double qpcMs = qpcDelta * 1000.0 / _qpcFreq;
+            double tickMs = (double)(t1 - t0);
+
+            qpcSamples.Add(qpcMs);
+            if (qpcMs < r.MinMeasured) r.MinMeasured = qpcMs;
+            if (tickMs < r.MinTick) r.MinTick = tickMs;
+            if (qpcDelta <= 0) r.NegOrZeroQpc++;
+            if (qpcMs < subMs) r.SubMsCount++;
+
+            double downErr = tickMs - qpcMs;
+            if (downErr > r.MaxDownErr) r.MaxDownErr = downErr;
+
+            // Anomaly: independent tick clock confirms real time elapsed
+            // (>= half the requested sleep) but QPC reported < subMs.
+            bool realTimeElapsed = tickMs >= Math.Max(2.0, d * 0.5);
+            if (realTimeElapsed && qpcMs < subMs)
+            {
+                r.Anomalies++;
+                if (proc0 != proc1) r.MigratedAnomalies++;
+                if (r.Examples.Count < 5)
+                {
+                    r.Examples.Add("ANOMALY dur=" + d + " i=" + i +
+                                   " qpcMs=" + F(qpcMs) + " tickMs=" + F(tickMs) +
+                                   " qpcDeltaTicks=" + qpcDelta +
+                                   " proc " + ProcStr(proc0) + "->" + ProcStr(proc1));
+                }
+            }
+        }
+        r.Iterations = i;
+        qpcSamples.Sort();
+        r.QpcP50 = Percentile(qpcSamples, 0.50);
+        r.QpcP01 = Percentile(qpcSamples, 0.01);
+        r.QpcMax = qpcSamples.Count > 0 ? qpcSamples[qpcSamples.Count - 1] : 0.0;
+        return r;
+    }
+
+    private sealed class Result
+    {
+        public int Duration;
+        public int Iterations;
+        public double SubMs;
+        public double MinMeasured = double.MaxValue;
+        public double MinTick = double.MaxValue;
+        public double MaxDownErr;
+        public double QpcP50;
+        public double QpcP01;
+        public double QpcMax;
+        public int SubMsCount;
+        public int Anomalies;
+        public int MigratedAnomalies;
+        public int NegOrZeroQpc;
+        public List<string> Examples = new List<string>();
+
+        public string Summary()
+        {
+            double rate = Iterations > 0 ? (100.0 * Anomalies / Iterations) : 0.0;
+            return "SWEEP dur=" + Duration +
+                   " n=" + Iterations +
+                   " qpcP50=" + F(QpcP50) +
+                   " qpcP01=" + F(QpcP01) +
+                   " qpcMin=" + F(MinMeasured) +
+                   " qpcMax=" + F(QpcMax) +
+                   " tickMin=" + F(MinTick) +
+                   " subMs(<" + F(SubMs) + ")=" + SubMsCount +
+                   " anomalies=" + Anomalies + " (" + F(rate) + "%)" +
+                   " migAnom=" + MigratedAnomalies +
+                   " negQpc=" + NegOrZeroQpc +
+                   " maxDownErrMs=" + F(MaxDownErr);
+        }
+    }
+
+    private static long ReadQpc()
+    {
+        if (_isWindows)
+        {
+            long v;
+            QueryPerformanceCounter(out v);
+            return v;
+        }
+        return Stopwatch.GetTimestamp();
+    }
+
+    private static ulong ReadTick()
+    {
+        if (_isWindows) return GetTickCount64();
+        return (ulong)(uint)Environment.TickCount;
+    }
+
+    private static uint CurrentProcessor()
+    {
+        if (_isWindows) return GetCurrentProcessorNumber();
+        return uint.MaxValue;
+    }
+
+    private static string ProcStr(uint p)
+    {
+        return p == uint.MaxValue ? "?" : p.ToString(CultureInfo.InvariantCulture);
+    }
+
+    private static List<Thread> StartLoad(int n)
+    {
+        List<Thread> threads = new List<Thread>();
+        for (int i = 0; i < n; i++)
+        {
+            Thread t = new Thread(Spin);
+            t.IsBackground = true;
+            t.Start();
+            threads.Add(t);
+        }
+        return threads;
+    }
+
+    private static void Spin()
+    {
+        double x = 0.0;
+        while (!_stopLoad)
+        {
+            for (int i = 0; i < 100000; i++) x += i * 0.5;
+            if (x < 0) Console.Write("");
+        }
+    }
+
+    private static int[] ParseInts(string csv)
+    {
+        string[] parts = csv.Split(',');
+        List<int> list = new List<int>();
+        foreach (string p in parts)
+        {
+            string s = p.Trim();
+            if (s.Length > 0) list.Add(int.Parse(s, CultureInfo.InvariantCulture));
+        }
+        return list.ToArray();
+    }
+
+    private static double Percentile(List<double> sorted, double q)
+    {
+        if (sorted.Count == 0) return 0.0;
+        int idx = (int)Math.Floor(q * (sorted.Count - 1));
+        if (idx < 0) idx = 0;
+        if (idx >= sorted.Count) idx = sorted.Count - 1;
+        return sorted[idx];
+    }
+
+    private static string F(double d)
+    {
+        return d.ToString("0.###", CultureInfo.InvariantCulture);
+    }
+
+    private static void Line(string s)
+    {
+        Console.WriteLine("QPCDIAG:: " + s);
+    }
+}
+'@
+        if (-not ('QpcAnomalyRepro' -as [type])) {
+            Add-Type -TypeDefinition $src -Language CSharp -ErrorAction Stop | Out-Null
+        }
+        try { Write-Host ("QPCDIAG:: HOST psVersion=" + $PSVersionTable.PSVersion.ToString() + " psEdition=" + $PSVersionTable.PSEdition) } catch { }
+        try { Write-Host ("QPCDIAG:: HOST framework=" + [System.Runtime.InteropServices.RuntimeInformation]::FrameworkDescription) } catch { Write-Host "QPCDIAG:: HOST framework=unknown" }
+        $argv = [string[]]@('--durations','10,20,50,100,200','--iters','100000','--budget-ms','25000','--load','4','--sub-ms','1.0')
+        [QpcAnomalyRepro]::Main($argv) | Out-Null
+        $true | Should -Be $true
+    }
+}

--- a/tst/functions/assert/Time/zzz-QpcRepro.Tests.ps1
+++ b/tst/functions/assert/Time/zzz-QpcRepro.Tests.ps1
@@ -1,331 +1,86 @@
 Set-StrictMode -Version Latest
 
-Describe 'QPC anomaly diagnostic' {
-    It 'measures QueryPerformanceCounter against an independent timer clock across sleep durations' {
-        $src = @'
-// QpcAnomalyRepro
-// -----------------------------------------------------------------------------
-// Standalone, framework-agnostic repro for a per-call QueryPerformanceCounter
-// (QPC / Stopwatch) under-measurement seen on some virtualized Windows hosts.
-//
-// It brackets a real Thread.Sleep(D) with TWO INDEPENDENT clocks:
-//
-//   * QPC          - QueryPerformanceCounter (raw P/Invoke on Windows, the same
-//                    source System.Diagnostics.Stopwatch uses). This is the
-//                    suspected-buggy clock.
-//   * Independent  - timeGetTime (Windows, ~1ms with timeBeginPeriod(1)) /
-//                    Environment.TickCount (other). Driven by the periodic
-//                    system timer interrupt, NOT by TSC/QPC, so it is an
-//                    independent witness that real time actually elapsed. Its
-//                    ~1ms quantization is far smaller than the multi-ms QPC
-//                    under-measurement it exposes.
-//
-// If a single bracketed measurement reports QPC < 1 ms while the independent
-// tick counter confirms the full sleep elapsed, the sleep did NOT return early:
-// QPC under-measured a real interval. That is the bug, and it is what makes a
-// "measured time" occasionally read ~0 on CI.
-//
-// The program also sweeps several sleep durations so you can see whether a
-// longer duration is "safe" (i.e. how low the measured value can drop for a
-// real 10 / 20 / 50 / 100 / 200 ms interval) and what the worst downward error
-// is. That answers "what is the shortest duration users can rely on?".
-//
-// Build (portable):   dotnet run -c Release -- [options]
-// Windows PS 5.1:      see Run-Repro.ps1 (compiles this with Add-Type on .NET FW)
-//
-// Options (all optional):
-//   --durations 10,20,50,100,200   sleep targets in ms (csv)
-//   --iters 3000                   max iterations per duration
-//   --budget-ms 20000              wall-time cap per duration (ms)
-//   --load 0                       background CPU-spinner threads (raise to
-//                                  increase core migration / repro rate)
-//   --sub-ms 1.0                   threshold (ms) below which a measurement is
-//                                  considered "impossibly fast"
-// -----------------------------------------------------------------------------
-
+Describe 'Sleep timing diagnostic' {
+    It 'compares Start-Sleep vs Thread.Sleep measured by QPC against an independent timer clock' {
+        $helper = @'
 using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Globalization;
 using System.Runtime.InteropServices;
-using System.Threading;
 
-public static class QpcAnomalyRepro
+public static class Clock
 {
-    [DllImport("kernel32.dll")] private static extern ulong GetTickCount64();
-    [DllImport("kernel32.dll")] private static extern uint GetCurrentProcessorNumber();
-    [DllImport("kernel32.dll")] private static extern bool QueryPerformanceCounter(out long value);
-    [DllImport("kernel32.dll")] private static extern bool QueryPerformanceFrequency(out long value);
+    private static readonly bool Win = Environment.OSVersion.Platform == PlatformID.Win32NT;
+
+    [DllImport("kernel32.dll")] private static extern bool QueryPerformanceCounter(out long v);
+    [DllImport("kernel32.dll")] private static extern bool QueryPerformanceFrequency(out long v);
     [DllImport("winmm.dll")] private static extern uint timeGetTime();
-    [DllImport("winmm.dll")] private static extern uint timeBeginPeriod(uint period);
-    [DllImport("winmm.dll")] private static extern uint timeEndPeriod(uint period);
+    [DllImport("winmm.dll")] private static extern uint timeBeginPeriod(uint p);
+    [DllImport("winmm.dll")] private static extern uint timeEndPeriod(uint p);
 
-    private static bool _isWindows;
-    private static long _qpcFreq;
-    private static volatile bool _stopLoad;
-
-    public static int Main(string[] args)
+    public static long Qpc()
     {
-        _isWindows = Environment.OSVersion.Platform == PlatformID.Win32NT;
-
-        int[] durations = new int[] { 10, 20, 50, 100, 200 };
-        int maxIters = 3000;
-        int budgetMs = 20000;
-        int loadThreads = 0;
-        double subMs = 1.0;
-
-        for (int i = 0; i < args.Length - 1; i++)
-        {
-            string a = args[i];
-            string v = args[i + 1];
-            if (a == "--durations") durations = ParseInts(v);
-            else if (a == "--iters") maxIters = int.Parse(v, CultureInfo.InvariantCulture);
-            else if (a == "--budget-ms") budgetMs = int.Parse(v, CultureInfo.InvariantCulture);
-            else if (a == "--load") loadThreads = int.Parse(v, CultureInfo.InvariantCulture);
-            else if (a == "--sub-ms") subMs = double.Parse(v, CultureInfo.InvariantCulture);
-        }
-
-        if (_isWindows)
-        {
-            timeBeginPeriod(1);
-            long f;
-            _qpcFreq = QueryPerformanceFrequency(out f) ? f : Stopwatch.Frequency;
-        }
-        else
-        {
-            _qpcFreq = Stopwatch.Frequency;
-        }
-
-        Line("ENV os=" + Environment.OSVersion +
-             " bits=" + (IntPtr.Size * 8) +
-             " clr=" + Environment.Version +
-             " cpus=" + Environment.ProcessorCount +
-             " qpcFreq=" + _qpcFreq +
-             " swFreq=" + Stopwatch.Frequency +
-             " swHighRes=" + Stopwatch.IsHighResolution +
-             " load=" + loadThreads);
-
-        List<Thread> load = StartLoad(loadThreads);
-
-        double worstDownErr = 0.0;
-        double lowestMeasuredEver = double.MaxValue;
-        int totalAnomalies = 0;
-
-        try
-        {
-            foreach (int d in durations)
-            {
-                Result r = RunDuration(d, maxIters, budgetMs, subMs);
-                Line(r.Summary());
-                for (int k = 0; k < r.Examples.Count && k < 5; k++) Line(r.Examples[k]);
-                if (r.MaxDownErr > worstDownErr) worstDownErr = r.MaxDownErr;
-                if (r.MinMeasured < lowestMeasuredEver) lowestMeasuredEver = r.MinMeasured;
-                totalAnomalies += r.Anomalies;
-            }
-        }
-        finally
-        {
-            _stopLoad = true;
-            foreach (Thread t in load) t.Join();
-            if (_isWindows) timeEndPeriod(1);
-        }
-
-        Line("RELIABILITY totalAnomalies=" + totalAnomalies +
-             " lowestMeasuredMs=" + F(lowestMeasuredEver) +
-             " worstDownErrMs=" + F(worstDownErr));
-        Line("RELIABILITY note: measured time can drop to ~" + F(lowestMeasuredEver) +
-             " ms regardless of the real duration; keep assertion thresholds at least ~" +
-             F(Math.Ceiling(worstDownErr)) + " ms away from the real run time (a safe rule is a floor/ceiling far from it).");
-        return 0;
+        if (Win) { long v; QueryPerformanceCounter(out v); return v; }
+        return System.Diagnostics.Stopwatch.GetTimestamp();
     }
-
-    private static Result RunDuration(int d, int maxIters, int budgetMs, double subMs)
+    public static long Freq()
     {
-        Result r = new Result();
-        r.Duration = d;
-        r.SubMs = subMs;
-        List<double> qpcSamples = new List<double>(maxIters);
-
-        Stopwatch budget = Stopwatch.StartNew();
-        int i = 0;
-        for (; i < maxIters; i++)
-        {
-            if (budget.ElapsedMilliseconds > budgetMs) break;
-
-            uint proc0 = CurrentProcessor();
-            long q0 = ReadQpc();
-            ulong t0 = ReadTick();
-
-            Thread.Sleep(d);
-
-            ulong t1 = ReadTick();
-            long q1 = ReadQpc();
-            uint proc1 = CurrentProcessor();
-
-            long qpcDelta = q1 - q0;
-            double qpcMs = qpcDelta * 1000.0 / _qpcFreq;
-            double tickMs = (double)(t1 - t0);
-
-            qpcSamples.Add(qpcMs);
-            if (qpcMs < r.MinMeasured) r.MinMeasured = qpcMs;
-            if (tickMs < r.MinTick) r.MinTick = tickMs;
-            if (qpcDelta <= 0) r.NegOrZeroQpc++;
-            if (qpcMs < subMs) r.SubMsCount++;
-
-            double downErr = tickMs - qpcMs;
-            if (downErr > r.MaxDownErr) r.MaxDownErr = downErr;
-
-            // Anomaly: independent tick clock confirms real time elapsed
-            // (>= half the requested sleep) but QPC reported < subMs.
-            bool realTimeElapsed = tickMs >= Math.Max(2.0, d * 0.5);
-            if (realTimeElapsed && qpcMs < subMs)
-            {
-                r.Anomalies++;
-                if (proc0 != proc1) r.MigratedAnomalies++;
-                if (r.Examples.Count < 5)
-                {
-                    r.Examples.Add("ANOMALY dur=" + d + " i=" + i +
-                                   " qpcMs=" + F(qpcMs) + " tickMs=" + F(tickMs) +
-                                   " qpcDeltaTicks=" + qpcDelta +
-                                   " proc " + ProcStr(proc0) + "->" + ProcStr(proc1));
-                }
-            }
-        }
-        r.Iterations = i;
-        qpcSamples.Sort();
-        r.QpcP50 = Percentile(qpcSamples, 0.50);
-        r.QpcP01 = Percentile(qpcSamples, 0.01);
-        r.QpcMax = qpcSamples.Count > 0 ? qpcSamples[qpcSamples.Count - 1] : 0.0;
-        return r;
+        if (Win) { long v; QueryPerformanceFrequency(out v); return v; }
+        return System.Diagnostics.Stopwatch.Frequency;
     }
-
-    private sealed class Result
+    public static long Indep()
     {
-        public int Duration;
-        public int Iterations;
-        public double SubMs;
-        public double MinMeasured = double.MaxValue;
-        public double MinTick = double.MaxValue;
-        public double MaxDownErr;
-        public double QpcP50;
-        public double QpcP01;
-        public double QpcMax;
-        public int SubMsCount;
-        public int Anomalies;
-        public int MigratedAnomalies;
-        public int NegOrZeroQpc;
-        public List<string> Examples = new List<string>();
-
-        public string Summary()
-        {
-            double rate = Iterations > 0 ? (100.0 * Anomalies / Iterations) : 0.0;
-            return "SWEEP dur=" + Duration +
-                   " n=" + Iterations +
-                   " qpcP50=" + F(QpcP50) +
-                   " qpcP01=" + F(QpcP01) +
-                   " qpcMin=" + F(MinMeasured) +
-                   " qpcMax=" + F(QpcMax) +
-                   " tickMin=" + F(MinTick) +
-                   " subMs(<" + F(SubMs) + ")=" + SubMsCount +
-                   " anomalies=" + Anomalies + " (" + F(rate) + "%)" +
-                   " migAnom=" + MigratedAnomalies +
-                   " negQpc=" + NegOrZeroQpc +
-                   " maxDownErrMs=" + F(MaxDownErr);
-        }
+        if (Win) return timeGetTime();
+        return (long)(uint)Environment.TickCount;
     }
-
-    private static long ReadQpc()
-    {
-        if (_isWindows)
-        {
-            long v;
-            QueryPerformanceCounter(out v);
-            return v;
-        }
-        return Stopwatch.GetTimestamp();
-    }
-
-    private static ulong ReadTick()
-    {
-        if (_isWindows) return timeGetTime();
-        return (ulong)(uint)Environment.TickCount;
-    }
-
-    private static uint CurrentProcessor()
-    {
-        if (_isWindows) return GetCurrentProcessorNumber();
-        return uint.MaxValue;
-    }
-
-    private static string ProcStr(uint p)
-    {
-        return p == uint.MaxValue ? "?" : p.ToString(CultureInfo.InvariantCulture);
-    }
-
-    private static List<Thread> StartLoad(int n)
-    {
-        List<Thread> threads = new List<Thread>();
-        for (int i = 0; i < n; i++)
-        {
-            Thread t = new Thread(Spin);
-            t.IsBackground = true;
-            t.Start();
-            threads.Add(t);
-        }
-        return threads;
-    }
-
-    private static void Spin()
-    {
-        double x = 0.0;
-        while (!_stopLoad)
-        {
-            for (int i = 0; i < 100000; i++) x += i * 0.5;
-            if (x < 0) Console.Write("");
-        }
-    }
-
-    private static int[] ParseInts(string csv)
-    {
-        string[] parts = csv.Split(',');
-        List<int> list = new List<int>();
-        foreach (string p in parts)
-        {
-            string s = p.Trim();
-            if (s.Length > 0) list.Add(int.Parse(s, CultureInfo.InvariantCulture));
-        }
-        return list.ToArray();
-    }
-
-    private static double Percentile(List<double> sorted, double q)
-    {
-        if (sorted.Count == 0) return 0.0;
-        int idx = (int)Math.Floor(q * (sorted.Count - 1));
-        if (idx < 0) idx = 0;
-        if (idx >= sorted.Count) idx = sorted.Count - 1;
-        return sorted[idx];
-    }
-
-    private static string F(double d)
-    {
-        return d.ToString("0.###", CultureInfo.InvariantCulture);
-    }
-
-    private static void Line(string s)
-    {
-        Console.WriteLine("QPCDIAG:: " + s);
-    }
+    public static void BeginPeriod() { if (Win) timeBeginPeriod(1); }
+    public static void EndPeriod() { if (Win) timeEndPeriod(1); }
 }
 '@
-        if (-not ('QpcAnomalyRepro' -as [type])) {
-            Add-Type -TypeDefinition $src -Language CSharp -ErrorAction Stop | Out-Null
-        }
+        if (-not ('Clock' -as [type])) { Add-Type -TypeDefinition $helper -Language CSharp -ErrorAction Stop | Out-Null }
+
         try { Write-Host ("QPCDIAG:: HOST psVersion=" + $PSVersionTable.PSVersion.ToString() + " psEdition=" + $PSVersionTable.PSEdition) } catch { }
         try { Write-Host ("QPCDIAG:: HOST framework=" + [System.Runtime.InteropServices.RuntimeInformation]::FrameworkDescription) } catch { Write-Host "QPCDIAG:: HOST framework=unknown" }
-        # No background load: a lone Start-Sleep(10) really takes ~10-16ms, the danger zone where a
-        # bounded QPC under-measurement can drop the measured value below a small threshold.
-        $argv = [string[]]@('--durations','10,15,20,30,50,100','--iters','100000','--budget-ms','30000','--load','0','--sub-ms','1.0')
-        [QpcAnomalyRepro]::Main($argv) | Out-Null
+
+        [Clock]::BeginPeriod()
+        $freq = [Clock]::Freq()
+        Write-Host ("QPCDIAG:: ENV qpcFreq=" + $freq + " cpus=" + [Environment]::ProcessorCount)
+
+        $durations = 10, 15, 20, 30, 50, 100
+        $budgetMs  = 20000
+        $maxIters  = 100000
+
+        function Measure-Op {
+            param($Label, $D, $Invoke)
+            $subMs = 0; $early = 0; $glitch = 0
+            $minSw = [double]::MaxValue; $minIndep = [double]::MaxValue
+            $n = 0
+            $budget = [System.Diagnostics.Stopwatch]::StartNew()
+            while ($n -lt $maxIters -and $budget.ElapsedMilliseconds -lt $budgetMs) {
+                $q0 = [Clock]::Qpc(); $t0 = [Clock]::Indep()
+                & $Invoke
+                $t1 = [Clock]::Indep(); $q1 = [Clock]::Qpc()
+                $swMs = ($q1 - $q0) * 1000.0 / $freq
+                $indepMs = [double]($t1 - $t0)
+                if ($swMs -lt $minSw) { $minSw = $swMs }
+                if ($indepMs -lt $minIndep) { $minIndep = $indepMs }
+                if ($swMs -lt 1.0) {
+                    $subMs++
+                    if ($indepMs -lt 2.0) { $early++ }
+                    elseif ($indepMs -ge ($D / 2.0)) { $glitch++ }
+                }
+                $n++
+            }
+            Write-Host ("QPCDIAG:: {0} dur={1} n={2} swMin={3} indepMin={4} subMs(<1)={5} earlyReturn={6} qpcGlitch={7}" -f `
+                $Label, $D, $n, [math]::Round($minSw, 3), $minIndep, $subMs, $early, $glitch)
+        }
+
+        foreach ($d in $durations) {
+            $ssb = [scriptblock]::Create("Start-Sleep -Milliseconds $d")
+            $tsb = [scriptblock]::Create("[System.Threading.Thread]::Sleep($d)")
+            Measure-Op -Label 'STARTSLEEP' -D $d -Invoke $ssb
+            Measure-Op -Label 'THREADSLEEP' -D $d -Invoke $tsb
+        }
+
+        [Clock]::EndPeriod()
         $true | Should -Be $true
     }
 }


### PR DESCRIPTION
Temporary diagnostic to reproduce and characterize the QueryPerformanceCounter/Stopwatch under-measurement on Windows CI agents. Not for merge; will be deleted after harvesting results.