### PR TITLE
Fix false error in CI

### DIFF
--- a/tst/Pester.RSpec.Configuration.ts.ps1
+++ b/tst/Pester.RSpec.Configuration.ts.ps1
@@ -1343,6 +1343,7 @@ i -PassThru:$PassThru {
                     Throw       = $true
                 }
                 Output = @{
+                    CIFormat      = 'None'
                     CIDebugOutput = 'Something'
                 }
             }


### PR DESCRIPTION
## PR Summary
New CIDebugOutput tests outputs an error by design. Disabling CIFormat to avoid it being flagged in report.

Related #2870

## PR Checklist

- [x] PR has meaningful title
- [x] Summary describes changes
- [x] PR is ready to be merged
  - If not, use the arrow next to `Create Pull Request` to mark it as a draft. PR can be marked `Ready for review` when it's ready.
- [x] Tests are added/update *(if required)*
- [ ] Documentation is updated/added *(if required)*