### PR TITLE
Add -IgnoreOrder to Should-ContainCollection

### DIFF
--- a/src/functions/assert/Collection/Should-ContainCollection.ps1
+++ b/src/functions/assert/Collection/Should-ContainCollection.ps1
@@ -6,11 +6,16 @@
     .DESCRIPTION
     The items of the expected collection must appear in the actual collection in the same order. Gaps between the matched items are allowed, but each actual item is used at most once, so repeated expected items need at least as many matching items in the actual collection. A single value is treated as a one-item collection. Items are compared using PowerShell equality, the same as the `-contains` operator.
 
+    Use `-IgnoreOrder` to check that the expected items are present in any order. Each actual item is still used at most once, so repeated expected items need at least as many matching items in the actual collection.
+
     .PARAMETER Expected
-    One or more items to look for as an ordered subsequence. A single value is treated as a one-item collection.
+    One or more items to look for. By default they must appear as an ordered subsequence; with `-IgnoreOrder` the order does not matter. A single value is treated as a one-item collection.
 
     .PARAMETER Actual
     The collection to search in.
+
+    .PARAMETER IgnoreOrder
+    Ignores the order of the items, so the expected items only need to be present in the actual collection, in any order.
 
     .PARAMETER Because
     The reason why the input should be the expected value.
@@ -24,6 +29,14 @@
     ```
 
     These assertions pass, because the expected items are present in the same order. Gaps between them, as in `@(1, 3)`, are allowed, and a single value is treated as a one-item collection.
+
+    .EXAMPLE
+    ```powershell
+    'b', 3, 2, 'a' | Should-ContainCollection @('a', 2) -IgnoreOrder
+    1, 2, 3 | Should-ContainCollection @(3, 2, 1) -IgnoreOrder
+    ```
+
+    These assertions pass, because with `-IgnoreOrder` the expected items only need to be present, not in any particular order.
 
     .EXAMPLE
     ```powershell
@@ -54,13 +67,21 @@
         $Actual,
         [Parameter(Position = 0, Mandatory)]
         $Expected,
+        [switch]$IgnoreOrder,
         [String]$Because
     )
 
     $assert = New-ShouldAssertion -Caller $PSCmdlet -Actual $Actual -Buffer $local:Input -As 'CollectionItems'
     $Actual = $assert.Actual()
 
-    if (-not (Is-CollectionSubsequence -Expected $Expected -Actual $Actual)) {
-        $assert.Fail("Expected <expectedType> <expected> to be present in <actualType> <actual>,<because> but it was not there.", @{ Expected = $Expected; Because = $Because })
+    if ($IgnoreOrder) {
+        if (-not (Is-CollectionSubset -Expected $Expected -Actual $Actual)) {
+            $assert.Fail("Expected <expectedType> <expected> to be present in <actualType> <actual> in any order,<because> but it was not there.", @{ Expected = $Expected; Because = $Because })
+        }
+    }
+    else {
+        if (-not (Is-CollectionSubsequence -Expected $Expected -Actual $Actual)) {
+            $assert.Fail("Expected <expectedType> <expected> to be present in <actualType> <actual>,<because> but it was not there.", @{ Expected = $Expected; Because = $Because })
+        }
     }
 }

