### PR TITLE
Read the mock parameter filter marker directly instead of Get-Variable

### DIFF
--- a/src/functions/Mock.ps1
+++ b/src/functions/Mock.ps1
@@ -1,4 +1,9 @@
 
+# Module-scope marker used to make Should throw (instead of recording a failure) when it runs
+# inside a Mock ParameterFilter. Initialized once so the hot save/restore in Test-ParameterFilter
+# and the read in Set-AssertionPassResult can access it directly instead of via Get-Variable, and
+# so the direct read is safe even under Set-StrictMode.
+$script:______isInMockParameterFilter = $false
 
 function New-MockBehavior {
     [CmdletBinding()]
@@ -1339,18 +1344,13 @@ function Test-ParameterFilter {
 
     $parameterFilterInvocations = [Collections.Generic.List[string]]@()
 
-    $previousIsInMockParameterFilter = & $SafeCommands['Get-Variable'] -Name '______isInMockParameterFilter' -Scope Script -ValueOnly -ErrorAction Ignore
+    $previousIsInMockParameterFilter = $script:______isInMockParameterFilter
     $script:______isInMockParameterFilter = $true
     try {
         $result = & $wrapper $parameters
     }
     finally {
-        if ($null -eq $previousIsInMockParameterFilter) {
-            & $SafeCommands['Remove-Variable'] -Name '______isInMockParameterFilter' -Scope Script -ErrorAction Ignore
-        }
-        else {
-            $script:______isInMockParameterFilter = $previousIsInMockParameterFilter
-        }
+        $script:______isInMockParameterFilter = $previousIsInMockParameterFilter
     }
     $passed = [bool]$result
     if ($passed) {
@@ -1414,7 +1414,9 @@ function Get-ContextToDefine {
         [System.Collections.IDictionary] $DynamicParamAliases
     )
 
-    $conflictingParameterNames = Get-ConflictingParameterNames
+    # Inlined Get-ConflictingParameterNames (body is `$script:ConflictingParameterNames`, as already used
+    # directly further down in this same function) to drop a function call from this per-mock-invocation path.
+    $conflictingParameterNames = $script:ConflictingParameterNames
     $r = @{ }
     # key the parameters by aliases so we can resolve to
     # the param itself and define it and all of it's aliases
@@ -1442,7 +1444,7 @@ function Get-ContextToDefine {
 
     foreach ($p in $Metadata.Parameters.GetEnumerator()) {
         $aliases = $p.Value.Aliases
-        if ($null -ne $aliases -and 0 -lt @($aliases).Count) {
+        if ($null -ne $aliases -and 0 -lt $aliases.Count) {
             foreach ($a in $aliases) { $h.Add($a, $p) }
         }
     }

--- a/src/functions/assert/Common/Set-AssertionPassResult.ps1
+++ b/src/functions/assert/Common/Set-AssertionPassResult.ps1
@@ -1,5 +1,5 @@
 ﻿function Set-AssertionPassResult {
-    if (& $SafeCommands['Get-Variable'] -Name '______isInMockParameterFilter' -Scope Script -ValueOnly -ErrorAction Ignore) {
+    if ($script:______isInMockParameterFilter) {
         $true
     }
 }


### PR DESCRIPTION
`Test-ParameterFilter` called `Get-Variable -Scope Script -ErrorAction Ignore` to save the previous value of `______isInMockParameterFilter` before every parameter filter evaluation, and `Set-AssertionPassResult` did the same lookup on every passing `Should-*` assertion. `Get-Variable` with `-ErrorAction Ignore` is expensive for something that runs this often, and the only reason for it was that the variable might not exist yet.

The variable is now initialized once at module scope to `$false`, so both places do a direct `$script:` read, which also stays safe under `Set-StrictMode`. The save/restore in `Test-ParameterFilter` becomes a plain assignment, without the conditional `Remove-Variable` branch.

Two small ride-alongs in the same file: `Get-ContextToDefine` inlines `Get-ConflictingParameterNames` (its whole body is the same `$script:` variable read the function already does directly a few lines below), and an `@()` wrapper is dropped around an alias collection that already has `.Count`.

Verification: full suite green on macOS (inline and dot-sourced build), `Pester.Mock.RSpec.ts.ps1` and the Mock.Tests.ps1 suite pass, including the tests that mix `Should` inside `-ParameterFilter` where the marker controls throw-vs-collect behavior.

Related perf PRs: #2914, #2915, #2917, #2918. Measured together they cut ~21% from four representative workloads (inline build, macOS).

🤖
