### PR TITLE
Document PR-only workflow and no force-push for agents

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -15,6 +15,10 @@ These instructions apply to all Copilot sessions working in this repository.
   closes automatically on merge. Do **not** mention the fixed issue in commit
   messages (no `Fix #34:` prefix or similar) — it's unnecessary noise.
 - Give every PR a meaningful title and a summary describing the changes.
+- **Make changes through a pull request, and never force-push a branch.** Add new
+  commits on top instead. We squash-merge, so the commit history inside a PR is
+  irrelevant (it becomes a single commit on merge), and plain pushes avoid needless
+  merge conflicts.
 
 ## Building
 


### PR DESCRIPTION
Adds a rule to the agent instructions: make changes through a pull request, and never force-push a branch. We squash-merge, so the commit history inside a PR does not matter, and plain pushes avoid needless merge conflicts.

🤖
