### PR TITLE
Surface verbose/debug output when a CI debug flag is enabled

### DIFF
--- a/src/Pester.Runtime.ps1
+++ b/src/Pester.Runtime.ps1
@@ -1073,8 +1073,20 @@ function Invoke-ContainerRun {
         # add OneTimeTestSetup to set variables, by having $setVariables script that will invoke in the user scope
         # and $setVariablesWithContext that carries the data as is closure, this way we avoid having to provide parameters to
         # before all script, but it might be better to make this a plugin, because there we can pass data.
+
+        # When a CI system has its debug switch enabled (e.g. Azure DevOps System.Debug or GitHub Actions
+        # runner debug logging) and the user did not opt out, surface Write-Verbose / Write-Debug from
+        # tests and setup blocks by raising the preferences in the user's root scope below. This is scoped
+        # to the run and does not leak into the caller's session afterwards. See issue #1694.
+        $surfaceCIDebugOutput = Test-CIDebugOutputEnabled -PesterPreference $PesterPreference
+
         $setVariables = {
             param($private:____parameters)
+
+            if ($____parameters.SurfaceCIDebugOutput) {
+                $VerbosePreference = 'Continue'
+                $DebugPreference = 'Continue'
+            }
 
             if ($null -eq $____parameters.Data) {
                 return
@@ -1092,8 +1104,9 @@ function Invoke-ContainerRun {
             $action = $setVariables
             $setup = $RootBlock.OneTimeTestSetup
             $parameters = @{
-                Data         = $RootBlock.BlockContainer.Data
-                Set_Variable = $SafeCommands["Set-Variable"]
+                Data                 = $RootBlock.BlockContainer.Data
+                Set_Variable         = $SafeCommands["Set-Variable"]
+                SurfaceCIDebugOutput = $surfaceCIDebugOutput
             }
 
             {

--- a/src/Pester.Utility.ps1
+++ b/src/Pester.Utility.ps1
@@ -122,6 +122,25 @@ function notDefined {
 }
 
 
+function Get-CIDebugFlag {
+    # Returns $true when a known CI system has its debug/verbose logging switch enabled.
+    # Mirrors the CI detection used for Output.CIFormat so more CI systems can be added here later.
+    # - Azure DevOps: enabling the 'System.Debug' pipeline variable sets $env:SYSTEM_DEBUG to the
+    #   literal string 'true'.
+    # - GitHub Actions: enabling step debug logging (secret/variable ACTIONS_STEP_DEBUG=true) sets
+    #   $env:RUNNER_DEBUG to '1' inside a step. This is the same signal actions/toolkit core.isDebug() uses.
+    # -eq is case-insensitive in PowerShell, so 'True'/'TRUE'/'true' all match.
+    ('true' -eq $env:SYSTEM_DEBUG) -or ('1' -eq $env:RUNNER_DEBUG)
+}
+
+function Test-CIDebugOutputEnabled ([PesterConfiguration]$PesterPreference) {
+    # CI debug-output surfacing is enabled when the user has not opted out (Output.CIDebugOutput is
+    # not 'None') and a known CI system has its debug switch enabled. Lives here in Pester.Utility so it
+    # is available both to Resolve-OutputConfiguration and to the runtime (Invoke-ContainerRun).
+    ('None' -ne $PesterPreference.Output.CIDebugOutput.Value) -and (Get-CIDebugFlag)
+}
+
+
 function sum ($InputObject, $PropertyName, $Zero) {
     if (none $InputObject.Length) {
         return $Zero

--- a/src/csharp/Pester/OutputConfiguration.cs
+++ b/src/csharp/Pester/OutputConfiguration.cs
@@ -26,6 +26,7 @@ namespace Pester
         private StringOption _stackTraceVerbosity;
         private StringOption _ciFormat;
         private StringOption _ciLogLevel;
+        private StringOption _ciDebugOutput;
         private StringOption _renderMode;
 
         public static OutputConfiguration Default { get { return new OutputConfiguration(); } }
@@ -42,6 +43,7 @@ namespace Pester
                 configuration.AssignObjectIfNotNull<string>(nameof(StackTraceVerbosity), v => StackTraceVerbosity = v);
                 configuration.AssignObjectIfNotNull<string>(nameof(CIFormat), v => CIFormat = v);
                 configuration.AssignObjectIfNotNull<string>(nameof(CILogLevel), v => CILogLevel = v);
+                configuration.AssignObjectIfNotNull<string>(nameof(CIDebugOutput), v => CIDebugOutput = v);
                 configuration.AssignObjectIfNotNull<string>(nameof(RenderMode), v => RenderMode = v);
             }
         }
@@ -52,6 +54,7 @@ namespace Pester
             StackTraceVerbosity = new StringOption("The verbosity of stacktrace output, options are None, FirstLine, Filtered and Full.", "Filtered");
             CIFormat = new StringOption("The CI format of error output in build logs, options are None, Auto, AzureDevops and GithubActions.", "Auto");
             CILogLevel = new StringOption("The CI log level in build logs, options are Error and Warning.", "Error");
+            CIDebugOutput = new StringOption("Whether to automatically surface verbose and debug output when a CI system has its debug switch enabled (Azure DevOps 'System.Debug', GitHub Actions runner debug logging), options are None and Auto.", "Auto");
             RenderMode = new StringOption("The mode used to render console output, options are Auto, Ansi, ConsoleColor and Plaintext.", "Auto");
         }
 
@@ -115,6 +118,22 @@ namespace Pester
                 else
                 {
                     _ciLogLevel = new StringOption(_ciLogLevel, value?.Value);
+                }
+            }
+        }
+
+        public StringOption CIDebugOutput
+        {
+            get { return _ciDebugOutput; }
+            set
+            {
+                if (_ciDebugOutput == null)
+                {
+                    _ciDebugOutput = value;
+                }
+                else
+                {
+                    _ciDebugOutput = new StringOption(_ciDebugOutput, value?.Value);
                 }
             }
         }

--- a/src/en-US/about_PesterConfiguration.help.txt
+++ b/src/en-US/about_PesterConfiguration.help.txt
@@ -223,6 +223,10 @@ SECTIONS AND OPTIONS
         Type: string
         Default value: 'Error'
 
+        CIDebugOutput: Whether to automatically surface verbose and debug output when a CI system has its debug switch enabled (Azure DevOps 'System.Debug', GitHub Actions runner debug logging), options are None and Auto.
+        Type: string
+        Default value: 'Auto'
+
         RenderMode: The mode used to render console output, options are Auto, Ansi, ConsoleColor and Plaintext.
         Type: string
         Default value: 'Auto'

--- a/src/functions/Output.ps1
+++ b/src/functions/Output.ps1
@@ -1143,6 +1143,19 @@ function Resolve-OutputConfiguration ([PesterConfiguration]$PesterPreference) {
         throw (Get-StringOptionErrorMessage -OptionPath 'Output.CILogLevel' -SupportedValues $supportedCILogLevels -Value $PesterPreference.Output.CILogLevel.Value)
     }
 
+    $supportedCIDebugOutput = 'None', 'Auto'
+    if ($PesterPreference.Output.CIDebugOutput.Value -notin $supportedCIDebugOutput) {
+        throw (Get-StringOptionErrorMessage -OptionPath 'Output.CIDebugOutput' -SupportedValues $supportedCIDebugOutput -Value $PesterPreference.Output.CIDebugOutput.Value)
+    }
+    elseif ((-not $PesterPreference.Output.Verbosity.IsModified) -and (Test-CIDebugOutputEnabled -PesterPreference $PesterPreference)) {
+        # A CI system has its debug switch enabled and the user did not pick a verbosity explicitly.
+        # Raise the verbosity to Diagnostic so the run shows detailed output and Pester's debug messages,
+        # matching how e.g. Azure DevOps' System.Debug makes the rest of the pipeline verbose.
+        # The user's own Write-Verbose / Write-Debug in tests is surfaced separately during the run,
+        # see Invoke-ContainerRun in Pester.Runtime.ps1.
+        $PesterPreference.Output.Verbosity = 'Diagnostic'
+    }
+
     if ('Diagnostic' -eq $PesterPreference.Output.Verbosity.Value) {
         # Enforce the default debug-output as a minimum. This is the key difference between Detailed and Diagnostic
         $PesterPreference.Debug.WriteDebugMessages = $true

--- a/tst/Pester.RSpec.Configuration.ts.ps1
+++ b/tst/Pester.RSpec.Configuration.ts.ps1
@@ -82,6 +82,10 @@ i -PassThru:$PassThru {
             [PesterConfiguration]::Default.Output.CILogLevel.Value | Verify-Equal 'Error'
         }
 
+        t "Output.CIDebugOutput is Auto" {
+            [PesterConfiguration]::Default.Output.CIDebugOutput.Value | Verify-Equal 'Auto'
+        }
+
         t "Output.RenderMode is Auto" {
             [PesterConfiguration]::Default.Output.RenderMode.Value | Verify-Equal 'Auto'
         }
@@ -1306,6 +1310,183 @@ i -PassThru:$PassThru {
             }
 
             { Invoke-Pester -Configuration $c } | Verify-Throw
+        }
+    }
+
+    b "Output.CIDebugOutput" {
+        t "Each option can be set and updated" {
+            $c = [PesterConfiguration] @{
+                Run = @{
+                    ScriptBlock = { }
+                    PassThru    = $true
+                }
+            }
+
+            foreach ($option in "None", "Auto") {
+                $c.Output.CIDebugOutput = $option
+                $r = Invoke-Pester -Configuration $c
+                $r.Configuration.Output.CIDebugOutput.Value | Verify-Equal $option
+            }
+        }
+
+        t "Exception is thrown when incorrect option is set" {
+            $sb = {
+                Describe "a" {
+                    It "b" {}
+                }
+            }
+
+            $c = [PesterConfiguration] @{
+                Run    = @{
+                    ScriptBlock = $sb
+                    PassThru    = $true
+                    Throw       = $true
+                }
+                Output = @{
+                    CIDebugOutput = 'Something'
+                }
+            }
+
+            { Invoke-Pester -Configuration $c } | Verify-Throw
+        }
+
+        t "Raises Output.Verbosity to Diagnostic when a CI debug flag is set and Verbosity is not set" {
+            $c = [PesterConfiguration] @{
+                Run = @{
+                    ScriptBlock = { }
+                    PassThru    = $true
+                }
+            }
+
+            $previousSystemDebug = $env:SYSTEM_DEBUG
+            $previousRunnerDebug = $env:RUNNER_DEBUG
+            $env:SYSTEM_DEBUG = 'true'
+            $env:RUNNER_DEBUG = $null
+
+            try {
+                $r = Invoke-Pester -Configuration $c
+                $r.Configuration.Output.Verbosity.Value | Verify-Equal 'Diagnostic'
+            }
+            finally {
+                $env:SYSTEM_DEBUG = $previousSystemDebug
+                $env:RUNNER_DEBUG = $previousRunnerDebug
+            }
+        }
+
+        t "Does not override an explicit Output.Verbosity when a CI debug flag is set" {
+            $c = [PesterConfiguration] @{
+                Run    = @{
+                    ScriptBlock = { }
+                    PassThru    = $true
+                }
+                Output = @{
+                    Verbosity = 'Detailed'
+                }
+            }
+
+            $previousSystemDebug = $env:SYSTEM_DEBUG
+            $previousRunnerDebug = $env:RUNNER_DEBUG
+            $env:SYSTEM_DEBUG = 'true'
+            $env:RUNNER_DEBUG = $null
+
+            try {
+                $r = Invoke-Pester -Configuration $c
+                $r.Configuration.Output.Verbosity.Value | Verify-Equal 'Detailed'
+            }
+            finally {
+                $env:SYSTEM_DEBUG = $previousSystemDebug
+                $env:RUNNER_DEBUG = $previousRunnerDebug
+            }
+        }
+
+        t "Surfaces Write-Verbose and Write-Debug from a test when a CI debug flag is set" {
+            $c = [PesterConfiguration] @{
+                Run    = @{
+                    ScriptBlock = {
+                        Describe "d" {
+                            It "i" {
+                                Write-Verbose "verbose-from-test-marker"
+                                Write-Debug "debug-from-test-marker"
+                                $true | Should -BeTrue
+                            }
+                        }
+                    }
+                    PassThru    = $true
+                }
+                # Keep Pester's own output quiet so we only observe the surfaced test output.
+                Output = @{
+                    Verbosity = 'None'
+                }
+            }
+
+            $previousSystemDebug = $env:SYSTEM_DEBUG
+            $previousRunnerDebug = $env:RUNNER_DEBUG
+            $env:SYSTEM_DEBUG = 'true'
+            $env:RUNNER_DEBUG = $null
+
+            try {
+                $output = Invoke-Pester -Configuration $c 5>&1 4>&1
+            }
+            finally {
+                $env:SYSTEM_DEBUG = $previousSystemDebug
+                $env:RUNNER_DEBUG = $previousRunnerDebug
+            }
+
+            $foundVerbose = $false
+            $foundDebug = $false
+            foreach ($item in @($output)) {
+                if ($item -is [System.Management.Automation.VerboseRecord] -and $item.Message -eq 'verbose-from-test-marker') {
+                    $foundVerbose = $true
+                }
+                if ($item -is [System.Management.Automation.DebugRecord] -and $item.Message -eq 'debug-from-test-marker') {
+                    $foundDebug = $true
+                }
+            }
+
+            $foundVerbose | Verify-True
+            $foundDebug | Verify-True
+        }
+
+        t "Does not surface Write-Verbose from a test when opted out with 'None'" {
+            $c = [PesterConfiguration] @{
+                Run    = @{
+                    ScriptBlock = {
+                        Describe "d" {
+                            It "i" {
+                                Write-Verbose "verbose-from-test-marker"
+                                $true | Should -BeTrue
+                            }
+                        }
+                    }
+                    PassThru    = $true
+                }
+                Output = @{
+                    Verbosity     = 'None'
+                    CIDebugOutput = 'None'
+                }
+            }
+
+            $previousSystemDebug = $env:SYSTEM_DEBUG
+            $previousRunnerDebug = $env:RUNNER_DEBUG
+            $env:SYSTEM_DEBUG = 'true'
+            $env:RUNNER_DEBUG = $null
+
+            try {
+                $output = Invoke-Pester -Configuration $c 5>&1 4>&1
+            }
+            finally {
+                $env:SYSTEM_DEBUG = $previousSystemDebug
+                $env:RUNNER_DEBUG = $previousRunnerDebug
+            }
+
+            $foundVerbose = $false
+            foreach ($item in @($output)) {
+                if ($item -is [System.Management.Automation.VerboseRecord] -and $item.Message -eq 'verbose-from-test-marker') {
+                    $foundVerbose = $true
+                }
+            }
+
+            $foundVerbose | Verify-False
         }
     }
 

--- a/tst/functions/Output.Tests.ps1
+++ b/tst/functions/Output.Tests.ps1
@@ -668,6 +668,139 @@ InModuleScope -ModuleName Pester -ScriptBlock {
             }
         }
     }
