### PR TITLE
Support custom PSTypeNames in BeOfType/Should-HaveType assertions

### DIFF
--- a/src/functions/assert/General/Should-HaveType.ps1
+++ b/src/functions/assert/General/Should-HaveType.ps1
@@ -6,8 +6,10 @@
     .DESCRIPTION
     This assertion uses `-is` to verify that the actual value is assignable to the expected type. Derived types and implemented interfaces also satisfy the check.
 
+    When the expected type is given as a name that does not resolve to a loaded .NET type, the assertion falls back to matching against the actual value's `PSTypeNames`. This allows asserting against PowerShell custom types, such as objects tagged with a `PSTypeName` or extended with `Add-Member -TypeName`.
+
     .PARAMETER Expected
-    The expected type.
+    The expected type. Provide a `[Type]`, a type name that resolves to a loaded .NET type, or a custom type name to match against the actual value's `PSTypeNames`.
 
     .PARAMETER Actual
     The actual value.
@@ -22,6 +24,14 @@
     ```
 
     These assertions will pass, because the actual value is of the expected type.
+
+    .EXAMPLE
+    ```powershell
+    $actual = [PSCustomObject]@{ PSTypeName = 'MyApp.Person'; Name = 'Jane' }
+    $actual | Should-HaveType 'MyApp.Person'
+    ```
+
+    This assertion will pass, because 'MyApp.Person' is not a loaded .NET type, so the actual value's PSTypeNames are checked instead.
 
     .NOTES
     Use the `-ErrorAction` parameter to control soft-assertion behavior for this assertion. `-ErrorAction Continue` records the failure and lets the rest of the test run (a soft assertion), while `-ErrorAction Stop` fails the test immediately, for example to guard a precondition before continuing.
@@ -41,14 +51,29 @@
         [Parameter(Position = 1, ValueFromPipeline = $true)]
         $Actual,
         [Parameter(Position = 0, Mandatory)]
-        [Type]$Expected,
+        $Expected,
         [String]$Because
     )
 
     $assert = New-ShouldAssertion -Caller $PSCmdlet -Actual $Actual -Buffer $local:Input -As 'ExactType'
     $Actual = $assert.Actual()
 
-    if ($Actual -isnot $Expected) {
-        $assert.Fail("Expected value to have type <expected>,<because> but got <actualType> <actual>.", @{ Expected = $Expected; Because = $Because })
+    # Resolve the expected type. A [Type], or a type name that resolves to a loaded .NET type,
+    # is matched with -is (inheritance and interfaces included). A name that does not resolve
+    # is matched against the actual value's PSTypeNames, so custom PowerShell types work too (#1315).
+    $expectedType = $Expected -as [Type]
+    $expectedName = $null
+    if ($null -eq $expectedType -and $Expected -is [string]) {
+        $expectedName = $Expected -replace '^\[(.*)\]$', '$1'
+        $expectedType = $expectedName -as [Type]
+    }
+
+    if ($null -ne $expectedType) {
+        if ($Actual -isnot $expectedType) {
+            $assert.Fail("Expected value to have type <expected>,<because> but got <actualType> <actual>.", @{ Expected = $expectedType; Because = $Because })
+        }
+    }
+    elseif (-not ($null -ne $Actual -and $Actual.PSTypeNames -contains $expectedName)) {
+        $assert.Fail("Expected value to have type or PSTypeName <expected>,<because> but got <actualType> <actual>.", @{ Expected = $expectedName; Because = $Because })
     }
 }

--- a/src/functions/assert/General/Should-NotHaveType.ps1
+++ b/src/functions/assert/General/Should-NotHaveType.ps1
@@ -6,8 +6,10 @@
     .DESCRIPTION
     This assertion uses `-is` to verify that the actual value is not assignable to the expected type. Derived types and implemented interfaces still count as the expected type.
 
+    When the expected type is given as a name that does not resolve to a loaded .NET type, the assertion falls back to matching against the actual value's `PSTypeNames`, so PowerShell custom types are supported too.
+
     .PARAMETER Expected
-    The expected type.
+    The expected type. Provide a `[Type]`, a type name that resolves to a loaded .NET type, or a custom type name to match against the actual value's `PSTypeNames`.
 
     .PARAMETER Actual
     The actual value.
@@ -42,13 +44,29 @@
         [Parameter(Position = 1, ValueFromPipeline = $true)]
         $Actual,
         [Parameter(Position = 0, Mandatory)]
-        [Type]$Expected,
+        $Expected,
         [String]$Because
     )
 
     $assert = New-ShouldAssertion -Caller $PSCmdlet -Actual $Actual -Buffer $local:Input -As 'ExactType'
     $Actual = $assert.Actual()
-    if ($Actual -is $Expected) {
-        $assert.Fail("Expected value to be of different type than <expected>,<because> but got <actualType> <actual>.", @{ Expected = $Expected; Because = $Because })
+
+    # Resolve the expected type. A [Type], or a type name that resolves to a loaded .NET type,
+    # is matched with -is (inheritance and interfaces included). A name that does not resolve
+    # is matched against the actual value's PSTypeNames, so custom PowerShell types work too (#1315).
+    $expectedType = $Expected -as [Type]
+    $expectedName = $null
+    if ($null -eq $expectedType -and $Expected -is [string]) {
+        $expectedName = $Expected -replace '^\[(.*)\]$', '$1'
+        $expectedType = $expectedName -as [Type]
+    }
+
+    if ($null -ne $expectedType) {
+        if ($Actual -is $expectedType) {
+            $assert.Fail("Expected value to be of different type than <expected>,<because> but got <actualType> <actual>.", @{ Expected = $expectedType; Because = $Because })
+        }
+    }
+    elseif ($null -ne $Actual -and $Actual.PSTypeNames -contains $expectedName) {
+        $assert.Fail("Expected value to be of different type or PSTypeName than <expected>,<because> but got <actualType> <actual>.", @{ Expected = $expectedName; Because = $Because })
     }
 }

--- a/src/functions/assertions/BeOfType.ps1
+++ b/src/functions/assertions/BeOfType.ps1
@@ -6,6 +6,11 @@ function Should-BeOfTypeAssertion($ActualValue, $ExpectedType, [switch] $Negate,
     (or a subclass of the specified type) using PowerShell's -is operator.
     Expected type can be provided using full type name strings or a type wrapped in parentheses.
 
+    When the expected type name does not resolve to a loaded .NET type, the assertion falls
+    back to matching against the actual value's PSTypeNames. This allows asserting against
+    PowerShell custom types, such as objects tagged with a PSTypeName or extended with
+    Add-Member -TypeName.
+
     .EXAMPLE
     $actual = Get-Item $env:SystemRoot
     $actual | Should -BeOfType System.IO.DirectoryInfo
@@ -31,36 +36,61 @@ function Should-BeOfTypeAssertion($ActualValue, $ExpectedType, [switch] $Negate,
     $actual | Should -BeOfType ([System.IO.DirectoryInfo])
 
     Test using a type-object. Remember to use parentheses for consistent behavior with PowerShell classes.
+
+    .EXAMPLE
+    $actual = [PSCustomObject]@{ PSTypeName = 'MyApp.Person'; Name = 'Jane' }
+    $actual | Should -BeOfType 'MyApp.Person'
+
+    This test passes, because 'MyApp.Person' is not a loaded .NET type, so the assertion
+    checks the actual value's PSTypeNames instead.
     #>
+
+    # When the expected type is given as a name that does not resolve to a loaded .NET type,
+    # we fall back to matching the actual value's type names instead of using the -is operator.
+    $isNameCheck = $false
+    $expectedName = $null
+
     if ($ExpectedType -is [string]) {
         # parses type that is provided as a string in brackets (such as [int])
         $trimmedType = $ExpectedType -replace '^\[(.*)\]$', '$1'
         $parsedType = $trimmedType -as [Type]
         if ($null -eq $parsedType) {
-            # PowerShell classes loaded via dot-sourcing may not be visible to
-            # the module scope. Try to resolve from the actual value's type (#2701).
-            if ($null -ne $ActualValue) {
-                $actualType = $ActualValue.GetType()
-                # Walk the inheritance chain to find a matching type name
-                $t = $actualType
+            # The expected type name does not resolve to a loaded .NET type. Instead of
+            # throwing, match it against the actual value's type names (#1315):
+            #  - PowerShell custom types exposed through PSTypeNames (e.g. a [PSCustomObject]
+            #    tagged with a PSTypeName, or Add-Member -TypeName 'MyType'), and
+            #  - the actual value's inheritance chain by short Name/FullName, which also
+            #    covers PowerShell classes that are not visible in the module scope (#2701).
+            $isNameCheck = $true
+            $expectedName = $trimmedType
+        }
+        else {
+            $ExpectedType = $parsedType
+        }
+    }
+
+    if ($isNameCheck) {
+        $succeeded = $false
+        if ($null -ne $ActualValue) {
+            if ($ActualValue.PSTypeNames -contains $expectedName) {
+                $succeeded = $true
+            }
+            else {
+                $t = $ActualValue.GetType()
                 while ($null -ne $t) {
-                    if ($t.Name -eq $trimmedType -or $t.FullName -eq $trimmedType) {
-                        $parsedType = $t
+                    if ($t.Name -eq $expectedName -or $t.FullName -eq $expectedName) {
+                        $succeeded = $true
                         break
                     }
                     $t = $t.BaseType
                 }
             }
-
-            if ($null -eq $parsedType) {
-                throw [ArgumentException]"Could not find type [$trimmedType]. Make sure that the assembly that contains that type is loaded."
-            }
         }
-
-        $ExpectedType = $parsedType
+    }
+    else {
+        $succeeded = $ActualValue -is $ExpectedType
     }
 
-    $succeeded = $ActualValue -is $ExpectedType
     if ($Negate) {
         $succeeded = -not $succeeded
     }
@@ -76,6 +106,33 @@ function Should-BeOfTypeAssertion($ActualValue, $ExpectedType, [switch] $Negate,
 
     if ($true -eq $succeeded) { return [Pester.ShouldResult]@{Succeeded = $succeeded } }
 
+    if ($isNameCheck) {
+        if ($null -ne $ActualValue) {
+            $actualTypeNames = ($ActualValue.PSTypeNames -replace '^(.*)$', '[$1]') -join ', '
+        }
+        else {
+            $actualTypeNames = Format-Nicely $null
+        }
+
+        if ($Negate) {
+            $failureMessage = "Expected the value to not have type or PSTypeName [$expectedName],$(Format-Because $Because) but got $(Format-Nicely $ActualValue) with type $(Format-Nicely $actualType) and PSTypeNames $actualTypeNames."
+        }
+        else {
+            $failureMessage = "Expected the value to have type or PSTypeName [$expectedName],$(Format-Because $Because) but got $(Format-Nicely $ActualValue) with type $(Format-Nicely $actualType) and PSTypeNames $actualTypeNames."
+        }
+
+        $ExpectedValue = if ($Negate) { "not type or PSTypeName [$expectedName]" } else { "type or PSTypeName [$expectedName]" }
+
+        return [Pester.ShouldResult] @{
+            Succeeded      = $succeeded
+            FailureMessage = $failureMessage
+            ExpectResult   = @{
+                Actual   = Format-Nicely $ActualValue
+                Expected = Format-Nicely $ExpectedValue
+                Because  = $Because
+            }
+        }
+    }
 
     if ($Negate) {
         $failureMessage = "Expected the value to not have type $(Format-Nicely $ExpectedType) or any of its subtypes,$(Format-Because $Because) but got $(Format-Nicely $ActualValue) with type $(Format-Nicely $actualType)."

--- a/tst/functions/assert/General/Should-HaveType.Tests.ps1
+++ b/tst/functions/assert/General/Should-HaveType.Tests.ps1
@@ -9,6 +9,17 @@ Describe "Should-HaveType" {
         { 1 | Should-HaveType ([string]) } | Verify-AssertionFailed
     }
 
+    It "Given a value with a matching custom PSTypeName it passes" {
+        $actual = [PSCustomObject]@{ PSTypeName = 'MyApp.Person'; Name = 'Jane' }
+        $actual | Should-HaveType 'MyApp.Person'
+    }
+
+    It "Given a value without the expected custom PSTypeName it fails" {
+        $actual = [PSCustomObject]@{ PSTypeName = 'MyApp.Person'; Name = 'Jane' }
+        $err = { $actual | Should-HaveType 'MyApp.Animal' } | Verify-AssertionFailed
+        $err.Exception.Message | Verify-Like "*Expected value to have type or PSTypeName*MyApp.Animal*"
+    }
+
     It "Can be called with positional parameters" {
         { Should-HaveType ([string]) 1 } | Verify-AssertionFailed
     }

--- a/tst/functions/assert/General/Should-NotHaveType.Tests.ps1
+++ b/tst/functions/assert/General/Should-NotHaveType.Tests.ps1
@@ -9,6 +9,17 @@ Describe "Should-NotHaveType" {
         1 | Should-NotHaveType ([string])
     }
 
+    It "Given a value without the expected custom PSTypeName it passes" {
+        $actual = [PSCustomObject]@{ PSTypeName = 'MyApp.Person'; Name = 'Jane' }
+        $actual | Should-NotHaveType 'MyApp.Animal'
+    }
+
+    It "Given a value with a matching custom PSTypeName it fails" {
+        $actual = [PSCustomObject]@{ PSTypeName = 'MyApp.Person'; Name = 'Jane' }
+        $err = { $actual | Should-NotHaveType 'MyApp.Person' } | Verify-AssertionFailed
+        $err.Exception.Message | Verify-Like "*Expected value to be of different type or PSTypeName than*MyApp.Person*"
+    }
+
     It "Can be called with positional parameters" {
         { Should-NotHaveType ([int]) 1 } | Verify-AssertionFailed
     }

--- a/tst/functions/assertions/BeOfType.Tests.ps1
+++ b/tst/functions/assertions/BeOfType.Tests.ps1
@@ -13,11 +13,35 @@ InPesterModuleScope {
             2.0 | Should -Not -BeOfType ([string])
         }
 
-        It "throws argument execption if type isn't a loaded type" {
-            $err = { 5 | Should -BeOfType 'UnknownType' } | Verify-Throw
-            $err.Exception | Verify-Type ([ArgumentException])
-            # Verify expected type is included in error message
-            $err.Exception.Message | Verify-Equal 'Could not find type [UnknownType]. Make sure that the assembly that contains that type is loaded.'
+        It "passes when the actual value has a matching custom PSTypeName" {
+            $obj = [PSCustomObject]@{ PSTypeName = 'MyApp.Person'; Name = 'Jane' }
+            $obj | Should -BeOfType 'MyApp.Person'
+        }
+
+        It "passes when a custom PSTypeName was added with Add-Member" {
+            $obj = [PSCustomObject]@{ Name = 'Jane' }
+            $obj.PSObject.TypeNames.Insert(0, 'MyApp.Widget')
+            $obj | Should -BeOfType 'MyApp.Widget'
+        }
+
+        It "fails when the actual value does not have the expected custom PSTypeName" {
+            $obj = [PSCustomObject]@{ PSTypeName = 'MyApp.Person'; Name = 'Jane' }
+            $err = { $obj | Should -BeOfType 'MyApp.Animal' -Because 'reason' } | Verify-AssertionFailed
+            $err.Exception.Message | Verify-Like 'Expected the value to have type or PSTypeName [[]MyApp.Animal], because reason, but got*and PSTypeNames [[]MyApp.Person]*'
+        }
+
+        It "-Not passes when the actual value does not have the expected custom PSTypeName" {
+            $obj = [PSCustomObject]@{ PSTypeName = 'MyApp.Person'; Name = 'Jane' }
+            $obj | Should -Not -BeOfType 'MyApp.Animal'
+        }
+
+        It "matches a custom PSTypeName that does not resolve as a real type instead of throwing" {
+            $err = { 5 | Should -BeOfType 'UnknownType' } | Verify-AssertionFailed
+            $err.Exception.Message | Verify-Like 'Expected the value to have type or PSTypeName [[]UnknownType],*but got 5 with type [[]int]*'
+        }
+
+        It "-Not passes for a custom type name that no real value matches" {
+            5 | Should -Not -BeOfType 'UnknownType'
         }
 
         It "returns the correct assertion message when actual value has a real type" {
@@ -32,11 +56,14 @@ InPesterModuleScope {
     }
 
     Describe "Should -Not -BeOfType" {
-        It "throws argument execption if type isn't a loaded type" {
-            $err = { 5 | Should -Not -BeOfType 'UnknownType' } | Verify-Throw
-            $err.Exception | Verify-Type ([ArgumentException])
-            # Verify expected type is included in error message
-            $err.Exception.Message | Verify-Equal 'Could not find type [UnknownType]. Make sure that the assembly that contains that type is loaded.'
+        It "passes when a non-resolving type name is not among the actual value's PSTypeNames" {
+            5 | Should -Not -BeOfType 'UnknownType'
+        }
+
+        It "returns the correct assertion message when -Not is used against a matching custom PSTypeName" {
+            $obj = [PSCustomObject]@{ PSTypeName = 'MyApp.Person'; Name = 'Jane' }
+            $err = { $obj | Should -Not -BeOfType 'MyApp.Person' -Because 'reason' } | Verify-AssertionFailed
+            $err.Exception.Message | Verify-Like 'Expected the value to not have type or PSTypeName [[]MyApp.Person], because reason, but got*and PSTypeNames [[]MyApp.Person]*'
         }
 
         It "returns the correct assertion message when actual value has a real type" {
@@ -77,7 +104,7 @@ InPesterModuleScope {
             # nested Invoke-Pester, but we verify the hierarchy walk works correctly.
             $obj = [System.IO.MemoryStream]::new()
             try {
-                # MemoryStream inherits from Stream — verify base type matching works
+                # MemoryStream inherits from Stream - verify base type matching works
                 $obj | Should -BeOfType 'Stream'
                 $obj | Should -BeOfType 'System.IO.Stream'
                 $obj | Should -BeOfType 'MarshalByRefObject'
@@ -87,9 +114,9 @@ InPesterModuleScope {
             }
         }
 
-        It "throws ArgumentException when actual is `$null and type is not resolvable" {
-            $err = { $null | Should -BeOfType 'SomeNonExistentClass' } | Verify-Throw
-            $err.Exception | Verify-Type ([ArgumentException])
+        It "fails with a clear message when actual is `$null and type is not resolvable" {
+            $err = { $null | Should -BeOfType 'SomeNonExistentClass' } | Verify-AssertionFailed
+            $err.Exception.Message | Verify-Like 'Expected the value to have type or PSTypeName [[]SomeNonExistentClass],*but got $null with type $null and PSTypeNames $null.'
         }
     }
 }


