### PR TITLE
Fix mocking commands with a PowerShell 6+ -Encoding parameter

### DIFF
--- a/src/functions/Mock.ps1
+++ b/src/functions/Mock.ps1
@@ -86,6 +86,7 @@ function Create-MockHook ($contextInfo, $InvokeMockCallback) {
         }
 
         $metadata = Repair-ConflictingParameters -Metadata $metadata -RemoveParameterType $RemoveParameterType -RemoveParameterValidation $RemoveParameterValidation
+        $metadata = Repair-EncodingParameters -Metadata $metadata
         $paramBlock = [Management.Automation.ProxyCommand]::GetParamBlock($metadata)
         $paramBlock = Repair-EnumParameters -ParamBlock $paramBlock -Metadata $metadata
         $paramBlock = Repair-OrderedType -ParamBlock $paramBlock -Metadata $metadata
@@ -2024,6 +2025,53 @@ function Repair-ConflictingParameters {
         $attrIndexesToRemove.Reverse()
         foreach ($index in $attrIndexesToRemove) {
             $null = $paramMetadata.Attributes.RemoveAt($index)
+        }
+    }
+
+    $repairedMetadata
+}
+
+function Repair-EncodingParameters {
+    [CmdletBinding()]
+    [OutputType([System.Management.Automation.CommandMetadata])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [System.Management.Automation.CommandMetadata]
+        $Metadata
+    )
+
+    # PowerShell 6+ cmdlets that accept an -Encoding parameter (Out-File, Export-Csv,
+    # Import-Csv, Export-Clixml, ...) declare it as [System.Text.Encoding] and rely on an
+    # internal ArgumentToEncodingTransformationAttribute to turn friendly names such as
+    # 'utf8NoBOM' into a System.Text.Encoding value while the code is parsed. ProxyCommand's
+    # GetParamBlock cannot reproduce that internal attribute, so the generated mock ends up with
+    # a bare [System.Text.Encoding] parameter that rejects the string names. Calling the mock
+    # with e.g. -Encoding utf8NoBOM then throws a ParameterBindingArgumentTransformationException.
+    # https://github.com/pester/Pester/issues/1877
+    #
+    # Relax the parameter type to [object] so any value the real command accepts (a friendly
+    # name, a code-page name or an actual System.Text.Encoding object) binds and routes to the
+    # mock, while the original argument is preserved for -ParameterFilter. A [ValidateSet] of the
+    # known names is intentionally not added: it would reject valid inputs the real cmdlet accepts,
+    # such as code-page names and System.Text.Encoding objects. The [System.Text.Encoding] check
+    # is self-gating to PowerShell 6+; Windows PowerShell declares -Encoding as an enum instead.
+    $repairedMetadata = [System.Management.Automation.CommandMetadata]$Metadata
+
+    foreach ($paramMetadata in $repairedMetadata.Parameters.Values) {
+        if ($paramMetadata.IsDynamic -or $paramMetadata.ParameterType -ne [System.Text.Encoding]) {
+            continue
+        }
+
+        $hasEncodingTransform = $false
+        foreach ($attr in $paramMetadata.Attributes) {
+            if ($attr -is [System.Management.Automation.ArgumentTransformationAttribute]) {
+                $hasEncodingTransform = $true
+                break
+            }
+        }
+
+        if ($hasEncodingTransform) {
+            $paramMetadata.ParameterType = [object]
         }
     }
 

--- a/tst/functions/Mock.Tests.ps1
+++ b/tst/functions/Mock.Tests.ps1
@@ -3004,6 +3004,48 @@ Describe 'Mocking command with OrderedDictionary-parameters' {
     }
 }
 