+
+    Describe 'Get-CIDebugFlag' {
+        BeforeAll {
+            $script:originalSystemDebug = $env:SYSTEM_DEBUG
+            $script:originalRunnerDebug = $env:RUNNER_DEBUG
+        }
+        AfterAll {
+            $env:SYSTEM_DEBUG = $script:originalSystemDebug
+            $env:RUNNER_DEBUG = $script:originalRunnerDebug
+        }
+        BeforeEach {
+            $env:SYSTEM_DEBUG = $null
+            $env:RUNNER_DEBUG = $null
+        }
+
+        It 'returns $false when no CI debug flag is set' {
+            Get-CIDebugFlag | Should -BeFalse
+        }
+
+        It "returns `$true when Azure DevOps System.Debug is '<value>' (case-insensitive)" -TestCases @(
+            @{ Value = 'true' }
+            @{ Value = 'True' }
+            @{ Value = 'TRUE' }
+        ) {
+            $env:SYSTEM_DEBUG = $Value
+            Get-CIDebugFlag | Should -BeTrue
+        }
+
+        It "returns `$false when Azure DevOps System.Debug is 'false'" {
+            $env:SYSTEM_DEBUG = 'false'
+            Get-CIDebugFlag | Should -BeFalse
+        }
+
+        It "returns `$true when GitHub Actions RUNNER_DEBUG is '1'" {
+            $env:RUNNER_DEBUG = '1'
+            Get-CIDebugFlag | Should -BeTrue
+        }
+
+        It "returns `$false when GitHub Actions RUNNER_DEBUG is '0'" {
+            $env:RUNNER_DEBUG = '0'
+            Get-CIDebugFlag | Should -BeFalse
+        }
+    }
+
+    Describe 'Test-CIDebugOutputEnabled' {
+        BeforeAll {
+            $script:originalSystemDebug = $env:SYSTEM_DEBUG
+            $script:originalRunnerDebug = $env:RUNNER_DEBUG
+        }
+        AfterAll {
+            $env:SYSTEM_DEBUG = $script:originalSystemDebug
+            $env:RUNNER_DEBUG = $script:originalRunnerDebug
+        }
+        BeforeEach {
+            $env:SYSTEM_DEBUG = $null
+            $env:RUNNER_DEBUG = $null
+        }
+
+        It 'is $true when a CI debug flag is set and not opted out' {
+            $env:SYSTEM_DEBUG = 'true'
+            $c = [PesterConfiguration]::Default
+            Test-CIDebugOutputEnabled -PesterPreference $c | Should -BeTrue
+        }
+
+        It "is `$false when opted out via CIDebugOutput = 'None'" {
+            $env:SYSTEM_DEBUG = 'true'
+            $c = [PesterConfiguration]::Default
+            $c.Output.CIDebugOutput = 'None'
+            Test-CIDebugOutputEnabled -PesterPreference $c | Should -BeFalse
+        }
+
+        It 'is $false when no CI debug flag is set' {
+            $c = [PesterConfiguration]::Default
+            Test-CIDebugOutputEnabled -PesterPreference $c | Should -BeFalse
+        }
+    }
+
+    Describe 'Resolve-OutputConfiguration - CI debug output' {
+        BeforeAll {
+            $script:originalSystemDebug = $env:SYSTEM_DEBUG
+            $script:originalRunnerDebug = $env:RUNNER_DEBUG
+        }
+        AfterAll {
+            $env:SYSTEM_DEBUG = $script:originalSystemDebug
+            $env:RUNNER_DEBUG = $script:originalRunnerDebug
+        }
+        BeforeEach {
+            $env:SYSTEM_DEBUG = $null
+            $env:RUNNER_DEBUG = $null
+        }
+
+        It 'raises Verbosity to Diagnostic when Azure DevOps System.Debug is enabled and Verbosity is unset' {
+            $env:SYSTEM_DEBUG = 'true'
+            $c = [PesterConfiguration]::Default
+            Resolve-OutputConfiguration -PesterPreference $c
+            $c.Output.Verbosity.Value | Should -Be 'Diagnostic'
+        }
+
+        It 'raises Verbosity to Diagnostic when GitHub Actions RUNNER_DEBUG is enabled and Verbosity is unset' {
+            $env:RUNNER_DEBUG = '1'
+            $c = [PesterConfiguration]::Default
+            Resolve-OutputConfiguration -PesterPreference $c
+            $c.Output.Verbosity.Value | Should -Be 'Diagnostic'
+        }
+
+        It 'does not change Verbosity when no CI debug flag is set' {
+            $c = [PesterConfiguration]::Default
+            Resolve-OutputConfiguration -PesterPreference $c
+            $c.Output.Verbosity.Value | Should -Be 'Normal'
+        }
+
+        It 'does not override an explicit Verbosity choice' {
+            $env:SYSTEM_DEBUG = 'true'
+            $c = [PesterConfiguration]::Default
+            $c.Output.Verbosity = 'Detailed'
+            Resolve-OutputConfiguration -PesterPreference $c
+            $c.Output.Verbosity.Value | Should -Be 'Detailed'
+        }
+
+        It "does nothing when opted out via CIDebugOutput = 'None'" {
+            $env:SYSTEM_DEBUG = 'true'
+            $c = [PesterConfiguration]::Default
+            $c.Output.CIDebugOutput = 'None'
+            Resolve-OutputConfiguration -PesterPreference $c
+            $c.Output.Verbosity.Value | Should -Be 'Normal'
+        }
+
+        It 'throws for an unsupported CIDebugOutput value' {
+            $c = [PesterConfiguration]::Default
+            $c.Output.CIDebugOutput = 'Bogus'
+            { Resolve-OutputConfiguration -PesterPreference $c } | Should -Throw -ExpectedMessage '*Output.CIDebugOutput*'
+        }
+    }
 }
 
 # Can't run inside InModuleScope Pester { } because variables defined in BeforeDiscovery will be lost due to same module state as scriptblock = no testcases


