### PR TITLE
Fix flaky test on Windows CI

### DIFF
--- a/src/Pester.Runtime.ps1
+++ b/src/Pester.Runtime.ps1
@@ -999,7 +999,7 @@ function Invoke-ContainerDiscovery {
 
     $root.DiscoveryDuration = $perContainerDiscoveryDuration.Elapsed
     if ($PesterPreference.Debug.WriteDebugMessages.Value) {
-        Write-PesterDebugMessage -Scope Discovery -LazyMessage { "Found $(@(View-Flat -Block $root).Count) tests in $([int]$root.DiscoveryDuration.TotalMilliseconds) ms" }
+        Write-PesterDebugMessage -Scope Discovery -LazyMessage { "Found $(@(View-Flat -Block $root).Count) tests in $([int]$root.DiscoveryDuration.TotalMilliseconds)ms" }
         Write-PesterDebugMessage -Scope DiscoveryCore "Discovery done in this container."
     }
 
@@ -1320,14 +1320,14 @@ function Invoke-PluginStep {
             } while ($false)
 
             if ($PesterPreference.Debug.WriteDebugMessages.Value) {
-                Write-PesterDebugMessage -Scope Plugin "Success $($p.Name) step $Step in $($stepSw.ElapsedMilliseconds) ms"
+                Write-PesterDebugMessage -Scope Plugin "Success $($p.Name) step $Step in $($stepSw.ElapsedMilliseconds)ms"
             }
         }
         catch {
             $failed = $true
             $err.Add($_)
             if ($PesterPreference.Debug.WriteDebugMessages.Value) {
-                Write-PesterDebugMessage -Scope Plugin "Failed $($p.Name) step $Step in $($stepSw.ElapsedMilliseconds) ms" -ErrorRecord $_
+                Write-PesterDebugMessage -Scope Plugin "Failed $($p.Name) step $Step in $($stepSw.ElapsedMilliseconds)ms" -ErrorRecord $_
             }
         }
     }

--- a/src/functions/Coverage.Plugin.ps1
+++ b/src/functions/Coverage.Plugin.ps1
@@ -102,7 +102,7 @@
             })
 
         if ($PesterPreference.Output.Verbosity.Value -in "Detailed", "Diagnostic") {
-            Write-PesterHostMessage -ForegroundColor Magenta "Code Coverage preparation finished after $($sw.ElapsedMilliseconds) ms."
+            Write-PesterHostMessage -ForegroundColor Magenta "Code Coverage preparation finished after $($sw.ElapsedMilliseconds)ms."
         }
     }
 
@@ -213,7 +213,7 @@
             }
         }
         if ($PesterPreference.Output.Verbosity.Value -in 'Detailed', 'Diagnostic') {
-            Write-PesterHostMessage -ForegroundColor Magenta "Code Coverage result processed in $($sw.ElapsedMilliseconds) ms."
+            Write-PesterHostMessage -ForegroundColor Magenta "Code Coverage result processed in $($sw.ElapsedMilliseconds)ms."
         }
         $reportText = Write-CoverageReport $coverageReport
 

--- a/src/functions/Coverage.ps1
+++ b/src/functions/Coverage.ps1
@@ -28,7 +28,7 @@
     # not actual breakpoints
     $breakpoints = @(Get-CoverageBreakpoints -CoverageInfo $coverageInfo -Logger $Logger)
     if ($null -ne $logger) {
-        & $logger "Figuring out $($breakpoints.Count) measurable code locations took $($sw.ElapsedMilliseconds) ms."
+        & $logger "Figuring out $($breakpoints.Count) measurable code locations took $($sw.ElapsedMilliseconds)ms."
     }
 
     if ($UseBreakpoints) {
@@ -76,7 +76,7 @@
         $sw.Stop()
 
         if ($null -ne $logger) {
-            & $logger "Setting $($breakpoints.Count) breakpoints took $($sw.ElapsedMilliseconds) ms."
+            & $logger "Setting $($breakpoints.Count) breakpoints took $($sw.ElapsedMilliseconds)ms."
         }
     }
     else {
@@ -110,7 +110,7 @@ function Exit-CoverageAnalysis {
     }
 
     if ($null -ne $logger) {
-        & $logger "Removing $($breakpoints.Count) breakpoints took $($sw.ElapsedMilliseconds) ms."
+        & $logger "Removing $($breakpoints.Count) breakpoints took $($sw.ElapsedMilliseconds)ms."
     }
 }
 
@@ -272,7 +272,7 @@ function Get-CoverageBreakpoints {
             }
         }
         if ($null -ne $Logger) {
-            & $Logger  "Analyzing $analyzedCommands of $totalCommands commands in file '$($fileGroup.Name)' for code coverage, in $($sw.ElapsedMilliseconds) ms"
+            & $Logger  "Analyzing $analyzedCommands of $totalCommands commands in file '$($fileGroup.Name)' for code coverage, in $($sw.ElapsedMilliseconds)ms"
         }
     }
 }

