### PR TITLE
Migrate Should-MatchString.Tests.ps1 to Verify-* assertions

### DIFF
--- a/tst/functions/assert/String/Should-MatchString.Tests.ps1
+++ b/tst/functions/assert/String/Should-MatchString.Tests.ps1
@@ -20,13 +20,13 @@ Describe "Should-MatchString" {
         }
 
         It "Fails when the regular expression does not match" {
-            { Should-MatchString -Expected "^\d+$" -Actual "foobar" } | Should -Throw -ErrorId "PesterAssertionFailed"
+            { Should-MatchString -Expected "^\d+$" -Actual "foobar" } | Verify-AssertionFailed
         }
     }
 
     Context "Case sensitive matching" {
         It "Fails when only case-insensitive matching would succeed" {
-            { Should-MatchString -Actual "foobar" -Expected "FOO.*BAR" -CaseSensitive } | Should -Throw -ErrorId "PesterAssertionFailed"
+            { Should-MatchString -Actual "foobar" -Expected "FOO.*BAR" -CaseSensitive } | Verify-AssertionFailed
         }
 
         It "Passes when the case-sensitive pattern matches" {
@@ -47,28 +47,28 @@ Describe "Should-MatchString" {
     }
 
     It "Throws when given a collection as actual" {
-        $err = { "abc", "def" | Should-MatchString -Expected "abc" } | Should -Throw -PassThru
-        $err.Exception.Message | Should -Be "Actual is expected to be string, to avoid confusing behavior that -match operator exhibits with collections. To assert on collections use Should-Any, Should-All or some other collection assertion."
+        $err = { "abc", "def" | Should-MatchString -Expected "abc" } | Verify-Throw
+        $err.Exception.Message | Verify-Equal "Actual is expected to be string, to avoid confusing behavior that -match operator exhibits with collections. To assert on collections use Should-Any, Should-All or some other collection assertion."
     }
 
     It "Throws when given a non-string pattern" {
-        $err = { Should-MatchString -Actual "abc" -Expected 123 } | Should -Throw -PassThru
-        $err.Exception.Message | Should -Be "Expected is expected to be string, to avoid confusing behavior that -match operator exhibits with collections."
+        $err = { Should-MatchString -Actual "abc" -Expected 123 } | Verify-Throw
+        $err.Exception.Message | Verify-Equal "Expected is expected to be string, to avoid confusing behavior that -match operator exhibits with collections."
     }
 
     It "Can be called with positional parameters" {
-        { Should-MatchString "^\d+$" "abc" } | Should -Throw -ErrorId "PesterAssertionFailed"
+        { Should-MatchString "^\d+$" "abc" } | Verify-AssertionFailed
     }
 
     Context "Verify messages" {
         It "Returns the correct message for failed matches" {
-            $err = { Should-MatchString -Actual "ab" -Expected "\d" -Because "reason" } | Should -Throw -PassThru
-            $err.Exception.Message | Should -Be "Expected the string 'ab' to match pattern '\d', because reason, but it did not."
+            $err = { Should-MatchString -Actual "ab" -Expected "\d" -Because "reason" } | Verify-AssertionFailed
+            $err.Exception.Message | Verify-Equal "Expected the string 'ab' to match pattern '\d', because reason, but it did not."
         }
 
         It "Returns the correct message for failed case-sensitive matches" {
-            $err = { Should-MatchString -Actual "ab" -Expected "AB" -CaseSensitive } | Should -Throw -PassThru
-            $err.Exception.Message | Should -Be "Expected the string 'ab' to case sensitively match pattern 'AB', but it did not."
+            $err = { Should-MatchString -Actual "ab" -Expected "AB" -CaseSensitive } | Verify-AssertionFailed
+            $err.Exception.Message | Verify-Equal "Expected the string 'ab' to case sensitively match pattern 'AB', but it did not."
         }
     }
 }
@@ -80,11 +80,11 @@ Describe "Should-NotMatchString" {
         }
 
         It "Fails when the string matches the regular expression" {
-            { Should-NotMatchString -Expected "foo.*bar" -Actual "foobar" } | Should -Throw -ErrorId "PesterAssertionFailed"
+            { Should-NotMatchString -Expected "foo.*bar" -Actual "foobar" } | Verify-AssertionFailed
         }
 
         It "Fails for strings with different case" {
-            { Should-NotMatchString -Expected "FOO.*BAR" -Actual "foobar" } | Should -Throw -ErrorId "PesterAssertionFailed"
+            { Should-NotMatchString -Expected "FOO.*BAR" -Actual "foobar" } | Verify-AssertionFailed
         }
 
         It "Passes for multiple regex examples. comparing '<actual>':'<expected>'" -TestCases @(
@@ -103,7 +103,7 @@ Describe "Should-NotMatchString" {
         }
 
         It "Fails when the case-sensitive pattern matches" {
-            { Should-NotMatchString -Actual "FooBar" -Expected "Foo.*Bar" -CaseSensitive } | Should -Throw -ErrorId "PesterAssertionFailed"
+            { Should-NotMatchString -Actual "FooBar" -Expected "Foo.*Bar" -CaseSensitive } | Verify-AssertionFailed
         }
     }
 
@@ -120,28 +120,28 @@ Describe "Should-NotMatchString" {
     }
 
     It "Throws when given a collection as actual" {
-        $err = { "abc", "def" | Should-NotMatchString -Expected "abc" } | Should -Throw -PassThru
-        $err.Exception.Message | Should -Be "Actual is expected to be string, to avoid confusing behavior that -match operator exhibits with collections. To assert on collections use Should-Any, Should-All or some other collection assertion."
+        $err = { "abc", "def" | Should-NotMatchString -Expected "abc" } | Verify-Throw
+        $err.Exception.Message | Verify-Equal "Actual is expected to be string, to avoid confusing behavior that -match operator exhibits with collections. To assert on collections use Should-Any, Should-All or some other collection assertion."
     }
 
     It "Throws when given a non-string pattern" {
-        $err = { Should-NotMatchString -Actual "abc" -Expected 123 } | Should -Throw -PassThru
-        $err.Exception.Message | Should -Be "Expected is expected to be string, to avoid confusing behavior that -match operator exhibits with collections."
+        $err = { Should-NotMatchString -Actual "abc" -Expected 123 } | Verify-Throw
+        $err.Exception.Message | Verify-Equal "Expected is expected to be string, to avoid confusing behavior that -match operator exhibits with collections."
     }
 
     It "Can be called with positional parameters" {
-        { Should-NotMatchString "^a" "abc" } | Should -Throw -ErrorId "PesterAssertionFailed"
+        { Should-NotMatchString "^a" "abc" } | Verify-AssertionFailed
     }
 
     Context "Verify messages" {
         It "Returns the correct message for failed non-matches" {
-            $err = { Should-NotMatchString -Actual "ab" -Expected ".*" -Because "reason" } | Should -Throw -PassThru
-            $err.Exception.Message | Should -Be "Expected the string 'ab' to not match pattern '.*', because reason, but it matched it."
+            $err = { Should-NotMatchString -Actual "ab" -Expected ".*" -Because "reason" } | Verify-AssertionFailed
+            $err.Exception.Message | Verify-Equal "Expected the string 'ab' to not match pattern '.*', because reason, but it matched it."
         }
 
         It "Returns the correct message for failed case-sensitive non-matches" {
-            $err = { Should-NotMatchString -Actual "AB" -Expected "A.*" -CaseSensitive } | Should -Throw -PassThru
-            $err.Exception.Message | Should -Be "Expected the string 'AB' to case sensitively not match pattern 'A.*', but it matched it."
+            $err = { Should-NotMatchString -Actual "AB" -Expected "A.*" -CaseSensitive } | Verify-AssertionFailed
+            $err.Exception.Message | Verify-Equal "Expected the string 'AB' to case sensitively not match pattern 'A.*', but it matched it."
         }
     }
 }


### PR DESCRIPTION
Fix #2876

Migrates `tst/functions/assert/String/Should-MatchString.Tests.ps1` from Pester `Should` to the `Verify-*` helpers, matching the other assert unit tests (e.g. `Should-BeLikeString.Tests.ps1`):

- `{ ... } | Should -Throw -ErrorId "PesterAssertionFailed"` becomes `{ ... } | Verify-AssertionFailed`
- `$err = { ... } | Should -Throw -PassThru` becomes `Verify-Throw` for argument-validation errors, `Verify-AssertionFailed` for assertion failures (both return the error object)
- `$err.Exception.Message | Should -Be "..."` becomes `$err.Exception.Message | Verify-Equal "..."`

Passing assertions (direct `Should-MatchString` / `Should-NotMatchString` calls) are unchanged. `test.ps1` for the file: 32 passed.