### PR TITLE
Resolve relative report output paths against the invocation directory

### DIFF
--- a/src/functions/Coverage.Plugin.ps1
+++ b/src/functions/Coverage.Plugin.ps1
@@ -240,4 +240,10 @@ function Resolve-CodeCoverageConfiguration {
     if ($PesterPreference.CodeCoverage.OutputFormat.Value -notin $supportedFormats) {
         throw (Get-StringOptionErrorMessage -OptionPath 'CodeCoverage.OutputFormat' -SupportedValues $supportedFormats -Value $PesterPreference.CodeCoverage.OutputFormat.Value)
     }
+
+    # Resolve the output path to an absolute path now, while the current location still points to
+    # the directory Invoke-Pester was called from. The report is written after all tests ran, and a
+    # test can change the current location (e.g. Set-Location), so a relative path would otherwise be
+    # resolved against the wrong directory or a directory that no longer exists (#2641).
+    $PesterPreference.CodeCoverage.OutputPath = $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($PesterPreference.CodeCoverage.OutputPath.Value)
 }

--- a/src/functions/TestResults.ps1
+++ b/src/functions/TestResults.ps1
@@ -575,4 +575,10 @@ function Resolve-TestResultConfiguration {
     if ($PesterPreference.TestResult.OutputFormat.Value -notin $supportedFormats) {
         throw (Get-StringOptionErrorMessage -OptionPath 'TestResult.OutputFormat' -SupportedValues $supportedFormats -Value $PesterPreference.TestResult.OutputFormat.Value)
     }
+
+    # Resolve the output path to an absolute path now, while the current location still points to
+    # the directory Invoke-Pester was called from. The report is written after all tests ran, and a
+    # test can change the current location (e.g. Set-Location), so a relative path would otherwise be
+    # resolved against the wrong directory or a directory that no longer exists (#2641).
+    $PesterPreference.TestResult.OutputPath = $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($PesterPreference.TestResult.OutputPath.Value)
 }

--- a/tst/functions/TestResults.Tests.ps1
+++ b/tst/functions/TestResults.Tests.ps1
@@ -137,3 +137,77 @@ InPesterModuleScope {
         }
     }
 }
+
+# Regression tests for https://github.com/pester/Pester/issues/2641
+# Relative report output paths must resolve against the directory Invoke-Pester was called from,
+# not the current location after the run. A test can change the current location (e.g. Set-Location),
+# and reports are written after all tests ran, so the path is resolved eagerly during configuration.
+Describe 'Relative report output paths (#2641)' {
+    It 'writes the TestResult report next to the invocation directory when a test changes the location' {
+        $runFrom = (New-Item -ItemType Directory -Path (Join-Path $TestDrive 'tr-run-from') -Force).FullName
+        $elsewhere = (New-Item -ItemType Directory -Path (Join-Path $TestDrive 'tr-elsewhere') -Force).FullName
+
+        $sb = {
+            Describe 'd' {
+                It 'changes the current location' {
+                    Set-Location $Elsewhere
+                }
+            }
+        }
+        $container = New-PesterContainer -ScriptBlock $sb -Data @{ Elsewhere = $elsewhere }
+
+        $conf = New-PesterConfiguration
+        $conf.Run.Container = $container
+        $conf.Run.PassThru = $true
+        $conf.Output.Verbosity = 'None'
+        $conf.TestResult.Enabled = $true
+        $conf.TestResult.OutputPath = 'testResults.xml'
+
+        Push-Location -Path $runFrom
+        try {
+            $r = Invoke-Pester -Configuration $conf
+        }
+        finally {
+            Pop-Location
+        }
+
+        $r.Result | Should -Be 'Passed'
+        Should -Exist -ActualValue (Join-Path $runFrom 'testResults.xml')
+        Should -Not -Exist -ActualValue (Join-Path $elsewhere 'testResults.xml')
+    }
+
+    It 'writes the CodeCoverage report next to the invocation directory when a test changes the location' {
+        $runFrom = (New-Item -ItemType Directory -Path (Join-Path $TestDrive 'cc-run-from') -Force).FullName
+        $elsewhere = (New-Item -ItemType Directory -Path (Join-Path $TestDrive 'cc-elsewhere') -Force).FullName
+        $covered = Join-Path $TestDrive 'covered.ps1'
+        Set-Content -Path $covered -Value 'function Get-Thing { 1 + 1 }'
+
+        $sb = {
+            Describe 'd' {
+                It 'changes the current location' {
+                    Set-Location $Elsewhere
+                }
+            }
+        }
+        $container = New-PesterContainer -ScriptBlock $sb -Data @{ Elsewhere = $elsewhere }
+
+        $conf = New-PesterConfiguration
+        $conf.Run.Container = $container
+        $conf.Run.PassThru = $true
+        $conf.Output.Verbosity = 'None'
+        $conf.CodeCoverage.Enabled = $true
+        $conf.CodeCoverage.Path = $covered
+        $conf.CodeCoverage.OutputPath = 'coverage.xml'
+
+        Push-Location -Path $runFrom
+        try {
+            $null = Invoke-Pester -Configuration $conf
+        }
+        finally {
+            Pop-Location
+        }
+
+        Should -Exist -ActualValue (Join-Path $runFrom 'coverage.xml')
+        Should -Not -Exist -ActualValue (Join-Path $elsewhere 'coverage.xml')
+    }
+}


### PR DESCRIPTION
Fix #2641

## Problem

`TestResult.OutputPath` and `CodeCoverage.OutputPath` were only resolved to a full path when the report was written, at the very end of the run. Because a test can change the current location (for example with `Set-Location`), a relative output path was resolved against whatever directory the last test left behind. The report then landed in the wrong place, or the run failed with a `Cannot find path` error when that directory had been removed (such as a cleaned-up `TestDrive` folder):

```powershell
Invoke-Pester -Container (New-PesterContainer -ScriptBlock {
    Describe "a" {
        It "b" {
            $testDrive = (Get-PSDrive TestDrive).Root
            $f = New-Item -ItemType Directory -Path "$testDrive/will-delete" -Force
            Set-Location $f
        }
    }
}) -CI
```

## Fix

Resolve both output paths to absolute eagerly in `Resolve-TestResultConfiguration` and `Resolve-CodeCoverageConfiguration`. These run during plugin setup, before any test body executes, while the current location still points to the directory `Invoke-Pester` was called from. Paths that are already absolute are unaffected.

This matches the direction suggested in the issue: resolve the output paths early during configuration resolution.

## Tests

Added regression tests in `tst/functions/TestResults.Tests.ps1` that run a nested `Invoke-Pester` with a relative output path and a test that changes the current location mid-run, asserting the report is written next to the invocation directory (and not the directory the test switched to). Both cover the `TestResult` and `CodeCoverage` reports and fail without the fix.