--- a/tst/Pester.RSpec.Parallel.ts.ps1
+++ b/tst/Pester.RSpec.Parallel.ts.ps1
@@ -710,7 +710,7 @@ Running tests from 'A.Tests.ps1'
 Describing A
   [+] a1 passes <time>
 Discovery: Discovering tests in B.Tests.ps1
-Discovery: Found 1 tests in <time>ms
+Discovery: Found 1 tests in <time>
 
 Running tests from 'B.Tests.ps1'
 Describing B

--- a/tst/Pester.RSpec.Parallel.ts.ps1
+++ b/tst/Pester.RSpec.Parallel.ts.ps1
@@ -694,8 +694,7 @@ Describe 'B' { It 'b1 passes' { 1 | Should -Be 1 } }
                     $normalized = $sb.ToString() `
                         -replace 'Pester v\S+', 'Pester v<version>' `
                         -replace ([regex]::Escape($folder + [IO.Path]::DirectorySeparatorChar)), '' `
-                        -replace '\d+ ms', '<time> ms' `
-                        -replace '\d+ms', '<time>ms'
+                        -replace '\d+(.\d+)?m?s', '<time>'
                     $actual = (($normalized -split "`r`n|`r|`n").ForEach({ $_.TrimEnd() }) -join "`n").Trim()
 
                     # Each file's discovery is immediately followed by that same file's run - A fully, then
@@ -705,18 +704,18 @@ Pester v<version>
 
 Running tests from 2 files in parallel.
 Discovery: Discovering tests in A.Tests.ps1
-Discovery: Found 1 tests in <time> ms
+Discovery: Found 1 tests in <time>
 
 Running tests from 'A.Tests.ps1'
 Describing A
-  [+] a1 passes <time>ms
+  [+] a1 passes <time>
 Discovery: Discovering tests in B.Tests.ps1
-Discovery: Found 1 tests in <time> ms
+Discovery: Found 1 tests in <time>ms
 
 Running tests from 'B.Tests.ps1'
 Describing B
-  [+] b1 passes <time>ms
-Tests completed in <time>ms
+  [+] b1 passes <time>
+Tests completed in <time>
 Tests Passed: 2, Failed: 0, Skipped: 0, Inconclusive: 0, NotRun: 0
 '@ -replace "`r`n", "`n"
 

--- a/tst/Pester.Runtime.ts.ps1
+++ b/tst/Pester.Runtime.ts.ps1
@@ -2134,15 +2134,15 @@ i -PassThru:$PassThru {
             $totalReported = $actualDuration + $actualFrameworkDuration + $actualDiscoveryDuration
             $totalDifference = $container.Total - $totalReported
             $testCount = $cs.Count * $bs.Count * $ts.Count
-            Write-Host Test count $testCount
-            Write-Host Per test $([int]($container.Total.TotalMilliseconds / $testCount)) ms
-            Write-Host Per test without discovery $([int](($actualDuration + $actualFrameworkDuration).TotalMilliseconds / $testCount)) ms
-            Write-Host Reported discovery duration $actualDiscoveryDuration.TotalMilliseconds ms
-            Write-Host Reported total duration $actualDuration.TotalMilliseconds ms
-            Write-Host Reported total overhead $actualFrameworkDuration.TotalMilliseconds ms
-            Write-Host Reported total $totalReported.TotalMilliseconds ms
-            Write-Host Measured total $container.Total.TotalMilliseconds ms
-            Write-Host Total difference $totalDifference.TotalMilliseconds ms
+            Write-Host "Test count $testCount"
+            Write-Host "Per test $([int]($container.Total.TotalMilliseconds / $testCount))ms"
+            Write-Host "Per test without discovery $([int](($actualDuration + $actualFrameworkDuration).TotalMilliseconds / $testCount))ms"
+            Write-Host "Reported discovery duration $($actualDiscoveryDuration.TotalMilliseconds)ms"
+            Write-Host "Reported total duration $($actualDuration.TotalMilliseconds)ms"
+            Write-Host "Reported total overhead $($actualFrameworkDuration.TotalMilliseconds)ms"
+            Write-Host "Reported total $($totalReported.TotalMilliseconds)ms"
+            Write-Host "Measured total $($container.Total.TotalMilliseconds)ms"
+            Write-Host "Total difference $($totalDifference.TotalMilliseconds)ms"
 
 
             # the difference here is because of the code that is running after all tests have been discovered


### PR DESCRIPTION
## PR Summary
Fixing a flaky output test because Windows might use seconds and not milliseconds.

Includes minor cleanup in output to remove whitespace between time and time suffix. Future PR should consider extracting `Get-HumanTime` from `Output.ps1` to `Pester.Utility.ps1` to get consistency.

## PR Checklist

- [x] PR has meaningful title
- [x] Summary describes changes
- [x] PR is ready to be merged
  - If not, use the arrow next to `Create Pull Request` to mark it as a draft. PR can be marked `Ready for review` when it's ready.
- [x] Tests are added/update *(if required)*
- [ ] Documentation is updated/added *(if required)*