### PR TITLE
Clarify Should -Not -Invoke failure message

### DIFF
--- a/src/functions/Mock.ps1
+++ b/src/functions/Mock.ps1
@@ -483,6 +483,11 @@ function Should-InvokeVerifiableInternal {
     }
 }
 
+function Format-TimesCalled ([int] $Count) {
+    # Format a call count with the grammatically correct noun, e.g. "1 time" or "2 times".
+    if ($Count -eq 1) { "$Count time" } else { "$Count times" }
+}
+
 function Should-InvokeInternal {
     [CmdletBinding(DefaultParameterSetName = 'ParameterFilter')]
     [OutputType([Pester.ShouldResult])]
@@ -602,78 +607,69 @@ function Should-InvokeInternal {
         }
     }
 
+    $failure = $null
     if ($Negate) {
         # Negative checks
         if (-not $PSBoundParameters.ContainsKey('Times') -and -not $Exactly -and $matchingCalls.Count -ge 1) {
             # Plain 'Should -Not -Invoke' (no -Times/-Exactly) means the command should not have
             # been called at all. Word the failure that way instead of the confusing default
             # "not to be called exactly 1 times".
-            $timeWord = if ($matchingCalls.Count -eq 1) { 'time' } else { 'times' }
-            return [Pester.ShouldResult] @{
-                Succeeded      = $false
-                FailureMessage = "Expected ${commandName}${moduleMessage} not to be called,$(Format-Because $Because) but it was called $($matchingCalls.Count) $timeWord`n$(Format-MockCallHistoryMessage $callHistory $matchingCalls $nonMatchingCalls)"
-                ExpectResult   = [Pester.ShouldExpectResult]@{
-                    Expected = "${commandName}${moduleMessage} not to be called"
-                    Actual   = "${commandName}${moduleMessage} was called $($matchingCalls.Count) $timeWord"
-                    Because  = Format-Because $Because
-                }
+            $failure = @{
+                Expected = 'not to be called'
+                But      = "but it was called $(Format-TimesCalled $matchingCalls.Count)"
             }
         }
         elseif ($matchingCalls.Count -eq $Times -and ($Exactly -or !$PSBoundParameters.ContainsKey('Times'))) {
-            return [Pester.ShouldResult] @{
-                Succeeded      = $false
-                FailureMessage = "Expected ${commandName}${moduleMessage} not to be called exactly $Times times,$(Format-Because $Because) but it was`n$(Format-MockCallHistoryMessage $callHistory $matchingCalls $nonMatchingCalls)"
-                ExpectResult   = [Pester.ShouldExpectResult]@{
-                    Expected = "${commandName}${moduleMessage} not to be called exactly $Times times"
-                    Actual   = "${commandName}${moduleMessage} was called $($matchingCalls.count) times"
-                    Because  = Format-Because $Because
-                }
+            $failure = @{
+                Expected = "not to be called exactly $(Format-TimesCalled $Times)"
+                But      = 'but it was'
             }
         }
         elseif ($matchingCalls.Count -ge $Times -and !$Exactly) {
-            return [Pester.ShouldResult] @{
-                Succeeded      = $false
-                FailureMessage = "Expected ${commandName}${moduleMessage} to be called less than $Times times,$(Format-Because $Because) but was called $($matchingCalls.Count) times`n$(Format-MockCallHistoryMessage $callHistory $matchingCalls $nonMatchingCalls)"
-                ExpectResult   = [Pester.ShouldExpectResult]@{
-                    Expected = "${commandName}${moduleMessage} to be called less than $Times times"
-                    Actual   = "${commandName}${moduleMessage} was called $($matchingCalls.count) times"
-                    Because  = Format-Because $Because
-                }
+            $failure = @{
+                Expected = "to be called less than $(Format-TimesCalled $Times)"
+                But      = "but was called $(Format-TimesCalled $matchingCalls.Count)"
             }
         }
     }
     else {
         if ($matchingCalls.Count -ne $Times -and ($Exactly -or ($Times -eq 0))) {
-            return [Pester.ShouldResult] @{
-                Succeeded      = $false
-                FailureMessage = "Expected ${commandName}${moduleMessage} to be called $Times times exactly,$(Format-Because $Because) but was called $($matchingCalls.Count) times`n$(Format-MockCallHistoryMessage $callHistory $matchingCalls $nonMatchingCalls)"
-                ExpectResult   = [Pester.ShouldExpectResult]@{
-                    Expected = "${commandName}${moduleMessage} to be called $Times times exactly"
-                    Actual   = "${commandName}${moduleMessage} was called $($matchingCalls.count) times"
-                    Because  = Format-Because $Because
-                }
+            $failure = @{
+                Expected = "to be called $(Format-TimesCalled $Times) exactly"
+                But      = "but was called $(Format-TimesCalled $matchingCalls.Count)"
             }
         }
         elseif ($matchingCalls.Count -lt $Times) {
-            return [Pester.ShouldResult] @{
-                Succeeded      = $false
-                FailureMessage = "Expected ${commandName}${moduleMessage} to be called at least $Times times,$(Format-Because $Because) but was called $($matchingCalls.Count) times`n$(Format-MockCallHistoryMessage $callHistory $matchingCalls $nonMatchingCalls)"
-                ExpectResult   = [Pester.ShouldExpectResult]@{
-                    Expected = "${commandName}${moduleMessage} to be called at least $Times times"
-                    Actual   = "${commandName}${moduleMessage} was called $($matchingCalls.count) times"
-                    Because  = Format-Because $Because
-                }
+            $failure = @{
+                Expected = "to be called at least $(Format-TimesCalled $Times)"
+                But      = "but was called $(Format-TimesCalled $matchingCalls.Count)"
             }
         }
         elseif ($filterIsExclusive -and $nonMatchingCalls.Count -gt 0) {
-            return [Pester.ShouldResult] @{
-                Succeeded      = $false
-                FailureMessage = "Expected ${commandName}${moduleMessage} to only be called with with parameters matching the specified filter,$(Format-Because $Because) but $($nonMatchingCalls.Count) non-matching calls were made`n$(Format-MockCallHistoryMessage $callHistory $matchingCalls $nonMatchingCalls)"
-                ExpectResult   = [Pester.ShouldExpectResult]@{
-                    Expected = "${commandName}${moduleMessage} to only be called with with parameters matching the specified filter"
-                    Actual   = "${commandName}${moduleMessage} was called $($nonMatchingCalls.Count) times with non-matching parameters"
-                    Because  = Format-Because $Because
-                }
+            $failure = @{
+                Expected = 'to only be called with with parameters matching the specified filter'
+                Actual   = "was called $($nonMatchingCalls.Count) times with non-matching parameters"
+                But      = "but $($nonMatchingCalls.Count) non-matching calls were made"
+            }
+        }
+    }
+
+    if ($null -ne $failure) {
+        $expected = "${commandName}${moduleMessage} $($failure.Expected)"
+        $actual = if ($failure.ContainsKey('Actual')) {
+            "${commandName}${moduleMessage} $($failure.Actual)"
+        }
+        else {
+            "${commandName}${moduleMessage} was called $(Format-TimesCalled $matchingCalls.Count)"
+        }
+
+        return [Pester.ShouldResult] @{
+            Succeeded      = $false
+            FailureMessage = "Expected $expected,$(Format-Because $Because) $($failure.But)`n$(Format-MockCallHistoryMessage $callHistory $matchingCalls $nonMatchingCalls)"
+            ExpectResult   = [Pester.ShouldExpectResult]@{
+                Expected = $expected
+                Actual   = $actual
+                Because  = Format-Because $Because
             }
         }
     }

--- a/src/functions/Mock.ps1
+++ b/src/functions/Mock.ps1
@@ -604,7 +604,22 @@ function Should-InvokeInternal {
 
     if ($Negate) {
         # Negative checks
-        if ($matchingCalls.Count -eq $Times -and ($Exactly -or !$PSBoundParameters.ContainsKey('Times'))) {
+        if (-not $PSBoundParameters.ContainsKey('Times') -and -not $Exactly -and $matchingCalls.Count -ge 1) {
+            # Plain 'Should -Not -Invoke' (no -Times/-Exactly) means the command should not have
+            # been called at all. Word the failure that way instead of the confusing default
+            # "not to be called exactly 1 times".
+            $timeWord = if ($matchingCalls.Count -eq 1) { 'time' } else { 'times' }
+            return [Pester.ShouldResult] @{
+                Succeeded      = $false
+                FailureMessage = "Expected ${commandName}${moduleMessage} not to be called,$(Format-Because $Because) but it was called $($matchingCalls.Count) $timeWord`n$(Format-MockCallHistoryMessage $callHistory $matchingCalls $nonMatchingCalls)"
+                ExpectResult   = [Pester.ShouldExpectResult]@{
+                    Expected = "${commandName}${moduleMessage} not to be called"
+                    Actual   = "${commandName}${moduleMessage} was called $($matchingCalls.Count) $timeWord"
+                    Because  = Format-Because $Because
+                }
+            }
+        }
+        elseif ($matchingCalls.Count -eq $Times -and ($Exactly -or !$PSBoundParameters.ContainsKey('Times'))) {
             return [Pester.ShouldResult] @{
                 Succeeded      = $false
                 FailureMessage = "Expected ${commandName}${moduleMessage} not to be called exactly $Times times,$(Format-Because $Because) but it was`n$(Format-MockCallHistoryMessage $callHistory $matchingCalls $nonMatchingCalls)"

--- a/tst/functions/Mock.Tests.ps1
+++ b/tst/functions/Mock.Tests.ps1
@@ -743,7 +743,7 @@ Describe "When Calling Should -Invoke 0 without exactly" {
     }
 
     It "Should throw if mock was called" {
-        $result.Exception.Message | Should -BeLike 'Expected FunctionUnderTest to be called 0 times exactly, but was called 1 times*'
+        $result.Exception.Message | Should -BeLike 'Expected FunctionUnderTest to be called 0 times exactly, but was called 1 time*'
     }
 
     It "Should not throw if mock was not called" {
@@ -757,7 +757,7 @@ Describe "When Calling Should -Invoke 0 without exactly" {
         Catch {
             $failure = $_
         }
-        $failure.Exception.Message | Should -BeLike 'Expected FunctionUnderTest to be called 0 times exactly, because of reasons, but was called 1 times*'
+        $failure.Exception.Message | Should -BeLike 'Expected FunctionUnderTest to be called 0 times exactly, because of reasons, but was called 1 time*'
     }
 }
 
@@ -846,7 +846,9 @@ Describe "When Calling Should -Not -Invoke [Times] without exactly" {
             $result = $_
         }
 
-        $result.Exception.Message | Should -BeLike "Expected FunctionUnderTest to be called less than $Times times, but was called $MockCalls times*"
+        $timesText = if ($Times -eq 1) { '1 time' } else { "$Times times" }
+        $callsText = if ($MockCalls -eq 1) { '1 time' } else { "$MockCalls times" }
+        $result.Exception.Message | Should -BeLike "Expected FunctionUnderTest to be called less than $timesText, but was called $callsText*"
     }
 
     It 'Should include reason when -Because is used' {
@@ -859,7 +861,7 @@ Describe "When Calling Should -Not -Invoke [Times] without exactly" {
         Catch {
             $failure = $_
         }
-        $failure.Exception.Message | Should -BeLike 'Expected FunctionUnderTest to be called less than 1 times, because of reasons, but was called 2 times*'
+        $failure.Exception.Message | Should -BeLike 'Expected FunctionUnderTest to be called less than 1 time, because of reasons, but was called 2 times*'
     }
 }
 
@@ -900,7 +902,7 @@ Describe "When Calling Should -Not -Invoke with exactly" {
     }
 
     It "Should throw if mock was called" {
-        $result.Exception.Message | Should -BeLike "Expected FunctionUnderTest not to be called exactly 1 times, but it was*"
+        $result.Exception.Message | Should -BeLike "Expected FunctionUnderTest not to be called exactly 1 time, but it was*"
     }
 
     It "Should not throw if mock was not called" {
@@ -914,7 +916,7 @@ Describe "When Calling Should -Not -Invoke with exactly" {
         Catch {
             $failure = $_
         }
-        $failure.Exception.Message | Should -BeLike 'Expected FunctionUnderTest not to be called exactly 1 times, because of reasons, but it was*'
+        $failure.Exception.Message | Should -BeLike 'Expected FunctionUnderTest not to be called exactly 1 time, because of reasons, but it was*'
     }
 }
 
@@ -953,7 +955,8 @@ Describe "When Calling Should -Not -Invoke [Times] with exactly" {
             $result = $_
         }
 
-        $result.Exception.Message | Should -BeLike "Expected FunctionUnderTest not to be called exactly $Times times, but it was*"
+        $timesText = if ($Times -eq 1) { '1 time' } else { "$Times times" }
+        $result.Exception.Message | Should -BeLike "Expected FunctionUnderTest not to be called exactly $timesText, but it was*"
     }
 }
 
@@ -1038,7 +1041,7 @@ Performed invocations:
             $failure = $_
         }
 
-        $failure.Exception.Message | Should -BeLike ("Expected FunctionUnderTest*was called 1 times*
+        $failure.Exception.Message | Should -BeLike ("Expected FunctionUnderTest*was called 1 time*
 Performed invocations:
   [[] ] FunctionUnderTest -param1 'one' from *Mock.Tests.ps1:*
   [[]*] FunctionUnderTest -param1 'two' from *Mock.Tests.ps1:*
@@ -1075,7 +1078,7 @@ Performed invocations:
             $failure = $_
         }
 
-        $failure.Exception.Message | Should -Be ('Expected FunctionUnderTest to be called 1 times exactly, but was called 0 times
+        $failure.Exception.Message | Should -Be ('Expected FunctionUnderTest to be called 1 time exactly, but was called 0 times
 Performed invocations:
   <none>' -replace "`r`n", "`n")
     }

--- a/tst/functions/Mock.Tests.ps1
+++ b/tst/functions/Mock.Tests.ps1
@@ -775,7 +775,36 @@ Describe "When Calling Should -Not -Invoke without exactly" {
     }
 
     It "Should throw if mock was called once" {
-        $result.Exception.Message | Should -BeLike "Expected FunctionUnderTest not to be called exactly 1 times, but it was*"
+        $result.Exception.Message | Should -BeLike "Expected FunctionUnderTest not to be called, but it was called 1 time*"
+    }
+
+    It "Should throw and report the call count using plural 'times' when called more than once" {
+        Mock FunctionUnderTest {}
+        FunctionUnderTest "one"
+        FunctionUnderTest "two"
+
+        try {
+            Should -Not -Invoke FunctionUnderTest
+        }
+        Catch {
+            $failure = $_
+        }
+
+        $failure.Exception.Message | Should -BeLike "Expected FunctionUnderTest not to be called, but it was called 2 times*"
+    }
+
+    It 'Should include reason when -Because is used' {
+        Mock FunctionUnderTest {}
+        FunctionUnderTest "one"
+
+        try {
+            Should -Not -Invoke FunctionUnderTest -Because 'of reasons'
+        }
+        Catch {
+            $failure = $_
+        }
+
+        $failure.Exception.Message | Should -BeLike 'Expected FunctionUnderTest not to be called, because of reasons, but it was called 1 time*'
     }
 
     It "Should not throw if mock was not called" {


### PR DESCRIPTION
Fix #1832

A plain `Should -Not -Invoke` (no `-Times`/`-Exactly`) failed with:

> Expected Test-Me not to be called exactly 1 times, but it was ...

That is confusing for a negative assertion, the user never asked for "exactly 1", `1` is just the internal default for `-Times`. `Should -Not -Invoke Foo` just means "Foo should not have been called at all".

The negative branch of `Should-InvokeInternal` now detects the plain case (`-Times` not bound, no `-Exactly`) and words it naturally, with correct singular/plural:

> Expected Test-Me not to be called, but it was called 1 time

> Expected Test-Me not to be called, but it was called 2 times

The `-Times` and `-Exactly` wordings are left as they were, so explicit-count assertions and the positive-assertion messages are unaffected. Updated `Mock.Tests.ps1` for the new message and added coverage for the plural case and `-Because`. 252 passed, no new analyzer findings.