### PR TITLE
Add Output.ShowTags option to show tags in console output

### DIFF
--- a/src/csharp/Pester/OutputConfiguration.cs
+++ b/src/csharp/Pester/OutputConfiguration.cs
@@ -28,6 +28,7 @@ namespace Pester
         private StringOption _ciLogLevel;
         private StringOption _ciDebugOutput;
         private StringOption _renderMode;
+        private BoolOption _showTags;
 
         public static OutputConfiguration Default { get { return new OutputConfiguration(); } }
         public static OutputConfiguration ShallowClone(OutputConfiguration configuration)
@@ -45,6 +46,7 @@ namespace Pester
                 configuration.AssignObjectIfNotNull<string>(nameof(CILogLevel), v => CILogLevel = v);
                 configuration.AssignObjectIfNotNull<string>(nameof(CIDebugOutput), v => CIDebugOutput = v);
                 configuration.AssignObjectIfNotNull<string>(nameof(RenderMode), v => RenderMode = v);
+                configuration.AssignValueIfNotNull<bool>(nameof(ShowTags), v => ShowTags = v);
             }
         }
 
@@ -56,6 +58,7 @@ namespace Pester
             CILogLevel = new StringOption("The CI log level in build logs, options are Error and Warning.", "Error");
             CIDebugOutput = new StringOption("Whether to automatically surface verbose and debug output when a CI system has its debug switch enabled (Azure DevOps 'System.Debug', GitHub Actions runner debug logging), options are None and Auto.", "Auto");
             RenderMode = new StringOption("The mode used to render console output, options are Auto, Ansi, ConsoleColor and Plaintext.", "Auto");
+            ShowTags = new BoolOption("Append the tags of each Describe, Context and It to its console output line, e.g. 'Describing Get-Planet [Tags: Slow, Unix]'.", false);
         }
 
         public StringOption Verbosity
@@ -150,6 +153,22 @@ namespace Pester
                 else
                 {
                     _renderMode = new StringOption(_renderMode, value?.Value);
+                }
+            }
+        }
+
+        public BoolOption ShowTags
+        {
+            get { return _showTags; }
+            set
+            {
+                if (_showTags == null)
+                {
+                    _showTags = value;
+                }
+                else
+                {
+                    _showTags = new BoolOption(_showTags, value.Value);
                 }
             }
         }

--- a/src/en-US/about_PesterConfiguration.help.txt
+++ b/src/en-US/about_PesterConfiguration.help.txt
@@ -231,6 +231,10 @@ SECTIONS AND OPTIONS
         Type: string
         Default value: 'Auto'
 
+        ShowTags: Append the tags of each Describe, Context and It to its console output line, e.g. 'Describing Get-Planet [Tags: Slow, Unix]'.
+        Type: bool
+        Default value: $false
+
     TestDrive:
         Enabled: Enable TestDrive.
         Type: bool

