### PR TITLE
Clear TestDrive with .NET IO instead of per-item Remove-Item

### DIFF
--- a/src/functions/TestDrive.ps1
+++ b/src/functions/TestDrive.ps1
@@ -131,12 +131,29 @@ function Clear-TestDrive {
             [System.StringComparer]::OrdinalIgnoreCase)
 
         # Only delete "root" new items (those whose parent directory is not also a new item).
-        # Deleting with -Recurse removes all descendants in one call, avoiding redundant
-        # Remove-Item calls on already-deleted children.
+        # Deleting recursively removes all descendants in one call, avoiding redundant
+        # deletions of already-deleted children.
         foreach ($item in $newItemSet) {
             $parent = [IO.Path]::GetDirectoryName($item)
             if (-not $newItemSet.Contains($parent)) {
-                & $SafeCommands['Remove-Item'] -Path $item -Force -Recurse -ErrorAction Ignore
+                # .NET deletes are ~5x faster than Remove-Item and treat the path literally, so
+                # bracket or wildcard characters in file names no longer glob (Remove-Item -Path
+                # left a file named like 'file[1].txt' behind). Directory.Delete removes reparse
+                # points (symlinks, junctions) without following them into their target, same as
+                # Remove-TestDrive already does for the whole drive. Read-only or locked items throw
+                # and fall back to Remove-Item, which keeps the previous -Force -ErrorAction Ignore
+                # semantics for those.
+                try {
+                    if ([IO.Directory]::Exists($item)) {
+                        [IO.Directory]::Delete($item, $true)
+                    }
+                    else {
+                        [IO.File]::Delete($item)
+                    }
+                }
+                catch {
+                    & $SafeCommands['Remove-Item'] -LiteralPath $item -Force -Recurse -ErrorAction Ignore
+                }
             }
         }
     }

--- a/src/functions/TestRegistry.ps1
+++ b/src/functions/TestRegistry.ps1
@@ -95,7 +95,8 @@ function Invoke-TestRegistryWithRetry {
 function New-RandomTempRegistry {
     do {
         $tempPath = Get-TempRegistry
-        $Path = & $SafeCommands['Join-Path'] -Path $tempPath -ChildPath ([IO.Path]::GetRandomFileName().Substring(0, 4))
+        # registry provider paths always use backslash; plain interpolation avoids a per-call cmdlet invocation
+        $Path = "$tempPath\$([IO.Path]::GetRandomFileName().Substring(0, 4))"
         # Test-Path is a read operation and can throw the same transient IOException as the
         # New-Item write below, so retry it the same way.
         $keyAlreadyExists = Invoke-TestRegistryWithRetry { & $SafeCommands['Test-Path'] -Path $Path -PathType Container }


### PR DESCRIPTION
`Clear-TestDrive` ran `Remove-Item -Path $item -Force -Recurse -ErrorAction Ignore` for every new root item after each block. Two problems with that:

- `Remove-Item` costs ~470us per item where `[IO.Directory]::Delete` / `[IO.File]::Delete` cost ~85us. On a TestDrive-heavy suite the cleanup was the single hottest line in the profile.
- `-Path` treats the path as a wildcard pattern. A file named like `file[1].txt` never matched its own name, was never deleted, and leaked across block teardowns. The reverse is also possible, a name with `*` in it could over-delete. The .NET calls treat the path literally, so this is also a small bug fix.

Symlink semantics stay the same: recursive `Directory.Delete` removes reparse points without following them into their target, which is what `Remove-TestDrive` has already been doing for the whole drive with the exact same call since 2021. I verified this empirically on macOS with dir symlinks, file symlinks, dangling links, the PowerShell/PowerShell#621 problematic link set, and a symlink cycle, the linked target content survives in all cases. Anything that throws (read-only files on Windows, locked files) falls back to `Remove-Item -LiteralPath -Force -Recurse -ErrorAction Ignore`, keeping the old behavior for those, just slower on that rare path.

A ride-along in `New-RandomTempRegistry`: `Join-Path` replaced with plain string interpolation, registry provider paths always use backslash and the base key has no trailing separator, so the result is identical and it skips a cmdlet invocation per new registry key.

One heads-up: the symlink tests in `TestDrive.Tests.ps1` are entirely commented out (they needed admin on Windows), so nothing in CI exercises symlink cleanup today. Might be worth re-enabling them at least on Linux/macOS runners in a separate PR.

Verification: full suite green on macOS (inline and dot-sourced build), `TestDrive.Tests.ps1` including the Clear-TestDrive #2657 regression suite and `Pester.TestDrive.ts.ps1` pass.

Related perf PRs: #2914, #2915, #2916, #2918. Measured together they cut ~21% from four representative workloads (inline build, macOS).

🤖