### PR DESCRIPTION
Fix #1694

## Problem

In Azure DevOps, turning on the `System.Debug` pipeline flag makes PowerShell verbose **everywhere except inside Pester tests**: a `Write-Verbose` in a test stays hidden unless the user manually sets `$VerbosePreference = 'Continue'`. Pester deliberately never mutates the user's ambient preference variables, and the `-Verbose` common parameter does not propagate into the test script blocks (they run in a separate session state without `CmdletBinding`), so the pipeline debug switch has no effect on test output. The same gap exists in GitHub Actions.

## What this does

When a known CI system has its debug switch enabled — and the user has not opted out — Pester makes the run more verbose automatically:

- **Raises `Output.Verbosity` to `Diagnostic`**, but only when the user did not set a verbosity explicitly. This mirrors how `System.Debug` makes the rest of the pipeline verbose, and also turns on Pester's own debug messages.
- **Surfaces the user's own `Write-Verbose` / `Write-Debug`** from tests and setup blocks, by setting `$VerbosePreference` / `$DebugPreference` to `Continue` in the test-container root scope. This is scoped to the run and does **not** leak into the caller's session afterwards.

The two behaviours are independent: an explicit `Output.Verbosity = 'Detailed'` is respected (not overridden), yet the test's `Write-Verbose` is still surfaced.

