### PR TITLE
Fix flaky output test in devcontainer

### DIFF
--- a/tst/Pester.RSpec.Output.ts.ps1
+++ b/tst/Pester.RSpec.Output.ts.ps1
@@ -422,6 +422,8 @@ i -PassThru:$PassThru {
 
         t "Paths are relative to repo root option when report root is not set" {
             $sb = {
+                # Set consistent console width to avoid line wrapping in the CC-report. Was broken in devcontainer.
+                & (Get-Module Pester) { $PSDefaultParameterValues['Out-String:Width'] = 120 }
                 $c = New-PesterConfiguration
                 $c.Run.Path = "tst/testProjectsForMissingCoverage/CoverageTestFile.Missing.Tests.ps1"
                 $c.Run.PassThru = $true


### PR DESCRIPTION
## PR Summary

Quick fix to flaky test CC-report test. Failed in devcontainer due to truncated output for unknown reason.

Before: 

```
Processing code coverage result.
Code Coverage result processed in 178 ms.
Covered 0% / 75%. 2 analyzed Commands in 1 File.
Missed commands:

File                                                            Class Function L
                                                                               i
                                                                               n
                                                                               e
----                                                            ----- -------- -
tst/testProjectsForMissingCoverage/CoverageTestFile.Missing.ps1       a        2
tst/testProjectsForMissingCoverage/CoverageTestFile.Missing.ps1       a        3


[n] - Paths are relative to repo root option when report root is not set -> Expected is not present in Actual! 
Expected: 'tst/testProjectsForMissingCoverage/CoverageTestFile.Missing.ps1*not covered*' 
Actual  : '' 
  at Verify-Like, /workspaces/Pester/tst/axiom/Verify-Like.ps1:15 
  at <ScriptBlock>, /workspaces/Pester/tst/Pester.RSpec.Output.ts.ps1:444 
```


## PR Checklist

- [x] PR has meaningful title
- [x] Summary describes changes
- [x] PR is ready to be merged
  - If not, use the arrow next to `Create Pull Request` to mark it as a draft. PR can be marked `Ready for review` when it's ready.
- [x] Tests are added/update *(if required)*
- [ ] Documentation is updated/added *(if required)*