### PR TITLE
Fail the test on a stray unmatched-label break/continue instead of aborting the whole run

### DIFF
--- a/src/Pester.Runtime.ps1
+++ b/src/Pester.Runtime.ps1
@@ -1377,6 +1377,22 @@ function Assert-Success {
     }
 }
 
+function New-EscapedFlowControlErrorRecord {
+    # User code can run `break` / `continue` with a label that does not match any enclosing
+    # loop (usually a typo). PowerShell raises a flow-control exception (BreakException /
+    # ContinueException) that a normal try/catch cannot see and that unwinds past the whole
+    # Pester runner, silently aborting the run with no result (see #2669). Invoke-ScriptBlock
+    # detects that escape and calls this helper to build a normal terminating error so the
+    # current test or block fails with a clear message instead of the run being torn down.
+    # We cannot recover the label or tell break from continue at that point (the flow-control
+    # exception is not surfaced), so the message names both keywords.
+    $message = "A 'break' or 'continue' statement with a label that does not match any enclosing loop escaped from your code. " +
+    "This is usually a misspelled or undefined loop label. Left unhandled it silently aborts the whole Pester run with no result (see https://github.com/pester/Pester/issues/2669), so Pester failed this test or block instead."
+
+    $exception = [System.InvalidOperationException]::new($message)
+    [Management.Automation.ErrorRecord]::new($exception, 'PesterFlowControlStatementEscaped', [Management.Automation.ErrorCategory]::InvalidOperation, $null)
+}
+
 function Invoke-ScriptBlock {
     param(
         [ScriptBlock] $ScriptBlock,
@@ -1671,16 +1687,41 @@ function Invoke-ScriptBlock {
                 & $OnUserScopeTransition
             }
         }
-        do {
-            $standardOutput = if ($NoNewScope) {
-                . $wrapperScriptBlock $parameters
+        # User code can run `break` / `continue` with a label that does not match any enclosing
+        # loop (usually a typo). PowerShell raises a flow-control exception (BreakException /
+        # ContinueException) that a normal try/catch cannot see. Left unhandled it unwinds past
+        # the whole Pester runner and silently aborts the run with no result (see #2669).
+        #
+        # The do/while ($false) below already absorbs a plain, unlabelled break/continue, so
+        # those keep their current behaviour and simply end the scriptblock. A labelled
+        # break/continue whose label matches no enclosing loop escapes the do/while; when that
+        # happens for user code we rethrow it from the finally as a normal terminating error so
+        # the outer catch records it as a failure of the current test or block instead of
+        # letting it tear down the whole run. Correctly labelled break/continue inside loops in
+        # user code stays within that code and never reaches here, so it is unaffected. This
+        # only guards user code ($MoveBetweenScopes); framework invocations run unchanged.
+        $flowControlEscaped = $MoveBetweenScopes
+        try {
+            do {
+                $standardOutput = if ($NoNewScope) {
+                    . $wrapperScriptBlock $parameters
+                }
+                else {
+                    & $wrapperScriptBlock $parameters
+                }
+                # if the code reaches here we did not break
+                #$break = $false
+            } while ($false)
+
+            # Reached when the wrapper returned normally or a plain unlabelled break/continue
+            # was absorbed by the do/while above. A labelled escape skips this assignment.
+            $flowControlEscaped = $false
+        }
+        finally {
+            if ($flowControlEscaped) {
+                throw (New-EscapedFlowControlErrorRecord)
             }
-            else {
-                & $wrapperScriptBlock $parameters
-            }
-            # if the code reaches here we did not break
-            #$break = $false
-        } while ($false)
+        }
     }
     catch {
         $err = $_

--- a/tst/Pester.RSpec.ts.ps1
+++ b/tst/Pester.RSpec.ts.ps1
@@ -3486,5 +3486,113 @@ Describe "Something" {
                 }
             }
         }