+Describe 'Mocking command with an Encoding parameter' {
+    # https://github.com/pester/Pester/issues/1877
+    # On PowerShell 6+ Out-File (and Export-Csv, Import-Csv, Export-Clixml, ...) declare -Encoding
+    # as [System.Text.Encoding] and rely on an internal transformation attribute to convert friendly
+    # names such as 'utf8NoBOM' into a System.Text.Encoding value. ProxyCommand-generation cannot
+    # reproduce that internal attribute, so mocking such a command and calling it with a friendly
+    # encoding name used to throw a ParameterBindingArgumentTransformationException. Repair-EncodingParameters
+    # relaxes the parameter type to [object] so the mock accepts any value the real command accepts.
+
+    # Self-gating: Windows PowerShell declares -Encoding as an enum, so the bug and fix only apply
+    # where Out-File uses [System.Text.Encoding].
+    if ((Get-Command Out-File).Parameters['Encoding'].ParameterType -eq [System.Text.Encoding]) {
+
+        It 'does not throw and returns the mock when called with a friendly encoding name' {
+            Mock Out-File { 'mocked' }
+            ('data' | Out-File -FilePath 'TestDrive:/f.txt' -Encoding utf8NoBOM) | Should -Be 'mocked'
+        }
+
+        It 'records the invocation with the friendly encoding name available to the parameter filter' {
+            Mock Out-File { 'mocked' }
+            'data' | Out-File -FilePath 'TestDrive:/f.txt' -Encoding utf8NoBOM
+            Should -Invoke Out-File -Times 1 -Exactly -ParameterFilter { $Encoding -eq 'utf8NoBOM' }
+        }
+
+        It 'still routes to the mock when called with a System.Text.Encoding object' {
+            Mock Out-File { 'mocked' }
+            ('data' | Out-File -FilePath 'TestDrive:/f.txt' -Encoding ([System.Text.Encoding]::UTF8)) | Should -Be 'mocked'
+            Should -Invoke Out-File -Times 1 -Exactly
+        }
+
+        It 'applies to other cmdlets that use the encoding transformation (Export-Csv)' {
+            Mock Export-Csv { 'mocked' }
+            ([pscustomobject]@{ A = 1 } | Export-Csv -Path 'TestDrive:/f.csv' -Encoding utf8NoBOM) | Should -Be 'mocked'
+        }
+
+        It 'still supports the -RemoveParameterType Encoding workaround' {
+            Mock Out-File { 'mocked' } -RemoveParameterType Encoding
+            ('data' | Out-File -FilePath 'TestDrive:/f.txt' -Encoding utf8NoBOM) | Should -Be 'mocked'
+        }
+    }
+}
+
 Describe "Running Mock with ModuleName in test scope" {
     BeforeAll {
         Get-Module "test" -ErrorAction SilentlyContinue | Remove-Module


### PR DESCRIPTION
Fix #1877

On PowerShell 6+, `Out-File` (and `Export-Csv`, `Import-Csv`, `Export-Clixml`, ...) declare `-Encoding` as `[System.Text.Encoding]` and rely on an internal `ArgumentToEncodingTransformationAttribute` to turn friendly names like `utf8NoBOM` into a real `System.Text.Encoding`.

`ProxyCommand.GetParamBlock`, which Pester uses to generate the mock bootstrap, cannot reproduce that internal attribute, so the generated mock ended up with a bare `[System.Text.Encoding] $Encoding` and calling it with a friendly name threw:

```
ParameterBindingArgumentTransformationException: Cannot process argument transformation on parameter 'Encoding'. Cannot convert the "utf8NoBOM" value of type "System.String" to type "System.Text.Encoding".
```

The only workaround was `Mock Out-File -RemoveParameterType Encoding`.

Adds a `Repair-EncodingParameters` helper (like the existing `Repair-ConflictingParameters` / `Repair-EnumParameters`) called from `Create-MockHook`. When a static parameter is `[System.Text.Encoding]` and carries an `ArgumentTransformationAttribute`, it relaxes the type to `[object]`, so the mock accepts whatever the real command accepts and keeps the original value for `-ParameterFilter`. It is self-gating, Windows PowerShell declares `-Encoding` as an enum so nothing changes there.

I went with `[object]` rather than the `[string]` + `[ValidateSet]` the issue sketched, because a ValidateSet turned out to reject valid inputs:

| caller passes | current (broken) | `[string]` + `ValidateSet` | `[object]` (this PR) |
| --- | --- | --- | --- |
| `-Encoding utf8NoBOM` | throws | works | works |
| `-Encoding windows-1251` (valid code page) | throws | throws | works |
| `-Encoding ([System.Text.Encoding]::UTF8)` | works | throws | works |

`[object]` is exactly what `-RemoveParameterType Encoding` already does internally, a ValidateSet would make the mock stricter than the real command. New tests in `Mock.Tests.ps1` cover the friendly name, `-ParameterFilter` visibility, passing a real `[System.Text.Encoding]`, another cmdlet (`Export-Csv`), and that `-RemoveParameterType` still works. 255 passed, no new analyzer findings.