### PR TITLE
Fix concurrent-import crash in Run.Parallel (thread-unsafe verb patch)

### DIFF
--- a/src/csharp/Pester/VerbsPatcher.cs
+++ b/src/csharp/Pester/VerbsPatcher.cs
@@ -15,6 +15,14 @@ namespace Pester
         // Concurrent bag in case we start this multiple times, and god forbid in parallel.
         private static ConcurrentBag<Task> s_tasks = new ConcurrentBag<Task>();
 
+        // s_validVerbs is PowerShell's own process-global static Dictionary (one instance per
+        // process, shared by every runspace). Dictionary<TKey,TValue> is not thread-safe, so when
+        // Run.Parallel imports Pester from several ForEach-Object -Parallel runspaces at once, the
+        // concurrent writes can tear the internal bucket array and throw IndexOutOfRangeException.
+        // VerbsPatcher lives in Pester.dll, which is loaded once per process, so this static lock
+        // object is shared across all runspaces and serializes every mutation of that dictionary.
+        private static readonly object s_lock = new object();
+
         public static void AllowShouldVerb(int powershellVersion)
         {
             var should = "Should";
@@ -25,17 +33,31 @@ namespace Pester
 
             // private static readonly Dictionary<string, bool> s_validVerbs;
             Dictionary<string, bool> validVerbs = (Dictionary<string, bool>)verbsField.GetValue(null);
-            // Overwrite when we call this multiple times.
-            validVerbs[should] = true; // The bool does not matter.
+            // Only the first import structurally mutates the shared dictionary; later parallel
+            // workers see the key already present and become no-ops. The lock prevents concurrent
+            // writes from corrupting the dictionary. Do not use TryAdd, it is not available on the
+            // net462 target.
+            lock (s_lock)
+            {
+                if (!validVerbs.ContainsKey(should))
+                {
+                    validVerbs[should] = true; // The bool does not matter.
+                }
+            }
 
             s_tasks.Add(Task.Run(async () =>
             {
                 await Task.Delay(5_000);
                 try
                 {
-                    if (validVerbs.ContainsKey(should))
+                    // Serialize the removal behind the same process-global lock so it cannot race
+                    // with a concurrent insert from another runspace. No await inside the lock.
+                    lock (s_lock)
                     {
-                        validVerbs.Remove(should);
+                        if (validVerbs.ContainsKey(should))
+                        {
+                            validVerbs.Remove(should);
+                        }
                     }
                 }
                 catch { }

--- a/src/csharp/Pester/VerbsPatcher.cs
+++ b/src/csharp/Pester/VerbsPatcher.cs
@@ -37,6 +37,16 @@ namespace Pester
             // workers see the key already present and become no-ops. The lock prevents concurrent
             // writes from corrupting the dictionary. Do not use TryAdd, it is not available on the
             // net462 target.
+            //
+            // We deliberately do NOT double-check with an unlocked ContainsKey before taking the
+            // lock. That would be an optimization to skip the lock once patched, but reading a
+            // plain Dictionary outside the lock while another runspace is inserting inside the lock
+            // is itself a data race: the insert can trigger an internal bucket-array resize, and a
+            // concurrent unlocked read can observe the torn array and throw IndexOutOfRange, the
+            // exact failure this lock exists to prevent. AllowShouldVerb runs once per runspace at
+            // import time and the lock only holds a ContainsKey plus at most one insert, so there
+            // is no contention worth optimizing here. A correct fast path would need a separate
+            // volatile flag rather than an unlocked read of this non-thread-safe dictionary.
             lock (s_lock)
             {
                 if (!validVerbs.ContainsKey(should))


### PR DESCRIPTION
`Run.Parallel` runs every test file in its own `ForEach-Object -Parallel` runspace, but those runspaces share one process and the same loaded assemblies. On import Pester calls `[Pester.VerbsPatcher]::AllowShouldVerb(...)`, which reflects into PowerShell's process-global `System.Management.Automation.Verbs.s_validVerbs` dictionary and does `validVerbs["Should"] = true` (plus a background task that removes it after 5 seconds).

`Dictionary<TKey,TValue>` is not thread-safe, so when several workers `Import-Module Pester` at the same time the concurrent writes tear the internal bucket array and throw:

```
Exception calling "AllowShouldVerb": "Index was outside the bounds of the array."
```

That kills the parallel `Invoke-Pester`, no `[Pester.Run]` object comes back, and `tst/Pester.RSpec.Parallel.ts.ps1` then fails on Windows PS7 with follow-on errors like `property TotalCount cannot be found` or `property Containers cannot be found`. It is Windows-only and intermittent, but it is not flakiness, it is an unsynchronized write to a shared dictionary, and it reproduces on `main`.

The fix is in `VerbsPatcher.cs` only. `Pester.dll` loads once per process, so a static lock is shared across all runspaces. I wrap both the insert and the delayed removal in `lock (s_lock)` and guard them with `ContainsKey`, so the first import mutates the dictionary and the rest are no-ops. No `await` inside the lock.

Not `Dictionary.TryAdd`, it does not exist on the net462 target. Not a bare retry/catch, a torn dictionary is permanently corrupt, not transiently retryable.

Verified: `build.ps1 -Clean` is clean, `test.ps1 -File tst/Pester.RSpec.Parallel.ts.ps1 -SkipPTests` passes (22), and `1..8 | ForEach-Object -Parallel { Import-Module ./bin/Pester.psd1 } -ThrottleLimit 8` no longer crashes.