## Detected CI debug flags

| CI | Env var | Enabled value |
|----|---------|---------------|
| Azure DevOps (`System.Debug`) | `SYSTEM_DEBUG` | `true` (compared case-insensitively) |
| GitHub Actions (step debug logging) | `RUNNER_DEBUG` | `1` (the same signal `actions/toolkit` `core.isDebug()` uses) |

Detection lives in a small, CI-agnostic helper pair (`Get-CIDebugFlag` / `Test-CIDebugOutputEnabled` in `Pester.Utility`), mirroring the existing `TF_BUILD` / `GITHUB_ACTIONS` detection used for `Output.CIFormat`, so more CI systems can be added in one place later. It lives in `Pester.Utility` so both `Resolve-OutputConfiguration` and the runtime (`Invoke-ContainerRun`) can reuse the same detection.

## Example

A test that logs progress with `Write-Verbose`:

```powershell
# Sample.Tests.ps1
Describe 'Deploy' {
    It 'creates the resource' {
        Write-Verbose "Requesting resource from https://example.test"
        Write-Debug   "raw response: { id = 42 }"
        $result = 42
        $result | Should -Be 42
    }
}
```

**Before this change** — even with the CI debug flag on, the verbose/debug lines are hidden:

```
Describing Deploy
  [+] creates the resource 8ms
Tests Passed: 1, Failed: 0
```

