### PR TITLE
Add test count to Normal-verbosity passing container line

### DIFF
--- a/src/functions/Output.ps1
+++ b/src/functions/Output.ps1
@@ -623,8 +623,11 @@ function Get-WriteScreenPlugin ($Verbosity) {
             $humanTime = "$(Get-HumanTime ($Context.Result.Duration))"
 
             if ($Context.Result.Passed) {
+                $testCount = $Context.Result.TotalCount
+                $testCountText = if (1 -eq $testCount) { '1 test' } else { "$testCount tests" }
                 Write-PesterHostMessage -ForegroundColor $ReportTheme.Pass "[+] $($Context.Result.Name)" -NoNewLine
-                Write-PesterHostMessage -ForegroundColor $ReportTheme.PassTime " $humanTime"
+                Write-PesterHostMessage -ForegroundColor $ReportTheme.PassTime " $humanTime" -NoNewLine
+                Write-PesterHostMessage -ForegroundColor $ReportTheme.PassTime " ($testCountText)"
             }
 
             # this won't work skipping the whole file when all it's tests are skipped is not a feature yet in 5.0.0

--- a/tst/Pester.RSpec.Output.ts.ps1
+++ b/tst/Pester.RSpec.Output.ts.ps1
@@ -186,6 +186,99 @@ i -PassThru:$PassThru {
         }
     }
 
+    b 'Output for container test count in Normal mode' {
+        t 'Passing container line shows the total test count' {
+            $sb = {
+                $PesterPreference = [PesterConfiguration]::Default
+                $PesterPreference.Output.Verbosity = 'Normal'
+                $PesterPreference.Output.CIFormat = 'None'
+                $PesterPreference.Output.RenderMode = 'Plaintext'
+
+                $container = New-PesterContainer -ScriptBlock {
+                    Describe 'd1' {
+                        It 'i1' {
+                            1 | Should -Be 1
+                        }
+
+                        It 'i2' {
+                            1 | Should -Be 1
+                        }
+
+                        It 'i3' {
+                            1 | Should -Be 1
+                        }
+                    }
+                }
+                Invoke-Pester -Container $container
+            }
+
+            $output = Invoke-InNewProcess $sb
+            # only print the relevant part of output
+            $null, $run = $output -join "`n" -split 'Running tests.'
+            $run | Write-Host
+
+            $passingLine = $output | Select-String -Pattern '^\[\+\].*\(3 tests\)\s*$'
+            @($passingLine).Count | Verify-Equal 1
+        }
+
+        t 'Passing container line uses singular test for a single test' {
+            $sb = {
+                $PesterPreference = [PesterConfiguration]::Default
+                $PesterPreference.Output.Verbosity = 'Normal'
+                $PesterPreference.Output.CIFormat = 'None'
+                $PesterPreference.Output.RenderMode = 'Plaintext'
+
+                $container = New-PesterContainer -ScriptBlock {
+                    Describe 'd1' {
+                        It 'i1' {
+                            1 | Should -Be 1
+                        }
+                    }
+                }
+                Invoke-Pester -Container $container
+            }
+
+            $output = Invoke-InNewProcess $sb
+            # only print the relevant part of output
+            $null, $run = $output -join "`n" -split 'Running tests.'
+            $run | Write-Host
+
+            $passingLine = $output | Select-String -Pattern '^\[\+\].*\(1 test\)\s*$'
+            @($passingLine).Count | Verify-Equal 1
+        }
+
+        t 'Detailed mode passing test lines do not include the container test count' {
+            $sb = {
+                $PesterPreference = [PesterConfiguration]::Default
+                $PesterPreference.Output.Verbosity = 'Detailed'
+                $PesterPreference.Output.CIFormat = 'None'
+                $PesterPreference.Output.RenderMode = 'Plaintext'
+
+                $container = New-PesterContainer -ScriptBlock {
+                    Describe 'd1' {
+                        It 'i1' {
+                            1 | Should -Be 1
+                        }
+
+                        It 'i2' {
+                            1 | Should -Be 1
+                        }
+                    }
+                }
+                Invoke-Pester -Container $container
+            }
+
+            $output = Invoke-InNewProcess $sb
+            # only print the relevant part of output
+            $null, $run = $output -join "`n" -split 'Running tests.'
+            $run | Write-Host
+
+            # Detailed shows per-test [+] lines; none of them should carry the "(N tests)" suffix
+            $countSuffix = $output | Select-String -Pattern '\(\d+ tests?\)\s*$'
+            @($countSuffix).Count | Verify-Equal 0
+        }
+    }
+
     b 'Output for container names' {
         t 'Script Block container names are output' {
             $sb = {


### PR DESCRIPTION
## Summary

In `Normal` verbosity, the per-file passing line now appends the container's total test count so it reads like:

```
[+] Some.Tests.ps1 522ms (101 tests)
```

Previously it ended at the duration:

```
[+] Some.Tests.ps1 522ms
```

The count comes from the container result's `TotalCount` and is pluralized (`1 test` / `N tests`). The change only touches the passing-container line in `ContainerRunEnd`; `Detailed`/`Diagnostic` output and the failing/skipped rendering are unchanged.

## Changes

- `src/functions/Output.ps1` - append ` (N tests)` (styled with `PassTime`) to the passing container line in Normal verbosity.
- `tst/Pester.RSpec.Output.ts.ps1` - new P-tests asserting the count appears in the Normal passing line, that a single-test container reads `(1 test)`, and that Detailed output does not carry the count suffix.

## Verification

- `./build.ps1` - succeeds.
- `Pester.RSpec.Output.ts.ps1` - 17 passed, 0 failed.
- `./test.ps1 -File ./tst/functions/Output.Tests.ps1 -SkipPTests` - 71 passed, 0 failed.
- `Invoke-ScriptAnalyzer -Path ./src -Recurse -Settings ./.github/workflows/PSScriptAnalyzerSettings.psd1` - no new findings on the changed lines.

Fix #2434