### PR TITLE
Collect code coverage in parallel runs

### DIFF
--- a/src/Main.ps1
+++ b/src/Main.ps1
@@ -626,9 +626,10 @@ function Invoke-Pester {
             }
 
             # Parallel mode runs each file in its own runspace and merges the executed
-            # containers back. It only applies to file-based runs on PowerShell 7+ and is not
-            # supported together with CodeCoverage yet; other cases fall back to the normal
-            # sequential path with a warning.
+            # containers back. It only applies to file-based runs on PowerShell 7+; other cases fall
+            # back to the normal sequential path with a warning. CodeCoverage is supported: each
+            # worker measures its own file with breakpoints and the parent merges the results (see
+            # the parallel branch below).
             $useParallel = $PesterPreference.Run.Parallel.Value
             $parallelSupported = $PSVersionTable.PSVersion.Major -ge 7
             $allFileContainers = 0 -eq @($containers | & $SafeCommands['Where-Object'] { 'File' -ne $_.Type }).Count
@@ -650,7 +651,7 @@ function Invoke-Pester {
             # them inherits those type constraints, which silently corrupts the loop variable.
             $parallelContainers = [System.Collections.Generic.List[object]]@()
             $nonParallelContainers = [System.Collections.Generic.List[object]]@()
-            if ($useParallel -and $parallelSupported -and $allFileContainers -and -not $coverageEnabled -and -not $skipRemainingRunScope) {
+            if ($useParallel -and $parallelSupported -and $allFileContainers -and -not $skipRemainingRunScope) {
                 foreach ($fileContainer in $containers) {
                     if (Test-PesterFileIsNonParallel -Path $fileContainer.Item.FullName) {
                         $nonParallelContainers.Add($fileContainer)
@@ -667,9 +668,6 @@ function Invoke-Pester {
             elseif ($useParallel -and -not $allFileContainers) {
                 & $SafeCommands['Write-Warning'] "Run.Parallel currently parallelizes only file-based runs (Run.Path). The provided ScriptBlock/Container test(s) will run sequentially instead."
             }
-            elseif ($useParallel -and $coverageEnabled) {
-                & $SafeCommands['Write-Warning'] "Run.Parallel does not support CodeCoverage yet. Running the tests sequentially instead."
-            }
             elseif ($useParallel -and $skipRemainingRunScope) {
                 & $SafeCommands['Write-Warning'] "Run.Parallel does not support Run.SkipRemainingOnFailure = 'Run' because skipping after the first failure cannot span the isolated worker runspaces. Running the tests sequentially instead."
             }
@@ -683,10 +681,27 @@ function Invoke-Pester {
             # If every file opted out with #pester:no-parallel, the run is effectively sequential,
             # so fall through to the sequential path - which fires the framework's own global
             # plugin steps at the correct interleaved points.
-            $ranInParallel = $useParallel -and $parallelSupported -and $allFileContainers -and -not $coverageEnabled -and -not $skipRemainingRunScope -and 0 -lt $parallelContainers.Count
+            $ranInParallel = $useParallel -and $parallelSupported -and $allFileContainers -and -not $skipRemainingRunScope -and 0 -lt $parallelContainers.Count
             if ($ranInParallel) {
                 $foldedContainers = [System.Collections.Generic.List[object]]@()
                 $hasNonParallel = 0 -lt $nonParallelContainers.Count
+
+                # CodeCoverage in a parallel run: every worker measures the same locations with
+                # breakpoints and returns its per-location hits (the default profiler/tracer keeps its
+                # state in a process-global static and is not concurrency-safe). The parent collects
+                # those, adds the coverage of any #pester:no-parallel files it runs in-session, merges
+                # them, and lets the Coverage plugin's End step emit the single report and output file.
+                # Force breakpoint mode on the captured plugin configuration so the End step (and the
+                # in-session non-parallel measurement) does not try to use the tracer's Measure.
+                $collectCoverageInParallel = $coverageEnabled
+                $parallelCoverage = [System.Collections.Generic.List[object]]@()
+                $coveragePlugins = [System.Collections.Generic.List[object]]@()
+                if ($collectCoverageInParallel) {
+                    $pluginConfiguration['Coverage'].UseBreakpoints = $true
+                    foreach ($pl in $plugins) {
+                        if ('Coverage' -eq $pl.Name) { $coveragePlugins.Add($pl) }
+                    }
+                }
 
                 # The parent owns ALL framing for a parallel run. It fires the global and
                 # per-container/per-test plugin steps to a REPORTING-only plugin subset (screen
@@ -741,6 +756,11 @@ function Invoke-Pester {
                         # RSpec-folded - collect them straight away (do not re-fold).
                         foreach ($c in $parallelResult.Containers) { $foldedContainers.Add($c) }
 
+                        # Gather this worker's measured coverage (already projected to a light shape).
+                        if ($collectCoverageInParallel -and $null -ne $parallelResult.Coverage) {
+                            foreach ($cc in $parallelResult.Coverage) { $parallelCoverage.Add($cc) }
+                        }
+
                         # All-parallel: the last file just finished discovery, so global discovery
                         # is complete - fire DiscoveryEnd before replaying that file's run segment,
                         # exactly as the interleaved sequential path does.
@@ -785,7 +805,38 @@ function Invoke-Pester {
                         $runStartFired = $true
                     }
 
+                    # Measure coverage for the in-session (#pester:no-parallel) files. Their
+                    # Invoke-Test call runs with -SkipFrameworkGlobalSteps, which suppresses the
+                    # Coverage plugin's own RunStart/RunEnd, so fire them here to set up and tear down
+                    # breakpoints around this batch. UseBreakpoints was forced above, so this measures
+                    # with breakpoints too and merges cleanly with the workers' hits.
+                    if ($collectCoverageInParallel) {
+                        Invoke-PluginStep -Plugins $coveragePlugins -Step RunStart -Context @{
+                            Blocks                   = $foldedContainers
+                            Configuration            = $pluginConfiguration
+                            Data                     = $pluginData
+                            WriteDebugMessages       = $PesterPreference.Debug.WriteDebugMessages.Value
+                            Write_PesterDebugMessage = if ($PesterPreference.Debug.WriteDebugMessages.Value) { $script:SafeCommands['Write-PesterDebugMessage'] }
+                        } -ThrowOnFailure
+                    }
+
                     $r = Invoke-Test -BlockContainer $nonParallelContainers -Plugin $plugins -PluginConfiguration $pluginConfiguration -PluginData $pluginData -SessionState $sessionState -Filter $filter -Configuration $PesterPreference -BeforeContainerInit $beforeContainerInit -SkipFrameworkGlobalSteps
+
+                    if ($collectCoverageInParallel) {
+                        Invoke-PluginStep -Plugins $coveragePlugins -Step RunEnd -Context @{
+                            Blocks                   = $foldedContainers
+                            Configuration            = $pluginConfiguration
+                            Data                     = $pluginData
+                            WriteDebugMessages       = $PesterPreference.Debug.WriteDebugMessages.Value
+                            Write_PesterDebugMessage = if ($PesterPreference.Debug.WriteDebugMessages.Value) { $script:SafeCommands['Write-PesterDebugMessage'] }
+                        } -ThrowOnFailure
+
+                        if ($pluginData.ContainsKey('Coverage') -and $null -ne $pluginData.Coverage) {
+                            foreach ($cc in (Convert-CommandCoverageToProjection -CommandCoverage @($pluginData.Coverage.CommandCoverage))) {
+                                $parallelCoverage.Add($cc)
+                            }
+                        }
+                    }
 
                     $rspecResult = Split-RSpecResult -Result $r
                     if (0 -lt $rspecResult.StrayOutput.Count) {
@@ -841,6 +892,20 @@ function Invoke-Pester {
                             if ($order.ContainsKey($key)) { $order[$key] } else { [int]::MaxValue }
                         }
                     })
+
+                # Merge every batch's measured locations into one CommandCoverage list and hand it to
+                # the plugin data, so the Coverage plugin's End step (fired once below) produces the
+                # single merged report and writes the output file. A location counts as covered when
+                # any file hit it; hit counts are summed across files.
+                if ($collectCoverageInParallel) {
+                    $mergedCoverage = @(Merge-CoverageFromParallel -CommandCoverage $parallelCoverage.ToArray())
+                    $pluginData['Coverage'] = @{
+                        CommandCoverage = $mergedCoverage
+                        Tracer          = $null
+                        Patched         = $false
+                        CoverageReport  = $null
+                    }
+                }
             }
             else {
                 $r = Invoke-Test -BlockContainer $containers -Plugin $plugins -PluginConfiguration $pluginConfiguration -PluginData $pluginData -SessionState $sessionState -Filter $filter -Configuration $PesterPreference -BeforeContainerInit $beforeContainerInit

--- a/src/functions/Coverage.Plugin.ps1
+++ b/src/functions/Coverage.Plugin.ps1
@@ -131,6 +131,14 @@
     $p.End = {
         param($Context)
 
+        # Parallel workers collect the raw breakpoint hits but must not produce the report or write
+        # the output file themselves - the parent merges every worker's CommandCoverage and generates
+        # the report once. The flag is set on the (per-runspace) module scope only inside a worker, so
+        # a normal run and the parent's own End step never see it. See Invoke-TestInParallel.
+        if (defined CodeCoverageSkipReport) {
+            return
+        }
+
         $run = $Context.TestRun
 
         if ($PesterPreference.Output.Verbosity.Value -ne "None") {
@@ -138,12 +146,16 @@
             Write-PesterHostMessage -ForegroundColor Magenta "Processing code coverage result."
         }
 
+        $configuration = $run.PluginConfiguration.Coverage
+
         $breakpoints = @($run.PluginData.Coverage.CommandCoverage)
-        $measure = if (-not $PesterPreference.CodeCoverage.UseBreakpoints.Value) { @($run.PluginData.Coverage.Tracer.Hits) }
+        # Read UseBreakpoints from the coverage plugin configuration captured at Start, not from the
+        # global $PesterPreference. A parallel run forces breakpoint-based coverage (the tracer uses a
+        # process-global static and is not concurrency-safe) by overriding it there, and the merged
+        # CommandCoverage already carries resolved HitCounts, so no tracer Measure is used.
+        $measure = if (-not $configuration.UseBreakpoints) { @($run.PluginData.Coverage.Tracer.Hits) }
         $coverageReport = Get-CoverageReport -CommandCoverage $breakpoints -Measure $measure
         $totalMilliseconds = $run.Duration.TotalMilliseconds
-
-        $configuration = $run.PluginConfiguration.Coverage
 
         $coverageXmlReport = switch ($configuration.OutputFormat) {
             'JaCoCo' { [xml](Get-JaCoCoReportXml -CommandCoverage $breakpoints -TotalMilliseconds $totalMilliseconds -CoverageReport $coverageReport -ReportRoot (Get-ReportRoot)) }

--- a/src/functions/Coverage.ps1
+++ b/src/functions/Coverage.ps1
@@ -629,6 +629,80 @@ function Merge-CommandCoverage {
     $c
 }
 
+function Merge-CoverageFromParallel {
+    <#
+    .SYNOPSIS
+    Merges the per-worker breakpoint coverage of a parallel run into a single CommandCoverage list.
+
+    .DESCRIPTION
+    EXPERIMENTAL. In a parallel run each file measures the same set of measurable locations
+    (CodeCoverage.Path is identical for every worker), so every worker returns a full projection of
+    those locations with its own per-location HitCount (see Invoke-TestInParallel). A location is
+    covered when at least one file hit it, so this collapses the projections by
+    "File:StartLine:StartColumn" and sums the HitCounts, keeping the first occurrence's discovery
+    order. Each merged entry is shaped like a breakpoint-based CommandCoverage item (a Breakpoint
+    with a HitCount) so Get-CoverageReport / Get-JaCoCoReportXml / Get-CoberturaReportXml consume it
+    unchanged.
+    #>
+    [CmdletBinding()]
+    param ([object[]] $CommandCoverage)
+
+    $merged = [System.Collections.Specialized.OrderedDictionary]::new()
+    foreach ($cc in $CommandCoverage) {
+        if ($null -eq $cc) { continue }
+        $key = "$($cc.File):$($cc.StartLine):$($cc.StartColumn)"
+        if ($merged.Contains($key)) {
+            $merged[$key].Breakpoint.HitCount += [int] $cc.HitCount
+        }
+        else {
+            $merged[$key] = [PSCustomObject] @{
+                File        = $cc.File
+                Class       = $cc.Class
+                Function    = $cc.Function
+                StartLine   = $cc.StartLine
+                EndLine     = $cc.EndLine
+                StartColumn = $cc.StartColumn
+                EndColumn   = $cc.EndColumn
+                Command     = $cc.Command
+                Breakpoint  = @{ HitCount = [int] $cc.HitCount }
+            }
+        }
+    }
+
+    @($merged.Values)
+}
+
+function Convert-CommandCoverageToProjection {
+    <#
+    .SYNOPSIS
+    Projects raw CommandCoverage breakpoint objects into the lightweight, HitCount-carrying shape
+    that Merge-CoverageFromParallel expects.
+
+    .DESCRIPTION
+    EXPERIMENTAL. Drops the heavy Ast / live Breakpoint references and flattens the breakpoint hit
+    count onto a HitCount property, so a batch of coverage measured in-process (e.g. the sequential
+    #pester:no-parallel files of a parallel run) can be merged with the projections returned by
+    parallel workers.
+    #>
+    [CmdletBinding()]
+    param ([object[]] $CommandCoverage)
+
+    foreach ($cc in $CommandCoverage) {
+        if ($null -eq $cc) { continue }
+        [PSCustomObject] @{
+            File        = $cc.File
+            Class       = $cc.Class
+            Function    = $cc.Function
+            StartLine   = $cc.StartLine
+            EndLine     = $cc.EndLine
+            StartColumn = $cc.StartColumn
+            EndColumn   = $cc.EndColumn
+            Command     = $cc.Command
+            HitCount    = [int] $cc.Breakpoint.HitCount
+        }
+    }
+}
+
 function Get-CoverageReport {
     # make sure this is an array, otherwise the counts start failing
     # on powershell 3

--- a/src/functions/Pester.Parallel.ps1
+++ b/src/functions/Pester.Parallel.ps1
@@ -147,9 +147,13 @@ function Invoke-TestInParallel {
 
     .NOTES
     Prototype limitations:
-    - CodeCoverage and TestResult are disabled inside workers to avoid output-file collisions;
-      merging coverage across workers is not handled yet. TestResult is produced once by the
-      parent from the merged result tree.
+    - TestResult is disabled inside workers to avoid output-file collisions; it is produced once by
+      the parent from the merged result tree.
+    - CodeCoverage, when enabled, is collected inside every worker using breakpoints (the default
+      profiler/tracer uses a process-global static and is not concurrency-safe across the worker
+      runspaces). Each worker returns its measured locations with per-location hit counts; the parent
+      merges them and produces the single coverage report and output file. Workers skip their own
+      report generation and file write via the CodeCoverageSkipReport module flag.
     #>
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('Pester.BuildAnalyzerRules\Measure-SafeCommands', '', Justification = 'Get-Module/Import-Module run in a fresh ForEach-Object -Parallel runspace where the module-internal $SafeCommands table is unavailable.')]
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('Pester.BuildAnalyzerRules\Measure-ObjectCmdlets', '', Justification = 'ForEach-Object -Parallel is the runspace-parallelism primitive with no language-keyword equivalent; the accompanying Where-Object/Sort-Object run once over the small per-run result set.')]
@@ -205,6 +209,10 @@ function Invoke-TestInParallel {
     $baseConfig.Run.ScriptBlock = [scriptblock[]]@()
     $baseConfig.Run.Container = @()
 
+    # Whether this run measures code coverage. When enabled the workers collect breakpoint-based
+    # coverage (see the .NOTES) and the parent merges it; when disabled coverage stays off entirely.
+    $collectCoverage = [bool] $Configuration.CodeCoverage.Enabled.Value
+
     # The per-container and per-test plugin steps each worker records and the parent replays.
     # Global steps (Start/DiscoveryStart/DiscoveryEnd/RunStart/RunEnd/End) are intentionally
     # excluded - the parent fires those once for the whole run.
@@ -218,15 +226,17 @@ function Invoke-TestInParallel {
     # Worker body. Imports Pester, runs the per-container initialization (so helper
     # modules/functions the parent provided are available), clones the base configuration (via
     # Merge so unset options keep their defaults), points it at a single file, disables
-    # parallel/exit/throw to avoid recursion and process exits, disables result/coverage file
-    # writing to avoid concurrent workers overwriting output files, and silences the worker's own
-    # console output. A recorder plugin is injected (via the supported $script:additionalPlugins
-    # channel) to capture the ordered plugin-event tape, which is returned to the parent for replay.
+    # parallel/exit/throw to avoid recursion and process exits, disables the TestResult file write
+    # (the parent produces it), and silences the worker's own console output. When coverage is on it
+    # is measured with breakpoints and the report/file write is suppressed, so the parent can merge
+    # every worker's hits and emit one report. A recorder plugin is injected (via the supported
+    # $script:additionalPlugins channel) to capture the ordered plugin-event tape returned for replay.
     $worker = {
         $item = $_
         $modulePath = $using:modulePath
         $baseConfig = $using:baseConfig
         $recordedSteps = $using:recordedSteps
+        $collectCoverage = $using:collectCoverage
 
         if (-not (Get-Module -Name Pester)) {
             Import-Module $modulePath
@@ -255,11 +265,21 @@ function Invoke-TestInParallel {
         $workerConfig.Run.Exit = $false
         $workerConfig.Run.Throw = $false
         $workerConfig.TestResult.Enabled = $false
-        $workerConfig.CodeCoverage.Enabled = $false
+        if ($collectCoverage) {
+            # Measure coverage with breakpoints, not the default profiler/tracer: the tracer keeps its
+            # state in a process-global static, so concurrent workers would overwrite each other's hits.
+            # Set-PSBreakpoint is per-runspace, so every worker measures its own file in isolation.
+            $workerConfig.CodeCoverage.Enabled = $true
+            $workerConfig.CodeCoverage.UseBreakpoints = $true
+        }
+        else {
+            $workerConfig.CodeCoverage.Enabled = $false
+        }
         # The BeforeContainer init already ran above (as $item.Init). Clear RepoRoot so the worker's
         # own sequential run does not resolve and dot-source the repo-root Pester.BeforeContainer.ps1
         # a second time; that would run the setup twice per file and diverge from a sequential run.
-        # RepoRoot is otherwise only used for CodeCoverage, which is disabled in workers.
+        # RepoRoot is otherwise only used for CodeCoverage report roots, which the parent applies when
+        # it generates the merged report.
         $workerConfig.Run.RepoRoot = ''
         # The worker stays silent; the parent renders all output by replaying the recorded tape.
         $workerConfig.Output.Verbosity = 'None'
@@ -270,7 +290,8 @@ function Invoke-TestInParallel {
         # reporting plugins would then fail to render the "Describing"/"Context" headers in
         # Detailed/Diagnostic output (#2824). The parent runs the same cleanup itself after folding
         # the worker's containers into its own run (Remove-RSpecNonPublicProperties in Main.ps1,
-        # after the tape has been replayed), so the user still receives a cleaned result.
+        # after the tape has been replayed), so the user still receives a cleaned result. Keeping the
+        # raw object also preserves PluginData.Coverage so the worker's measured hits reach the parent.
         $workerConfig.Debug.ReturnRawResultObject = $true
 
         $pesterModule = Get-Module -Name Pester
@@ -292,13 +313,21 @@ function Invoke-TestInParallel {
             New-PluginObject @h
         } $tape $recordedSteps
 
-        # Inject the recorder via the supported additional-plugins channel, run, then clear it.
+        # Inject the recorder via the supported additional-plugins channel. When coverage is on, also
+        # tell the Coverage plugin's End step to skip report generation and the output-file write in
+        # this worker - the parent merges every worker's raw hits and emits the single report/file.
         & $pesterModule { param($p) $script:additionalPlugins = $p } $recorder
+        if ($collectCoverage) {
+            & $pesterModule { $script:CodeCoverageSkipReport = $true }
+        }
         try {
             $out = Invoke-Pester -Configuration $workerConfig
         }
         finally {
             & $pesterModule { $script:additionalPlugins = $null }
+            if ($collectCoverage) {
+                & $pesterModule { $script:CodeCoverageSkipReport = $null }
+            }
         }
 
         $runObject = $null
@@ -306,10 +335,21 @@ function Invoke-TestInParallel {
             if ($o -is [Pester.Run]) { $runObject = $o; break }
         }
 
+        # Project the measured breakpoint locations to a light shape (no Ast / live Breakpoint refs)
+        # carrying just the metadata and hit count the parent needs to merge and report coverage.
+        # Convert-CommandCoverageToProjection is module-internal, so call it in the module scope.
+        $coverage = if ($collectCoverage -and $null -ne $runObject -and $null -ne $runObject.PluginData -and $runObject.PluginData.ContainsKey('Coverage')) {
+            @(& $pesterModule { param($cc) Convert-CommandCoverageToProjection -CommandCoverage $cc } @($runObject.PluginData.Coverage.CommandCoverage))
+        }
+        else {
+            @()
+        }
+
         [PSCustomObject]@{
             Path       = $item.Path
             Containers = @($runObject.Containers)
             Tape       = $tape.ToArray()
+            Coverage   = $coverage
         }
     }
 

--- a/tst/Pester.RSpec.Parallel.ts.ps1
+++ b/tst/Pester.RSpec.Parallel.ts.ps1
@@ -429,14 +429,18 @@ Describe 'S' {
             ($warnings -join "`n") | Verify-Like (Get-ExpectedParallelFallbackWarning '*parallelizes only file-based runs*')
         }
 
-        t "falls back to sequential with a warning when CodeCoverage is enabled" {
+        t "collects and merges code coverage across parallel workers" {
             $folder = Join-Path ([IO.Path]::GetTempPath()) ([Guid]::NewGuid().Guid)
             $null = New-Item -ItemType Directory -Path $folder -Force
             try {
-                # A code file to measure coverage on, plus two parallelizable test files that use it.
+                # A shared code file to measure coverage on, plus two parallelizable test files that
+                # each exercise a different function in it. The parallel run must collect coverage
+                # from every worker and merge it into one report - matching a sequential run exactly.
                 Set-Content -Path (Join-Path $folder 'lib.ps1') -Value @'
 function Get-One { 1 }
 function Get-Two { 2 }
+function Get-Three { 3 }
+function Get-Four { 4 }
 '@
                 Set-Content -Path (Join-Path $folder 'A.Tests.ps1') -Value @'
 BeforeAll { . $PSScriptRoot/lib.ps1 }
@@ -446,6 +450,59 @@ Describe 'A' { It 'a1 passes' { Get-One | Should -Be 1 } }
 BeforeAll { . $PSScriptRoot/lib.ps1 }
 Describe 'B' { It 'b1 passes' { Get-Two | Should -Be 2 } }
 '@
+                $newConfig = {
+                    $c = [PesterConfiguration]::Default
+                    $c.Run.Path = $folder
+                    $c.Run.PassThru = $true
+                    $c.CodeCoverage.Enabled = $true
+                    $c.CodeCoverage.Path = (Join-Path $folder 'lib.ps1')
+                    $c
+                }
+
+                $sequential = & $newConfig
+                $sequential.Run.Parallel = $false
+                $seq = Invoke-Pester -Configuration $sequential
+
+                $parallel = & $newConfig
+                $parallel.Run.Parallel = $true
+                $par = Invoke-Pester -Configuration $parallel
+
+                # Two of the four functions are covered; parallel must match sequential exactly.
+                $par.PassedCount | Verify-Equal 2
+                $par.CodeCoverage | Verify-NotNull
+                $par.CodeCoverage.CommandsAnalyzedCount | Verify-Equal $seq.CodeCoverage.CommandsAnalyzedCount
+                $par.CodeCoverage.CommandsExecutedCount | Verify-Equal $seq.CodeCoverage.CommandsExecutedCount
+                $par.CodeCoverage.CommandsMissedCount | Verify-Equal $seq.CodeCoverage.CommandsMissedCount
+                $par.CodeCoverage.CommandsExecutedCount | Verify-Equal 2
+            }
+            finally { Remove-Item -Path $folder -Recurse -Force }
+        }
+
+        t "merges code coverage from a file marked #pester:no-parallel" {
+            $folder = Join-Path ([IO.Path]::GetTempPath()) ([Guid]::NewGuid().Guid)
+            $null = New-Item -ItemType Directory -Path $folder -Force
+            try {
+                # A,B run in parallel; C opts out and runs in the parent. Coverage from the in-parent
+                # (non-parallel) file must be merged with the worker coverage.
+                Set-Content -Path (Join-Path $folder 'lib.ps1') -Value @'
+function Get-One { 1 }
+function Get-Two { 2 }
+function Get-Three { 3 }
+function Get-Four { 4 }
+'@
+                Set-Content -Path (Join-Path $folder 'A.Tests.ps1') -Value @'
+BeforeAll { . $PSScriptRoot/lib.ps1 }
+Describe 'A' { It 'a1 passes' { Get-One | Should -Be 1 } }
+'@
+                Set-Content -Path (Join-Path $folder 'B.Tests.ps1') -Value @'
+BeforeAll { . $PSScriptRoot/lib.ps1 }
+Describe 'B' { It 'b1 passes' { Get-Two | Should -Be 2 } }
+'@
+                Set-Content -Path (Join-Path $folder 'C.Tests.ps1') -Value @'
+#pester:no-parallel
+BeforeAll { . $PSScriptRoot/lib.ps1 }
+Describe 'C' { It 'c1 passes' { Get-Three | Should -Be 3 } }
+'@
                 $c = [PesterConfiguration]::Default
                 $c.Run.Path = $folder
                 $c.Run.Parallel = $true
@@ -453,16 +510,15 @@ Describe 'B' { It 'b1 passes' { Get-Two | Should -Be 2 } }
                 $c.CodeCoverage.Enabled = $true
                 $c.CodeCoverage.Path = (Join-Path $folder 'lib.ps1')
 
-                $r = Invoke-Pester -Configuration $c -WarningVariable warnings 3>$null
+                $r = Invoke-Pester -Configuration $c
 
-                # The tests still run and produce correct counts.
-                $r.TotalCount | Verify-Equal 2
-                $r.PassedCount | Verify-Equal 2
-                # Parallel cannot collect coverage yet, so it must warn and run sequentially...
-                ($warnings -join "`n") | Verify-Like (Get-ExpectedParallelFallbackWarning '*does not support CodeCoverage*')
-                # ...which means real coverage was collected (the parallel path collects none).
+                $r.PassedCount | Verify-Equal 3
                 $r.CodeCoverage | Verify-NotNull
-                ($r.CodeCoverage.CommandsAnalyzedCount -gt 0) | Verify-True
+                # Get-One, Get-Two (workers) and Get-Three (#pester:no-parallel) were executed.
+                $r.CodeCoverage.CommandsExecutedCount | Verify-Equal 3
+                $r.CodeCoverage.CommandsMissedCount | Verify-Equal 1
+                $executedLines = $r.CodeCoverage.CommandsExecuted.StartLine
+                $executedLines -contains 3 | Verify-True
             }
             finally { Remove-Item -Path $folder -Recurse -Force }
         }


### PR DESCRIPTION
## Summary

`Run.Parallel` previously fell back to a sequential run (with a warning) whenever `CodeCoverage` was enabled. This enables coverage collection during parallel runs instead.

- Each worker measures its own file with **breakpoints** and returns its per-location hits. The default profiler/tracer keeps state in a process-global static and is **not** concurrency-safe across worker runspaces, so breakpoint mode is forced for parallel + coverage.
- The parent **merges** every worker's hits, adds the coverage of any `#pester:no-parallel` files it runs in-session, and lets the existing Coverage plugin `End` step emit the single merged report and output file (JaCoCo/Cobertura) plus `run.CodeCoverage`.
- **PowerShell 5.1 stays unsupported for parallel** — it still falls back to a sequential run (collecting coverage sequentially) with the version warning, since it lacks `ForEach-Object -Parallel`.

## Changes

- `src/functions/Pester.Parallel.ps1` — workers enable breakpoint coverage, suppress their own report/file write via a `CodeCoverageSkipReport` module flag, and return a lightweight per-location hit projection.
- `src/functions/Coverage.ps1` — new `Merge-CoverageFromParallel` and `Convert-CommandCoverageToProjection` helpers.
- `src/functions/Coverage.Plugin.ps1` — `End` step honors the skip flag and reads `UseBreakpoints` from the captured plugin configuration.
- `src/Main.ps1` — removes the coverage fallback/warning; collects worker coverage, measures `#pester:no-parallel` files in-session, merges everything, and hands it to the Coverage plugin for the single report.
- `tst/Pester.RSpec.Parallel.ts.ps1` — replaces the obsolete "falls back with warning when CodeCoverage" test with two tests: parallel coverage equals sequential, and coverage from a `#pester:no-parallel` file is merged in.

## Verification

- Parallel coverage matches a sequential run exactly (analyzed/executed/missed counts, percent, executed lines).
- Mixed `#pester:no-parallel` case merges correctly; JaCoCo + Cobertura XML valid; output file written; no stray worker output files.
- All 21 parallel P-tests pass (incl. 2 new coverage tests); all 12 coverage P-tests pass.
- No new PSScriptAnalyzer custom-rule violations in the changed lines.

Related to #1704.