### PR TITLE
Summarise complex objects when formatting instead of hanging

### DIFF
--- a/src/Format.ps1
+++ b/src/Format.ps1
@@ -76,7 +76,7 @@ function Format-Nicely ($Value, [switch]$Pretty) {
         return '[' + (Format-Type -Value $Value) + ']'
     }
 
-    if (Is-DecimalNumber -Value $Value) {
+    if ((Is-IntegralNumber -Value $Value) -or (Is-DecimalNumber -Value $Value)) {
         return Format-Number -Value $Value
     }
 

--- a/src/Format2.ps1
+++ b/src/Format2.ps1
@@ -1,7 +1,22 @@
-﻿function Format-Collection2 ($Value, [switch]$Pretty, [int]$Depth = 0) {
+﻿# Default recursion budget for formatting. A depth of 10 is never useful in an assertion message and
+# is well below PowerShell's own call-depth limit, so it is fixed here rather than exposed as a
+# configuration. MaxDepth counts *down* as we recurse; formatting stops once it reaches 0.
+$maximumFormatDepth = 10
+
+# Types that are too big, slow, or self-referential to expand in full, matched by base type so a single
+# entry covers every subtype. For these Get-DisplayProperty2 returns a short list of representative
+# properties, so Format-Nicely2 renders a compact summary (e.g. 'FunctionInfo{Name=Invoke-Pester}')
+# instead of walking the whole object. Ordered from the most concrete type to the least concrete.
+$script:representativePropertyByBaseType = @(
+    # A CommandInfo (function, cmdlet, alias, external script, ...) expands into an enormous, deeply
+    # nested tree that looks like a hang (#2865); its Name is the one useful thing to show.
+    @{ Type = [System.Management.Automation.CommandInfo]; Property = @('Name') }
+)
+
+function Format-Collection2 ($Value, [switch]$Pretty, [int]$MaxDepth = $maximumFormatDepth) {
     $length = 0
     $o = foreach ($v in $Value) {
-        $formatted = Format-Nicely2 -Value $v -Pretty:$Pretty -Depth ($Depth + 1)
+        $formatted = Format-Nicely2 -Value $v -Pretty:$Pretty -MaxDepth ($MaxDepth - 1)
         $length += $formatted.Length + 1 # 1 is for the separator
         $formatted
     }
@@ -19,7 +34,7 @@
     }
 }
 
-function Format-Object2 ($Value, $Property, [switch]$Pretty, [int]$Depth = 0) {
+function Format-Object2 ($Value, $Property, [switch]$Pretty, [int]$MaxDepth = $maximumFormatDepth) {
     if ($null -eq $Property) {
         $Property = foreach ($p in $Value.PSObject.Properties) { $p.Name }
     }
@@ -31,7 +46,7 @@ function Format-Object2 ($Value, $Property, [switch]$Pretty, [int]$Depth = 0) {
     $valueType = Get-ShortType $Value
     $items = foreach ($p in $orderedProperty) {
         $v = ([PSObject]$Value.$p)
-        $f = Format-Nicely2 -Value $v -Pretty:$Pretty -Depth ($Depth + 1)
+        $f = Format-Nicely2 -Value $v -Pretty:$Pretty -MaxDepth ($MaxDepth - 1)
         "$p=$f"
     }
 
@@ -81,31 +96,31 @@ function Format-Number2 ($Value) {
     [string]$Value
 }
 
-function Format-Hashtable2 ($Value, [int]$Depth = 0) {
+function Format-Hashtable2 ($Value, [int]$MaxDepth = $maximumFormatDepth) {
     $head = '@{'
     $tail = '}'
 
     $entries = foreach ($v in $Value.Keys | & $SafeCommands['Sort-Object']) {
-        $formattedValue = Format-Nicely2 -Value $Value.$v -Depth ($Depth + 1)
+        $formattedValue = Format-Nicely2 -Value $Value.$v -MaxDepth ($MaxDepth - 1)
         "$v=$formattedValue"
     }
 
     $head + ( $entries -join '; ') + $tail
 }
 
-function Format-Dictionary2 ($Value, [int]$Depth = 0) {
+function Format-Dictionary2 ($Value, [int]$MaxDepth = $maximumFormatDepth) {
     $head = 'Dictionary{'
     $tail = '}'
 
     $entries = foreach ($v in $Value.Keys | & $SafeCommands['Sort-Object'] ) {
-        $formattedValue = Format-Nicely2 -Value $Value.$v -Depth ($Depth + 1)
+        $formattedValue = Format-Nicely2 -Value $Value.$v -MaxDepth ($MaxDepth - 1)
         "$v=$formattedValue"
     }
 
     $head + ( $entries -join '; ') + $tail
 }
 
-function Format-Nicely2 ($Value, [switch]$Pretty, [int]$Depth = 0) {
+function Format-Nicely2 ($Value, [switch]$Pretty, [int]$MaxDepth = $maximumFormatDepth) {
     if ($null -eq $Value) {
         return Format-Null2 -Value $Value
     }
@@ -122,7 +137,7 @@ function Format-Nicely2 ($Value, [switch]$Pretty, [int]$Depth = 0) {
         return Format-Type2 -Value $Value
     }
 
-    if (Is-DecimalNumber -Value $Value) {
+    if ((Is-IntegralNumber -Value $Value) -or (Is-DecimalNumber -Value $Value)) {
         return Format-Number2 -Value $Value
     }
 
@@ -130,20 +145,18 @@ function Format-Nicely2 ($Value, [switch]$Pretty, [int]$Depth = 0) {
         return Format-ScriptBlock2 -Value $Value
     }
 
-    # Deeply nested or self-referential objects (e.g. SMO stubs or DirectoryInfo, whose
-    # Parent/Root point back up the tree) would otherwise recurse until PowerShell throws
-    # "The script failed due to call depth overflow" (#2828, #2474). Once we are past a sane
-    # nesting depth stop expanding and just print the value's type, which is enough for a
-    # diagnostic message and cannot recurse further. Scalars above are always fully formatted;
-    # only the container/object branches below recurse, so the guard sits in front of them.
-    # A depth of 10 is never useful in an assertion message and is well below PowerShell's own
-    # call-depth limit, so it is fixed here rather than exposed as a configurable variable.
-    if ($Depth -ge 10) {
+    # Budget exhausted. Deeply nested or self-referential values (e.g. SMO stubs or DirectoryInfo,
+    # whose Parent/Root point back up the tree) would otherwise recurse until PowerShell throws
+    # "The script failed due to call depth overflow" (#2828, #2474). Once the budget runs out stop
+    # expanding and just print the value's type, which cannot recurse further. Scalars above are
+    # always fully formatted; only the container/object branches below recurse, so the guard sits in
+    # front of them.
+    if ($MaxDepth -le 0) {
         return Get-ShortType2 -Value $Value
     }
 
     if (Is-Collection -Value $Value) {
-        return Format-Collection2 -Value $Value -Pretty:$Pretty -Depth $Depth
+        return Format-Collection2 -Value $Value -Pretty:$Pretty -MaxDepth $MaxDepth
     }
 
     if (Is-Value -Value $Value) {
@@ -151,18 +164,38 @@ function Format-Nicely2 ($Value, [switch]$Pretty, [int]$Depth = 0) {
     }
 
     if (Is-Hashtable -Value $Value) {
-        return Format-Hashtable2 -Value $Value -Depth $Depth
+        return Format-Hashtable2 -Value $Value -MaxDepth $MaxDepth
     }
 
     if (Is-Dictionary -Value $Value) {
-        return Format-Dictionary2 -Value $Value -Depth $Depth
+        return Format-Dictionary2 -Value $Value -MaxDepth $MaxDepth
     }
 
     if ((Is-DataTable -Value $Value) -or (Is-DataRow -Value $Value)) {
         return Format-DataTable2 -Value $Value -Pretty:$Pretty
     }
 
-    Format-Object2 -Value $Value -Property (Get-DisplayProperty2 $Value.GetType()) -Pretty:$Pretty -Depth $Depth
+    # Some types are too big, slow or self-referential to expand in full (e.g. CommandInfo fans out into
+    # a huge, deeply nested tree that is so slow to format it looks like a hang, #2865). For those the
+    # registry returns a short list of representative properties, so we render a compact summary like
+    # 'FunctionInfo{Name=Invoke-Pester}' that adds real information (the name) rather than a giant dump.
+    # This is bounded and cannot explode, so it is used at any depth and in both detailed assertion
+    # messages and shallow callers such as test-name templates.
+    $displayProperty = Get-DisplayProperty2 $Value.GetType()
+    if ($null -ne $displayProperty) {
+        return Format-Object2 -Value $Value -Property $displayProperty -Pretty:$Pretty -MaxDepth $MaxDepth
+    }
+
+    # Any other object is expanded property by property. Unlike scalars and containers such an object
+    # needs a whole extra level of budget to expand: with only one level left it collapses to just its
+    # type. That keeps detailed assertion messages (which start with the full budget) while letting
+    # shallow callers such as test-name templates render an unknown complex object as little text like
+    # '[SomeType]' instead of walking a giant, slow property tree.
+    if ($MaxDepth -le 1) {
+        return Get-ShortType2 -Value $Value
+    }
+
+    Format-Object2 -Value $Value -Pretty:$Pretty -MaxDepth $MaxDepth
 }
 
 function Format-NicelyForTemplate ($Value) {
@@ -175,24 +208,27 @@ function Format-NicelyForTemplate ($Value) {
         return $Value
     }
 
-    Format-Nicely2 -Value $Value
+    # Test/block names should stay short, so use a shallow budget (#2865). Scalars, a single level of
+    # arrays and hashtables still render nicely (e.g. '@(1, 2, 3)', "@{Name='x'}"). A registered type
+    # renders its compact representative summary (e.g. a CommandInfo referenced whole via '<cmd>'
+    # instead of '<cmd.Name>' becomes 'FunctionInfo{Name=Invoke-Pester}'), and any other complex object
+    # collapses to just its type like '[SomeType]' instead of expanding into an enormous, slow property
+    # dump. Either way the result is little text and hints the author to reference a specific property.
+    Format-Nicely2 -Value $Value -MaxDepth 1
 }
 
 function Get-DisplayProperty2 ([Type]$Type) {
     # rename to Get-DisplayProperty?
 
-    <# some objects are simply too big to show all of their properties,
-    so we can create a list of properties to show from an object
-    maybe the default info from Get-FormatData could be utilized here somehow
-    so we show only stuff that would normally show in format-table view
-    leveraging the work PS team already did #>
+    <# Some objects are simply too big, slow, or self-referential to show all of their properties, so we
+    keep a small registry of representative properties to show instead. This both keeps assertion
+    messages readable and stops complex objects that are referenced whole in a test-name template from
+    expanding into an enormous, slow property dump (#2865, #2474). To tame a new type, add one entry.
 
-    # this will become more advanced, basically something along the lines of:
-    # foreach type, try constructing the type, and if it exists then check if the
-    # incoming type is assignable to the current type, if so then return the properties,
-    # this way I can specify the map from the most concrete type to the least concrete type
-    # and for types that do not exist
+    maybe the default info from Get-FormatData could be utilized here somehow so we show only stuff that
+    would normally show in format-table view, leveraging the work the PS team already did. #>
 
+    # Exact type -> representative properties. Fast, and does not affect subtypes.
     $propertyMap = @{
         'System.Diagnostics.Process'  = 'Id', 'Name'
         # DirectoryInfo and FileInfo have circular references (Root, Directory) that cause infinite recursion
@@ -200,7 +236,19 @@ function Get-DisplayProperty2 ([Type]$Type) {
         'System.IO.FileInfo'          = 'Name', 'FullName', 'Length'
     }
 
-    $propertyMap[$Type.FullName]
+    $exact = $propertyMap[$Type.FullName]
+    if ($null -ne $exact) {
+        return $exact
+    }
+
+    # Base type -> representative properties, matched by assignability so a single entry covers every
+    # subtype (e.g. CommandInfo covers FunctionInfo, CmdletInfo, AliasInfo, ExternalScriptInfo, ...).
+    # Ordered from the most concrete type to the least concrete; the first assignable entry wins.
+    foreach ($entry in $script:representativePropertyByBaseType) {
+        if ($entry.Type.IsAssignableFrom($Type)) {
+            return $entry.Property
+        }
+    }
 }
 
 function Get-ShortType2 ($Value) {

--- a/src/TypeClass.ps1
+++ b/src/TypeClass.ps1
@@ -16,8 +16,14 @@ function Is-ScriptBlock ($Value) {
     $Value -is [ScriptBlock]
 }
 
+function Is-IntegralNumber ($Value) {
+    # Note: Using .NET type names for consistency because PowerShell 5.1 doesn't support short/ushort/uint/ulong
+    $Value -is [Int32] -or $Value -is [Int64] -or $Value -is [Int16] -or $Value -is [SByte] -or
+    $Value -is [UInt32] -or $Value -is [UInt64] -or $Value -is [UInt16] -or $Value -is [Byte]
+}
+
 function Is-DecimalNumber ($Value) {
-    $Value -is [float] -or $Value -is [single] -or $Value -is [double] -or $Value -is [decimal]
+    $Value -is [Single] -or $Value -is [Double] -or $Value -is [Decimal]
 }
 
 function Is-Hashtable ($Value) {

--- a/tst/Format2.Tests.ps1
+++ b/tst/Format2.Tests.ps1
@@ -217,6 +217,71 @@ InPesterModuleScope {
             $formatted.Contains("'bottom'") | Verify-False
             $formatted.Contains('[PSObject]') | Verify-True
         }
+
+        # Regression test for https://github.com/pester/Pester/issues/2865
+        # A shallow -MaxDepth collapses arbitrary objects to their type instead of walking their
+        # properties. This is what stops complex objects (e.g. CommandInfo) from fanning out into an
+        # enormous, deeply nested tree that takes so long to format it looks like a hang.
+        It "With -MaxDepth 1 collapses an unregistered object to its type but still renders scalars and a level of containers" {
+            $object = [PSCustomObject]@{ Name = 'Jakub'; Age = 28 }
+            # An unknown object needs more than one level of budget, so it collapses to its type ...
+            Format-Nicely2 -Value $object -MaxDepth 1 | Verify-Equal '[PSObject]'
+            # ... while scalars and a single level of arrays/hashtables still render, and objects
+            # nested inside them collapse to their type instead of expanding.
+            Format-Nicely2 -Value 'Jakub' -MaxDepth 1 | Verify-Equal "'Jakub'"
+            Format-Nicely2 -Value @(1, 2, 3) -MaxDepth 1 | Verify-Equal '@(1, 2, 3)'
+            Format-Nicely2 -Value @{ Name = 'x' } -MaxDepth 1 | Verify-Equal "@{Name='x'}"
+            Format-Nicely2 -Value @{ cmd = $object } -MaxDepth 1 | Verify-Equal '@{cmd=[PSObject]}'
+        }
+
+        It "Renders a registered type as a compact representative summary even at a shallow -MaxDepth" {
+            # A CommandInfo is registered (base type) to show only its Name, so it never fans out into a
+            # slow, deeply nested dump and stays informative at any depth (#2865).
+            $command = Get-Command -Name 'Get-Command'
+            Format-Nicely2 -Value $command -MaxDepth 1 | Verify-Equal "Management.Automation.CmdletInfo{Name='Get-Command'}"
+        }
+
+        It "Formats integers as numbers so a simple array renders at a shallow depth" {
+            # Integers must be treated as scalars (not ValueType objects), otherwise a plain array
+            # collapses to '@([int], [int], [int])' once the budget is shallow (#2865).
+            Format-Nicely2 -Value 42 -MaxDepth 1 | Verify-Equal '42'
+            Format-Nicely2 -Value @(1, 2, 3) -MaxDepth 1 | Verify-Equal '@(1, 2, 3)'
+        }
+    }
+
+    Describe "Format-NicelyForTemplate" {
+        It "Passes a top-level string through unquoted so '<user.name>' stays clean" {
+            Format-NicelyForTemplate -Value 'Jakub' | Verify-Equal 'Jakub'
+        }
+
+        It "Renders '<value>' as '<expected>'" -TestCases @(
+            @{ Value = $null; Expected = '$null' }
+            @{ Value = $true; Expected = '$true' }
+            @{ Value = 42; Expected = '42' }
+            @{ Value = @(1, 2, 3); Expected = '@(1, 2, 3)' }
+            @{ Value = @{ Name = 'x'; Age = 1 }; Expected = "@{Age=1; Name='x'}" }
+        ) {
+            param ($Value, $Expected)
+            Format-NicelyForTemplate -Value $Value | Verify-Equal $Expected
+        }
+
+        # Regression test for https://github.com/pester/Pester/issues/2865
+        # Referencing a whole complex object (like CommandInfo) in a test/block name used to expand
+        # into an enormous, deeply nested property dump that took so long to build it looked like a
+        # hang. A CommandInfo is a registered type, so it must instead render a compact representative
+        # summary (its Name) and return promptly.
+        It "Renders a registered complex type like CommandInfo as a short summary instead of hanging" {
+            $job = Start-Job -ScriptBlock {
+                param($modulePath)
+                Import-Module $modulePath
+                & (Get-Module Pester) { Format-NicelyForTemplate -Value (Get-Command -Name 'Invoke-Pester') }
+            } -ArgumentList (Get-Module Pester).Path
+            $result = $job | Wait-Job -Timeout 30 | Receive-Job
+            $job | Remove-Job -Force
+
+            # Completes at all (no hang) and shows only the representative property, not the property tree.
+            $result | Verify-Equal "Management.Automation.FunctionInfo{Name='Invoke-Pester'}"
+        }
     }
 
     Describe "Get-DisplayProperty2" {
@@ -239,6 +304,19 @@ InPesterModuleScope {
         It "Returns 'Name FullName Length' for FileInfo" {
             $Actual = Get-DisplayProperty2 -Type ([System.IO.FileInfo])
             "$Actual" | Verify-Equal "Name FullName Length"
+        }
+
+        # Regression test for https://github.com/pester/Pester/issues/2865
+        # CommandInfo is registered by base type, so all of its subtypes (FunctionInfo, CmdletInfo,
+        # AliasInfo, ExternalScriptInfo, ...) are summarised by their Name from a single entry.
+        It "Returns 'Name' for the CommandInfo subtype '<type>'" -TestCases @(
+            @{ Type = [System.Management.Automation.FunctionInfo] }
+            @{ Type = [System.Management.Automation.CmdletInfo] }
+            @{ Type = [System.Management.Automation.AliasInfo] }
+        ) {
+            param ($Type)
+            $Actual = Get-DisplayProperty2 -Type $Type
+            "$Actual" | Verify-Equal "Name"
         }
     }
 

--- a/tst/Pester.RSpec.ts.ps1
+++ b/tst/Pester.RSpec.ts.ps1
@@ -2266,6 +2266,25 @@ i -PassThru:$PassThru {
             $r.Containers[0].Blocks[0].ExpandedName | Verify-Equal "d Jakub"
         }
 
+        # Regression test for https://github.com/pester/Pester/issues/2865
+        # Referencing a whole complex object (e.g. a CommandInfo as <func> instead of <func.Name>)
+        # used to expand into an enormous property tree that took so long it looked like Pester hung.
+        # A CommandInfo is a registered type, so it must render a compact summary (its Name) and
+        # complete promptly.
+        t "a complex object like CommandInfo in the name renders a short summary instead of hanging" {
+            $sb = {
+                Describe 'd <func>' {
+                    It 'i <func>' { }
+                } -ForEach @(@{ func = (Get-Command -Name 'Invoke-Pester') })
+            }
+
+            $container = New-PesterContainer -ScriptBlock $sb
+            $r = Invoke-Pester -Container $container -PassThru
+            $r.Containers[0].Blocks[0].Tests[0].Result | Verify-Equal "Passed"
+            $r.Containers[0].Blocks[0].Tests[0].ExpandedName | Verify-Equal "i Management.Automation.FunctionInfo{Name='Invoke-Pester'}"
+            $r.Containers[0].Blocks[0].ExpandedName | Verify-Equal "d Management.Automation.FunctionInfo{Name='Invoke-Pester'}"
+        }
+
         t "`$variable remains as literal text after expanding" {
             $sb = {
                 Describe "d `$abc" {

--- a/tst/TypeClass.Tests.ps1
+++ b/tst/TypeClass.Tests.ps1
@@ -45,15 +45,40 @@ Describe "Is-Value" {
 
 #number
 
-Describe "Is-DecimalNumber" {
-    It "Given a number it returns `$true" -TestCases @(
-        @{ Value = 1.1; },
-        @{ Value = [double] 1.1; },
-        @{ Value = [float] 1.1; },
-        @{ Value = [single] 1.1; },
-        @{ Value = [decimal] 1.1; }
+Describe 'Is-IntegralNumber' {
+    It "Given a number of type '<Type.Name>' it returns `$true" -TestCases @(
+        @{ Type = [Int16] },    # [short]
+        @{ Type = [UInt16] },   # [ushort]
+        @{ Type = [Int32] },    # [int]
+        @{ Type = [UInt32] },   # [uint]
+        @{ Type = [Int64] },    # [long]
+        @{ Type = [UInt64] },   # [ulong]
+        @{ Type = [byte] },
+        @{ Type = [sbyte] }
     ) {
-        Is-DecimalNumber -Value $Value | Verify-True
+        Is-IntegralNumber -Value (1 -as $Type) | Verify-True
+    }
+
+    It "Given a decimal number it returns `$false" {
+        Is-IntegralNumber -Value 1.1 | Verify-False
+    }
+
+    It "Given a string it returns `$false" {
+        Is-IntegralNumber -Value 'abc' | Verify-False
+    }
+}
+
+Describe "Is-DecimalNumber" {
+    It "Given a number of type '<Type.Name>' it returns `$true" -TestCases @(
+        @{ Type = [double] },
+        @{ Type = [Single] }, # [float]
+        @{ Type = [Decimal] }
+    ) {
+        Is-DecimalNumber -Value (1.1 -as $Type) | Verify-True
+    }
+
+    It "Given an integral number it returns `$false" {
+        Is-DecimalNumber -Value 1 | Verify-False
     }
 
     It "Given a string it returns `$false" {


### PR DESCRIPTION
Fix #2865

Expanding `<...>` in a test name hangs when the value is a complex object with many properties like `CommandInfo`. `Format-NicelyForTemplate` walks the whole object graph down to depth 10, and something like `CommandInfo` fans out to a huge number of nodes before it stops, so it looks like a hang.

This limits template formatting to one level of recursion, so an unregistered complex object collapses to its type instead of expanding. `CommandInfo` is registered by its base type and renders just its `Name`.

```powershell
& (Get-Module Pester) { Format-Nicely2 (Get-Command Invoke-Pester) }
# Management.Automation.FunctionInfo{Name='Invoke-Pester'}   (was: hang)
```

Along the way:
- The depth budget is now a decreasing `-MaxDepth` instead of an increasing `-Depth` with a hard limit. It is easier to restrict something to max 1 level than to start at depth 9.
- Integers go through `Format-Number` too, not just decimals. Otherwise a plain `@(1,2,3)` in a name would degrade to `@([int], [int], [int])` at the shallow template depth.

Supersedes #2866, same approach, thanks @fflaten.

🤖
