### PR TITLE
Add CLAUDE.md so Claude Code reads the repo agent instructions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,12 @@
+<!--
+  The single source of truth for agent instructions in this repo is
+  .github/copilot-instructions.md.
+
+  This file exists only to bridge those instructions to Claude Code, which reads
+  CLAUDE.md and does not read .github/copilot-instructions.md. The import below
+  pulls in the same content, so there is one file to maintain.
+
+  Edit .github/copilot-instructions.md, not this file.
+-->
+
+@.github/copilot-instructions.md


### PR DESCRIPTION
Claude Code reads `CLAUDE.md` and does not read `.github/copilot-instructions.md`, so it was picking up none of this repo's agent instructions (the push-to-origin rule for maintainers, the build-analyzer rules, and so on).

This adds a `CLAUDE.md` that imports `.github/copilot-instructions.md`, so that file stays the single source of truth — no duplicated content to keep in sync. Copilot is unaffected; it keeps reading `.github/copilot-instructions.md` as before.
