### PR TITLE
Reword recent long code comments

### DIFF
--- a/src/Main.ps1
+++ b/src/Main.ps1
@@ -673,14 +673,14 @@ function Invoke-Pester {
             }
 
             # Resolve the BeforeContainer initialization once for the whole run. It is the same for
-            # every file (from the repo-root Pester.BeforeContainer.ps1 convention file) and
-            # runs before each container in both the parallel and sequential paths below.
+            # every file (from the repo-root Pester.BeforeContainer.ps1 convention file), and it runs
+            # before each container in both the parallel and sequential paths below.
             $beforeContainerInit = Resolve-PesterBeforeContainer -Configuration $PesterPreference
 
             # Engage the parallel path only when at least one file can actually run in parallel.
             # If every file opted out with #pester:no-parallel, the run is effectively sequential,
-            # so fall through to the sequential path - which fires the framework's own global
-            # plugin steps at the correct interleaved points.
+            # so fall through to the sequential path, which fires the framework's own global plugin
+            # steps at the correct interleaved points.
             $ranInParallel = $useParallel -and $parallelSupported -and $allFileContainers -and -not $skipRemainingRunScope -and 0 -lt $parallelContainers.Count
             if ($ranInParallel) {
                 $foldedContainers = [System.Collections.Generic.List[object]]@()
@@ -721,9 +721,9 @@ function Invoke-Pester {
                 $replaySegment = {
                     param($entries)
                     foreach ($entry in $entries) {
-                        # Host/debug output captured in the worker carries no Step - replay it to the
+                        # Host/debug output captured in the worker carries no Step, so replay it to the
                         # real host now, in tape order, so it lands interleaved with the per-test output
-                        # it belongs to instead of appearing up front, detached from its test (#2825).
+                        # it belongs to instead of up front, detached from its test (#2825).
                         if ($null -eq $entry.Step) {
                             $hostArgs = $entry.Host
                             Write-PesterHostMessage @hostArgs
@@ -904,7 +904,7 @@ function Invoke-Pester {
                 # Merge every batch's measured locations into one CommandCoverage list and hand it to
                 # the plugin data, so the Coverage plugin's End step (fired once below) produces the
                 # single merged report and writes the output file. A location counts as covered when
-                # any file hit it; hit counts are summed across files.
+                # any file hit it, and hit counts are summed across files.
                 if ($collectCoverageInParallel) {
                     $mergedCoverage = @(Merge-CoverageFromParallel -CommandCoverage $parallelCoverage.ToArray())
                     $pluginData['Coverage'] = @{

--- a/src/Pester.RSpec.ps1
+++ b/src/Pester.RSpec.ps1
@@ -118,9 +118,8 @@ function Filter-Excluded ($Files, $ExcludePath) {
         return @($Files)
     }
 
-    # Directory exclusions are compared as path prefixes below. Match them
-    # case-insensitively on Windows, but case-sensitively on Linux and macOS
-    # where the filesystem is case-sensitive.
+    # Directory exclusions are compared as path prefixes below. Match them case-insensitively
+    # on Windows, and case-sensitively on Linux and macOS where the filesystem is case-sensitive.
     $pathComparison = if ('Windows' -eq (GetPesterOs)) {
         [System.StringComparison]::OrdinalIgnoreCase
     }
@@ -143,10 +142,10 @@ function Filter-Excluded ($Files, $ExcludePath) {
                 break
             }
 
-            # A directory exclusion (e.g. C:\proj\excluded) should exclude every file
-            # underneath it, see https://github.com/pester/Pester/issues/1575. Trailing
-            # separators are trimmed so both 'C:\proj\excluded' and 'C:\proj\excluded\'
-            # behave the same. Wildcard patterns are already handled by -like above.
+            # A directory exclusion (e.g. C:\proj\excluded) should exclude every file under it,
+            # see https://github.com/pester/Pester/issues/1575. Trailing separators are trimmed so
+            # 'C:\proj\excluded' and 'C:\proj\excluded\' behave the same. Wildcard patterns are
+            # already handled by -like above.
             if (-not [System.Management.Automation.WildcardPattern]::ContainsWildcardCharacters($exclusion)) {
                 $prefix = $exclusion.TrimEnd("\") + "\"
                 if ($p.StartsWith($prefix, $pathComparison)) {

--- a/src/Pester.Runtime.ps1
+++ b/src/Pester.Runtime.ps1
@@ -1074,10 +1074,10 @@ function Invoke-ContainerRun {
         # and $setVariablesWithContext that carries the data as is closure, this way we avoid having to provide parameters to
         # before all script, but it might be better to make this a plugin, because there we can pass data.
 
-        # When a CI system has its debug switch enabled (e.g. Azure DevOps System.Debug or GitHub Actions
-        # runner debug logging) and the user did not opt out, surface Write-Verbose / Write-Debug from
-        # tests and setup blocks by raising the preferences in the user's root scope below. This is scoped
-        # to the run and does not leak into the caller's session afterwards. See issue #1694.
+        # When a CI system has its debug switch enabled (e.g. Azure DevOps System.Debug or GitHub
+        # Actions runner debug logging) and the user did not opt out, surface Write-Verbose and
+        # Write-Debug from tests and setup blocks by raising the preferences in the user's root scope
+        # below. This is scoped to the run and does not leak into the caller's session afterwards (#1694).
         $surfaceCIDebugOutput = Test-CIDebugOutputEnabled -PesterPreference $PesterPreference
 
         $setVariables = {
@@ -1378,14 +1378,13 @@ function Assert-Success {
 }
 
 function New-EscapedFlowControlErrorRecord {
-    # User code can run `break` / `continue` with a label that does not match any enclosing
-    # loop (usually a typo). PowerShell raises a flow-control exception (BreakException /
-    # ContinueException) that a normal try/catch cannot see and that unwinds past the whole
-    # Pester runner, silently aborting the run with no result (see #2669). Invoke-ScriptBlock
-    # detects that escape and calls this helper to build a normal terminating error so the
-    # current test or block fails with a clear message instead of the run being torn down.
-    # We cannot recover the label or tell break from continue at that point (the flow-control
-    # exception is not surfaced), so the message names both keywords.
+    # User code can run `break` or `continue` with a label that matches no enclosing loop,
+    # usually a typo. PowerShell raises a flow-control exception (BreakException / ContinueException)
+    # that a normal try/catch does not see, and it unwinds past the whole Pester runner and aborts
+    # the run with no result (#2669). Invoke-ScriptBlock catches that escape and calls this helper
+    # to build a normal terminating error, so the current test or block just fails with a clear
+    # message. At that point we cannot recover the label or tell break from continue, so the
+    # message names both keywords.
     $message = "A 'break' or 'continue' statement with a label that does not match any enclosing loop escaped from your code. " +
     "This is usually a misspelled or undefined loop label. Left unhandled it silently aborts the whole Pester run with no result (see https://github.com/pester/Pester/issues/2669), so Pester failed this test or block instead."
 
@@ -1687,19 +1686,18 @@ function Invoke-ScriptBlock {
                 & $OnUserScopeTransition
             }
         }
-        # User code can run `break` / `continue` with a label that does not match any enclosing
-        # loop (usually a typo). PowerShell raises a flow-control exception (BreakException /
-        # ContinueException) that a normal try/catch cannot see. Left unhandled it unwinds past
-        # the whole Pester runner and silently aborts the run with no result (see #2669).
+        # User code can run `break` or `continue` with a label that matches no enclosing loop,
+        # usually a typo. PowerShell raises a flow-control exception (BreakException / ContinueException)
+        # that a normal try/catch does not see, and left unhandled it unwinds past the whole Pester
+        # runner and aborts the run with no result (#2669).
         #
-        # The do/while ($false) below already absorbs a plain, unlabelled break/continue, so
-        # those keep their current behaviour and simply end the scriptblock. A labelled
-        # break/continue whose label matches no enclosing loop escapes the do/while; when that
-        # happens for user code we rethrow it from the finally as a normal terminating error so
-        # the outer catch records it as a failure of the current test or block instead of
-        # letting it tear down the whole run. Correctly labelled break/continue inside loops in
-        # user code stays within that code and never reaches here, so it is unaffected. This
-        # only guards user code ($MoveBetweenScopes); framework invocations run unchanged.
+        # The do/while ($false) below already absorbs a plain, unlabelled break/continue, those just
+        # end the scriptblock as before. A labelled break/continue whose label matches no enclosing
+        # loop escapes the do/while, and for user code we rethrow it from the finally as a normal
+        # terminating error, so the outer catch records it as a failed test or block instead of
+        # tearing down the run. Correctly labelled break/continue inside a loop stays in that loop
+        # and never reaches here, so it is unaffected. We only guard user code ($MoveBetweenScopes),
+        # framework invocations run unchanged.
         $flowControlEscaped = $MoveBetweenScopes
         try {
             do {
@@ -2051,9 +2049,9 @@ function Invoke-Test {
         # global steps once for the whole run while this call handles only the
         # non-parallel containers' per-container/per-test steps.
         [switch] $SkipFrameworkGlobalSteps,
-        # Initialization text (resolved from the repo-root Pester.BeforeContainer.ps1)
-        # dot-sourced into the run session state before each container
-        # is discovered and run, so the same setup is available in sequential and parallel runs.
+        # Initialization text (resolved from the repo-root Pester.BeforeContainer.ps1), dot-sourced
+        # into the run session state before each container is discovered and run, so the same setup
+        # is available in sequential and parallel runs.
         [string] $BeforeContainerInit
     )
 

--- a/src/csharp/Pester/GlobalMockHook.cs
+++ b/src/csharp/Pester/GlobalMockHook.cs
@@ -9,8 +9,8 @@ namespace Pester
     // A normal Pester mock defines a bootstrap function + alias in a single session state (the test's,
     // or the -ModuleName target's). Code in another module resolves the command in its own session
     // state and never sees that alias, which is why -ModuleName exists. This hook uses
-    // InvokeCommand.PreCommandLookupAction - a runspace-global callback fired on every parser-driven
-    // command lookup - to redirect the lookup to the mock's bootstrap function no matter which module
+    // InvokeCommand.PreCommandLookupAction, a runspace-global callback fired on every parser-driven
+    // command lookup, to redirect the lookup to the mock's bootstrap function no matter which module
     // the call comes from.
     //
     // The callback does NOT fire for '& $capturedCommandInfo' (Get-Command / Pester's $SafeCommands

--- a/src/functions/Coverage.Plugin.ps1
+++ b/src/functions/Coverage.Plugin.ps1
@@ -132,7 +132,7 @@
         param($Context)
 
         # Parallel workers collect the raw breakpoint hits but must not produce the report or write
-        # the output file themselves - the parent merges every worker's CommandCoverage and generates
+        # the output file themselves, the parent merges every worker's CommandCoverage and generates
         # the report once. The flag is set on the (per-runspace) module scope only inside a worker, so
         # a normal run and the parent's own End step never see it. See Invoke-TestInParallel.
         if (defined_ CodeCoverageSkipReport) {
@@ -241,9 +241,9 @@ function Resolve-CodeCoverageConfiguration {
         throw (Get-StringOptionErrorMessage -OptionPath 'CodeCoverage.OutputFormat' -SupportedValues $supportedFormats -Value $PesterPreference.CodeCoverage.OutputFormat.Value)
     }
 
-    # Resolve the output path to an absolute path now, while the current location still points to
+    # Resolve the output path to an absolute path now, while the current location still points at
     # the directory Invoke-Pester was called from. The report is written after all tests ran, and a
-    # test can change the current location (e.g. Set-Location), so a relative path would otherwise be
-    # resolved against the wrong directory or a directory that no longer exists (#2641).
+    # test can change the current location (e.g. Set-Location), so a relative path would resolve
+    # against the wrong directory, or one that no longer exists (#2641).
     $PesterPreference.CodeCoverage.OutputPath = $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($PesterPreference.CodeCoverage.OutputPath.Value)
 }

--- a/src/functions/Mock.ps1
+++ b/src/functions/Mock.ps1
@@ -224,8 +224,8 @@ function Create-MockHook ($contextInfo, $InvokeMockCallback) {
         BootstrapFunctionName   = $mockName
         IsGlobal                = $false
         # The run that created this mock. A global mock installs a script-scope bootstrap alias in this
-        # run; if that alias leaks into a nested Invoke-Pester run, the bootstrap compares this id to the
-        # currently executing run and defers to the original command when they differ (see Invoke-Mock).
+        # run, and if that alias leaks into a nested Invoke-Pester run, the bootstrap compares this id to
+        # the currently executing run and defers to the original command when they differ (see Invoke-Mock).
         OwnerRunId              = [Pester.GlobalMockHook]::CurrentRunId
         BootstrapFunctionInfo   = $null
     }
@@ -887,7 +887,7 @@ function Resolve-Command {
 
     if ($Global -and $command.Name -like 'PesterMock_*' -and $command.Mock.Hook.OwnerRunId -ne [Pester.GlobalMockHook]::CurrentRunId) {
         # The resolved command is a mock bootstrap, but it belongs to a different (outer) Pester run whose
-        # script-scope alias leaked into this run. Do not reuse it - unwrap to the original command so this
+        # script-scope alias leaked into this run. Do not reuse it, unwrap to the original command so this
         # run creates and owns its own hook, and the outer run's mock stays intact.
         if ($PesterPreference.Debug.WriteDebugMessages.Value) {
             Write-PesterDebugMessage -Scope MockCore "Resolved a global mock bootstrap owned by another run; unwrapping to the original command $($command.Mock.Hook.OriginalCommand.Name) so this run gets its own hook."
@@ -1829,9 +1829,10 @@ function Get-DynamicParametersForCmdlet {
             $command = $ExecutionContext.InvokeCommand.GetCommand($CmdletName, [System.Management.Automation.CommandTypes]::Cmdlet, $paramsArg)
         }
         catch {
-            # Resolving a cmdlet's dynamic parameters can fail when they are built from external state that isn't
-            # available while the command is mocked - e.g. Set-PSRepository's -Location comes from the package
-            # provider and validates while resolving. Fall back to no dynamic parameters instead of failing. (#619)
+            # Resolving a cmdlet's dynamic parameters can fail when they are built from external state that
+            # isn't available while the command is mocked. For example Set-PSRepository's -Location comes from
+            # the package provider and validates while resolving. Fall back to no dynamic parameters instead
+            # of failing. (#619)
             return
         }
     }
@@ -2208,11 +2209,11 @@ function Repair-OrderedType {
     )
 
     # ProxyCommand.GetParamBlock serializes [System.Collections.Specialized.OrderedDictionary]
-    # parameters using the [ordered] type accelerator on PowerShell 7+ (Windows PowerShell 5.1 emits
-    # the full type name). That accelerator is only valid as a cast on a hash literal ([ordered]@{}),
-    # not as a parameter type constraint, so [scriptblock]::Create would throw a ParseException before
-    # the mock is ever invoked. Replace the accelerator with the full type name for each affected
-    # parameter. https://github.com/pester/Pester/issues/2370
+    # parameters with the [ordered] type accelerator on PowerShell 7+ (Windows PowerShell 5.1 emits
+    # the full type name). The accelerator is only valid as a cast on a hash literal ([ordered]@{}),
+    # not as a parameter type constraint, so [scriptblock]::Create throws a ParseException before the
+    # mock ever runs. Replace the accelerator with the full type name for each affected parameter.
+    # https://github.com/pester/Pester/issues/2370
     if ($ParamBlock -notmatch '\[ordered(?:\[\])?\]') {
         # No ordered accelerator present (e.g. Windows PowerShell). Return original string.
         return $ParamBlock
@@ -2230,9 +2231,8 @@ function Repair-OrderedType {
         $fullType = if ($isArray) { '[System.Collections.Specialized.OrderedDictionary[]]' } else { '[System.Collections.Specialized.OrderedDictionary]' }
         $paramName = $param.Name
 
-        # Only rewrite the accelerator that is the type constraint for this specific parameter,
-        # i.e. the token immediately preceding ${ParameterName}. This avoids touching any legitimate
-        # [ordered]@{} cast that might appear elsewhere.
+        # Only rewrite the accelerator that is the type constraint for this parameter, the token
+        # right before ${ParameterName}. This leaves any legitimate [ordered]@{} cast elsewhere alone.
         $pattern = "$([regex]::Escape($accelerator))(?<ws>\s*)$([regex]::Escape('${' + $paramName + '}'))"
         $evaluator = {
             param($match)

--- a/src/functions/Output.ps1
+++ b/src/functions/Output.ps1
@@ -127,13 +127,13 @@ function Write-PesterHostMessage {
     process {
         # In a parallel worker the whole run is silenced (Output.Verbosity = 'None') and its output is
         # captured into the shared event tape (see Invoke-TestInParallel) so the parent can replay it in
-        # order. Instead of writing to the host right away - which in a ForEach-Object -Parallel runspace
-        # surfaces live and detached from the test that produced it (#2825) - append the message to the
-        # tape. The worker runs one file synchronously, so append order already is the correct order, and
-        # host/debug entries land interleaved with the per-test steps the recorder captured around them.
-        # Read the tape via GetValue (not the 'defined' helper): 'defined' returns the value through a
-        # function output, which enumerates a collection and would hand back its first element instead of
-        # the list itself. GetValue returns the list object and tolerates the variable being unset ($null).
+        # order. In a ForEach-Object -Parallel runspace writing to the host right away surfaces live and
+        # detached from the test that produced it (#2825), so instead append the message to the tape. The
+        # worker runs one file synchronously, so append order is already the correct order, and host/debug
+        # entries land interleaved with the per-test steps the recorder captured around them.
+        # Read the tape via GetValue, not the 'defined' helper: 'defined' returns the value through a
+        # function output, which enumerates a collection and hands back its first element instead of the
+        # list itself. GetValue returns the list object and tolerates the variable being unset ($null).
         $parallelOutputTape = $ExecutionContext.SessionState.PSVariable.GetValue('parallelOutputTape')
         if ($null -ne $parallelOutputTape) {
             $captured = @{}
@@ -1151,11 +1151,11 @@ function Resolve-OutputConfiguration ([PesterConfiguration]$PesterPreference) {
         throw (Get-StringOptionErrorMessage -OptionPath 'Output.CIDebugOutput' -SupportedValues $supportedCIDebugOutput -Value $PesterPreference.Output.CIDebugOutput.Value)
     }
     elseif ((-not $PesterPreference.Output.Verbosity.IsModified) -and (Test-CIDebugOutputEnabled -PesterPreference $PesterPreference)) {
-        # A CI system has its debug switch enabled and the user did not pick a verbosity explicitly.
-        # Raise the verbosity to Diagnostic so the run shows detailed output and Pester's debug messages,
-        # matching how e.g. Azure DevOps' System.Debug makes the rest of the pipeline verbose.
-        # The user's own Write-Verbose / Write-Debug in tests is surfaced separately during the run,
-        # see Invoke-ContainerRun in Pester.Runtime.ps1.
+        # A CI system has its debug switch enabled and the user did not set a verbosity. Raise it to
+        # Diagnostic so the run shows detailed output and Pester's debug messages, the same way e.g.
+        # Azure DevOps' System.Debug makes the rest of the pipeline verbose. The user's own
+        # Write-Verbose and Write-Debug in tests is surfaced separately during the run, see
+        # Invoke-ContainerRun in Pester.Runtime.ps1.
         $PesterPreference.Output.Verbosity = 'Diagnostic'
     }
 

--- a/src/functions/Pester.Parallel.ps1
+++ b/src/functions/Pester.Parallel.ps1
@@ -209,7 +209,7 @@ function Invoke-TestInParallel {
     $baseConfig.Run.Container = @()
 
     # Whether this run measures code coverage. When enabled the workers collect breakpoint-based
-    # coverage (see the .NOTES) and the parent merges it; when disabled coverage stays off entirely.
+    # coverage (see the .NOTES) and the parent merges it. When disabled coverage stays off entirely.
     $collectCoverage = [bool] $Configuration.CodeCoverage.Enabled.Value
 
     # The per-container and per-test plugin steps each worker records and the parent replays.
@@ -283,7 +283,7 @@ function Invoke-TestInParallel {
         # The worker stays silent; the parent renders all output by replaying the recorded tape.
         $workerConfig.Output.Verbosity = 'None'
         # Keep the raw result object in the worker. At the end of a run Pester strips internal,
-        # non-public state - including each block's FrameworkData - off the result tree. The tape
+        # non-public state (including each block's FrameworkData) off the result tree. The tape
         # holds live references to those same Block/Test objects, so that cleanup would blank out
         # FrameworkData.CommandUsed (Describe/Context) before the parent replays the tape, and the
         # reporting plugins would then fail to render the "Describing"/"Context" headers in
@@ -318,7 +318,7 @@ function Invoke-TestInParallel {
         # wrapped in a hashtable when handed across the module boundary: passing the (still empty) list
         # positionally coerces it to a fixed-size array, which then throws on .Add during the run.
         # When coverage is on, also tell the Coverage plugin's End step to skip report generation and
-        # the output-file write in this worker - the parent merges every worker's raw hits and emits the
+        # the output-file write in this worker, the parent merges every worker's raw hits and emits the
         # single report/file.
         & $pesterModule { param($p) $script:additionalPlugins = $p } $recorder
         & $pesterModule { param($box) $script:parallelOutputTape = $box.Tape } @{ Tape = $tape }

--- a/src/functions/Pester.SessionState.Mock.ps1
+++ b/src/functions/Pester.SessionState.Mock.ps1
@@ -246,7 +246,7 @@ function Mock {
     # A global mock is not scoped to a single module, it is defined in the caller scope and the
     # engine-level hook routes calls from every module to it. ModuleName is therefore not the
     # destination of the mock. It is still used as a hint to resolve the command though (see the
-    # -Global path in Resolve-Command), so a module-private command can be found and mocked. So we
+    # -Global path in Resolve-Command), so a module-private command can be found and mocked. We
     # keep whatever ModuleName the caller passed and let Resolve-Command use it only for lookup.
     if (-not $isGlobalMock -and -not $PSBoundParameters.ContainsKey('ModuleName') -and $null -ne $SessionState.Module) {
         # use the caller module name as ModuleName, so calling the mock in InModuleScope uses the ModuleName as target module

--- a/src/functions/TestRegistry.ps1
+++ b/src/functions/TestRegistry.ps1
@@ -71,12 +71,10 @@ function Get-TestRegistryChildItem ([string]$TestRegistryPath) {
 }
 
 function Invoke-TestRegistryWithRetry {
-    # Reading from and writing to the registry can intermittently throw
-    # 'IOException: No more data is available' when TestRegistry is used from parallel
-    # runspaces on Windows PowerShell (.NET Framework). This is a known .NET Framework bug
-    # that is fixed in .NET Core / PowerShell 7. Retry the operation once on that transient
-    # error, so both reads and writes are resilient. See
-    # https://github.com/pester/Pester/issues/2418
+    # Registry reads and writes occasionally throw 'IOException: No more data is available' when
+    # TestRegistry is used from parallel runspaces on Windows PowerShell (.NET Framework). It is a
+    # known .NET Framework bug, fixed in .NET Core / PowerShell 7. Retry once on that transient
+    # error, so both reads and writes survive it. See https://github.com/pester/Pester/issues/2418
     param(
         [Parameter(Mandatory)]
         [scriptblock] $ScriptBlock

--- a/src/functions/TestResults.JUnit4.ps1
+++ b/src/functions/TestResults.JUnit4.ps1
@@ -46,8 +46,8 @@ function Write-JUnitTestSuiteElements {
     Write-JUnitTestSuiteAttributes -Action $Container -XmlWriter $XmlWriter -Package $container.Name -Id $Id
 
     if (Test-ContainerFailedDiscovery -Container $Container) {
-        # The container failed during discovery and has no tests to carry the error, so write a
-        # synthetic testcase holding the discovery error, since JUnit has no suite-level error. (#2664)
+        # The container failed during discovery and has no tests to carry the error, and JUnit has
+        # no suite-level error, so write a synthetic testcase that holds the discovery error. (#2664)
         Write-JUnitDiscoveryFailureElement -Container $Container -XmlWriter $XmlWriter
     }
 

--- a/src/functions/TestResults.NUnit25.ps1
+++ b/src/functions/TestResults.NUnit25.ps1
@@ -100,8 +100,8 @@ function Write-NUnitTestSuiteElements {
     Write-NUnitTestSuiteAttributes -TestSuiteInfo $suiteInfo -XmlWriter $XmlWriter
 
     if ($Node -is [Pester.Container] -and (Test-ContainerFailedDiscovery -Container $Node)) {
-        # The container failed during discovery and has no tests to carry the error, so surface
-        # the discovery error on the suite itself. The schema requires failure before results. (#2664)
+        # The container failed during discovery and has no tests to carry the error, so surface the
+        # discovery error on the suite itself. The schema wants the failure before any results. (#2664)
         $discoveryError = Get-ErrorForXmlReport -TestResult $Node
         $XmlWriter.WriteStartElement('failure')
         $XmlWriter.WriteElementString('message', $discoveryError.FailureMessage)

--- a/src/functions/TestResults.NUnit3.ps1
+++ b/src/functions/TestResults.NUnit3.ps1
@@ -28,7 +28,7 @@ function Write-NUnit3TestRunAttributes {
     $XmlWriter.WriteAttributeString('name', $Result.Configuration.TestResult.TestSuiteName.Value) # required attr. in schema, but not in docs or nunit-console output...
     $XmlWriter.WriteAttributeString('fullname', $Result.Configuration.TestResult.TestSuiteName.Value) # required attr. in schema, but not in docs or nunit-console output...
     # Containers that failed during discovery have no tests, so count each as one failed item
-    # to keep the run totals from silently reporting zero. (#2664)
+    # and the run totals do not report zero. (#2664)
     $discoveryFailedCount = Get-DiscoveryFailedContainerCount -Result $Result
     $testcasecount = ($Result.TotalCount - $Result.NotRunCount) + $discoveryFailedCount
     $XmlWriter.WriteAttributeString('testcasecount', $testcasecount) # all testcases in run (before filtering). would've been totalcount if we listed shouldrun=false
@@ -271,7 +271,7 @@ function Get-NUnit3TestSuiteInfo {
         'Ignored'
     }
     elseif ($TestSuite -isnot [Pester.Run] -and (-not $TestSuite.ShouldRun) -and $TestSuite.Result -eq 'Failed') {
-        # Discovery failed - not runnable code
+        # Discovery failed, so the code is not runnable
         'NotRunnable'
     }
     else {
@@ -285,7 +285,7 @@ function Get-NUnit3TestSuiteInfo {
     }
 
     # A container that failed during discovery has no tests, so count it as one failed item
-    # to keep the suite totals from silently reporting zero. (#2664)
+    # and the suite totals do not report zero. (#2664)
     $isDiscoveryFailure = $TestSuite -is [Pester.Container] -and (Test-ContainerFailedDiscovery -Container $TestSuite)
     $testcasecount = if ($isDiscoveryFailure) { 1 } else { ($TestSuite.TotalCount - $TestSuite.NotRunCount) }
     $failedCount = if ($isDiscoveryFailure) { 1 } else { $TestSuite.FailedCount }
@@ -343,8 +343,8 @@ function Write-NUnit3TestSuiteAttributes {
 }
 
 function Get-NUnit3Result ($InputObject) {
-    # A discovery failure has no tests (TotalCount -eq NotRunCount), so check the failed
-    # state first, otherwise such a failure would be reported as Inconclusive. (#2664)
+    # A discovery failure has no tests (TotalCount -eq NotRunCount), so check the failed state
+    # first, otherwise it would be reported as Inconclusive. (#2664)
     if ($InputObject.Result -eq 'Failed' -or $InputObject.FailedCount -gt 0) {
         # also checking result to cover setup/teardown and discovery errors
         'Failed'

--- a/src/functions/TestResults.ps1
+++ b/src/functions/TestResults.ps1
@@ -501,17 +501,16 @@ function Get-ErrorForXmlReport ($TestResult) {
 
 function Test-ContainerFailedDiscovery {
     param($Container)
-    # A container that failed during discovery never runs its tests (ShouldRun = $false),
-    # but it is marked as Failed and carries the discovery error in its ErrorRecord. Such
-    # containers would otherwise be skipped by the report writers, silently omitting the
-    # failure from the exported TestResult XML. (#2664)
+    # A container that failed during discovery never runs its tests (ShouldRun = $false), but it
+    # is marked Failed and keeps the discovery error in its ErrorRecord. The report writers would
+    # otherwise skip it and drop the failure from the exported TestResult XML. (#2664)
     (-not $Container.ShouldRun) -and ($Container.Result -eq 'Failed') -and ($Container.ErrorRecord.Count -gt 0)
 }
 
 function Get-DiscoveryFailedContainerCount {
     param([Pester.Run] $Result)
-    # Number of containers that failed during discovery. Used so the exported report totals
-    # reflect these failures instead of silently reporting zero. (#2664)
+    # Number of containers that failed during discovery, so the exported report totals count
+    # them instead of reporting zero. (#2664)
     $count = 0
     foreach ($container in $Result.Containers) {
         if (Test-ContainerFailedDiscovery -Container $container) {
@@ -598,9 +597,9 @@ function Resolve-TestResultConfiguration {
         throw (Get-StringOptionErrorMessage -OptionPath 'TestResult.OutputFormat' -SupportedValues $supportedFormats -Value $PesterPreference.TestResult.OutputFormat.Value)
     }
 
-    # Resolve the output path to an absolute path now, while the current location still points to
+    # Resolve the output path to an absolute path now, while the current location still points at
     # the directory Invoke-Pester was called from. The report is written after all tests ran, and a
-    # test can change the current location (e.g. Set-Location), so a relative path would otherwise be
-    # resolved against the wrong directory or a directory that no longer exists (#2641).
+    # test can change the current location (e.g. Set-Location), so a relative path would resolve
+    # against the wrong directory, or one that no longer exists (#2641).
     $PesterPreference.TestResult.OutputPath = $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($PesterPreference.TestResult.OutputPath.Value)
 }

--- a/tst/Pester.RSpec.InNewProcess.ts.ps1
+++ b/tst/Pester.RSpec.InNewProcess.ts.ps1
@@ -420,10 +420,9 @@ i -PassThru:$PassThru {
 
     b 'User alias shadowing internal helper does not break Pester' {
         # https://github.com/pester/Pester/issues/2113
-        # A user module (for example ListFunctions) can export an alias whose name
-        # collides with one of Pester's short internal helper functions (like 'any').
-        # PowerShell resolves aliases before functions and traverses the scope chain
-        # up to global, so such an alias shadowed Pester's internal helper and
+        # A user module (for example ListFunctions) can export an alias whose name collides with
+        # one of Pester's short internal helpers (like 'any'). PowerShell resolves aliases before
+        # functions and walks the scope chain up to global, so the alias shadowed our helper and
         # Invoke-Pester crashed with a ParameterBindingException before running any test.
         t 'Invoke-Pester succeeds when a global alias shadows the internal any helper' {
             $sb = {

--- a/tst/Pester.RSpec.Output.ts.ps1
+++ b/tst/Pester.RSpec.Output.ts.ps1
@@ -273,7 +273,7 @@ i -PassThru:$PassThru {
             $null, $run = $output -join "`n" -split 'Running tests.'
             $run | Write-Host
 
-            # Detailed shows per-test [+] lines; none of them should carry the "(N tests)" suffix
+            # Detailed shows per-test [+] lines, none of them should carry the "(N tests)" suffix
             $countSuffix = $output | Select-String -Pattern '\(\d+ tests?\)\s*$'
             @($countSuffix).Count | Verify-Equal 0
         }

--- a/tst/Pester.RSpec.Parallel.ts.ps1
+++ b/tst/Pester.RSpec.Parallel.ts.ps1
@@ -282,12 +282,12 @@ Describe 'Module import' {
         }
 
         t "shares a single bootstrap across many files in parallel, anchored on the stable `$PSScriptRoot" {
-            # Compelling real-world case: instead of repeating an Import-Module + mock defaults setup
-            # in every test file, put it once in Pester.BeforeContainer.ps1. Because it is a real
-            # file, it always has a stable `$PSScriptRoot` to resolve the module relative to
-            # (unlike the removed Run.BeforeContainer scriptblock option, which only had the unstable
-            # `$pwd` - see #2838). Each parallel worker starts from a clean runspace and re-runs the
-            # bootstrap, so the shared helpers are available to every file without duplication.
+            # A real-world case: instead of repeating an Import-Module + mock defaults setup in every
+            # test file, put it once in Pester.BeforeContainer.ps1. Because it is a real file it always
+            # has a stable `$PSScriptRoot` to resolve the module relative to, unlike the removed
+            # Run.BeforeContainer scriptblock option, which only had the unstable `$pwd` (#2838). Each
+            # parallel worker starts from a clean runspace and re-runs the bootstrap, so the shared
+            # helpers are available to every file without duplication.
             $folder = Join-Path ([IO.Path]::GetTempPath()) ([Guid]::NewGuid().Guid)
             $null = New-Item -ItemType Directory -Path $folder -Force
 
@@ -458,7 +458,7 @@ Describe 'S' {
             try {
                 # A shared code file to measure coverage on, plus two parallelizable test files that
                 # each exercise a different function in it. The parallel run must collect coverage
-                # from every worker and merge it into one report - matching a sequential run exactly.
+                # from every worker and merge it into one report, matching a sequential run exactly.
                 Set-Content -Path (Join-Path $folder 'lib.ps1') -Value @'
 function Get-One { 1 }
 function Get-Two { 2 }
@@ -490,7 +490,7 @@ Describe 'B' { It 'b1 passes' { Get-Two | Should -Be 2 } }
                 $parallel.Run.Parallel = $true
                 $par = Invoke-Pester -Configuration $parallel
 
-                # Two of the four functions are covered; parallel must match sequential exactly.
+                # Two of the four functions are covered, parallel must match sequential exactly.
                 $par.PassedCount | Verify-Equal 2
                 $par.CodeCoverage | Verify-NotNull
                 $par.CodeCoverage.CommandsAnalyzedCount | Verify-Equal $seq.CodeCoverage.CommandsAnalyzedCount
@@ -505,7 +505,7 @@ Describe 'B' { It 'b1 passes' { Get-Two | Should -Be 2 } }
             $folder = Join-Path ([IO.Path]::GetTempPath()) ([Guid]::NewGuid().Guid)
             $null = New-Item -ItemType Directory -Path $folder -Force
             try {
-                # A,B run in parallel; C opts out and runs in the parent. Coverage from the in-parent
+                # A and B run in parallel, C opts out and runs in the parent. Coverage from the in-parent
                 # (non-parallel) file must be merged with the worker coverage.
                 Set-Content -Path (Join-Path $folder 'lib.ps1') -Value @'
 function Get-One { 1 }
@@ -650,9 +650,10 @@ Describe 'OuterTwo' {
 
     b "Run.Parallel debug output" {
         t "captures debug output and replays it interleaved with each file's tests" {
-            # Each worker runs silently and records its screen and debug output into the shared tape;
-            # the parent replays that tape in order. So debug output must come back interleaved with the
-            # per-test output of the file that produced it, not dumped up front detached from it (#2825).
+            # Each worker writes nothing to the host directly and records its screen and debug output into
+            # the shared tape, and the parent replays that tape in order. So debug output must come back
+            # interleaved with the per-test output of the file that produced it, not dumped up front
+            # detached from it (#2825).
             $folder = Join-Path ([IO.Path]::GetTempPath()) ([Guid]::NewGuid().Guid)
             $null = New-Item -ItemType Directory -Path $folder -Force
             try {
@@ -697,8 +698,8 @@ Describe 'B' { It 'b1 passes' { 1 | Should -Be 1 } }
                         -replace '\d+(.\d+)?m?s', '<time>'
                     $actual = (($normalized -split "`r`n|`r|`n").ForEach({ $_.TrimEnd() }) -join "`n").Trim()
 
-                    # Each file's discovery is immediately followed by that same file's run - A fully, then
-                    # B fully - instead of both discoveries being dumped up front, detached from the tests.
+                    # Each file's discovery is immediately followed by that same file's run (A fully, then
+                    # B fully), instead of both discoveries being dumped up front, detached from the tests.
                     $expected = @'
 Pester v<version>
 

--- a/tst/Pester.RSpec.TestResults.JUnit4.ts.ps1
+++ b/tst/Pester.RSpec.TestResults.JUnit4.ts.ps1
@@ -293,7 +293,7 @@ i -PassThru:$PassThru {
 
             $xmlResult = $r | ConvertTo-JUnitReport
 
-            # the report totals reflect the failure instead of silently reporting zero
+            # the report totals reflect the failure instead of reporting zero
             $xmlResult.'testsuites'.errors | Verify-Equal '1'
             $xmlResult.'testsuites'.tests | Verify-Equal '1'
 

--- a/tst/Pester.RSpec.TestResults.NUnit25.ts.ps1
+++ b/tst/Pester.RSpec.TestResults.NUnit25.ts.ps1
@@ -576,7 +576,7 @@ i -PassThru:$PassThru {
 
             $xmlResult = [xml] ($r | ConvertTo-NUnitReport)
 
-            # the report totals reflect the failure instead of silently reporting zero
+            # the report totals reflect the failure instead of reporting zero
             $xmlResult.'test-results'.errors | Verify-Equal '1'
             $xmlResult.'test-results'.'test-suite'.result | Verify-Equal 'Failure'
             $xmlResult.'test-results'.'test-suite'.success | Verify-Equal 'False'

--- a/tst/Pester.RSpec.TestResults.NUnit3.ts.ps1
+++ b/tst/Pester.RSpec.TestResults.NUnit3.ts.ps1
@@ -899,7 +899,7 @@ i -PassThru:$PassThru {
 
             $xmlResult = $r | ConvertTo-NUnitReport -Format NUnit3
 
-            # the run totals reflect the failure instead of silently reporting Inconclusive/zero
+            # the run totals reflect the failure instead of reporting Inconclusive or zero
             $xmlResult.'test-run'.result | Verify-Equal 'Failed'
             $xmlResult.'test-run'.failed | Verify-Equal '1'
             $xmlResult.'test-run'.total | Verify-Equal '1'

--- a/tst/Pester.RSpec.ts.ps1
+++ b/tst/Pester.RSpec.ts.ps1
@@ -3373,13 +3373,13 @@ i -PassThru:$PassThru {
 
     b 'Stray output during the run does not crash Pester (#2655)' {
         t 'a real run with stray output finishes, keeps its results, and warns instead of crashing' {
-            # Reproduce the leak end-to-end the way it happens in the wild: something writes to the
-            # success stream while the run is in progress, so the stray value ends up in Invoke-Test's
-            # output next to the real [Pester.Container]. A repo-root Pester.BeforeContainer.ps1 that
-            # emits to the success stream is a reliable stand-in for the original trigger - an
-            # unredirected native command (winrm/net) in a setup block - which could not be reproduced
-            # deterministically. Before #2655 that stray object was added to the strongly-typed
-            # Run.Containers list and threw "Cannot find an overload for Add", taking down the whole run.
+            # Reproduce the leak end-to-end the way it really happens: something writes to the success
+            # stream while the run is in progress, so the stray value ends up in Invoke-Test's output
+            # next to the real [Pester.Container]. A repo-root Pester.BeforeContainer.ps1 that emits to
+            # the success stream is a reliable stand-in for the original trigger (an unredirected native
+            # command like winrm/net in a setup block), which could not be reproduced deterministically.
+            # Before #2655 that stray object was added to the strongly-typed Run.Containers list and
+            # threw "Cannot find an overload for Add", taking down the whole run.
             $sb = {
                 Describe 'd' {
                     It 'passes' { $true | Should -Be $true }

--- a/tst/functions/Coverage.Tests.ps1
+++ b/tst/functions/Coverage.Tests.ps1
@@ -1014,10 +1014,10 @@ InPesterModuleScope {
         }
 
         # https://github.com/pester/Pester/issues/1143
-        # The '& $wrappedCmd @PSBoundParameters' line inside a steppable-pipeline proxy
-        # function must not be reported as missed. PowerShell never fires the breakpoint on
-        # that scriptblock (the command runs through the steppable pipeline), so both the
-        # inner command and the scriptblock-literal wrapper it lives in are ignored.
+        # The '& $wrappedCmd @PSBoundParameters' line inside a steppable-pipeline proxy function
+        # must not be reported as missed. PowerShell never fires the breakpoint on that scriptblock
+        # (the command runs through the steppable pipeline), so we ignore both the inner command and
+        # the scriptblock-literal wrapper it lives in.
         Context 'Steppable-pipeline proxy function using <description>' -Foreach @(
             @{ UseBreakpoints = $true; Description = "breakpoints" }
             @{ UseBreakpoints = $false; Description = "Profiler based cc" }

--- a/tst/functions/TestRegistry.Tests.ps1
+++ b/tst/functions/TestRegistry.Tests.ps1
@@ -1,8 +1,8 @@
 ﻿Set-StrictMode -Version Latest
 
 Describe 'Invoke-TestRegistryWithRetry' {
-    # This helper makes TestRegistry reads and writes resilient to the transient
-    # 'IOException: No more data is available' that happens on parallel Windows PowerShell
+    # This helper makes TestRegistry reads and writes survive the transient
+    # 'IOException: No more data is available' that shows up on parallel Windows PowerShell
     # runs (.NET Framework). The retry logic itself is OS-agnostic, so these tests run
     # everywhere. See https://github.com/pester/Pester/issues/2418
     It 'Returns the result of the script block on success' {


### PR DESCRIPTION
Went through the long comments we added over the past week and tightened them up. Mechanism first, shorter sentences, dashes turned into commas or periods, and the odd bit of repetition removed. The global-mock, parallel replay, coverage, discovery-failure and TestRegistry comments got most of the attention.

Comment-only, no behaviour changes. Issue references and all technical detail kept as they were.