### PR TITLE
Fix false error in CI

### DIFF
--- a/tst/Pester.RSpec.Output.ts.ps1
+++ b/tst/Pester.RSpec.Output.ts.ps1
@@ -256,6 +256,7 @@ i -PassThru:$PassThru {
                 $PesterPreference = [PesterConfiguration]::Default
                 $PesterPreference.Output.Verbosity = 'Detailed'
                 $PesterPreference.Output.RenderMode = 'ConsoleColor'
+                $PesterPreference.Output.CIFormat = 'None'
 
                 $container = New-PesterContainer -ScriptBlock {
                     BeforeAll {


### PR DESCRIPTION
## PR Summary
Disables CI error-formatting in output test to fix false error in CI-report. The error is printed for easier troubleshooting should the test actually fail.

Fix #2862

## PR Checklist

- [x] PR has meaningful title
- [x] Summary describes changes
- [x] PR is ready to be merged
  - If not, use the arrow next to `Create Pull Request` to mark it as a draft. PR can be marked `Ready for review` when it's ready.
- [x] Tests are added/update *(if required)*
- [ ] Documentation is updated/added *(if required)*