### PR TITLE
Drop Run.BeforeContainer option, keep the Pester.BeforeContainer.ps1 convention

### DIFF
--- a/src/Main.ps1
+++ b/src/Main.ps1
@@ -675,7 +675,7 @@ function Invoke-Pester {
             }
 
             # Resolve the BeforeContainer initialization once for the whole run. It is the same for
-            # every file (from Run.BeforeContainer or the repo-root Pester.BeforeContainer.ps1) and
+            # every file (from the repo-root Pester.BeforeContainer.ps1 convention file) and
             # runs before each container in both the parallel and sequential paths below.
             $beforeContainerInit = Resolve-PesterBeforeContainer -Configuration $PesterPreference
 

--- a/src/Pester.Runtime.ps1
+++ b/src/Pester.Runtime.ps1
@@ -1997,8 +1997,8 @@ function Invoke-Test {
         # global steps once for the whole run while this call handles only the
         # non-parallel containers' per-container/per-test steps.
         [switch] $SkipFrameworkGlobalSteps,
-        # Initialization text (resolved from Run.BeforeContainer or the repo-root
-        # Pester.BeforeContainer.ps1) dot-sourced into the run session state before each container
+        # Initialization text (resolved from the repo-root Pester.BeforeContainer.ps1)
+        # dot-sourced into the run session state before each container
         # is discovered and run, so the same setup is available in sequential and parallel runs.
         [string] $BeforeContainerInit
     )

--- a/src/csharp/Pester/RunConfiguration.cs
+++ b/src/csharp/Pester/RunConfiguration.cs
@@ -33,7 +33,6 @@ namespace Pester
         private BoolOption _passThru;
         private BoolOption _skipRun;
         private BoolOption _parallel;
-        private ScriptBlockArrayOption _beforeContainer;
         private IntOption _parallelThrottleLimit;
         private StringOption _skipRemainingOnFailure;
         private BoolOption _failOnNullOrEmptyForEach;
@@ -59,7 +58,6 @@ namespace Pester
                 configuration.AssignValueIfNotNull<bool>(nameof(PassThru), v => PassThru = v);
                 configuration.AssignValueIfNotNull<bool>(nameof(SkipRun), v => SkipRun = v);
                 configuration.AssignValueIfNotNull<bool>(nameof(Parallel), v => Parallel = v);
-                configuration.AssignArrayIfNotNull<ScriptBlock>(nameof(BeforeContainer), v => BeforeContainer = v);
                 configuration.AssignValueIfNotNull<int>(nameof(ParallelThrottleLimit), v => ParallelThrottleLimit = v);
                 configuration.AssignObjectIfNotNull<string>(nameof(SkipRemainingOnFailure), v => SkipRemainingOnFailure = v);
                 configuration.AssignValueIfNotNull<bool>(nameof(FailOnNullOrEmptyForEach), v => FailOnNullOrEmptyForEach = v);
@@ -79,11 +77,10 @@ namespace Pester
             PassThru = new BoolOption("Return result object to the pipeline after finishing the test run.", false);
             SkipRun = new BoolOption("Runs the discovery phase but skips run. Use it with PassThru to get object populated with all tests.", false);
             Parallel = new BoolOption("EXPERIMENTAL: Run test files in parallel, each file in its own runspace, using PowerShell 7+ 'ForEach-Object -Parallel'. Files that contain the '#pester:no-parallel' directive run sequentially after the parallel batch. Falls back to a sequential run on Windows PowerShell 5.1, when non-file containers (ScriptBlock) are used, when CodeCoverage is enabled, or when Run.SkipRemainingOnFailure is set to 'Run'.", false);
-            BeforeContainer = new ScriptBlockArrayOption("EXPERIMENTAL: One or more ScriptBlocks run before each test file is discovered and run, in both sequential and parallel runs. Use it to import helper modules or dot-source setup that the parent session would normally provide, e.g. { . './setup.ps1' } - this is especially useful in parallel runs, where each worker starts from a clean runspace. One scriptblock is usually enough and can dot-source as many files as needed. When set, the convention file is ignored; when not set, Pester dot-sources a 'Pester.BeforeContainer.ps1' from the repository root (Run.RepoRoot) if one is present.", new ScriptBlock[0]);
             ParallelThrottleLimit = new IntOption("EXPERIMENTAL: Maximum number of test files to run at the same time when Run.Parallel is enabled, passed through to 'ForEach-Object -Parallel -ThrottleLimit'. The default 0 uses all available processors ([Environment]::ProcessorCount). Set a lower number to cap how many runspaces run concurrently. Only used when Run.Parallel is enabled.", 0);
             SkipRemainingOnFailure = new StringOption("Skips remaining tests after failure for selected scope, options are None, Run, Container and Block.", "None");
             FailOnNullOrEmptyForEach = new BoolOption("Fails discovery when -ForEach is provided $null or @() in a block or test. Can be overridden for a specific Describe/Context/It using -AllowNullOrEmptyForEach.", true);
