### PR TITLE
Retry transient IOException on TestRegistry reads

### DIFF
--- a/src/functions/TestRegistry.ps1
+++ b/src/functions/TestRegistry.ps1
@@ -70,23 +70,41 @@ function Get-TestRegistryChildItem ([string]$TestRegistryPath) {
         & $SafeCommands['Select-Object'] -ExpandProperty PSPath
 }
 
+function Invoke-TestRegistryWithRetry {
+    # Reading from and writing to the registry can intermittently throw
+    # 'IOException: No more data is available' when TestRegistry is used from parallel
+    # runspaces on Windows PowerShell (.NET Framework). This is a known .NET Framework bug
+    # that is fixed in .NET Core / PowerShell 7. Retry the operation once on that transient
+    # error, so both reads and writes are resilient. See
+    # https://github.com/pester/Pester/issues/2418
+    param(
+        [Parameter(Mandatory)]
+        [scriptblock] $ScriptBlock
+    )
+
+    try {
+        & $ScriptBlock
+    }
+    catch [System.IO.IOException] {
+        # when running in parallel this occasionally triggers
+        # IOException: No more data is available
+        # let's just retry the operation
+        & $SafeCommands['Write-Warning'] "IO exception during a TestRegistry operation, retrying."
+        & $ScriptBlock
+    }
+}
+
 function New-RandomTempRegistry {
     do {
         $tempPath = Get-TempRegistry
         $Path = & $SafeCommands['Join-Path'] -Path $tempPath -ChildPath ([IO.Path]::GetRandomFileName().Substring(0, 4))
-    } until (-not (& $SafeCommands['Test-Path'] -Path $Path -PathType Container))
+        # Test-Path is a read operation and can throw the same transient IOException as the
+        # New-Item write below, so retry it the same way.
+        $keyAlreadyExists = Invoke-TestRegistryWithRetry { & $SafeCommands['Test-Path'] -Path $Path -PathType Container }
+    } until (-not $keyAlreadyExists)
 
     try {
-        try {
-            & $SafeCommands['New-Item'] -Path $Path -ErrorAction Stop
-        }
-        catch [System.IO.IOException] {
-            # when running in parallel this occasionally triggers
-            # IOException: No more data is available
-            # let's just retry the operation
-            & $SafeCommands['Write-Warning'] "IO exception during creating path $path"
-            & $SafeCommands['New-Item'] -Path $Path -ErrorAction Stop
-        }
+        Invoke-TestRegistryWithRetry { & $SafeCommands['New-Item'] -Path $Path -ErrorAction Stop }
     }
     catch [Exception] {
         throw ([Exception]"Was not able to registry key for TestRegistry at '$Path'", ($_.Exception))

--- a/tst/functions/TestRegistry.Tests.ps1
+++ b/tst/functions/TestRegistry.Tests.ps1
@@ -1,5 +1,55 @@
 ﻿Set-StrictMode -Version Latest
 
+Describe 'Invoke-TestRegistryWithRetry' {
+    # This helper makes TestRegistry reads and writes resilient to the transient
+    # 'IOException: No more data is available' that happens on parallel Windows PowerShell
+    # runs (.NET Framework). The retry logic itself is OS-agnostic, so these tests run
+    # everywhere. See https://github.com/pester/Pester/issues/2418
+    It 'Returns the result of the script block on success' {
+        InModuleScope -ModuleName Pester {
+            Invoke-TestRegistryWithRetry { 'result' } | Should -Be 'result'
+        }
+    }
+
+    It 'Invokes the script block once on success' {
+        InModuleScope -ModuleName Pester {
+            $calls = @{ Count = 0 }
+            $null = Invoke-TestRegistryWithRetry { $calls.Count++ }
+            $calls.Count | Should -Be 1
+        }
+    }
+
+    It 'Retries once and returns the second result when the first attempt throws a transient IOException' {
+        InModuleScope -ModuleName Pester {
+            $calls = @{ Count = 0 }
+            $result = Invoke-TestRegistryWithRetry {
+                $calls.Count++
+                if ($calls.Count -eq 1) {
+                    throw [System.IO.IOException] 'No more data is available'
+                }
+                'recovered'
+            }
+            $calls.Count | Should -Be 2
+            $result | Should -Be 'recovered'
+        }
+    }
+
+    It 'Rethrows when the transient IOException persists on retry' {
+        InModuleScope -ModuleName Pester {
+            { Invoke-TestRegistryWithRetry { throw [System.IO.IOException] 'No more data is available' } } |
+                Should -Throw -ExceptionType ([System.IO.IOException])
+        }
+    }
+
+    It 'Does not retry on non-IOException errors' {
+        InModuleScope -ModuleName Pester {
+            $calls = @{ Count = 0 }
+            { Invoke-TestRegistryWithRetry { $calls.Count++; throw 'boom' } } | Should -Throw
+            $calls.Count | Should -Be 1
+        }
+    }
+}
+
 $os = InModuleScope -ModuleName Pester { GetPesterOs }
 if ("Windows" -ne $os) {
     # test registry are only for Windows


### PR DESCRIPTION
Fix #2418

## Problem

`New-RandomTempRegistry` probes the registry with a bare `Test-Path` inside its `do/until` loop:

```powershell
} until (-not (& $SafeCommands['Test-Path'] -Path $Path -PathType Container))
```

On parallel Windows PowerShell 5.1 (.NET Framework) runs this read can intermittently throw `IOException: No more data is available`. As confirmed in the issue thread, this is a known .NET Framework bug that is fixed in .NET Core / PowerShell 7. Only the `New-Item` write in that function was retried, so the read could still crash TestRegistry setup with the reported error.

## Fix

Extract the existing retry-on-`IOException` logic into a small `Invoke-TestRegistryWithRetry` helper and use it for both the `Test-Path` read and the `New-Item` write, so all registry operations in `New-RandomTempRegistry` are resilient to the transient error (per fflaten's suggestion that "we might need this for all read operations in TestRegistry.ps1"). The behavior mirrors the previous inline retry: retry once on `IOException`, otherwise rethrow.

Added focused, OS-agnostic tests for the helper's retry behavior (success returns the result, retries once on a transient `IOException`, rethrows when it persists, and does not retry on other errors).

## Verification

- `./build.ps1` succeeds.
- `./test.ps1 -File tst/functions/TestRegistry.Tests.ps1 -SkipPTests` -> 5 passed, 0 failed.
- `Invoke-ScriptAnalyzer -Path ./src -Recurse -Settings ./.github/workflows/PSScriptAnalyzerSettings.psd1` -> no new findings on the changed lines.

The race is intermittent and .NET Framework only, so there is no deterministic PS7 repro; the fix makes the read resilient the same way the write already was.