### PR TITLE
Bump prerelease to alpha3

### DIFF
--- a/src/Pester.psd1
+++ b/src/Pester.psd1
@@ -172,10 +172,10 @@
             LicenseUri   = "https://www.apache.org/licenses/LICENSE-2.0.html"
 
             # Release notes for this particular version of the module
-            ReleaseNotes = 'https://github.com/pester/Pester/releases/tag/6.1.0-alpha2'
+            ReleaseNotes = 'https://github.com/pester/Pester/releases/tag/6.1.0-alpha3'
 
             # Prerelease string of this module
-            Prerelease   = 'alpha2'
+            Prerelease   = 'alpha3'
         }
 
         # Minimum assembly version required


### PR DESCRIPTION
Bumps the prerelease branding in `src/Pester.psd1` from `alpha2` to `alpha3`:

- `Prerelease` → `alpha3`
- `ReleaseNotes` URL → the `6.1.0-alpha3` tag

Follow-up to #2852 (alpha2 bump).