### PR TITLE
Harden internal helpers against user command shadowing

### DIFF
--- a/src/Main.ps1
+++ b/src/Main.ps1
@@ -580,7 +580,7 @@ function Invoke-Pester {
             }
 
             # this is here to support Pester test runner in VSCode. Don't use it unless you are prepared to get broken in the future. And if you decide to use it, let us know in https://github.com/pester/Pester/issues/2021 so we can warn you about removing this.
-            if (defined additionalPlugins) { $plugins.AddRange(@($script:additionalPlugins)) }
+            if (defined_ additionalPlugins) { $plugins.AddRange(@($script:additionalPlugins)) }
 
             $filter = New-FilterObject `
                 -Tag $PesterPreference.Filter.Tag.Value `
@@ -590,7 +590,7 @@ function Invoke-Pester {
                 -FullName $PesterPreference.Filter.FullName.Value
 
             $containers = @()
-            if (any $PesterPreference.Run.ScriptBlock.Value) {
+            if (any_ $PesterPreference.Run.ScriptBlock.Value) {
                 $containers += @( $PesterPreference.Run.ScriptBlock.Value | & $SafeCommands['ForEach-Object'] { New-BlockContainerObject -ScriptBlock $_ })
             }
 
@@ -599,12 +599,12 @@ function Invoke-Pester {
                 $containers += (New-BlockContainerObject -Container $c -Data $c.Data)
             }
 
-            if ((any $PesterPreference.Run.Path.Value)) {
-                if (((none $PesterPreference.Run.ScriptBlock.Value) -and (none $PesterPreference.Run.Container.Value)) -or ('.' -ne $PesterPreference.Run.Path.Value[0])) {
+            if ((any_ $PesterPreference.Run.Path.Value)) {
+                if (((none_ $PesterPreference.Run.ScriptBlock.Value) -and (none_ $PesterPreference.Run.Container.Value)) -or ('.' -ne $PesterPreference.Run.Path.Value[0])) {
                     #TODO: Skipping the invocation when scriptblock is provided and the default path, later keep path in the default parameter set and remove scriptblock from it, so get-help still shows . as the default value and we can still provide script blocks via an advanced settings parameter
                     # TODO: pass the startup options as context to Start instead of just paths
 
-                    $exclusions = combineNonNull @($PesterPreference.Run.ExcludePath.Value, ($PesterPreference.Run.Container.Value | & $SafeCommands['Where-Object'] { "File" -eq $_.Type } | & $SafeCommands['ForEach-Object'] { $_.Item.FullName }))
+                    $exclusions = combineNonNull_ @($PesterPreference.Run.ExcludePath.Value, ($PesterPreference.Run.Container.Value | & $SafeCommands['Where-Object'] { "File" -eq $_.Type } | & $SafeCommands['ForEach-Object'] { $_.Item.FullName }))
                     $containers += @(Find-File -Path $PesterPreference.Run.Path.Value -ExcludePath $exclusions -Extension $PesterPreference.Run.TestExtension.Value | & $SafeCommands['ForEach-Object'] { New-BlockContainerObject -File $_ })
                 }
             }
@@ -620,7 +620,7 @@ function Invoke-Pester {
                 } -ThrowOnFailure
             }
 
-            if ((none $containers)) {
+            if ((none_ $containers)) {
                 throw "No test files were found and no scriptblocks were provided. Please ensure that you provided at least one path to a *$($PesterPreference.Run.TestExtension.Value) file, or a directory that contains such file.$(if ($null -ne $PesterPreference.Run.ExcludePath.Value -and 0 -lt @($PesterPreference.Run.ExcludePath.Value).Length) {" And that there is at least one file not excluded by ExcludeFile filter '$($PesterPreference.Run.ExcludePath.Value -join "', '")'."}) Or that you provided a ScriptBlock test container."
                 return
             }
@@ -713,7 +713,7 @@ function Invoke-Pester {
                 foreach ($pl in $plugins) {
                     if ('WriteScreen' -eq $pl.Name) { $reportingPlugins.Add($pl) }
                 }
-                if (defined additionalPlugins) { $reportingPlugins.AddRange(@($script:additionalPlugins)) }
+                if (defined_ additionalPlugins) { $reportingPlugins.AddRange(@($script:additionalPlugins)) }
 
                 # Replays one segment of a worker's recorded event tape to the reporting plugins.
                 # The recorded context carries the worker's PluginConfiguration; swap in the parent's
@@ -1022,7 +1022,7 @@ function Invoke-Pester {
         $global:LASTEXITCODE = $failedCount
 
         if ($PesterPreference.Run.Throw.Value -and 0 -ne $failedCount) {
-            $messages = combineNonNull @(
+            $messages = combineNonNull_ @(
                 $(if (0 -lt $run.FailedCount) { "$($run.FailedCount) test$(if (1 -lt $run.FailedCount) { "s" }) failed" })
                 $(if (0 -lt $run.FailedBlocksCount) { "$($run.FailedBlocksCount) block$(if (1 -lt $run.FailedBlocksCount) { "s" }) failed" })
                 $(if (0 -lt $run.FailedContainersCount) { "$($run.FailedContainersCount) container$(if (1 -lt $run.FailedContainersCount) { "s" }) failed" })
@@ -1226,9 +1226,9 @@ function ConvertTo-Pester4Result {
                 Parameters             = $test.Data
                 ParameterizedSuiteName = $test.DisplayName
 
-                FailureMessage         = $(if (any $test.ErrorRecord -and $null -ne $test.ErrorRecord[-1].Exception) { $test.ErrorRecord[-1].DisplayErrorMessage })
-                ErrorRecord            = $(if (any $test.ErrorRecord) { $test.ErrorRecord[-1] })
-                StackTrace             = $(if (any $test.ErrorRecord) { $test.ErrorRecord[1].DisplayStackTrace })
+                FailureMessage         = $(if (any_ $test.ErrorRecord -and $null -ne $test.ErrorRecord[-1].Exception) { $test.ErrorRecord[-1].DisplayErrorMessage })
+                ErrorRecord            = $(if (any_ $test.ErrorRecord) { $test.ErrorRecord[-1] })
+                StackTrace             = $(if (any_ $test.ErrorRecord) { $test.ErrorRecord[1].DisplayStackTrace })
             }
 
             $null = $legacyResult.TestResult.Add($result)

--- a/src/Pester.Runtime.ps1
+++ b/src/Pester.Runtime.ps1
@@ -52,7 +52,7 @@ $script:SessionStateInternalProperty = [System.Management.Automation.SessionStat
 $script:ScriptBlockSessionStateInternalProperty = [System.Management.Automation.ScriptBlock].GetProperty('SessionStateInternal', $flags)
 $script:ScriptBlockSessionStateProperty = [System.Management.Automation.ScriptBlock].GetProperty("SessionState", $flags)
 
-if (notDefined PesterPreference) {
+if (notDefined_ PesterPreference) {
     $PesterPreference = [PesterConfiguration]::Default
 }
 else {
@@ -127,7 +127,7 @@ function Find-Test {
     # define the state if we don't have it yet, this will happen when we call this function directly
     # but normally the parent invoker (most often Invoke-Pester) will set the state. So we don't want to reset
     # it here.
-    if (notDefined state) {
+    if (notDefined_ state) {
         $state = New-PesterState
     }
 
@@ -2029,7 +2029,7 @@ function Invoke-Test {
     # define the state if we don't have it yet, this will happen when we call this function directly
     # but normally the parent invoker (most often Invoke-Pester) will set the state. So we don't want to reset
     # it here.
-    if (notDefined state) {
+    if (notDefined_ state) {
         $state = New-PesterState
     }
 
@@ -2443,7 +2443,7 @@ function PostProcess-ExecutedBlock {
             $childBlocks = $b.Blocks
             $anyChildBlockFailed = $false
             $aggregatedChildDuration = [TimeSpan]::Zero
-            if (none $childBlocks) {
+            if (none_ $childBlocks) {
                 # one thing to consider here is what happens when a block fails, in the current
                 # execution model the block can fail when a setup or teardown fails, with failed
                 # setup it is easy all the tests in the block are considered failed, with teardown

--- a/src/Pester.Utility.ps1
+++ b/src/Pester.Utility.ps1
@@ -1,4 +1,4 @@
-﻿function or {
+﻿function or_ {
     [CmdletBinding()]
     param (
         [Parameter(Mandatory = $true, Position = 0)]
@@ -16,7 +16,7 @@
 }
 
 # looks for a property on object that might be null
-function tryGetProperty {
+function tryGetProperty_ {
     [CmdletBinding()]
     param (
         [Parameter(Position = 0)]
@@ -39,7 +39,7 @@ function tryGetProperty {
     # }
 }
 
-function trySetProperty {
+function trySetProperty_ {
     [CmdletBinding()]
     param (
         [Parameter(Position = 0)]
@@ -61,7 +61,7 @@ function trySetProperty {
 # combines collections that are not null or empty, but does not remove null values
 # from collections so e.g. combineNonNull @(@(1,$null), @(1,2,3), $null, $null, 10)
 # returns 1, $null, 1, 2, 3, 10
-function combineNonNull ($Array) {
+function combineNonNull_ ($Array) {
     foreach ($i in $Array) {
 
         $arr = @($i)
@@ -74,14 +74,14 @@ function combineNonNull ($Array) {
 }
 
 
-filter selectNonNull {
+filter selectNonNull_ {
     param($Collection)
     @(foreach ($i in $Collection) {
             if ($i) { $i }
         })
 }
 
-function any ($InputObject) {
+function any_ ($InputObject) {
     # inlining version
     $(<# any #> if (-not ($s = $InputObject)) { return $false } else { @($s).Length -gt 0 })
     # if (-not $InputObject) {
@@ -91,11 +91,11 @@ function any ($InputObject) {
     # @($InputObject).Length -gt 0
 }
 
-function none ($InputObject) {
-    -not (any $InputObject)
+function none_ ($InputObject) {
+    -not (any_ $InputObject)
 }
 
-function defined {
+function defined_ {
     param(
         [Parameter(Mandatory)]
         [String] $Name
@@ -109,7 +109,7 @@ function defined {
     $ExecutionContext.SessionState.PSVariable.GetValue($Name)
 }
 
-function notDefined {
+function notDefined_ {
     param(
         [Parameter(Mandatory)]
         [String] $Name
@@ -141,8 +141,8 @@ function Test-CIDebugOutputEnabled ([PesterConfiguration]$PesterPreference) {
 }
 
 
-function sum ($InputObject, $PropertyName, $Zero) {
-    if (none $InputObject.Length) {
+function sum_ ($InputObject, $PropertyName, $Zero) {
+    if (none_ $InputObject.Length) {
         return $Zero
     }
 
@@ -154,7 +154,7 @@ function sum ($InputObject, $PropertyName, $Zero) {
     $acc
 }
 
-function tryGetValue {
+function tryGetValue_ {
     [CmdletBinding()]
     param(
         $Hashtable,
@@ -168,7 +168,7 @@ function tryGetValue {
     }
 }
 
-function tryAddValue {
+function tryAddValue_ {
     [CmdletBinding()]
     param(
         $Hashtable,
@@ -181,7 +181,7 @@ function tryAddValue {
     }
 }
 
-function getOrUpdateValue {
+function getOrUpdateValue_ {
     [CmdletBinding()]
     param(
         $Hashtable,
@@ -202,7 +202,7 @@ function getOrUpdateValue {
     }
 }
 
-function tryRemoveKey ($Hashtable, $Key) {
+function tryRemoveKey_ ($Hashtable, $Key) {
     if ($Hashtable.ContainsKey($Key)) {
         $Hashtable.Remove($Key)
     }

--- a/src/functions/Coverage.Plugin.ps1
+++ b/src/functions/Coverage.Plugin.ps1
@@ -135,7 +135,7 @@
         # the output file themselves - the parent merges every worker's CommandCoverage and generates
         # the report once. The flag is set on the (per-runspace) module scope only inside a worker, so
         # a normal run and the parent's own End step never see it. See Invoke-TestInParallel.
-        if (defined CodeCoverageSkipReport) {
+        if (defined_ CodeCoverageSkipReport) {
             return
         }
 

--- a/src/functions/Pester.SessionState.Mock.ps1
+++ b/src/functions/Pester.SessionState.Mock.ps1
@@ -602,7 +602,7 @@ function Get-MockDataForCurrentScope {
         $location = $currentBlock = Get-CurrentBlock
     }
 
-    if (none @($currentTest, $currentBlock)) {
+    if (none_ @($currentTest, $currentBlock)) {
         throw "I am neither in a test or a block, where am I?"
     }
 

--- a/tst/Pester.RSpec.InNewProcess.ts.ps1
+++ b/tst/Pester.RSpec.InNewProcess.ts.ps1
@@ -417,4 +417,43 @@ i -PassThru:$PassThru {
                 @($whatIfLines).Count | Verify-Equal 0
         }
     }
+
+    b 'User alias shadowing internal helper does not break Pester' {
+        # https://github.com/pester/Pester/issues/2113
+        # A user module (for example ListFunctions) can export an alias whose name
+        # collides with one of Pester's short internal helper functions (like 'any').
+        # PowerShell resolves aliases before functions and traverses the scope chain
+        # up to global, so such an alias shadowed Pester's internal helper and
+        # Invoke-Pester crashed with a ParameterBindingException before running any test.
+        t 'Invoke-Pester succeeds when a global alias shadows the internal any helper' {
+            $sb = {
+                # Mimic ListFunctions' Assert-AnyObject: a command with a mandatory
+                # [ScriptBlock] $Condition parameter, exposed through the alias 'any'.
+                function Assert-AnyObject {
+                    param([Parameter(Mandatory)][ScriptBlock] $Condition)
+                }
+                Set-Alias -Name any -Value Assert-AnyObject -Scope Global
+
+                $PesterPreference = [PesterConfiguration]::Default
+                $PesterPreference.Output.Verbosity = 'None'
+
+                $container = New-PesterContainer -ScriptBlock {
+                    Describe 'd1' {
+                        It 'i1' {
+                            1 | Should -Be 1
+                        }
+                    }
+                }
+                $r = Invoke-Pester -Container $container -PassThru
+                if ($r.FailedCount -ne 0) { throw "Expected 0 failures, got $($r.FailedCount)" }
+                if ($r.PassedCount -ne 1) { throw "Expected 1 passed, got $($r.PassedCount)" }
+
+                # Reached only if Invoke-Pester ran to completion instead of crashing.
+                'REGRESSION-2113-OK'
+            }
+
+            $output = Invoke-InNewProcess $sb
+            $output | Select-String -SimpleMatch -Pattern 'REGRESSION-2113-OK' | Verify-NotNull
+        }
+    }
 }

--- a/tst/Pester.Runtime.ts.ps1
+++ b/tst/Pester.Runtime.ts.ps1
@@ -82,29 +82,29 @@ i -PassThru:$PassThru {
 
     b "tryGetProperty" {
         t "given null it returns null" {
-            tryGetProperty $null Name | Verify-Null
+            tryGetProperty_ $null Name | Verify-Null
         }
 
         t "given an object that has the property it return the correct value" {
             $p = (Get-Process -Id $Pid)
-            tryGetProperty $p Name | Verify-Equal $p.Name
+            tryGetProperty_ $p Name | Verify-Equal $p.Name
         }
     }
 
     b "or" {
 
         t "given a non-null value it returns it" {
-            "a" | or "b" | Verify-Equal "a"
+            "a" | or_ "b" | Verify-Equal "a"
         }
 
         t "given null it returns the default value" {
-            $null | or "b" | Verify-Equal "b"
+            $null | or_ "b" | Verify-Equal "b"
         }
     }
 
     b "combineNonNull" {
         t "combines values from multiple arrays, skipping nulls and empty arrays, but keeping nulls in the arrays" {
-            $r = combineNonNull @(@(1, $null), @(1, 2, 3), $null, $null, 10)
+            $r = combineNonNull_ @(@(1, $null), @(1, 2, 3), $null, $null, 10)
             # expecting: 1, $null, 1, 2, 3, 10
             $r[0] | Verify-Equal 1
             $r[1] | Verify-Null
@@ -118,27 +118,27 @@ i -PassThru:$PassThru {
     b "any" {
 
         t "given a non-null value it returns true" {
-            any "b" | Verify-True
+            any_ "b" | Verify-True
         }
 
         t "given null it returns false" {
-            any $null | Verify-False
+            any_ $null | Verify-False
         }
 
         t "given empty array it returns false" {
-            any @() | Verify-False
+            any_ @() | Verify-False
         }
 
         t "given null in array it returns false" {
-            any @($null) | Verify-False
+            any_ @($null) | Verify-False
         }
 
         t "given array with value it returns true" {
-            any @("b") | Verify-True
+            any_ @("b") | Verify-True
         }
 
         t "given array with multiple values it returns true" {
-            any @("b", "c") | Verify-True
+            any_ @("b", "c") | Verify-True
         }
     }
 


### PR DESCRIPTION
Fix #2113

## Problem

`Invoke-Pester` crashes before any tests run when a user session or module defines an **alias** whose name collides with one of Pester's short internal helper functions.

The real-world trigger is the [`ListFunctions`](https://www.powershellgallery.com/packages/ListFunctions) gallery module, which exports an alias `Any` → `Assert-AnyObject`. PowerShell command resolution checks **aliases before functions** and traverses the scope chain up to global, so a global/session alias `any` is found *before* Pester's module-internal `any` helper. At `Invoke-Pester` time Pester calls `any $PesterPreference.Run.ScriptBlock.Value`; the alias redirects to `Assert-AnyObject`, binding a `ScriptBlock[]` to its mandatory `[ScriptBlock] $Condition` parameter and throwing:

```
ParameterBindingException: Cannot convert ... to ScriptBlock required by parameter 'Condition'
```

Only *aliases* shadow a module-internal function this way — a global function does not.

## Fix

Naming-convention hardening (the approach agreed in the issue thread): **suffix the shadow-prone internal helper names with `_`**. No aliases, no `$SafeCommands` routing. This keeps IntelliSense working, has minimal collision likelihood, and avoids both the SafeCommands hot-path cost and an alias layer.

Renamed these 14 helpers in `src/Pester.Utility.ps1` and updated every call site:

`any`, `or`, `none`, `sum`, `defined`, `notDefined`, `tryGetProperty`, `trySetProperty`, `combineNonNull`, `selectNonNull`, `tryGetValue`, `tryAddValue`, `getOrUpdateValue`, `tryRemoveKey` → same names with a trailing `_`.

Call sites were located with an AST scan (`CommandAst.GetCommandName()`), not a text search, so only genuine command/pipeline invocations were touched — the English word "or", the `-or`/`-and` operators, comments, strings, and `$any`-style variables are untouched. These helpers are internal (not exported via `Export-ModuleMember`), so the public surface is unchanged.

## Tests

Added a regression test in `tst/Pester.RSpec.InNewProcess.ts.ps1` that, in an isolated child process, defines a global `any` alias pointing at a command with a mandatory `[ScriptBlock] $Condition` (mirroring `Assert-AnyObject`) and asserts `Invoke-Pester` still runs a trivial passing container. It **fails before** this change and **passes after**. The existing runtime P-tests that exercise these helpers were updated to the suffixed names.

- `./build.ps1 -Clean` — succeeds
- `tst/Pester.RSpec.InNewProcess.ts.ps1`, `tst/Pester.Runtime.ts.ps1`, `tst/Pester.Utility.ts.ps1` — all pass
- PSScriptAnalyzer with the repo settings — no new findings on the changed files