### PR TITLE
Skip unused work in discovery post-processing and output

### DIFF
--- a/src/Format2.ps1
+++ b/src/Format2.ps1
@@ -122,11 +122,13 @@ function Format-Nicely2 ($Value, [switch]$Pretty, [int]$Depth = 0) {
         return Format-Type2 -Value $Value
     }
 
-    if (Is-DecimalNumber -Value $Value) {
+    # Inlined Is-DecimalNumber / Is-ScriptBlock to avoid a function call per formatted value on this
+    # hot dispatch path (used for every <template> name expansion). The helpers stay defined for other callers.
+    if ($Value -is [float] -or $Value -is [single] -or $Value -is [double] -or $Value -is [decimal]) {
         return Format-Number2 -Value $Value
     }
 
-    if (Is-ScriptBlock -Value $Value) {
+    if ($Value -is [ScriptBlock]) {
         return Format-ScriptBlock2 -Value $Value
     }
 
@@ -142,11 +144,15 @@ function Format-Nicely2 ($Value, [switch]$Pretty, [int]$Depth = 0) {
         return Get-ShortType2 -Value $Value
     }
 
-    if (Is-Collection -Value $Value) {
+    # Inlined Is-Collection (same LanguagePrimitives::GetEnumerator check the helper runs).
+    if ($null -ne [System.Management.Automation.LanguagePrimitives]::GetEnumerator($Value)) {
         return Format-Collection2 -Value $Value -Pretty:$Pretty -Depth $Depth
     }
 
-    if (Is-Value -Value $Value) {
+    # Inlined Is-Value. The helper's leading `$Value = $($Value)` (which unwraps single-element and empty
+    # collections) is intentionally dropped: any collection was already handled by the Is-Collection branch
+    # above, so here $Value is never a collection and the unwrap is a no-op.
+    if ($Value -is [ValueType] -or $Value -is [string] -or $Value -is [scriptblock]) {
         return $Value
     }
 

--- a/src/Main.ps1
+++ b/src/Main.ps1
@@ -853,7 +853,7 @@ function Invoke-Pester {
                     }
 
                     foreach ($c in $rspecResult.Containers) {
-                        Fold-Container -Container $c  -OnTest { param($t) Add-RSpecTestObjectProperties $t }
+                        Add-RSpecTestObjectPropertiesToContainer $c
                         $foldedContainers.Add($c)
                     }
                 }
@@ -931,7 +931,7 @@ function Invoke-Pester {
                 }
 
                 foreach ($c in $rspecContainers) {
-                    Fold-Container -Container $c  -OnTest { param($t) Add-RSpecTestObjectProperties $t }
+                    Add-RSpecTestObjectPropertiesToContainer $c
                 }
             }
 

--- a/src/Pester.RSpec.ps1
+++ b/src/Pester.RSpec.ps1
@@ -203,6 +203,24 @@ function Add-RSpecBlockObjectProperties ($BlockObject) {
     }
 }
 
+function Add-RSpecTestObjectPropertiesToContainer ($Container) {
+    # Direct walk over the container tree instead of Fold-Container. It visits every test in the
+    # same pre-order (tests of a block before its child blocks), but without the fold's per-item
+    # scriptblock dispatch and per-block advanced-function recursion.
+    foreach ($b in $Container.Blocks) {
+        Add-RSpecTestObjectPropertiesToBlock $b
+    }
+}
+
+function Add-RSpecTestObjectPropertiesToBlock ($Block) {
+    foreach ($t in $Block.Tests) {
+        Add-RSpecTestObjectProperties $t
+    }
+    foreach ($b in $Block.Blocks) {
+        Add-RSpecTestObjectPropertiesToBlock $b
+    }
+}
+
 function PostProcess-RspecTestRun ($TestRun, [switch] $Parallel, [TimeSpan] $RunDuration) {
     $discoveryOnly = $PesterPreference.Run.SkipRun.Value
 
@@ -507,56 +525,32 @@ function Remove-RSpecNonPublicProperties ($run) {
     #     'Duration'
     # )
 
-    Fold-Run $run -OnRun {
-        param($i)
-        # $ps = $i.PsObject.Properties.Name
-        # foreach ($p in $ps) {
-        #     if ($p -like 'Plugin*') {
-        #         $i.PsObject.Properties.Remove($p)
-        #     }
-        # }
+    # Direct walk over the run tree instead of Fold-Run; same visit of every block and test,
+    # without the fold's per-item scriptblock dispatch. Containers need no cleanup.
+    foreach ($r in $run) {
+        $r.PluginConfiguration = $null
+        $r.PluginData = $null
+        $r.Plugins = $null
 
-        $i.PluginConfiguration = $null
-        $i.PluginData = $null
-        $i.Plugins = $null
+        foreach ($c in $r.Containers) {
+            foreach ($b in $c.Blocks) {
+                Remove-RSpecNonPublicPropertiesFromBlock $b
+            }
+        }
+    }
+}
 
-    } -OnContainer {
-        param($i)
-        # $ps = $i.PsObject.Properties.Name
-        # foreach ($p in $ps) {
-        #     if ($p -like 'Own*') {
-        #         $i.PsObject.Properties.Remove($p)
-        #     }
-        # }
+function Remove-RSpecNonPublicPropertiesFromBlock ($Block) {
+    $Block.FrameworkData = $null
+    $Block.PluginData = $null
 
-        # $i.FrameworkData = $null
-        # $i.PluginConfiguration = $null
-        # $i.PluginData = $null
-        # $i.Plugins = $null
+    foreach ($t in $Block.Tests) {
+        $t.FrameworkData = $null
+        $t.PluginData = $null
+    }
 
-    } -OnBlock {
-        param($i)
-        # $ps = $i.PsObject.Properties.Name
-        # foreach ($p in $ps) {
-        #     if ($p -eq 'FrameworkData' -or $p -like 'Own*' -or $p -like 'Plugin*') {
-        #         $i.PsObject.Properties.Remove($p)
-        #     }
-        # }
-
-        $i.FrameworkData = $null
-        $i.PluginData = $null
-
-    } -OnTest {
-        param($i)
-        # $ps = $i.PsObject.Properties.Name
-        # foreach ($p in $ps) {
-        #     if ($p -eq 'FrameworkData' -or $p -like 'Plugin*') {
-        #         $i.PsObject.Properties.Remove($p)
-        #     }
-        # }
-
-        $i.FrameworkData = $null
-        $i.PluginData = $null
+    foreach ($b in $Block.Blocks) {
+        Remove-RSpecNonPublicPropertiesFromBlock $b
     }
 }
 

--- a/src/functions/Output.ps1
+++ b/src/functions/Output.ps1
@@ -555,7 +555,12 @@ function Get-WriteScreenPlugin ($Verbosity) {
     $p.DiscoveryEnd = {
         param ($Context)
 
-        $discoveredTests = @(View-Flat -Block $Context.BlockContainers)
+        # flattening the tree costs time proportional to the number of discovered tests, and the
+        # result is only read by the two guarded blocks below, so skip it in the default run
+        # (Normal verbosity, not discovery-only) where neither guard can be entered
+        $discoveredTests = if ($PesterPreference.Run.SkipRun.Value -or $PesterPreference.Output.Verbosity.Value -in 'Detailed', 'Diagnostic') {
+            @(View-Flat -Block $Context.BlockContainers)
+        }
 
         if ($PesterPreference.Run.SkipRun.Value) {
             # Only announce the discovery result on screen when we are not going to run


### PR DESCRIPTION
Three changes on the discovery and post-processing side:

- The WriteScreen plugin flattened the whole discovered tree with `View-Flat` on `DiscoveryEnd`, but the result is only read when `Run.SkipRun` is set or verbosity is `Detailed`/`Diagnostic`. In the default run it was computed and thrown away, the cost grows with the number of discovered tests. It is now computed only when one of those two guarded blocks can actually read it.
- The RSpec decoration walk (`Add-RSpecTestObjectProperties` per test, run once per container after it finishes) and `Remove-RSpecNonPublicProperties` used `Fold-Container`/`Fold-Run`, which pay a scriptblock dispatch per item plus an advanced-function recursion per block. Both are now direct recursive loops that visit the same items in the same pre-order (tests of a block before its child blocks). The decoration body itself is unchanged and stays in one place, the walker just calls it.
- `Format-Nicely2` called the `Is-DecimalNumber`, `Is-ScriptBlock`, `Is-Collection` and `Is-Value` helpers on every formatted value, and it runs for every `<template>` name expansion of data-driven tests. The type checks are inlined (`Is-Collection` is the same `LanguagePrimitives::GetEnumerator` test), the helpers stay defined for their other callers.

Verification: full suite green on macOS (inline and dot-sourced build), `Pester.RSpec.ts.ps1`, `Pester.RSpec.Parallel.ts.ps1` (covers the parallel decoration path, which changed too) and `Pester.RSpec.Output.ts.ps1` pass in fresh processes. Result object shape is covered by `Pester.RSpec.ResultObject.ts.ps1`, also green.

Related perf PRs: #2914, #2915, #2916, #2917. Measured together they cut ~21% from four representative workloads (inline build, macOS).

🤖
