### PR TITLE
Add timestamp attribute to JUnit testsuite element

### DIFF
--- a/src/functions/TestResults.JUnit4.ps1
+++ b/src/functions/TestResults.JUnit4.ps1
@@ -70,6 +70,11 @@ function Write-JUnitTestSuiteAttributes {
     $XmlWriter.WriteAttributeString('package', $Package)
     $XmlWriter.WriteAttributeString('time', $Action.Duration.TotalSeconds.ToString('0.000', [System.Globalization.CultureInfo]::InvariantCulture))
 
+    if ($null -ne $Action.ExecutedAt -and $Action.ExecutedAt -gt [datetime]::MinValue) {
+        # JUnit uses local time without timezone offset for the testsuite timestamp, unlike NUnit3. See https://github.com/pester/Pester/issues/2410
+        $XmlWriter.WriteAttributeString('timestamp', $Action.ExecutedAt.ToString('yyyy-MM-ddTHH:mm:ss', [System.Globalization.CultureInfo]::InvariantCulture))
+    }
+
     $XmlWriter.WriteStartElement('properties')
 
     foreach ($keyValuePair in $environment.GetEnumerator()) {

--- a/tst/Pester.RSpec.TestResults.JUnit4.ts.ps1
+++ b/tst/Pester.RSpec.TestResults.JUnit4.ts.ps1
@@ -42,6 +42,23 @@ i -PassThru:$PassThru {
             $xmlTestCase.time | Verify-XmlTime -AsJUnitFormat -Expected $r.Containers[0].Blocks[0].Tests[0].Duration
         }
 
+        t "should write the testsuite timestamp as local time without timezone" {
+            $sb = {
+                Describe "Mocked Describe" {
+                    It "Successful testcase" {
+                        $true | Should -Be $true
+                    }
+                }
+            }
+
+            $r = Invoke-Pester -Container (New-PesterContainer -ScriptBlock $sb) -PassThru -Output None
+
+            $xmlResult = $r | ConvertTo-JUnitReport
+            $xmlTestSuite = $xmlResult.'testsuites'.'testsuite'
+            $expectedTimestamp = $r.Containers[0].ExecutedAt.ToString('yyyy-MM-ddTHH:mm:ss', [System.Globalization.CultureInfo]::InvariantCulture)
+            $xmlTestSuite.timestamp | Verify-Equal $expectedTimestamp
+        }
+
         t "should write a failed test result" {
             $sb = {
                 Describe "Mocked Describe" {


### PR DESCRIPTION
Fix #2410

Adds the optional `timestamp` attribute to each `<testsuite>` in the JUnit XML report, taken from the container's `ExecutedAt` (the same property the NUnit25/NUnit3 writers use). Readers like Allure can then show the run time instead of `UNKNOWN`.

Per JUnit convention the timestamp is local time with no timezone offset (`yyyy-MM-ddTHH:mm:ss`), unlike NUnit3 which writes UTC with an offset. See the issue and https://github.com/jest-community/jest-junit/issues/43.

```xml
<testsuite name="&lt;ScriptBlock&gt;:1" tests="136" ... time="2.644" timestamp="2023-12-05T21:04:41">
```

The write is guarded so nothing is emitted when `ExecutedAt` is unset. The attribute is already declared `use="optional"` in `junit_schema_4.xsd`, so schema validation still passes. Added a P test asserting the attribute is present and formatted as local time without timezone, all 15 JUnit4 tests pass.