### PR TITLE
Fix code coverage false negative for steppable-pipeline proxy functions

### DIFF
--- a/src/functions/Coverage.ps1
+++ b/src/functions/Coverage.ps1
@@ -425,7 +425,7 @@ function IsIgnoredCommand {
         return $true
     }
 
-    if ($Command.Extent.Text -match '^{?& \$wrappedCmd @PSBoundParameters ?}?$' -and
+    if ($Command.Extent.Text -match '^{? ?& \$wrappedCmd @PSBoundParameters ?}?$' -and
         (Get-AstTopParent -Ast $Command) -like '*$steppablePipeline.Begin($PSCmdlet)*$steppablePipeline.Process($_)*$steppablePipeline.End()*' ) {
         # Fix for proxy function wrapped pipeline command. PowerShell does not increment the hit count when
         # these functions are executed using the steppable pipeline; further, these checks are redundant, as

--- a/tst/functions/Coverage.Tests.ps1
+++ b/tst/functions/Coverage.Tests.ps1
@@ -1012,6 +1012,72 @@ InPesterModuleScope {
                 }
             }
         }
+
+        # https://github.com/pester/Pester/issues/1143
+        # The '& $wrappedCmd @PSBoundParameters' line inside a steppable-pipeline proxy
+        # function must not be reported as missed. PowerShell never fires the breakpoint on
+        # that scriptblock (the command runs through the steppable pipeline), so both the
+        # inner command and the scriptblock-literal wrapper it lives in are ignored.
+        Context 'Steppable-pipeline proxy function using <description>' -Foreach @(
+            @{ UseBreakpoints = $true; Description = "breakpoints" }
+            @{ UseBreakpoints = $false; Description = "Profiler based cc" }
+        ) {
+            BeforeAll {
+                $proxyScriptPath = Join-Path -Path $root -ChildPath TestScriptProxy.ps1
+                Set-Content -Path $proxyScriptPath -Value @'
+                function Test-Proxy {
+                    [CmdletBinding()]
+                    param(
+                        [Parameter(Position = 0, ValueFromPipeline, ValueFromRemainingArguments)]
+                        [object] $InputObject
+                    )
+                    begin {
+                        $wrappedCmd = $ExecutionContext.InvokeCommand.GetCommand('Microsoft.PowerShell.Utility\Write-Output', [System.Management.Automation.CommandTypes]::Cmdlet)
+                        $scriptCmd = { & $wrappedCmd @PSBoundParameters }
+                        $steppablePipeline = $scriptCmd.GetSteppablePipeline($myInvocation.CommandOrigin)
+                        $steppablePipeline.Begin($PSCmdlet)
+                    }
+                    process {
+                        $steppablePipeline.Process($_)
+                    }
+                    end {
+                        $steppablePipeline.End()
+                    }
+                }
+
+                Test-Proxy 'hello' | Out-Null
+'@
+
+                $breakpoints = Enter-CoverageAnalysis -CodeCoverage @{ Path = $proxyScriptPath; Function = 'Test-Proxy' } -UseBreakpoints $UseBreakpoints
+
+                @($breakpoints).Count | Should -Be 5 -Because 'the & $wrappedCmd call and the scriptblock literal wrapping it are ignored'
+
+                if ($UseBreakpoints) {
+                    & $proxyScriptPath | Out-Null
+                }
+                else {
+                    $patched, $tracer = Start-TraceScript $breakpoints
+                    try { & $proxyScriptPath | Out-Null } finally { Stop-TraceScript -Patched $patched }
+                    $measure = $tracer.Hits
+                }
+
+                $coverageReport = Get-CoverageReport -CommandCoverage $breakpoints -Measure $measure
+            }
+
+            It 'Reports no missed commands for the steppable-pipeline proxy' {
+                $coverageReport.MissedCommands.Count | Should -Be 0
+            }
+
+            It 'Reports every analyzed command as executed' {
+                $coverageReport.NumberOfCommandsExecuted | Should -Be $coverageReport.NumberOfCommandsAnalyzed
+            }
+
+            AfterAll {
+                if ($UseBreakpoints) {
+                    Exit-CoverageAnalysis -CommandCoverage $breakpoints
+                }
+            }
+        }
     }
 
     Describe 'Path resolution for test files' {


### PR DESCRIPTION
Fix #1143

## Problem

Code coverage marked the `{ & $wrappedCmd @PSBoundParameters }` line inside a steppable-pipeline proxy function (e.g. a `Write-Host`/`Write-Output` proxy generated from `[System.Management.Automation.ProxyCommand]`) as **not covered**, even when the function was fully exercised.

Repro'd on current `main` (`6.1.0-alpha1`): the false negative now only occurs with the **legacy breakpoint engine** (`CodeCoverage.UseBreakpoints = $true`). The default profiler-based engine already reports the line as covered.

## Root cause

`IsIgnoredCommand` in `src/functions/Coverage.ps1` (added in #1656, the original #1143 fix) ignores the breakpoint for this pattern because PowerShell never increments its hit count when the command runs through the steppable pipeline. The regex was written with optional braces — `^{?& \$wrappedCmd @PSBoundParameters ?}?$` — to match **both** the inner `& $wrappedCmd @PSBoundParameters` command *and* the scriptblock literal wrapping it.

However, the wrapper's AST text is `{ & $wrappedCmd @PSBoundParameters }` — **with spaces inside the braces** — so `^{?& ` (brace immediately followed by `&`) never matched it. This didn't surface until the Pester 5 rewrite, whose `CoverageLocationVisitor.VisitCommandExpression` emits that scriptblock literal as its own `CommandExpressionAst` coverage point. The breakpoint set on it never fires, so it was reported as missed.

## Fix

Allow the optional space after `{` so the wrapper is ignored as well, matching the profiler engine:

```diff
-    if ($Command.Extent.Text -match '^{?& \$wrappedCmd @PSBoundParameters ?}?$' -and
+    if ($Command.Extent.Text -match '^{? ?& \$wrappedCmd @PSBoundParameters ?}?$' -and
```

The ignore remains gated by the existing top-parent check (`*$steppablePipeline.Begin($PSCmdlet)*$steppablePipeline.Process($_)*$steppablePipeline.End()*`), so it only affects the standard proxy/steppable-pipeline shape.

## Verification

- Added a regression test to `tst/functions/Coverage.Tests.ps1` exercising **both** engines. It fails on the breakpoint engine without the fix (analyzed breakpoint count `6` and one missed command) and passes with it (count `5`, zero missed).
- Full `tst/functions/Coverage.Tests.ps1` suite: **121 passed, 0 failed**.
- Before the fix: profiler `0 missed / 100%`, breakpoint `1 missed`. After the fix: both engines `0 missed / 100%`.