--- a/src/functions/assert/Common/Is-CollectionSubset.ps1
+++ b/src/functions/assert/Common/Is-CollectionSubset.ps1
@@ -1,0 +1,47 @@
+function Is-CollectionSubset ($Expected, $Actual) {
+    # Returns $true when every item of $Expected can be matched to a distinct item of $Actual,
+    # ignoring order. This is a multiset (bag) subset check: each $Actual item is consumed at
+    # most once, so repeated items in $Expected need at least as many matching items in $Actual
+    # (e.g. @(1, 1) needs two 1s in $Actual, not one reused twice). This is the order-insensitive
+    # counterpart to Is-CollectionSubsequence.
+    #
+    # A single, non-collection value is treated as a one-item collection, which keeps the
+    # original single-item containment behaviour as the one-item special case.
+
+    # Materialise the expected items so we can iterate them without flattening nested
+    # collections, the same way @(...) would.
+    $expectedItems = [System.Collections.Generic.List[object]]::new()
+    foreach ($item in $Expected) { $expectedItems.Add($item) }
+
+    # An empty expected collection is vacuously present in any collection.
+    if (0 -eq $expectedItems.Count) { return $true }
+
+    # Copy the actual items so we can mark the ones we have already used.
+    $actualItems = [System.Collections.Generic.List[object]]::new()
+    foreach ($item in $Actual) { $actualItems.Add($item) }
+
+    # Marker object for actual items that were already matched. Using a fresh reference means
+    # the user can put anything in the collection, including $null, and never collide with the
+    # marker, because they can never get a reference to it.
+    $consumed = [Object]::new()
+
+    foreach ($expectedItem in $expectedItems) {
+        $found = $false
+        for ($a = 0; $a -lt $actualItems.Count; $a++) {
+            # Skip items we have already consumed. Reference comparison, so $null actual items
+            # are not treated as consumed.
+            if ($consumed -eq $actualItems[$a]) { continue }
+            # Compare with -eq, actual item on the left, to match the equality semantics of
+            # PowerShell's -contains operator. Cast to [bool] so an actual item that is itself a
+            # collection collapses to a single truthy/falsy result instead of a filtered array.
+            if ([bool]($actualItems[$a] -eq $expectedItem)) {
+                $actualItems[$a] = $consumed
+                $found = $true
+                break
+            }
+        }
+        if (-not $found) { return $false }
+    }
+
+    return $true
+}

--- a/tst/functions/assert/Collection/Should-ContainCollection.Tests.ps1
+++ b/tst/functions/assert/Collection/Should-ContainCollection.Tests.ps1
@@ -56,6 +56,39 @@ InPesterModuleScope {
             { Should-ContainCollection 1 3, 4, 5 } | Verify-AssertionFailed
         }
     }
+
+    Describe "Should-ContainCollection -IgnoreOrder" {
+        It "Passes when the expected items are present in the same order" {
+            1, 2, 3 | Should-ContainCollection @(1, 2) -IgnoreOrder
+        }
+
+        It "Passes when the expected items are present in a different order" {
+            1, 2, 3 | Should-ContainCollection @(3, 2, 1) -IgnoreOrder
+            1, 2, 3 | Should-ContainCollection @(3, 1) -IgnoreOrder
+        }
+
+        It "Passes for the reported repro with a `$null and unordered items" {
+            'b', 3, 2, 'a', $null | Should-ContainCollection ('a', 2, $null) -IgnoreOrder
+        }
+
+        It "Passes when there are enough duplicate items to match repeated expected items" {
+            1, 1, 2 | Should-ContainCollection @(1, 1) -IgnoreOrder
+        }
+
+        It "Passes when a single value is treated as a one-item collection" {
+            1, 2, 3 | Should-ContainCollection 2 -IgnoreOrder
+        }
+
+        It "Fails when an expected item is missing, even ignoring order" {
+            $err = { 1, 2, 3 | Should-ContainCollection @(3, 4) -IgnoreOrder } | Verify-AssertionFailed
+            $err.Exception.Message | Verify-Equal "Expected [Object[]] @(3, 4) to be present in [Object[]] @(1, 2, 3) in any order, but it was not there."
+        }
+
+        It "Fails when a repeated expected item cannot be matched by a single actual item" {
+            { 1, 2 | Should-ContainCollection @(1, 1) -IgnoreOrder } | Verify-AssertionFailed
+            { 2, 'a', $null | Should-ContainCollection ($null, $null) -IgnoreOrder } | Verify-AssertionFailed
+        }
+    }
 }
 
 Describe "Should-ContainCollection input hint" {


### PR DESCRIPTION
Fix #2874

`Should-ContainCollection` requires the expected items in the same order, which is annoying when migrating from `Should -BeIn` where the order did not matter. This adds an `-IgnoreOrder` switch that only checks that the expected items are present, in any order.

```powershell
'b',3,2,'a',$null | Should-ContainCollection 'a',2,$null -IgnoreOrder
```

The check is a multiset subset (new internal `Is-CollectionSubset`), so duplicates and `$null` are handled correctly, each expected item is matched at most once. Without the switch the ordered behavior is unchanged.

Added tests for the ordered and unordered cases, duplicates and `$null`.

🤖
