### PR TITLE
Fix mock bootstrap proxy for cmdlets with no DefaultParameterSetName

### DIFF
--- a/src/functions/Mock.ps1
+++ b/src/functions/Mock.ps1
@@ -88,6 +88,7 @@ function Create-MockHook ($contextInfo, $InvokeMockCallback) {
             # default makes the no-argument call succeed, matching the real cmdlet's behaviour. (#1531)
             if ([string]::IsNullOrEmpty($metadata.DefaultParameterSetName)) {
                 $cmdletBinding = $cmdletBinding.Insert($cmdletBinding.Length - 2, "DefaultParameterSetName='__AllParameterSets'")
+                $cmdletBinding = $cmdletBinding.Insert($cmdletBinding.Length - 2, ',')
             }
             $cmdletBinding = $cmdletBinding.Insert($cmdletBinding.Length - 2, 'PositionalBinding=$false')
         }

--- a/src/functions/Mock.ps1
+++ b/src/functions/Mock.ps1
@@ -79,18 +79,15 @@ function Create-MockHook ($contextInfo, $InvokeMockCallback) {
         }
         $cmdletBinding = [Management.Automation.ProxyCommand]::GetCmdletBindingAttribute($metadata)
         if ($contextInfo.Command.CommandType -eq 'Cmdlet') {
+            if ($cmdletBinding -ne '[CmdletBinding()]') {
+                $cmdletBinding = $cmdletBinding.Insert($cmdletBinding.Length - 2, ',')
+            }
             # When the cmdlet has no explicit DefaultParameterSetName and its dynamic parameters
             # introduce multiple named parameter sets, PowerShell cannot resolve which set applies
             # when the mock is called without arguments. Injecting '__AllParameterSets' as the
             # default makes the no-argument call succeed, matching the real cmdlet's behaviour. (#1531)
             if ([string]::IsNullOrEmpty($metadata.DefaultParameterSetName)) {
-                if ($cmdletBinding -ne '[CmdletBinding()]') {
-                    $cmdletBinding = $cmdletBinding.Insert($cmdletBinding.Length - 2, ',')
-                }
                 $cmdletBinding = $cmdletBinding.Insert($cmdletBinding.Length - 2, "DefaultParameterSetName='__AllParameterSets'")
-            }
-            if ($cmdletBinding -ne '[CmdletBinding()]') {
-                $cmdletBinding = $cmdletBinding.Insert($cmdletBinding.Length - 2, ',')
             }
             $cmdletBinding = $cmdletBinding.Insert($cmdletBinding.Length - 2, 'PositionalBinding=$false')
         }

--- a/src/functions/Mock.ps1
+++ b/src/functions/Mock.ps1
@@ -79,6 +79,16 @@ function Create-MockHook ($contextInfo, $InvokeMockCallback) {
         }
         $cmdletBinding = [Management.Automation.ProxyCommand]::GetCmdletBindingAttribute($metadata)
         if ($contextInfo.Command.CommandType -eq 'Cmdlet') {
+            # When the cmdlet has no explicit DefaultParameterSetName and its dynamic parameters
+            # introduce multiple named parameter sets, PowerShell cannot resolve which set applies
+            # when the mock is called without arguments. Injecting '__AllParameterSets' as the
+            # default makes the no-argument call succeed, matching the real cmdlet's behaviour. (#1531)
+            if ([string]::IsNullOrEmpty($metadata.DefaultParameterSetName)) {
+                if ($cmdletBinding -ne '[CmdletBinding()]') {
+                    $cmdletBinding = $cmdletBinding.Insert($cmdletBinding.Length - 2, ',')
+                }
+                $cmdletBinding = $cmdletBinding.Insert($cmdletBinding.Length - 2, "DefaultParameterSetName='__AllParameterSets'")
+            }
             if ($cmdletBinding -ne '[CmdletBinding()]') {
                 $cmdletBinding = $cmdletBinding.Insert($cmdletBinding.Length - 2, ',')
             }

--- a/tst/functions/Mock.Tests.ps1
+++ b/tst/functions/Mock.Tests.ps1
@@ -2027,6 +2027,23 @@ Describe 'Mocking commands with potentially ambiguous parameter sets' {
     }
 }
 
+Describe 'Mocking a cmdlet with multiple non-default parameter sets and no DefaultParameterSetName (#1531)' {
+    # Get-PackageSource has two provider-specific parameter sets (NuGet and PowerShellGet) with no
+    # default, and its dynamic parameters introduce those sets. Without a DefaultParameterSetName in
+    # the generated bootstrap proxy, PowerShell cannot resolve the parameter set when the mock is
+    # called with no arguments, producing "Parameter set cannot be resolved". The fix injects
+    # DefaultParameterSetName='__AllParameterSets' into the proxy [CmdletBinding()] for any cmdlet
+    # whose metadata has an empty DefaultParameterSetName.
+
+    It 'Can mock Get-PackageSource and call it with no arguments' -Skip:($null -eq (Get-Command Get-PackageSource -ErrorAction SilentlyContinue)) {
+        Mock Get-PackageSource { [PSCustomObject]@{ Name = 'MockedSource'; ProviderName = 'NuGet' } }
+
+        $result = Get-PackageSource
+        $result.Name | Should -Be 'MockedSource'
+        Should -Invoke Get-PackageSource -Times 1
+    }
+}
+
 Describe 'When mocking a command that has an ArgumentList parameter with validation' {
     BeforeAll {
         Mock Start-Process { return 'mocked' }


### PR DESCRIPTION
Fix #1531

Mocking a cmdlet with multiple non-mandatory parameter sets and no `DefaultParameterSetName` (e.g. `Get-PackageSource` with its `NuGet` and `PowerShellGet` dynamic sets) failed at call time with:

```
ParameterBindingException: Parameter set cannot be resolved using the specified named parameters.
One or more parameters issued cannot be used together or an insufficient number of parameters were provided.
```

When `Create-MockHook` builds the bootstrap proxy it always injects `PositionalBinding=$false` into the generated `[CmdletBinding()]`. For a cmdlet whose dynamic parameters add several named sets with no default, PowerShell has no set to fall back on when the proxy is called with no arguments, hence the ambiguity. The real cmdlet handles this in C# and is fine, the PS-level proxy is not.

Fix: when `$metadata.DefaultParameterSetName` is null or empty, inject `DefaultParameterSetName='__AllParameterSets'` into the proxy's `[CmdletBinding()]`. Cmdlets that already have a default set are untouched, the existing value is preserved and the injection is skipped.

Added a regression test in `Mock.Tests.ps1` that mocks `Get-PackageSource` (ships with PS7) and calls it with no arguments, skipped when the cmdlet is not available.