### PR TITLE
Exclude directories, not just files, in ExcludePath

### DIFF
--- a/src/Pester.RSpec.ps1
+++ b/src/Pester.RSpec.ps1
@@ -118,15 +118,41 @@ function Filter-Excluded ($Files, $ExcludePath) {
         return @($Files)
     }
 
+    # Directory exclusions are compared as path prefixes below. Match them
+    # case-insensitively on Windows, but case-sensitively on Linux and macOS
+    # where the filesystem is case-sensitive.
+    $pathComparison = if ('Windows' -eq (GetPesterOs)) {
+        [System.StringComparison]::OrdinalIgnoreCase
+    }
+    else {
+        [System.StringComparison]::Ordinal
+    }
+
+    # normalize backslashes for cross-platform ease of use
+    $exclusions = @($ExcludePath) -replace "/", "\"
+
     foreach ($file in @($Files)) {
         # normalize backslashes for cross-platform ease of use
         $p = $file.FullName -replace "/", "\"
         $excluded = $false
 
-        foreach ($exclusion in (@($ExcludePath) -replace "/", "\")) {
+        foreach ($exclusion in $exclusions) {
+            # Wildcard patterns and exact file paths keep the original -like behavior.
             if ($p -like $exclusion) {
                 $excluded = $true
-                continue
+                break
+            }
+
+            # A directory exclusion (e.g. C:\proj\excluded) should exclude every file
+            # underneath it, see https://github.com/pester/Pester/issues/1575. Trailing
+            # separators are trimmed so both 'C:\proj\excluded' and 'C:\proj\excluded\'
+            # behave the same. Wildcard patterns are already handled by -like above.
+            if (-not [System.Management.Automation.WildcardPattern]::ContainsWildcardCharacters($exclusion)) {
+                $prefix = $exclusion.TrimEnd("\") + "\"
+                if ($p.StartsWith($prefix, $pathComparison)) {
+                    $excluded = $true
+                    break
+                }
             }
         }
 

--- a/tst/Pester.RSpec.ts.ps1
+++ b/tst/Pester.RSpec.ts.ps1
@@ -280,6 +280,42 @@ i -PassThru:$PassThru {
         }
     }
 
+    b "Excluding directories from a run" {
+        try {
+            $path = $pwd
+            $c = 'Describe "d1" { It "i1" { $true } }'
+            $root = Join-Path ([IO.Path]::GetTempPath()) "excludepath-dir-$([Guid]::NewGuid().Guid)"
+            $includedDir = Join-Path $root "included"
+            $excludedDir = Join-Path $root "excluded"
+            New-Item -ItemType Directory -Path $includedDir -Force | Out-Null
+            New-Item -ItemType Directory -Path $excludedDir -Force | Out-Null
+
+            $includedFile = Join-Path $includedDir "included.Tests.ps1"
+            $excludedFile = Join-Path $excludedDir "excluded.Tests.ps1"
+            $c | Set-Content $includedFile
+            $c | Set-Content $excludedFile
+
+            t "Excluding a directory excludes the tests underneath it but keeps sibling tests" {
+                $result = Invoke-Pester -Path $root -ExcludePath $excludedDir -PassThru
+
+                $result.Containers.Count | Verify-Equal 1
+                $result.Containers[0].Item.FullName | Verify-Equal $includedFile
+            }
+
+            t "Excluding a directory with a trailing separator excludes the tests underneath it" {
+                $excludedWithSeparator = $excludedDir + [System.IO.Path]::DirectorySeparatorChar
+                $result = Invoke-Pester -Path $root -ExcludePath $excludedWithSeparator -PassThru
+
+                $result.Containers.Count | Verify-Equal 1
+                $result.Containers[0].Item.FullName | Verify-Equal $includedFile
+            }
+        }
+        finally {
+            cd $path
+            Remove-Item $root -Recurse -Force -Confirm:$false -ErrorAction Stop
+        }
+    }
+
     b "Terminating and non-terminating Should" {
         t "Non-terminating assertion fails the test after running to completion" {
             $sb = {


### PR DESCRIPTION
Fix #1575

## Problem

`Run.ExcludePath` is documented as *"Directories or files to be excluded from the run."*, but directory exclusions were silently ignored — only file paths and wildcard patterns actually excluded anything.

The cause is in `Filter-Excluded` (`src/Pester.RSpec.ps1`): each discovered test file's full path was only tested against every exclusion with `-like`. When the exclusion is a **directory** (e.g. `C:\proj\excluded`), no file *inside* that directory matches, because `-like` needs an exact/glob match against the whole file path. So `Invoke-Pester -Path <root> -ExcludePath <root>\excluded` still ran the tests under `excluded`.

## Fix

Keep the existing wildcard/exact `-like` behavior, and additionally treat a **non-wildcard** exclusion as a directory prefix: a file is excluded when its normalized full path starts with the exclusion plus a directory separator.

- Trailing separators are trimmed, so `dir` and `dir\` behave the same.
- The prefix comparison is case-insensitive on Windows and case-sensitive on Linux/macOS (matching the filesystem).
- Wildcard exclusions (e.g. `*/excluded/*`) are left entirely to `-like`, so existing glob behavior is unchanged.

## Tests

Added a regression block in `tst/Pester.RSpec.ts.ps1` (`Excluding directories from a run`) with a two-subdirectory layout, asserting that:

- excluding a directory removes the tests underneath it while a sibling directory still runs, and
- the same works when the excluded path has a trailing separator.

Both fail on `main` and pass with this change. The rest of `Pester.RSpec.ts.ps1` is unaffected (the 3 remaining failures in that file are pre-existing and unrelated — `SkipRemainingOnFailureCount`). PSScriptAnalyzer with the repo settings reports no new findings on the changed lines.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>