### PR TITLE
Allow empty string for `Should-BeString -Expected`

### DIFF
--- a/src/functions/assert/String/Should-BeString.ps1
+++ b/src/functions/assert/String/Should-BeString.ps1
@@ -69,6 +69,13 @@ function Should-BeString {
 
     This assertion will fail, because the actual value is not equal to the expected value.
 
+    .EXAMPLE
+    ```powershell
+    "" | Should-BeString ""
+    ```
+
+    This assertion will pass, because an empty string is allowed as the expected value.
+
     .NOTES
     The `Should-BeString` assertion is the opposite of the `Should-NotBeString` assertion.
 
@@ -88,6 +95,7 @@ function Should-BeString {
         [Parameter(Position = 1, ValueFromPipeline = $true)]
         $Actual,
         [Parameter(Position = 0, Mandatory)]
+        [AllowEmptyString()]
         [String]$Expected,
         [String]$Because,
         [switch]$CaseSensitive,

--- a/tst/functions/assert/String/Should-BeString.Tests.ps1
+++ b/tst/functions/assert/String/Should-BeString.Tests.ps1
@@ -85,6 +85,37 @@ Describe "Should-BeString" {
         "abc" | Should-BeString "abc"
     }
 
+    Context "Empty expected string" {
+        It "Passes when both expected and actual are empty strings" {
+            Should-BeString -Expected "" -Actual ""
+        }
+
+        It "Passes when expected is empty and actual is passed by pipeline" {
+            "" | Should-BeString -Expected ""
+        }
+
+        It "Passes when empty expected is passed by position" {
+            "" | Should-BeString ""
+        }
+
+        It "Fails when expected is empty but actual is not" {
+            { Should-BeString -Expected "" -Actual "abc" } | Verify-AssertionFailed
+        }
+
+        It "Throws with default message when expected is empty but actual is not" {
+            $err = { Should-BeString -Expected "" -Actual "abc" } | Verify-AssertionFailed
+            $err.Exception.Message | Verify-Equal (@'
+Expected strings to be the same, but they were different.
+Expected length: 0
+Actual length:   3
+Strings differ at index 0.
+Expected: ''
+But was:  'abc'
+          ^
+'@ -replace "`r`n", "`n")
+        }
+    }
+
     It "Fails when collection of strings is passed in by pipeline, even if the last string is the same as the expected string" {
         { "bde", "abc" | Should-BeString -Expected "abc" } | Verify-AssertionFailed
     }


### PR DESCRIPTION
Fix #2857

## Problem

`Should-BeString` rejects an empty string for `-Expected`:

```powershell
"" | Should-BeString ""
# Cannot bind argument to parameter 'Expected' because it is an empty string.
```

This forces users porting v5 `-ForEach` tests to branch between `Should-BeString` and `Should-BeEmptyString` depending on whether the expected value is empty.

## Root cause

The rejection is not a deliberate assertion rule — there's no validation in the function body checking for empty. It's an implicit side effect of declaring the parameter as `[Parameter(Mandatory)][String]$Expected`: a mandatory, typed `[String]` parameter automatically refuses `""` during parameter binding.

Everything downstream already handles empty strings:
- `Test-StringEqual` compares empty strings correctly.
- `Get-StringDifferenceMessage` already declares `[AllowEmptyString()]` on `$Expected`/`$Actual`.
- The sibling `Should-NotBeString` doesn't mark `Expected` as `Mandatory`, so it already accepts empty strings — `Should-BeString` was the inconsistent one.

## Change

- Add `[AllowEmptyString()]` to `$Expected` (keeping `Mandatory`, so the argument is still required — it may just be empty).
- Add a comment-based-help example.
- Add tests covering: both empty (named, positional, pipeline) and the failure/diff message when expected is `""` but actual is non-empty.

All 42 tests in `Should-BeString.Tests.ps1` pass.