### PR DESCRIPTION
Fix #1315

`Should -BeOfType` (and its `-HaveType` alias) resolved the expected type name to a `[type]` and threw `Could not find type ...` when the name was not a loaded .NET type, so there was no way to assert against a PowerShell custom type.

Now when the expected name does not resolve to a real type, it falls back to matching the actual value's `PSTypeNames` instead of throwing. That covers objects tagged with `[PSCustomObject]@{ PSTypeName = 'MyType' }` or `Add-Member -TypeName`.

```powershell
$actual = [PSCustomObject]@{ PSTypeName = 'MyApp.Person'; Name = 'Jane' }
$actual | Should -BeOfType 'MyApp.Person'   # passes
```

This follows the behavior I asked for in the issue, the operator considers both the real type and the PSType:

- A name that resolves to a real type keeps the existing `-is` semantics (inheritance and interfaces), the `-Not` path, and the current message.
- A name that does not resolve is matched against `PSTypeNames`, plus the existing inheritance-chain-by-name walk from #2701 (short names like `MemoryStream`).
- Non-resolving names no longer throw, they pass or fail with a message listing the actual type and its PSTypeNames.

The same fallback goes into the assert-style `Should-HaveType` / `Should-NotHaveType` so both frameworks behave the same.

Touches `BeOfType.ps1`, `Should-HaveType.ps1`, `Should-NotHaveType.ps1` and their tests, where the old "Could not find type" throw tests become pass/fail tests. `test.ps1` green for the affected files, no new analyzer findings.