--- a/src/functions/Output.ps1
+++ b/src/functions/Output.ps1
@@ -14,6 +14,7 @@ $script:ReportStrings = DATA {
         Context           = 'Context {0}'
         Margin            = ' '
         Timing            = 'Tests completed in {0}'
+        Tags              = ' [Tags: {0}]'
 
         TestsPassed       = 'Tests Passed: {0}, '
         TestsFailed       = 'Failed: {0}, '
@@ -688,6 +689,10 @@ function Get-WriteScreenPlugin ($Verbosity) {
             throw "Unsupported level of output '$($PesterPreference.Output.Verbosity.Value)'"
         }
 
+        if ($PesterPreference.Output.ShowTags.Value -and $null -ne $_test.Tag -and 0 -lt @($_test.Tag).Count) {
+            $out += $ReportStrings.Tags -f ($_test.Tag -join ', ')
+        }
+
         # UserDuration and FrameworkDuration are kept on the result object for profiling,
         # but we only show the combined Duration here to keep the output easy to read.
         $humanTime = "$(Get-HumanTime ($_test.Duration))"
@@ -1062,6 +1067,10 @@ function Write-BlockToScreen {
 
     $name = if (-not [string]::IsNullOrWhiteSpace($Block.ExpandedName)) { $Block.ExpandedName } else { $Block.Name }
     $text = $ReportStrings.$commandUsed -f $name
+
+    if ($PesterPreference.Output.ShowTags.Value -and $null -ne $Block.Tag -and 0 -lt @($Block.Tag).Count) {
+        $text += $ReportStrings.Tags -f ($Block.Tag -join ', ')
+    }
 
     if ($PesterPreference.Debug.ShowNavigationMarkers.Value) {
         $text += ", $($block.ScriptBlock.File):$($block.StartLine)"

--- a/tst/Pester.RSpec.Configuration.ts.ps1
+++ b/tst/Pester.RSpec.Configuration.ts.ps1
@@ -90,6 +90,10 @@ i -PassThru:$PassThru {
             [PesterConfiguration]::Default.Output.RenderMode.Value | Verify-Equal 'Auto'
         }
 
+        t "Output.ShowTags is `$false" {
+            [PesterConfiguration]::Default.Output.ShowTags.Value | Verify-False
+        }
+
         # CodeCoverage configuration
         t "CodeCoverage.Enabled is `$false" {
             [PesterConfiguration]::Default.CodeCoverage.Enabled.Value | Verify-False

--- a/tst/functions/Output.Tests.ps1
+++ b/tst/functions/Output.Tests.ps1
@@ -823,3 +823,73 @@ Describe 'Write-PesterHostMessage' {
         }
     }
 }
+
+Describe 'Output.ShowTags' {
+    It 'defaults to $false and exposes a description' {
+        $c = New-PesterConfiguration
+        $c.Output.ShowTags.Value | Should -BeFalse
+        $c.Output.ShowTags.Description | Should -Not -BeNullOrEmpty
+    }
+
+    It 'round-trips when set through a hashtable' {
+        $c = New-PesterConfiguration -Hashtable @{ Output = @{ ShowTags = $true } }
+        $c.Output.ShowTags.Value | Should -BeTrue
+    }
+
+    Context 'Rendering' {
+        BeforeAll {
+            function Invoke-PesterCapturingOutput ([bool] $ShowTags) {
+                $sb = {
+                    Describe 'Planets' -Tag 'Slow' {
+                        It 'tagged test' -Tag 'Fast', 'Unit' {
+                            1 | Should -Be 1
+                        }
+
+                        Context 'Filtering' -Tag 'Ctx' {
+                            It 'untagged test' {
+                                2 | Should -Be 2
+                            }
+                        }
+                    }
+                }
+
+                $c = New-PesterConfiguration
+                $c.Run.ScriptBlock = $sb
+                $c.Output.Verbosity = 'Detailed'
+                $c.Output.RenderMode = 'Plaintext'
+                $c.Output.ShowTags = $ShowTags
+
+                $records = Invoke-Pester -Configuration $c 6>&1
+                ($records | ForEach-Object { $_.ToString() }) -join [Environment]::NewLine
+            }
+        }
+
+        It 'does not render tags when the option is off (default behaviour is unchanged)' {
+            $out = Invoke-PesterCapturingOutput -ShowTags $false
+            $out | Should -Match 'Describing Planets'
+            $out | Should -Match '\[\+\] tagged test'
+            $out | Should -Not -Match '\[Tags:'
+        }
+
+        It 'renders block tags on the Describe line when the option is on' {
+            $out = Invoke-PesterCapturingOutput -ShowTags $true
+            $out | Should -Match 'Describing Planets \[Tags: Slow\]'
+        }
+
+        It 'renders block tags on the Context line when the option is on' {
+            $out = Invoke-PesterCapturingOutput -ShowTags $true
+            $out | Should -Match 'Context Filtering \[Tags: Ctx\]'
+        }
+
+        It 'renders test tags on the It line when the option is on' {
+            $out = Invoke-PesterCapturingOutput -ShowTags $true
+            $out | Should -Match '\[\+\] tagged test \[Tags: Fast, Unit\]'
+        }
+
+        It 'leaves untagged blocks and tests unchanged when the option is on' {
+            $out = Invoke-PesterCapturingOutput -ShowTags $true
+            $untaggedLine = @($out -split [Environment]::NewLine) | Where-Object { $_ -match '\[\+\] untagged test' }
+            $untaggedLine | Should -Not -Match '\[Tags:'
+        }
+    }
+}


### PR DESCRIPTION
Fix #2098

Adds an `Output.ShowTags` switch (default `$false`). When it is on, the tags of each `Describe`, `Context` and `It` are appended to its console line, right after the name and before the duration:

```
Describing Get-Planet [Tags: Slow]
  [+] Given no parameters, it lists all 8 planets [Tags: Fast, Unit] 51ms
 Context Filtering by Name [Tags: Integration]
   [+] Given valid -Name 'Earth', it returns 'Earth' 23ms
```

Untagged blocks and tests render as before, and with the option off the output is identical to what it is today.

I named it `ShowTags` to match the other "show extra info" toggles (`Debug.ShowFullErrors`, `Debug.ShowNavigationMarkers`, `Debug.ShowStartMarkers`). `Render*` is for options that control how output is written (`Output.RenderMode`), not whether it is written.

`ShowTags` `BoolOption` in `OutputConfiguration.cs`, wired into `Write-BlockToScreen` and the `EachTestTeardownEnd` step in `Output.ps1`, with a `Tags` format string in `ReportStrings`. `about_PesterConfiguration.help.txt` is regenerated by the build. Added render tests (on/off, tagged Describe/Context/It, untagged unchanged) and config round-trip/default checks. Build clean, Output and Configuration tests green, no new analyzer findings.