### PR TITLE
Update devcontainer to .NET 10 SDK and PowerShell 7.6

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,7 @@
 // For format details, see https://aka.ms/vscode-remote/devcontainer.json
 {
 	"name": "Pester",
-	"image": "mcr.microsoft.com/devcontainers/dotnet:2-8.0-noble",
+	"image": "mcr.microsoft.com/devcontainers/dotnet:2-10.0-noble",
 	"remoteUser": "vscode",
 	"customizations": {
 		"codespaces": {


### PR DESCRIPTION
## PR Summary
Updates devcontainer to .NET 10 SDK and PowerShell 7.6 to match CI pipeline image (windows-2022).
.NET 8 and PS 7.4 are EOL in November.

Also fixes broken CC-output P-test caused by PS 7.4, replacing #2867

## PR Checklist

- [x] PR has meaningful title
- [x] Summary describes changes
- [x] PR is ready to be merged
  - If not, use the arrow next to `Create Pull Request` to mark it as a draft. PR can be marked `Ready for review` when it's ready.
- [ ] Tests are added/update *(if required)*
- [ ] Documentation is updated/added *(if required)*