+
+        t "an unmatched-label break escaping user code fails the test instead of aborting the run (#2669)" {
+            $sb = {
+                Describe 'unmatched break' {
+                    BeforeAll { function Invoke-StrayBreak { break outerLoop } }
+                    It 'first passes' { $true | Should -Be $true }
+                    It 'stray break fails' { Invoke-StrayBreak }
+                    It 'later test still runs' { $true | Should -Be $true }
+                }
+            }
+
+            $r = Invoke-Pester -Configuration ([PesterConfiguration]@{
+                    Run    = @{ ScriptBlock = $sb; PassThru = $true }
+                    Output = @{ Verbosity = 'None' }
+                })
+
+            # The run completed with a result and summary instead of silently aborting.
+            $r.Result | Verify-Equal 'Failed'
+            $r.TotalCount | Verify-Equal 3
+            $tests = $r.Containers[0].Blocks[0].Tests
+            $tests[0].Result | Verify-Equal 'Passed'
+            $tests[1].Result | Verify-Equal 'Failed'
+            # The sibling test after the offending one still ran.
+            $tests[2].Result | Verify-Equal 'Passed'
+            $tests[1].ErrorRecord[0].FullyQualifiedErrorId | Verify-Equal 'PesterFlowControlStatementEscaped'
+            $tests[1].ErrorRecord[0].Exception.Message | Verify-Like '*does not match any enclosing loop*'
+        }
+
+        t "an unmatched-label continue escaping user code fails the test instead of aborting the run (#2669)" {
+            $sb = {
+                Describe 'unmatched continue' {
+                    It 'stray continue fails' { continue outerLoop }
+                    It 'later test still runs' { $true | Should -Be $true }
+                }
+            }
+
+            $r = Invoke-Pester -Configuration ([PesterConfiguration]@{
+                    Run    = @{ ScriptBlock = $sb; PassThru = $true }
+                    Output = @{ Verbosity = 'None' }
+                })
+
+            $r.Result | Verify-Equal 'Failed'
+            $r.TotalCount | Verify-Equal 2
+            $tests = $r.Containers[0].Blocks[0].Tests
+            $tests[0].Result | Verify-Equal 'Failed'
+            $tests[0].ErrorRecord[0].FullyQualifiedErrorId | Verify-Equal 'PesterFlowControlStatementEscaped'
+            $tests[1].Result | Verify-Equal 'Passed'
+        }
+
+        t "an unmatched-label break in a setup fails the block instead of aborting the run (#2669)" {
+            $sb = {
+                Describe 'stray break in setup' {
+                    BeforeEach { break outerLoop }
+                    It 'is failed by the setup break' { $true | Should -Be $true }
+                }
+            }
+
+            $r = Invoke-Pester -Configuration ([PesterConfiguration]@{
+                    Run    = @{ ScriptBlock = $sb; PassThru = $true }
+                    Output = @{ Verbosity = 'None' }
+                })
+
+            $r.Result | Verify-Equal 'Failed'
+            $tests = $r.Containers[0].Blocks[0].Tests
+            $tests[0].Result | Verify-Equal 'Failed'
+            $tests[0].ErrorRecord[0].FullyQualifiedErrorId | Verify-Equal 'PesterFlowControlStatementEscaped'
+        }
+
+        t "correctly labelled break and continue inside loops in user code are unaffected" {
+            $sb = {
+                Describe 'labelled loops still work' {
+                    It 'labelled break stays inside its loop' {
+                        $sum = 0
+                        :outer foreach ($i in 1..5) {
+                            foreach ($j in 1..5) {
+                                if ($j -eq 3) { break outer }
+                                $sum += 1
+                            }
+                        }
+                        $sum | Should -Be 2
+                    }
+                    It 'labelled continue stays inside its loop' {
+                        $collected = @()
+                        :top foreach ($i in 1..3) {
+                            foreach ($j in 1..3) {
+                                if ($j -eq 2) { continue top }
+                                $collected += "$i$j"
+                            }
+                        }
+                        ($collected -join ',') | Should -Be '11,21,31'
+                    }
+                    It 'a plain break exiting user code is still absorbed' {
+                        break
+                        # unreachable: the plain break exits the test body without failing it
+                        $false | Should -Be $true
+                    }
+                }
+            }
+
+            $r = Invoke-Pester -Configuration ([PesterConfiguration]@{
+                    Run    = @{ ScriptBlock = $sb; PassThru = $true }
+                    Output = @{ Verbosity = 'None' }
+                })
+
+            $r.Result | Verify-Equal 'Passed'
+            $r.PassedCount | Verify-Equal 3
+            $r.FailedCount | Verify-Equal 0
+        }
     }
 }


### PR DESCRIPTION
## Problem

When user code called from a test runs `break <label>` or `continue <label>` with a label that does not match any enclosing loop (usually a typo or an undefined label), PowerShell raises a flow-control exception (`BreakException` / `ContinueException`) that a normal `try/catch` cannot see. It unwinds past Pester's test-execution loop and silently aborts the whole run: no test failure, no summary, no result output. PowerShell declined to change this upstream (PowerShell/PowerShell#26587).

## Fix

`Invoke-ScriptBlock` already wraps the user-code invocation in a `do { ... } while ($false)` that absorbs a plain, unlabelled `break`/`continue`. This change wraps that loop in a `try/finally` and tracks whether execution reached the point just after the loop:

- A plain unlabelled `break`/`continue` is absorbed by the `do/while` (behaviour unchanged).
- A correctly labelled `break`/`continue` inside a loop in user code never escapes that code (behaviour unchanged).
- A labelled `break`/`continue` whose label matches no enclosing loop escapes the `do/while` and skips the "after loop" assignment, so the `finally` rethrows it as a normal terminating error. The outer `catch` records it as a failure of the current test or block, and the run continues and prints a summary as usual.

Notes:

- The guard applies only to user code (`$MoveBetweenScopes`: test bodies, block bodies, and `Before*`/`After*` hooks), so framework and plugin invocations are unchanged.
- It uses no nested runspace, so code coverage and `Verbose`/`Debug` stream output are unaffected, and it works on all supported PowerShell versions (5.1+).
- The flow-control exception is not surfaced at the catch point, so the label and the break-vs-continue distinction cannot be recovered; the failure message names both keywords and links to this issue.

## Tests

Added regression tests in `tst/Pester.RSpec.ts.ps1` ("Invalid test definitions fail the run gracefully"):

- an escaping labelled `break` fails the offending test while sibling tests still run and the run completes with a summary;
- an escaping labelled `continue` does the same;
- an escaping `break` in a `BeforeEach` fails the block;
- correctly labelled `break`/`continue` inside loops, and a plain `break`, still behave as before.

The full P-test suite and the 2571 Pester unit tests pass, and PSScriptAnalyzer reports no new findings on the changed lines.

Fix #2669