-            RepoRoot = new StringOption("Root directory of the repository. Found by searching for the .git directory recursively. When not found, the current working directory is used.", FindRepoRoot());
+            RepoRoot = new StringOption("EXPERIMENTAL: Root directory of the repository. Found by searching for the .git directory recursively. When not found, the current working directory is used. Before each test file is discovered and run - in both sequential and parallel runs - Pester dot-sources a 'Pester.BeforeContainer.ps1' from this directory if one is present, so helper modules or dot-sourced setup the parent session would normally provide are available to every container. This is especially useful in parallel runs where each worker starts from a clean runspace and re-runs it.", FindRepoRoot());
         }
 
         public StringArrayOption Path
@@ -242,22 +239,6 @@ namespace Pester
                 else
                 {
                     _parallel = new BoolOption(_parallel, value.Value);
-                }
-            }
-        }
-
-        public ScriptBlockArrayOption BeforeContainer
-        {
-            get { return _beforeContainer; }
-            set
-            {
-                if (_beforeContainer == null)
-                {
-                    _beforeContainer = value;
-                }
-                else
-                {
-                    _beforeContainer = new ScriptBlockArrayOption(_beforeContainer, value?.Value);
                 }
             }
         }

--- a/src/en-US/about_PesterConfiguration.help.txt
+++ b/src/en-US/about_PesterConfiguration.help.txt
@@ -69,10 +69,6 @@ SECTIONS AND OPTIONS
         Type: bool
         Default value: $false
 
-        BeforeContainer: EXPERIMENTAL: One or more ScriptBlocks run before each test file is discovered and run, in both sequential and parallel runs. Use it to import helper modules or dot-source setup that the parent session would normally provide, e.g. { . './setup.ps1' } - this is especially useful in parallel runs, where each worker starts from a clean runspace. One scriptblock is usually enough and can dot-source as many files as needed. When set, the convention file is ignored; when not set, Pester dot-sources a 'Pester.BeforeContainer.ps1' from the repository root (Run.RepoRoot) if one is present.
-        Type: scriptblock[]
-        Default value: @()
-
         ParallelThrottleLimit: EXPERIMENTAL: Maximum number of test files to run at the same time when Run.Parallel is enabled, passed through to 'ForEach-Object -Parallel -ThrottleLimit'. The default 0 uses all available processors ([Environment]::ProcessorCount). Set a lower number to cap how many runspaces run concurrently. Only used when Run.Parallel is enabled.
         Type: int
         Default value: 0
@@ -85,7 +81,7 @@ SECTIONS AND OPTIONS
         Type: bool
         Default value: $true
 
-        RepoRoot: Root directory of the repository. Found by searching for the .git directory recursively. When not found, the current working directory is used.
+        RepoRoot: EXPERIMENTAL: Root directory of the repository. Found by searching for the .git directory recursively. When not found, the current working directory is used. Before each test file is discovered and run - in both sequential and parallel runs - Pester dot-sources a 'Pester.BeforeContainer.ps1' from this directory if one is present, so helper modules or dot-sourced setup the parent session would normally provide are available to every container. This is especially useful in parallel runs where each worker starts from a clean runspace and re-runs it.
         Type: string
         Default value: '<path of .git>'
 

