### PR TITLE
Remove vestigial block setup/teardown

### DIFF
--- a/src/Pester.Runtime.ps1
+++ b/src/Pester.Runtime.ps1
@@ -26,10 +26,6 @@ else {
 # 'New-EachTestTeardown'
 # 'New-OneTimeTestSetup'
 # 'New-OneTimeTestTeardown'
-# 'New-EachBlockSetup'
-# 'New-EachBlockTeardown'
-# 'New-OneTimeBlockSetup'
-# 'New-OneTimeBlockTeardown'
 # 'Invoke-Test',
 # 'Find-Test',
 # 'Invoke-PluginStep'
@@ -390,7 +386,7 @@ function Invoke-Block ($previousBlock) {
                         -ScriptBlock $sb `
                         -OuterSetup @(
                         $(if (-not (Is-Discovery) -and (-not $Block.Skip)) {
-                                @($previousBlock.EachBlockSetup) + @($block.OneTimeTestSetup)
+                                @($block.OneTimeTestSetup)
                             })
                         $(if (-not $Block.IsRoot) {
                                 # expand block name by evaluating the <> templates, only match templates that have at least 1 character and are not escaped by `<abc`>
@@ -427,7 +423,7 @@ function Invoke-Block ($previousBlock) {
                             })
                     ) `
                         -OuterTeardown $( if (-not (Is-Discovery) -and (-not $Block.Skip)) {
-                            @($block.OneTimeTestTeardown) + @($previousBlock.EachBlockTeardown)
+                            @($block.OneTimeTestTeardown)
                         } ) `
                         -Context $context `
                         -MoveBetweenScopes `
@@ -839,41 +835,6 @@ function New-OneTimeTestTeardown {
             throw "AfterAll is already defined in this block. Each block can only have one AfterAll. Combine the code into a single AfterAll block."
         }
         $state.CurrentBlock.OneTimeTestTeardown = $ScriptBlock
-    }
-}
-
-# endpoint for adding a setup for each block in the current block
-function New-EachBlockSetup {
-    param (
-        [Parameter(Mandatory = $true)]
-        [ScriptBlock] $ScriptBlock
-    )
-    if (Is-Discovery) {
-        $state.CurrentBlock.EachBlockSetup = $ScriptBlock
-    }
-}
-
-# endpoint for adding a teardown for each block in the current block
-function New-EachBlockTeardown {
-    param (
-        [Parameter(Mandatory = $true)]
-        [ScriptBlock] $ScriptBlock
-    )
-    if (Is-Discovery) {
-        $state.CurrentBlock.EachBlockTeardown = $ScriptBlock
-    }
-}
-
-# endpoint for adding a setup for all blocks in the current block
-# endpoint for adding a teardown for all clocks in the current block
-function New-OneTimeBlockTeardown {
-    [CmdletBinding()]
-    param (
-        [Parameter(Mandatory = $true)]
-        [ScriptBlock] $ScriptBlock
-    )
-    if (Is-Discovery) {
-        $state.CurrentBlock.OneTimeBlockTeardown = $ScriptBlock
     }
 }
 

--- a/src/csharp/Pester/Block.cs
+++ b/src/csharp/Pester/Block.cs
@@ -56,10 +56,6 @@ namespace Pester
         public ScriptBlock OneTimeTestSetup { get; set; }
         public ScriptBlock EachTestTeardown { get; set; }
         public ScriptBlock OneTimeTestTeardown { get; set; }
-        public ScriptBlock EachBlockSetup { get; set; }
-        public ScriptBlock OneTimeBlockSetup { get; set; }
-        public ScriptBlock EachBlockTeardown { get; set; }
-        public ScriptBlock OneTimeBlockTeardown { get; set; }
         public List<object> Order { get; set; } = new List<object>();
 
         public bool Passed { get; set; }

--- a/tst/Pester.Runtime.ts.ps1
+++ b/tst/Pester.Runtime.ts.ps1
@@ -1296,47 +1296,6 @@ i -PassThru:$PassThru {
             $container.OneTimeTestTeardown | Verify-Equal 1
         }
 
-        t "block setups&teardowns run only when there are some tests to run in the block" {
-            $container = [PSCustomObject]@{
-                OneTimeBlockSetup1    = 0
-                EachBlockSetup1       = 0
-                EachBlockTeardown1    = 0
-                OneTimeBlockTeardown1 = 0
-            }
-            $actual = Invoke-Test -SessionState $ExecutionContext.SessionState -BlockContainer (New-BlockContainerObject -ScriptBlock {
-
-                    # New-OneTimeBlockSetup { $container.OneTimeBlockSetup1++}
-                    New-EachBlockSetup {
-                        $container.EachBlockSetup1++
-                    }
-
-                    New-Block 'block1' {
-                        New-Test "test1" {
-                            "here"
-                        }
-                    }
-
-                    New-Block 'no test block' {
-
-                    }
-
-                    New-Block 'no running tests' {
-                        New-Test "do not run test" -Tag "DoNotRun" {
-                        }
-                    }
-
-                    New-EachBlockTeardown {
-                        $container.EachBlockTeardown1++
-                    }
-                    # New-OneTimeBlockTeardown { $container.OneTimeBlockTeardown1++ }
-                }) -Filter (New-FilterObject -ExcludeTag DoNotRun)
-
-            # $container.OneTimeBlockSetup1 | Verify-Equal 1
-            $container.EachBlockSetup1 | Verify-Equal 1
-            $container.EachBlockTeardown1 | Verify-Equal 1
-            # $container.OneTimeBlockTeardown1 | Verify-Equal 1
-        }
-
         t 'setup and teardown are executed on skipped parent blocks when a test is explicitly included' {
             $container = @{
                 OneTimeTestSetup    = 0
@@ -2262,7 +2221,7 @@ i -PassThru:$PassThru {
                         $Value | Verify-Equal 1
                     }
 
-                    New-OneTimeBlockTeardown {
+                    New-OneTimeTestTeardown {
                         $Value | Verify-Equal 1
                     }
 
@@ -2289,7 +2248,7 @@ i -PassThru:$PassThru {
                         $Color = "Blue"
                     }
 
-                    New-OneTimeBlockTeardown {
+                    New-OneTimeTestTeardown {
                         $Value | Verify-Equal 1
                     }
 


### PR DESCRIPTION
Draft, stacked on #2907 (which is stacked on #2906). Follow up to Frode's comment on #2907.

The block level setup/teardown is dead. `New-EachBlockSetup`, `New-EachBlockTeardown` and `New-OneTimeBlockTeardown` (and the never set `New-OneTimeBlockSetup` that #2907 already removed) are only ever called from the runtime tests. Real `BeforeAll` / `BeforeEach` / `AfterAll` / `AfterEach` go through the `*Test*` variants (`New-OneTimeTestSetup`, `New-EachTestSetup`, ...), so in a real run the `Block.EachBlockSetup` / `OneTimeBlockSetup` / `EachBlockTeardown` / `OneTimeBlockTeardown` properties are always null and the two reads in `Invoke-Test` are no-ops.

Removes:
- the three functions
- the four `ScriptBlock` properties on `Pester.Block`
- the two always null reads in `Invoke-Test`
- the runtime tests that exercised them. The two data availability tests keep their teardown check by switching to `New-OneTimeTestTeardown`.

The plugin block lifecycle (`OneTimeBlockSetupStart`, `EachBlockTeardownEnd`, ...) is a separate, live mechanism and is untouched.

These are genuinely dead so I deleted them rather than reaching for `[ExcludeFromCodeCoverage()]`.

Minor breaking change, fine for 6.1.0.

## Verification

Full `test.ps1` run passes.
