### PR TITLE
Report containers that fail during discovery in TestResult XML

### DIFF
--- a/src/functions/TestResults.JUnit4.ps1
+++ b/src/functions/TestResults.JUnit4.ps1
@@ -10,8 +10,9 @@
 
     $testSuiteNumber = 0
     foreach ($container in $Result.Containers) {
-        if (-not $container.ShouldRun) {
-            # skip containers that were discovered but none of their tests run
+        if ((-not $container.ShouldRun) -and -not (Test-ContainerFailedDiscovery -Container $container)) {
+            # skip containers that were discovered but none of their tests run,
+            # unless they failed during discovery so the error is still reported (#2664)
             continue
         }
 
@@ -29,7 +30,7 @@ function Write-JUnitTestResultAttributes {
     $XmlWriter.WriteAttributeString('xmlns', 'xsi', $null, 'http://www.w3.org/2001/XMLSchema-instance')
     $XmlWriter.WriteAttributeString('xsi', 'noNamespaceSchemaLocation', [Xml.Schema.XmlSchema]::InstanceNamespace , 'junit_schema_4.xsd')
     $XmlWriter.WriteAttributeString('name', $Result.Configuration.TestResult.TestSuiteName.Value)
-    $XmlWriter.WriteAttributeString('tests', $Result.TotalCount)
+    $XmlWriter.WriteAttributeString('tests', ($Result.TotalCount + (Get-DiscoveryFailedContainerCount -Result $Result)))
     $XmlWriter.WriteAttributeString('errors', $Result.FailedContainersCount + $Result.FailedBlocksCount)
     $XmlWriter.WriteAttributeString('failures', $Result.FailedCount)
     $XmlWriter.WriteAttributeString('disabled', $Result.NotRunCount + $Result.SkippedCount)
@@ -44,6 +45,12 @@ function Write-JUnitTestSuiteElements {
 
     Write-JUnitTestSuiteAttributes -Action $Container -XmlWriter $XmlWriter -Package $container.Name -Id $Id
 
+    if (Test-ContainerFailedDiscovery -Container $Container) {
+        # The container failed during discovery and has no tests to carry the error, so write a
+        # synthetic testcase holding the discovery error, since JUnit has no suite-level error. (#2664)
+        Write-JUnitDiscoveryFailureElement -Container $Container -XmlWriter $XmlWriter
+    }
+
     $testResults = [Pester.Factory]::CreateCollection()
     Fold-Container -Container $Container -OnTest { param ($t) if ($t.ShouldRun) { $testResults.Add($t) } }
     foreach ($t in $testResults) {
@@ -53,15 +60,41 @@ function Write-JUnitTestSuiteElements {
     $XmlWriter.WriteEndElement()
 }
 
+function Write-JUnitDiscoveryFailureElement {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '')]
+    param([Pester.Container] $Container, [System.Xml.XmlWriter] $XmlWriter)
+
+    $discoveryError = Get-ErrorForXmlReport -TestResult $Container
+
+    $XmlWriter.WriteStartElement('testcase')
+    $XmlWriter.WriteAttributeString('name', $Container.Name)
+    $XmlWriter.WriteAttributeString('status', 'Failed')
+    $XmlWriter.WriteAttributeString('classname', $Container.Name)
+    $XmlWriter.WriteAttributeString('assertions', '0')
+    $XmlWriter.WriteAttributeString('time', $Container.Duration.TotalSeconds.ToString('0.000', [System.Globalization.CultureInfo]::InvariantCulture))
+
+    $XmlWriter.WriteStartElement('error')
+    $XmlWriter.WriteAttributeString('message', $discoveryError.FailureMessage)
+    $XmlWriter.WriteString($discoveryError.StackTrace)
+    $XmlWriter.WriteEndElement() # Close error
+
+    $XmlWriter.WriteEndElement() # Close testcase
+}
+
 function Write-JUnitTestSuiteAttributes {
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns','')]
     param($Action, [System.Xml.XmlWriter] $XmlWriter, [string] $Package, [uint16] $Id)
 
     $environment = Get-RunTimeEnvironment
 
+    # A container that failed during discovery has no tests, so count the synthetic discovery
+    # testcase (see Write-JUnitDiscoveryFailureElement) as one erroring test. (#2664)
+    $discoveryFailed = Test-ContainerFailedDiscovery -Container $Action
+    $extraCount = if ($discoveryFailed) { 1 } else { 0 }
+
     $XmlWriter.WriteAttributeString('name', $Package)
-    $XmlWriter.WriteAttributeString('tests', $Action.TotalCount)
-    $XmlWriter.WriteAttributeString('errors', '0')
+    $XmlWriter.WriteAttributeString('tests', ($Action.TotalCount + $extraCount))
+    $XmlWriter.WriteAttributeString('errors', $extraCount)
     $XmlWriter.WriteAttributeString('failures', $Action.FailedCount)
     $XmlWriter.WriteAttributeString('hostname', $environment.'machine-name')
     $XmlWriter.WriteAttributeString('id', $Id)

--- a/src/functions/TestResults.NUnit25.ps1
+++ b/src/functions/TestResults.NUnit25.ps1
@@ -20,7 +20,7 @@ function Write-NUnitTestResultAttributes {
     $XmlWriter.WriteAttributeString('xsi', 'noNamespaceSchemaLocation', [Xml.Schema.XmlSchema]::InstanceNamespace , 'nunit_schema_2.5.xsd')
     $XmlWriter.WriteAttributeString('name', $Result.Configuration.TestResult.TestSuiteName.Value)
     $XmlWriter.WriteAttributeString('total', ($Result.TotalCount - $Result.NotRunCount))
-    $XmlWriter.WriteAttributeString('errors', '0')
+    $XmlWriter.WriteAttributeString('errors', (Get-DiscoveryFailedContainerCount -Result $Result))
     $XmlWriter.WriteAttributeString('failures', $Result.FailedCount)
     $XmlWriter.WriteAttributeString('not-run', $Result.NotRunCount)
     $XmlWriter.WriteAttributeString('inconclusive', $Result.InconclusiveCount)
@@ -48,8 +48,9 @@ function Write-NUnitTestResultChildNodes {
     $XmlWriter.WriteStartElement('results')
 
     foreach ($container in $Result.Containers) {
-        if (-not $container.ShouldRun) {
-            # skip containers that were discovered but none of their tests run
+        if ((-not $container.ShouldRun) -and -not (Test-ContainerFailedDiscovery -Container $container)) {
+            # skip containers that were discovered but none of their tests run,
+            # unless they failed during discovery so the error is still reported (#2664)
             continue
         }
 
@@ -97,6 +98,16 @@ function Write-NUnitTestSuiteElements {
     $XmlWriter.WriteStartElement('test-suite')
 
     Write-NUnitTestSuiteAttributes -TestSuiteInfo $suiteInfo -XmlWriter $XmlWriter
+
+    if ($Node -is [Pester.Container] -and (Test-ContainerFailedDiscovery -Container $Node)) {
+        # The container failed during discovery and has no tests to carry the error, so surface
+        # the discovery error on the suite itself. The schema requires failure before results. (#2664)
+        $discoveryError = Get-ErrorForXmlReport -TestResult $Node
+        $XmlWriter.WriteStartElement('failure')
+        $XmlWriter.WriteElementString('message', $discoveryError.FailureMessage)
+        $XmlWriter.WriteElementString('stack-trace', $discoveryError.StackTrace)
+        $XmlWriter.WriteEndElement() # Close failure tag
+    }
 
     $XmlWriter.WriteStartElement('results')
 
@@ -218,7 +229,7 @@ function Get-TestSuiteInfo {
 
     $suite = @{
         resultMessage = 'Failure'
-        success       = if ($TestSuite.FailedCount -eq 0) {
+        success       = if ($TestSuite.FailedCount -eq 0 -and $TestSuite.Result -ne 'Failed') {
             'True'
         }
         else {
@@ -361,7 +372,7 @@ function Write-NUnitTestCaseAttributes {
 function Get-GroupResult ($InputObject) {
     #I am not sure about the result precedence, and can't find any good source
     #TODO: Confirm this is the correct order of precedence
-    if ($inputObject.FailedCount -gt 0) {
+    if ($inputObject.FailedCount -gt 0 -or $InputObject.Result -eq 'Failed') {
         return 'Failure'
     }
     if ($InputObject.SkippedCount -gt 0) {

--- a/src/functions/TestResults.NUnit3.ps1
+++ b/src/functions/TestResults.NUnit3.ps1
@@ -27,18 +27,22 @@ function Write-NUnit3TestRunAttributes {
     $XmlWriter.WriteAttributeString('id', '0')
     $XmlWriter.WriteAttributeString('name', $Result.Configuration.TestResult.TestSuiteName.Value) # required attr. in schema, but not in docs or nunit-console output...
     $XmlWriter.WriteAttributeString('fullname', $Result.Configuration.TestResult.TestSuiteName.Value) # required attr. in schema, but not in docs or nunit-console output...
-    $XmlWriter.WriteAttributeString('testcasecount', ($Result.TotalCount - $Result.NotRunCount)) # all testcases in run (before filtering). would've been totalcount if we listed shouldrun=false
+    # Containers that failed during discovery have no tests, so count each as one failed item
+    # to keep the run totals from silently reporting zero. (#2664)
+    $discoveryFailedCount = Get-DiscoveryFailedContainerCount -Result $Result
+    $testcasecount = ($Result.TotalCount - $Result.NotRunCount) + $discoveryFailedCount
+    $XmlWriter.WriteAttributeString('testcasecount', $testcasecount) # all testcases in run (before filtering). would've been totalcount if we listed shouldrun=false
     $XmlWriter.WriteAttributeString('result', (Get-NUnit3Result $Result)) # Summary of run. May be Passed, Failed, Inconclusive or Skipped.
-    $XmlWriter.WriteAttributeString('total', ($Result.TotalCount - $Result.NotRunCount)) # testcasecount - filtered
+    $XmlWriter.WriteAttributeString('total', $testcasecount) # testcasecount - filtered
     $XmlWriter.WriteAttributeString('passed', $Result.PassedCount)
-    $XmlWriter.WriteAttributeString('failed', $Result.FailedCount)
+    $XmlWriter.WriteAttributeString('failed', ($Result.FailedCount + $discoveryFailedCount))
     $XmlWriter.WriteAttributeString('inconclusive', $Result.InconclusiveCount)
     $XmlWriter.WriteAttributeString('skipped', $Result.SkippedCount)
     $XmlWriter.WriteAttributeString('warnings', '0') # required attr.
     $XmlWriter.WriteAttributeString('start-time', (Get-UTCTimeString $Result.ExecutedAt))
     $XmlWriter.WriteAttributeString('end-time', (Get-UTCTimeString ($Result.ExecutedAt + $Result.Duration)))
     $XmlWriter.WriteAttributeString('duration', (Convert-TimeSpan $Result.Duration))
-    $XmlWriter.WriteAttributeString('asserts', ($Result.TotalCount - $Result.NotRunCount)) # required attr. assuming 1:1 per testcase
+    $XmlWriter.WriteAttributeString('asserts', $testcasecount) # required attr. assuming 1:1 per testcase
     $XmlWriter.WriteAttributeString('random-seed', (Get-Random)) # required attr. in schema, but not in docs or nunit-console output...
 }
 
@@ -54,8 +58,9 @@ function Write-NUnit3TestRunChildNode {
     $RuntimeEnvironment = Get-RunTimeEnvironment
 
     foreach ($container in $Result.Containers) {
-        if (-not $container.ShouldRun) {
-            # skip containers that were discovered but none of their tests run
+        if ((-not $container.ShouldRun) -and -not (Test-ContainerFailedDiscovery -Container $container)) {
+            # skip containers that were discovered but none of their tests run,
+            # unless they failed during discovery so the error is still reported (#2664)
             continue
         }
 
@@ -107,6 +112,12 @@ function Write-NUnit3TestSuiteElement {
         $CurrentPath = $null # child suites shouldn't use assembly-name in path
         Write-NUnit3TestSuiteAttributes -TestSuiteInfo $suiteInfo -XmlWriter $XmlWriter
         Write-NUnit3EnvironmentInformation -XmlWriter $XmlWriter -Environment $RuntimeEnvironment
+
+        if (Test-ContainerFailedDiscovery -Container $Node) {
+            # The container failed during discovery and has no tests to carry the error,
+            # so surface the discovery error on the suite itself. (#2664)
+            Write-NUnit3FailureElement -TestResult $Node -XmlWriter $XmlWriter
+        }
     }
     else {
         $CurrentPath = $suiteInfo.fullname
@@ -273,6 +284,12 @@ function Get-NUnit3TestSuiteInfo {
         Get-NUnit3Site
     }
 
+    # A container that failed during discovery has no tests, so count it as one failed item
+    # to keep the suite totals from silently reporting zero. (#2664)
+    $isDiscoveryFailure = $TestSuite -is [Pester.Container] -and (Test-ContainerFailedDiscovery -Container $TestSuite)
+    $testcasecount = if ($isDiscoveryFailure) { 1 } else { ($TestSuite.TotalCount - $TestSuite.NotRunCount) }
+    $failedCount = if ($isDiscoveryFailure) { 1 } else { $TestSuite.FailedCount }
+
     $suiteInfo = @{
         type          = $SuiteType
         name          = $name
@@ -283,10 +300,10 @@ function Get-NUnit3TestSuiteInfo {
         start         = (Get-UTCTimeString $TestSuite.ExecutedAt)
         end           = (Get-UTCTimeString ($TestSuite.ExecutedAt + $TestSuite.Duration))
         duration      = (Convert-TimeSpan $TestSuite.Duration)
-        testcasecount = ($TestSuite.TotalCount - $TestSuite.NotRunCount) # would've been totalcount if we listed shouldrun=false
-        total         = ($TestSuite.TotalCount - $TestSuite.NotRunCount)
+        testcasecount = $testcasecount # would've been totalcount if we listed shouldrun=false
+        total         = $testcasecount
         passed        = $TestSuite.PassedCount
-        failed        = $TestSuite.FailedCount
+        failed        = $failedCount
         skipped       = $TestSuite.SkippedCount
         inconclusive  = $TestSuite.InconclusiveCount
         site          = $site
@@ -326,12 +343,14 @@ function Write-NUnit3TestSuiteAttributes {
 }
 
 function Get-NUnit3Result ($InputObject) {
-    if ($InputObject.TotalCount -eq $InputObject.NotRunCount) {
-        'Inconclusive'
-    }
-    # also checking result to cover setup/teardown errors
-    elseif ($InputObject.Result -eq 'Failed' -or $InputObject.FailedCount -gt 0) {
+    # A discovery failure has no tests (TotalCount -eq NotRunCount), so check the failed
+    # state first, otherwise such a failure would be reported as Inconclusive. (#2664)
+    if ($InputObject.Result -eq 'Failed' -or $InputObject.FailedCount -gt 0) {
+        # also checking result to cover setup/teardown and discovery errors
         'Failed'
+    }
+    elseif ($InputObject.TotalCount -eq $InputObject.NotRunCount) {
+        'Inconclusive'
     }
     elseif ($InputObject.SkippedCount -gt 0) {
         'Skipped'

--- a/src/functions/TestResults.ps1
+++ b/src/functions/TestResults.ps1
@@ -499,6 +499,28 @@ function Get-ErrorForXmlReport ($TestResult) {
     }
 }
 
+function Test-ContainerFailedDiscovery {
+    param($Container)
+    # A container that failed during discovery never runs its tests (ShouldRun = $false),
+    # but it is marked as Failed and carries the discovery error in its ErrorRecord. Such
+    # containers would otherwise be skipped by the report writers, silently omitting the
+    # failure from the exported TestResult XML. (#2664)
+    (-not $Container.ShouldRun) -and ($Container.Result -eq 'Failed') -and ($Container.ErrorRecord.Count -gt 0)
+}
+
+function Get-DiscoveryFailedContainerCount {
+    param([Pester.Run] $Result)
+    # Number of containers that failed during discovery. Used so the exported report totals
+    # reflect these failures instead of silently reporting zero. (#2664)
+    $count = 0
+    foreach ($container in $Result.Containers) {
+        if (Test-ContainerFailedDiscovery -Container $container) {
+            $count++
+        }
+    }
+    $count
+}
+
 function Get-RunTimeEnvironment {
     # based on what we found during startup, use the appropriate cmdlet
     $computerName = $env:ComputerName

--- a/tst/Pester.RSpec.TestResults.JUnit4.ts.ps1
+++ b/tst/Pester.RSpec.TestResults.JUnit4.ts.ps1
@@ -270,6 +270,53 @@ i -PassThru:$PassThru {
         }
     }
 
+    b "When a container fails during discovery it is reported" {
+        # https://github.com/pester/Pester/issues/2664
+        # Passing an array directly to It (instead of via -TestCases) throws during discovery.
+        $sb = {
+            Describe "Count" {
+                It "Returns sum" @(
+                    @{ Name = 1; Expected = 2 }
+                    @{ Name = 2; Expected = 4 }
+                ) {
+                    $Name + $Name | Should -Be $Expected
+                }
+            }
+        }
+
+        t "discovery-failed container is written as an erroring testsuite carrying its error" {
+            $r = Invoke-Pester -Container (New-PesterContainer -ScriptBlock $sb) -PassThru -Output None
+
+            # sanity: the container failed during discovery and did not run any tests
+            $r.Containers[0].ShouldRun | Verify-False
+            $r.Containers[0].Result | Verify-Equal 'Failed'
+
+            $xmlResult = $r | ConvertTo-JUnitReport
+
+            # the report totals reflect the failure instead of silently reporting zero
+            $xmlResult.'testsuites'.errors | Verify-Equal '1'
+            $xmlResult.'testsuites'.tests | Verify-Equal '1'
+
+            $xmlTestSuite = $xmlResult.'testsuites'.'testsuite'
+            $xmlTestSuite.errors | Verify-Equal '1'
+            $xmlTestSuite.tests | Verify-Equal '1'
+
+            $xmlTestCase = $xmlTestSuite.'testcase'
+            $xmlTestCase.status | Verify-Equal 'Failed'
+            $xmlTestCase.error | Verify-NotNull
+            $xmlTestCase.error.message | Verify-Like '*ScriptBlock*'
+        }
+
+        t "discovery-failure report validates against the junit 4 schema" {
+            $r = Invoke-Pester -Container (New-PesterContainer -ScriptBlock $sb) -PassThru -Output None
+
+            $xmlResult = [xml] ($r | ConvertTo-JUnitReport)
+
+            $xmlResult.Schemas.Add($null, $schemaPath) > $null
+            $xmlResult.Validate( { throw $args[1].Exception })
+        }
+    }
+
     b "Writing JUnit report into file" {
         t "should write XML when using TestResult configuration" {
             try {

--- a/tst/Pester.RSpec.TestResults.NUnit25.ts.ps1
+++ b/tst/Pester.RSpec.TestResults.NUnit25.ts.ps1
@@ -553,6 +553,52 @@ i -PassThru:$PassThru {
         }
     }
 
+    b "When a container fails during discovery it is reported" {
+        # https://github.com/pester/Pester/issues/2664
+        # Passing an array directly to It (instead of via -TestCases) throws during discovery.
+        $sb = {
+            Describe "Count" {
+                It "Returns sum" @(
+                    @{ Name = 1; Expected = 2 }
+                    @{ Name = 2; Expected = 4 }
+                ) {
+                    $Name + $Name | Should -Be $Expected
+                }
+            }
+        }
+
+        t "discovery-failed container is written as a failed test-suite carrying its error" {
+            $r = Invoke-Pester -Configuration ([PesterConfiguration]@{ Run = @{ ScriptBlock = $sb; PassThru = $true }; Output = @{ Verbosity = 'None' } })
+
+            # sanity: the container failed during discovery and did not run any tests
+            $r.Containers[0].ShouldRun | Verify-False
+            $r.Containers[0].Result | Verify-Equal 'Failed'
+
+            $xmlResult = [xml] ($r | ConvertTo-NUnitReport)
+
+            # the report totals reflect the failure instead of silently reporting zero
+            $xmlResult.'test-results'.errors | Verify-Equal '1'
+            $xmlResult.'test-results'.'test-suite'.result | Verify-Equal 'Failure'
+            $xmlResult.'test-results'.'test-suite'.success | Verify-Equal 'False'
+
+            $xmlContainer = $xmlResult.'test-results'.'test-suite'.'results'.'test-suite'
+            $xmlContainer.result | Verify-Equal 'Failure'
+            $xmlContainer.success | Verify-Equal 'False'
+            $xmlContainer.failure | Verify-NotNull
+            $xmlContainer.failure.message | Verify-NotNull
+            $xmlContainer.failure.message | Verify-Like '*ScriptBlock*'
+        }
+
+        t "discovery-failure report validates against the nunit 2.5 schema" {
+            $r = Invoke-Pester -Configuration ([PesterConfiguration]@{ Run = @{ ScriptBlock = $sb; PassThru = $true }; Output = @{ Verbosity = 'None' } })
+
+            $xmlResult = [xml] ($r | ConvertTo-NUnitReport)
+
+            $xmlResult.Schemas.Add($null, $schemaPath) > $null
+            $xmlResult.Validate( { throw $args[1].Exception })
+        }
+    }
+
     b "Outputing into a file" {
         t "Write NUnit report using TestResult configuration with NUnitXml" {
             $sb = {

--- a/tst/Pester.RSpec.TestResults.NUnit3.ts.ps1
+++ b/tst/Pester.RSpec.TestResults.NUnit3.ts.ps1
@@ -876,6 +876,53 @@ i -PassThru:$PassThru {
         }
     }
 
+    b 'When a container fails during discovery it is reported' {
+        # https://github.com/pester/Pester/issues/2664
+        # Passing an array directly to It (instead of via -TestCases) throws during discovery.
+        $sb = {
+            Describe 'Count' {
+                It 'Returns sum' @(
+                    @{ Name = 1; Expected = 2 }
+                    @{ Name = 2; Expected = 4 }
+                ) {
+                    $Name + $Name | Should -Be $Expected
+                }
+            }
+        }
+
+        t 'discovery-failed container is written as a failed test-suite carrying its error' {
+            $r = Invoke-Pester -Configuration ([PesterConfiguration]@{ Run = @{ ScriptBlock = $sb; PassThru = $true }; Output = @{ Verbosity = 'None' } })
+
+            # sanity: the container failed during discovery and did not run any tests
+            $r.Containers[0].ShouldRun | Verify-False
+            $r.Containers[0].Result | Verify-Equal 'Failed'
+
+            $xmlResult = $r | ConvertTo-NUnitReport -Format NUnit3
+
+            # the run totals reflect the failure instead of silently reporting Inconclusive/zero
+            $xmlResult.'test-run'.result | Verify-Equal 'Failed'
+            $xmlResult.'test-run'.failed | Verify-Equal '1'
+            $xmlResult.'test-run'.total | Verify-Equal '1'
+
+            $xmlContainer = $xmlResult.'test-run'.'test-suite'
+            $xmlContainer.result | Verify-Equal 'Failed'
+            $xmlContainer.runstate | Verify-Equal 'NotRunnable'
+            $xmlContainer.failed | Verify-Equal '1'
+            $xmlContainer.failure | Verify-NotNull
+            $xmlContainer.failure.message.InnerText | Verify-Like '*ScriptBlock*'
+        }
+
+        t 'discovery-failure report validates against the nunit 3 schema' {
+            $r = Invoke-Pester -Configuration ([PesterConfiguration]@{ Run = @{ ScriptBlock = $sb; PassThru = $true }; Output = @{ Verbosity = 'None' } })
+
+            $xmlResult = [xml] ($r | ConvertTo-NUnitReport -Format NUnit3)
+
+            $xmlResult.Schemas.XmlResolver = New-Object System.Xml.XmlUrlResolver
+            $xmlResult.Schemas.Add($null, $schemaPath) > $null
+            $xmlResult.Validate( { throw $args[1].Exception })
+        }
+    }
+
     b 'Outputing into a file' {
         t 'Write NUnit3 report using TestResult.OutputFormat' {
             $sb = {


### PR DESCRIPTION
## Problem

Fix #2664

When a container throws during the **discovery** phase (for example passing an array directly to `It` instead of via `-TestCases`), the container never runs its tests (`ShouldRun = $false`) but is marked `Failed` and carries the discovery error in its `ErrorRecord`. All three report writers skipped containers where `-not ShouldRun`, so the exported NUnit 2.5, NUnit3 and JUnit TestResult XML reported `total=0` with no entries and the discovery failure was **silently omitted**. CI pipelines that only read the XML never saw the failure.

Repro (fails at discovery, reported green/empty before this change):

```powershell
Describe 'Count' {
    It 'Returns sum' @(
        @{ Name = 1; Expected = 2 }
        @{ Name = 2; Expected = 4 }
    ) {
        $Name + $Name | Should -Be $Expected
    }
}
```

## Fix

Add shared helpers `Test-ContainerFailedDiscovery` and `Get-DiscoveryFailedContainerCount` in `TestResults.ps1`, and update the three writers so a discovery-failed container is serialized as a failed entry carrying its error record/message, with totals reflecting it:

- **NUnit 2.5** (default): stop skipping the container; write a `<failure>` on its `<test-suite>` (before `<results>`, as the schema requires); count it in the run-level `errors`; honor `Result = 'Failed'` in `Get-GroupResult`/suite success.
- **NUnit3**: stop skipping; write a `<failure>` on the container test-suite; count it as one failed item at run and suite level (`runstate` was already `NotRunnable`); check the failed state before the inconclusive check in `Get-NUnit3Result` so the result is `Failed` instead of `Inconclusive`.
- **JUnit**: stop skipping; write a synthetic `<testcase>` with an `<error>` holding the discovery error (JUnit has no suite-level error element); count it in the suite and top-level totals.

## Tests

Added regression P-tests to all three `tst/Pester.RSpec.TestResults.*.ts.ps1` files asserting the discovery-failed container appears with its error and that the report stays schema-valid.

- `NUnit25` 24/24, `NUnit3` 36/36, `JUnit4` 16/16 - 0 failures.
- PSScriptAnalyzer on `./src` with the repo settings: no new findings on changed lines.

Built with `./build.ps1` (PowerShell-only change).