--- a/src/functions/Pester.Parallel.ps1
+++ b/src/functions/Pester.Parallel.ps1
@@ -46,12 +46,10 @@ function Resolve-PesterBeforeContainer {
     parallel runs. Parallel workers especially start from a clean runspace and would otherwise be
     missing it.
 
-    - If Run.BeforeContainer is set, its scriptblocks win and apply to every container.
-      ScriptBlocks cannot cross the runspace boundary, so they are returned as text and recreated
-      with [scriptblock]::Create where they run.
-    - Otherwise Pester looks for a single 'Pester.BeforeContainer.ps1' in the repository root
-      (Run.RepoRoot, which defaults to the nearest '.git' directory and can be overridden) and
-      dot-sources it, giving a zero-config per-repo bootstrap.
+    Pester looks for a single 'Pester.BeforeContainer.ps1' in the repository root (Run.RepoRoot,
+    which defaults to the nearest '.git' directory and can be overridden) and dot-sources it,
+    giving a zero-config per-repo bootstrap. Because it is a real file it always exposes a stable
+    '$PSScriptRoot' / '$PSCommandPath' to anchor relative paths against.
 
     The result is the same for every container, so callers resolve it once per run.
     Returns $null when there is nothing to run.
@@ -62,11 +60,6 @@ function Resolve-PesterBeforeContainer {
         [Parameter(Mandatory)]
         $Configuration
     )
-
-    $explicit = $Configuration.Run.BeforeContainer.Value
-    if ($explicit -and 0 -lt @($explicit).Count) {
-        return (@(foreach ($sb in $explicit) { $sb.ToString() }) -join [Environment]::NewLine)
-    }
 
     $repoRoot = $Configuration.Run.RepoRoot.Value
     if ([string]::IsNullOrEmpty($repoRoot)) {
@@ -163,8 +156,8 @@ function Invoke-TestInParallel {
         $Configuration
     )
 
-    # The BeforeContainer initialization is the same for every file (resolved from
-    # Run.BeforeContainer or the repo-root convention file), so resolve it once and reuse it.
+    # The BeforeContainer initialization is the same for every file (resolved from the repo-root
+    # Pester.BeforeContainer.ps1 convention file), so resolve it once and reuse it.
     $beforeContainerInit = Resolve-PesterBeforeContainer -Configuration $Configuration
     $work = @(foreach ($c in $BlockContainer) {
             [PSCustomObject]@{
@@ -198,10 +191,9 @@ function Invoke-TestInParallel {
     if ($throttle -lt 1) { $throttle = 1 }
 
     # Sanitize the configuration handed to workers: strip the options that hold scriptblocks so
-    # nothing with runspace affinity is sent across the boundary. BeforeContainer is
+    # nothing with runspace affinity is sent across the boundary. The BeforeContainer setup is
     # already resolved to text per work item above; ScriptBlock/Container are unused for file runs.
     $baseConfig = [PesterConfiguration]::Merge([PesterConfiguration]::Default, $Configuration)
-    $baseConfig.Run.BeforeContainer = [scriptblock[]]@()
     $baseConfig.Run.ScriptBlock = [scriptblock[]]@()
     $baseConfig.Run.Container = @()
 

--- a/tst/Pester.RSpec.Parallel.ts.ps1
+++ b/tst/Pester.RSpec.Parallel.ts.ps1
@@ -247,7 +247,7 @@ Describe 'Module import' {
         }
     }
 
-    b "Run.BeforeContainer" {
+    b "Pester.BeforeContainer.ps1 convention" {
         t "runs the repo-root Pester.BeforeContainer.ps1 before each file in a sequential run" {
             $folder = New-BeforeContainerTestFolder
             try {
@@ -281,25 +281,48 @@ Describe 'Module import' {
             finally { Remove-Item -Path $folder -Recurse -Force }
         }
 
-        t "uses explicit Run.BeforeContainer scriptblocks instead of the convention file" {
+        t "shares a single bootstrap across many files in parallel, anchored on the stable `$PSScriptRoot" {
+            # Compelling real-world case: instead of repeating an Import-Module + mock defaults setup
+            # in every test file, put it once in Pester.BeforeContainer.ps1. Because it is a real
+            # file, it always has a stable `$PSScriptRoot` to resolve the module relative to
+            # (unlike the removed Run.BeforeContainer scriptblock option, which only had the unstable
+            # `$pwd` - see #2838). Each parallel worker starts from a clean runspace and re-runs the
+            # bootstrap, so the shared helpers are available to every file without duplication.
             $folder = Join-Path ([IO.Path]::GetTempPath()) ([Guid]::NewGuid().Guid)
             $null = New-Item -ItemType Directory -Path $folder -Force
-            Set-Content -Path (Join-Path $folder 'Marker.Tests.ps1') -Value @'
-Describe 'Marker' {
-    It 'can call the helper defined by Run.BeforeContainer' {
-        Get-ExplicitMarker | Should -Be 'explicit'
-    }
+
+            Set-Content -Path (Join-Path $folder 'Helpers.psm1') -Value @'
+function Get-Answer { 42 }
+'@
+
+            # Resolve the module relative to $PSScriptRoot (the folder of this bootstrap file), which
+            # is stable regardless of the working directory Invoke-Pester was called from.
+            Set-Content -Path (Join-Path $folder 'Pester.BeforeContainer.ps1') -Value @'
+Import-Module -Name (Join-Path $PSScriptRoot 'Helpers.psm1') -Force
+'@
+
+            Set-Content -Path (Join-Path $folder 'First.Tests.ps1') -Value @'
+Describe 'First' {
+    It 'uses the shared helper' { Get-Answer | Should -Be 42 }
+}
+'@
+            Set-Content -Path (Join-Path $folder 'Second.Tests.ps1') -Value @'
+Describe 'Second' {
+    It 'uses the shared helper too' { Get-Answer | Should -Be 42 }
 }
 '@
             try {
                 $c = [PesterConfiguration]::Default
                 $c.Run.Path = $folder
+                $c.Run.RepoRoot = $folder
+                $c.Run.Parallel = $true
                 $c.Run.PassThru = $true
                 $c.Output.Verbosity = 'None'
-                $c.Run.BeforeContainer = { function Get-ExplicitMarker { 'explicit' } }
-                $r = Invoke-Pester -Configuration $c
+                # Call from a different working directory to prove the bootstrap does not depend on $pwd.
+                Push-Location ([IO.Path]::GetTempPath())
+                try { $r = Invoke-Pester -Configuration $c } finally { Pop-Location }
 
-                $r.PassedCount | Verify-Equal 1
+                $r.PassedCount | Verify-Equal 2
                 $r.FailedCount | Verify-Equal 0
             }
             finally { Remove-Item -Path $folder -Recurse -Force }

--- a/tst/Pester.RSpec.ts.ps1
+++ b/tst/Pester.RSpec.ts.ps1
@@ -3339,35 +3339,42 @@ i -PassThru:$PassThru {
         t 'a real run with stray output finishes, keeps its results, and warns instead of crashing' {
             # Reproduce the leak end-to-end the way it happens in the wild: something writes to the
             # success stream while the run is in progress, so the stray value ends up in Invoke-Test's
-            # output next to the real [Pester.Container]. A BeforeContainer block is a reliable stand-in
-            # for the original trigger - an unredirected native command (winrm/net) in a setup block -
-            # which could not be reproduced deterministically. Before #2655 that stray object was added
-            # to the strongly-typed Run.Containers list and threw "Cannot find an overload for Add",
-            # taking down the whole run.
+            # output next to the real [Pester.Container]. A repo-root Pester.BeforeContainer.ps1 that
+            # emits to the success stream is a reliable stand-in for the original trigger - an
+            # unredirected native command (winrm/net) in a setup block - which could not be reproduced
+            # deterministically. Before #2655 that stray object was added to the strongly-typed
+            # Run.Containers list and threw "Cannot find an overload for Add", taking down the whole run.
             $sb = {
                 Describe 'd' {
                     It 'passes' { $true | Should -Be $true }
                 }
             }
 
-            $r = Invoke-Pester -Configuration ([PesterConfiguration]@{
-                    Run    = @{
-                        ScriptBlock     = $sb
-                        PassThru        = $true
-                        BeforeContainer = { 'WinRM service is already running on this machine.' }
-                    }
-                    Output = @{ Verbosity = 'None' }
-                }) -WarningVariable warnings 3> $null
+            $repoRoot = Join-Path ([IO.Path]::GetTempPath()) ([Guid]::NewGuid().Guid)
+            $null = New-Item -ItemType Directory -Path $repoRoot -Force
+            Set-Content -Path (Join-Path $repoRoot 'Pester.BeforeContainer.ps1') -Value "'WinRM service is already running on this machine.'"
 
-            # The run completed instead of crashing, and the real results came through untouched.
-            $r | Verify-NotNull
-            $r.Result | Verify-Equal 'Passed'
-            $r.Containers.Count | Verify-Equal 1
-            $r.PassedCount | Verify-Equal 1
-            $r.FailedCount | Verify-Equal 0
+            try {
+                $r = Invoke-Pester -Configuration ([PesterConfiguration]@{
+                        Run    = @{
+                            ScriptBlock = $sb
+                            PassThru    = $true
+                            RepoRoot    = $repoRoot
+                        }
+                        Output = @{ Verbosity = 'None' }
+                    }) -WarningVariable warnings 3> $null
 
-            # The stray output was dropped with a warning that points at the likely cause.
-            ($warnings -join "`n") | Verify-Like "*unexpected output*WinRM service is already running on this machine.*"
+                # The run completed instead of crashing, and the real results came through untouched.
+                $r | Verify-NotNull
+                $r.Result | Verify-Equal 'Passed'
+                $r.Containers.Count | Verify-Equal 1
+                $r.PassedCount | Verify-Equal 1
+                $r.FailedCount | Verify-Equal 0
+
+                # The stray output was dropped with a warning that points at the likely cause.
+                ($warnings -join "`n") | Verify-Like "*unexpected output*WinRM service is already running on this machine.*"
+            }
+            finally { Remove-Item -Path $repoRoot -Recurse -Force }
         }
 
         t 'Split-RSpecResult keeps containers and collects stray output separately' {


### PR DESCRIPTION
## Summary

The experimental `BeforeContainer` bootstrap shipped with **two** entry points:

1. the `Run.BeforeContainer` scriptblock[] **configuration option**, and
2. the repo-root **`Pester.BeforeContainer.ps1` convention file** (resolved from `Run.RepoRoot`).

Having both created the inconsistent path story Frode raised in #2838: the file always
exposes a stable `$PSScriptRoot`/`$PSCommandPath` to anchor relative paths against, while
the scriptblock option only had the unstable `$pwd` and no file to anchor from.

This PR **removes the configuration option** and keeps only the zero-config convention file,
dot-sourced before each container in both sequential and parallel runs. One mechanism, one
consistent behaviour. (As Frode put it: *"Do we need to support BeforeContainer as a
configuration option? While nice for debugging, it has some quirks like this."*)

## Compelling example

Put shared setup once at the repo root in `Pester.BeforeContainer.ps1` and every test file –
sequential or parallel – gets it for free. Because it is a real file, `$PSScriptRoot` is stable
regardless of the working directory `Invoke-Pester` was called from:

```powershell
# ./Pester.BeforeContainer.ps1  (at Run.RepoRoot, e.g. the .git root)
Import-Module -Name (Join-Path $PSScriptRoot 'tests/Helpers.psm1') -Force

$PSDefaultParameterValues['Mock:ModuleName']          = 'MyModule'
$PSDefaultParameterValues['InModuleScope:ModuleName'] = 'MyModule'
$PSDefaultParameterValues['Should-Invoke:ModuleName'] = 'MyModule'
```

```powershell
# ./tests/Calculator.Tests.ps1 – no per-file bootstrap needed
Describe 'Calculator' {
    It 'adds' { Get-Answer | Should -Be 42 }   # helper came from the shared bootstrap
}
```

```powershell
$c = New-PesterConfiguration
$c.Run.Path     = './tests'
$c.Run.Parallel = $true            # each worker runspace re-runs the same bootstrap
Invoke-Pester -Configuration $c
```

This removes the ~duplicated `BeforeAll`/`Import-Module` boilerplate every file would otherwise
repeat, and – crucially – makes it work under `Run.Parallel`, where each worker starts from a
clean runspace (the real-world ask from #2772).

## Where this leaves Frode's 6.1.0 issues

| Issue | Status after this PR |
| --- | --- |
| **#2838** Inconsistent story for relative paths with BeforeContainer | **Fixed.** Only the file convention remains, which always has a stable `$PSScriptRoot`. The `$pwd`-only quirk is gone with the option. |
| **#2839** Expose current container to BeforeContainer | **Still open.** Conditional per-file setup (`if ($Container.Name -like '*.Integration.Tests.ps1')`) is a separate feature and is *not* addressed here. Removing the option narrows it to "expose the container to the convention file". |
| **#2825** Parallel debug output printed before the relevant test | **Still open / unrelated** to BeforeContainer (parallel diagnostic-output ordering). |

## Changes

- **`src/csharp/Pester/RunConfiguration.cs`** — remove the `BeforeContainer` option (field, ctor
  assignment, default initializer, property). Document the `Pester.BeforeContainer.ps1` convention
  on the `RepoRoot` option so it stays discoverable. `about_PesterConfiguration` help regenerated.
- **`src/functions/Pester.Parallel.ps1`** — `Resolve-PesterBeforeContainer` now resolves only the
  convention file; drop the worker-config sanitation line for the removed option.
- **`src/Main.ps1`, `src/Pester.Runtime.ps1`** — comment updates.
- **Tests** — replace the explicit-option cases in `Pester.RSpec.Parallel.ts.ps1` with a
  multi-file parallel example that shares one bootstrap via the stable `$PSScriptRoot`; rework the
  #2655 stray-output test in `Pester.RSpec.ts.ps1` to use a convention file instead of the option.

## Verification

- `./build.ps1 -Clean` — succeeds; about-help regenerated without the option.
- P-tests: `Pester.RSpec.Parallel.ts.ps1` (20/0) and `Pester.RSpec.ts.ps1` pass.
- `PesterConfiguration.Tests.ps1` (23/0) — format-data view stays in sync after removing the option.
- `Invoke-ScriptAnalyzer` with the custom build rules — no new findings in the changed files.

Fix #2838

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>