**After this change** — with the CI debug flag on, the same run shows the messages (verbosity is raised to `Diagnostic`):

```
Describing Deploy
VERBOSE: Requesting resource from https://example.test
DEBUG: raw response: { id = 42 }
  [+] creates the resource 9ms
Tests Passed: 1, Failed: 0
```

### Azure DevOps

Turn on `System.Debug` — either queue the pipeline with the **Debug** system diagnostics checkbox, or set the variable in YAML:

```yaml
variables:
  system.debug: true          # sets SYSTEM_DEBUG=true for every step

steps:
  - pwsh: Invoke-Pester -Path ./tests
    displayName: Run Pester
```

### GitHub Actions

Turn on step debug logging — either re-run the job with **"Enable debug logging"**, or set the repository secret/variable `ACTIONS_STEP_DEBUG=true`. The runner then exposes `RUNNER_DEBUG=1` inside each step:

```yaml
jobs:
  test:
    runs-on: ubuntu-latest
    steps:
      - uses: actions/checkout@v4
      - shell: pwsh
        run: Invoke-Pester -Path ./tests
```

No change to the test code or the Pester invocation is required in either case.

## Opt-out

A new `Output.CIDebugOutput` option (`None`, `Auto`; default `Auto`) controls the behaviour. Set it to `None` to disable both the verbosity raise and the verbose/debug surfacing even when a CI debug flag is present:

```powershell
$config = New-PesterConfiguration
$config.Output.CIDebugOutput = 'None'
$config.Run.Path = './tests'
Invoke-Pester -Configuration $config
```

Choosing a verbosity explicitly keeps that choice — the run stays at `Detailed`, but the test's `Write-Verbose` is still surfaced:

```powershell
$config = New-PesterConfiguration
$config.Output.Verbosity = 'Detailed'   # not overridden to Diagnostic
$config.Run.Path = './tests'
Invoke-Pester -Configuration $config
```

## Tests

- `tst/functions/Output.Tests.ps1` — unit tests for `Get-CIDebugFlag`, `Test-CIDebugOutputEnabled`, and the `Resolve-OutputConfiguration` behaviour (Azure DevOps flag, GitHub Actions flag, no-CI default, explicit-verbosity not overridden, opt-out, and invalid value throws).
- `tst/Pester.RSpec.Configuration.ts.ps1` — default value, set/update, invalid-throws, and end-to-end integration tests that run a real `Invoke-Pester` and assert both the verbosity raise and the surfaced `Write-Verbose` / `Write-Debug` (including the opt-out case).

All P-tests and the affected Pester tests pass, and `Invoke-ScriptAnalyzer` on `./src` reports no new findings versus the baseline.