### PR TITLE
Collect code coverage from Invoke-InNewProcess child processes

### DIFF
--- a/test.ps1
+++ b/test.ps1
@@ -64,6 +64,15 @@ if ($CC) {
     Write-Host "Running Code Coverage"
     $env:PESTER_CC_DEBUG = 0
     $env:PESTER_CC_IN_CC = 1
+    # Tests that spawn a child process via Invoke-InNewProcess (e.g. the Output and InNewProcess
+    # tests) execute Pester code the parent tracer cannot see. Point those children at a shared
+    # drop folder and the same coverage target; each child traces itself and writes the coordinates
+    # it hit there, and we merge them into $measure below before the report is generated.
+    $ccChildDir = Join-Path ([System.IO.Path]::GetTempPath()) "pester-cc-child-$PID"
+    if (Test-Path $ccChildDir) { Remove-Item $ccChildDir -Recurse -Force }
+    $null = New-Item -ItemType Directory -Path $ccChildDir -Force
+    $env:PESTER_CC_CHILD_OUTPUT = $ccChildDir
+    $env:PESTER_CC_CHILD_TARGET = if ($Inline) { "$PSScriptRoot/bin/Pester*" } else { "$PSScriptRoot/src/*" }
     $sw = [System.Diagnostics.Stopwatch]::StartNew()
     $here = {}
     $bp = Set-PSBreakpoint -Script $PSCommandPath -Line $here.StartPosition.StartLine -Action {}
@@ -198,12 +207,47 @@ if ($CC) {
 
         & $Stop_TraceScript -Patched $patched
         $measure = $tracer.Hits
+
+        # Merge the hits collected in child processes (Invoke-InNewProcess) into the in-process
+        # measure. Parent and child trace the same target, so a child hit at path + "line:column"
+        # maps onto the same not-yet-hit point here; flip it to Hit (the point is a struct, so we
+        # copy-modify-write back, exactly like the tracer does on a live hit).
+        $childFiles = @(Get-ChildItem -Path $ccChildDir -Filter '*.tsv' -File -ErrorAction SilentlyContinue)
+        $mergedPoints = 0
+        foreach ($cf in $childFiles) {
+            foreach ($rawLine in [System.IO.File]::ReadAllLines($cf.FullName)) {
+                if ([string]::IsNullOrWhiteSpace($rawLine)) { continue }
+                $tab = $rawLine.IndexOf("`t")
+                if ($tab -lt 0) { continue }
+                $path = $rawLine.Substring(0, $tab)
+                $key = $rawLine.Substring($tab + 1)
+                if (-not $measure.ContainsKey($path)) { continue }
+                $byKey = $measure[$path]
+                if (-not $byKey.ContainsKey($key)) { continue }
+                $list = $byKey[$key]
+                for ($i = 0; $i -lt $list.Count; $i++) {
+                    if (-not $list[$i].Hit) {
+                        $point = $list[$i]
+                        $point.Hit = $true
+                        $list[$i] = $point
+                        $mergedPoints++
+                    }
+                }
+            }
+        }
+        Write-Host "Merged code coverage from $($childFiles.Count) child process run(s), marking $mergedPoints additional point(s) as hit."
+
         $coverageReport = & $Get_CoverageReport -CommandCoverage $breakpoints -Measure $measure
     }
     finally {
         if ($null -ne $bp) {
             $bp | Remove-PSBreakpoint
         }
+        if ($ccChildDir -and (Test-Path $ccChildDir)) {
+            Remove-Item $ccChildDir -Recurse -Force -ErrorAction SilentlyContinue
+        }
+        $env:PESTER_CC_CHILD_OUTPUT = $null
+        $env:PESTER_CC_CHILD_TARGET = $null
     }
 
     [xml] $jaCoCoReport = [xml] (& $Get_JaCoCoReportXml -CommandCoverage $breakpoints -TotalMilliseconds $sw.ElapsedMilliseconds -CoverageReport $coverageReport -ReportRoot $PSScriptRoot)

--- a/tst/PTestHelpers.psm1
+++ b/tst/PTestHelpers.psm1
@@ -8,7 +8,57 @@
         param ($PesterPath, [ScriptBlock] $ScriptBlock)
         Import-Module $PesterPath
 
-        . $ScriptBlock
+        # During a code coverage run (test.ps1 -CC) the parent process traces itself, but the code
+        # that executes here in the child process is invisible to it. When the parent asks for it
+        # (via PESTER_CC_CHILD_* env vars, which we inherit) we trace this child the same way and
+        # dump the coordinates we hit, so the parent can merge them into the single coverage report.
+        # Note: this scriptblock is stringified and passed to the child as -Command, and on Windows
+        # PowerShell (legacy native argument passing) only the user ScriptBlock is quote-escaped
+        # below, so keep this block free of double quotes to avoid mangling the child command line.
+        # Coverage collection is best-effort: any failure here must fall back to a plain run so the
+        # test behaves exactly as without coverage.
+        $ccDir = $env:PESTER_CC_CHILD_OUTPUT
+        $ccTarget = $env:PESTER_CC_CHILD_TARGET
+        $ccTracer = $null
+        $ccPatched = $false
+        if ($ccDir -and $ccTarget) {
+            try {
+                $pesterModule = Get-Module Pester
+                $enter = & $pesterModule { Get-Command Enter-CoverageAnalysis }
+                $start = & $pesterModule { Get-Command Start-TraceScript }
+                $bps = & $enter -CodeCoverage $ccTarget -UseBreakpoints $false
+                $ccPatched, $ccTracer = & $start $bps
+            }
+            catch {
+                $ccTracer = $null
+            }
+        }
+        try {
+            . $ScriptBlock
+        }
+        finally {
+            if ($null -ne $ccTracer) {
+                try {
+                    $stop = & (Get-Module Pester) { Get-Command Stop-TraceScript }
+                    & $stop -Patched $ccPatched
+                    $hitLines = [System.Collections.Generic.List[string]]::new()
+                    $tab = [char]9
+                    foreach ($path in $ccTracer.Hits.Keys) {
+                        $byKey = $ccTracer.Hits[$path]
+                        foreach ($key in $byKey.Keys) {
+                            foreach ($point in $byKey[$key]) {
+                                if ($point.Hit) { $hitLines.Add($path + $tab + $key); break }
+                            }
+                        }
+                    }
+                    $outFile = Join-Path $ccDir ('child-' + [System.Guid]::NewGuid().ToString('n') + '.tsv')
+                    [System.IO.File]::WriteAllLines($outFile, $hitLines)
+                }
+                catch {
+                    # ignore, coverage from this child is simply skipped
+                }
+            }
+        }
     }.ToString()
 
     if ($PSVersionTable.PSVersion -ge '7.3' -and $PSNativeCommandArgumentPassing -ne 'Legacy') {


### PR DESCRIPTION
`test.ps1 -CC` traces the parent process, but the Output and InNewProcess tests run Pester in a child process through `Invoke-InNewProcess` and assert on its output. So the failure rendering, CI format output and discovery messages are covered by tests, the tracer just never sees them and reports them as missed. That made the coverage number lie about what is actually tested.

When `-CC` is on, `test.ps1` now points the children at a drop folder and the same coverage target via `PESTER_CC_CHILD_*` env vars, which the child process inherits. Each child traces itself the same way the parent does, dumps the `path` + `line:column` it hit, and the parent merges those into the measure before generating the report. Parent and child trace the same files, so a child hit maps onto the same not yet hit point and we just flip it to `Hit` (the point is a struct, so copy, set, write back, same as the tracer does on a live hit).

When `-CC` is off nothing changes, the child just runs `. $ScriptBlock` as before.

The trace output does not leak into the captured child output, `Tracer::Patch` swaps `$host.UI` for the tracing UI, so the Output test assertions are unaffected.

## Verification

Full `test.ps1 -CC` locally, 2606 passed, 0 failed, merged coverage from 31 child process runs.

| | before | after |
| --- | --- | --- |
| Output.ps1 | 74.1% | 80.0% |
| overall | 85.73% | 86.42% |

Validated both the dev (`src/*`) and inline (`bin/Pester*`) targets by hand, since CI runs `-CI -CC` which is inline.

This does not chase a coverage number, it stops the report from marking already tested code as missed, so the real gaps are easier to see.
