### PR TITLE
Show a compact string-diff message under ConciseView

### DIFF
--- a/src/functions/assert/String/Should-BeString.ps1
+++ b/src/functions/assert/String/Should-BeString.ps1
@@ -143,6 +143,21 @@ function Get-StringDifferenceMessage {
 
     $because = if ($Because) { " because $Because," } else { "" }
 
+    $expectedExpanded = Expand-SpecialCharacters -InputObject $Expected
+    $actualExpanded = Expand-SpecialCharacters -InputObject $Actual
+
+    # ConciseView (the default $ErrorView since PowerShell 7.2) reflows the error message: it
+    # collapses every newline into a space and re-wraps to the console width. That turns the
+    # aligned multi-line diff, including the caret, into an unreadable single line (#2872). No
+    # message shape survives that reflow, so under ConciseView we emit a compact single-line
+    # message instead, which stays readable once flattened.
+    if ('ConciseView' -eq $ErrorView) {
+        if ($Expected.Length -ne $Actual.Length) {
+            return "Expected strings to be the same,$because but they differ at index $differenceIndex. Expected: '$expectedExpanded' (length $($Expected.Length)), but was: '$actualExpanded' (length $($Actual.Length))."
+        }
+        return "Expected strings to be the same,$because but they differ at index $differenceIndex. Expected: '$expectedExpanded', but was: '$actualExpanded' (both length $($Expected.Length))."
+    }
+
     $lines = @(
         "Expected strings to be the same,$because but they were different."
     )
@@ -156,13 +171,14 @@ function Get-StringDifferenceMessage {
     }
     $lines += "Strings differ at index $differenceIndex."
 
-    $expectedExpanded = Expand-SpecialCharacters -InputObject $Expected
-    $actualExpanded = Expand-SpecialCharacters -InputObject $Actual
-
     $prefix = "Expected: '"
     $lines += "$prefix$expectedExpanded'"
     $lines += "But was:  '$actualExpanded'"
-    $lines += (' ' * ($prefix.Length - 1)) + ('-' * $differenceIndex) + '^'
+    # Point the caret at the first differing character. The line content starts at column
+    # $prefix.Length (just after the opening quote), so pad by that many spaces, then draw
+    # $differenceIndex dashes before the caret. This matches the classic Should -Be caret in
+    # Get-CompareStringMessage, which previously pointed one column further right (#2872).
+    $lines += (' ' * $prefix.Length) + ('-' * $differenceIndex) + '^'
 
     $lines -join "`n"
 }

--- a/src/functions/assertions/Be.ps1
+++ b/src/functions/assertions/Be.ps1
@@ -231,6 +231,20 @@ function Get-CompareStringMessage {
     }
 
     if ($null -ne $differenceIndex) {
+        $actualExpanded = Expand-SpecialCharacters -InputObject $actual
+        $expectedExpanded = Expand-SpecialCharacters -InputObject $ExpectedValue
+
+        # ConciseView (the default $ErrorView since PowerShell 7.2) collapses newlines and
+        # re-wraps the message to the console width, which mangles this multi-line diff and its
+        # caret into an unreadable single line (#2872). Emit a compact single-line message under
+        # ConciseView instead. See Get-StringDifferenceMessage in Should-BeString.ps1.
+        if ('ConciseView' -eq $ErrorView) {
+            if ($ExpectedValue.Length -ne $actual.Length) {
+                return "Expected strings to be the same,$(if ($null -ne $Because) { Format-Because $Because }) but they differ at index $differenceIndex. Expected: '$expectedExpanded' (length $ExpectedValueLength), but was: '$actualExpanded' (length $actualLength)."
+            }
+            return "Expected strings to be the same,$(if ($null -ne $Because) { Format-Because $Because }) but they differ at index $differenceIndex. Expected: '$expectedExpanded', but was: '$actualExpanded' (both length $ExpectedValueLength)."
+        }
+
         "Expected strings to be the same,$(if ($null -ne $Because) { Format-Because $Because }) but they were different."
 
         if ($ExpectedValue.Length -ne $actual.Length) {
@@ -242,9 +256,6 @@ function Get-CompareStringMessage {
             "String lengths are both $ExpectedValueLength."
             "Strings differ at index $differenceIndex."
         }
-
-        $actualExpanded = Expand-SpecialCharacters -InputObject $actual
-        $expectedExpanded = Expand-SpecialCharacters -InputObject $ExpectedValue
 
         $ellipsis = "..."
         # we will surround the output with Expected: '' and But was: '', from which the Expected: '' is longer

--- a/tst/functions/assert/String/Should-BeString.Tests.ps1
+++ b/tst/functions/assert/String/Should-BeString.Tests.ps1
@@ -111,7 +111,7 @@ Actual length:   3
 Strings differ at index 0.
 Expected: ''
 But was:  'abc'
-          ^
+           ^
 '@ -replace "`r`n", "`n")
         }
     }
@@ -155,7 +155,7 @@ String lengths are both 3.
 Strings differ at index 0.
 Expected: 'abc'
 But was:  'bde'
-          ^
+           ^
 '@ -replace "`r`n", "`n")
     }
 
@@ -167,7 +167,7 @@ String lengths are both 11.
 Strings differ at index 0.
 Expected: 'Hello World'
 But was:  'hello world'
-          ^
+           ^
 '@ -replace "`r`n", "`n")
     }
 
@@ -180,7 +180,7 @@ Actual length:   3
 Strings differ at index 3.
 Expected: 'abcdef'
 But was:  'abc'
-          ---^
+           ---^
 '@ -replace "`r`n", "`n")
     }
 
@@ -193,7 +193,39 @@ Actual length:   7
 Strings differ at index 3.
 Expected: 'abc␍␊def'
 But was:  'abc␊def'
-          ---^
+           ---^
 '@ -replace "`r`n", "`n")
+    }
+
+    Context "ConciseView renders a readable single-line message (#2872)" {
+        # ConciseView (the default $ErrorView since PowerShell 7.2) collapses newlines and
+        # re-wraps the message, mangling the multi-line diff. Under it we emit a compact
+        # single-line message instead. Users typically set $ErrorView globally, which is what
+        # the message builder reads, so drive the tests through $global:ErrorView.
+        BeforeAll { $script:originalErrorView = $global:ErrorView }
+        BeforeEach { $global:ErrorView = 'ConciseView' }
+        AfterAll { $global:ErrorView = $script:originalErrorView }
+
+        It "Uses a compact single-line message when the lengths differ" {
+            $err = { Should-BeString -Expected "ab" -Actual "abc" } | Verify-AssertionFailed
+            $err.Exception.Message | Verify-Equal "Expected strings to be the same, but they differ at index 2. Expected: 'ab' (length 2), but was: 'abc' (length 3)."
+        }
+
+        It "Uses a compact single-line message when the lengths are equal" {
+            $err = { Should-BeString -Expected "abcYef" -Actual "abcXef" } | Verify-AssertionFailed
+            $err.Exception.Message | Verify-Equal "Expected strings to be the same, but they differ at index 3. Expected: 'abcYef', but was: 'abcXef' (both length 6)."
+        }
+
+        It "Includes the reason in the compact message" {
+            $err = { Should-BeString -Expected "ab" -Actual "abc" -Because "reasons" } | Verify-AssertionFailed
+            $err.Exception.Message | Verify-Equal "Expected strings to be the same, because reasons, but they differ at index 2. Expected: 'ab' (length 2), but was: 'abc' (length 3)."
+        }
+
+        It "Keeps the compact message on a single line by escaping control characters" {
+            # The exact expected string below contains no newline, so this both verifies the escaping
+            # and proves the message stays on a single line (which is the whole point under ConciseView).
+            $err = { Should-BeString -Expected "abc`r`ndef" -Actual "abc`ndef" } | Verify-AssertionFailed
+            $err.Exception.Message | Verify-Equal "Expected strings to be the same, but they differ at index 3. Expected: 'abc␍␊def' (length 8), but was: 'abc␊def' (length 7)."
+        }
     }
 }

--- a/tst/functions/assertions/Be.Tests.ps1
+++ b/tst/functions/assertions/Be.Tests.ps1
@@ -220,6 +220,27 @@ InPesterModuleScope {
         It "The arrow points to the correct position when non-printable characters are replaced after the difference" {
             ShouldBeFailureMessage "abcd`n123" "abc!`n123" | Verify-Equal "Expected strings to be the same, but they were different.`nString lengths are both 8.`nStrings differ at index 3.`nExpected: 'abc!␊123'`nBut was:  'abcd␊123'`n           ---^"
         }
+
+        Context "ConciseView renders a readable single-line message (#2872)" {
+            # ConciseView (the default $ErrorView since PowerShell 7.2) collapses newlines and
+            # re-wraps the message, mangling the multi-line diff. Under it we emit a compact
+            # single-line message instead, matching Should-BeString.
+            BeforeAll { $script:originalErrorView = $global:ErrorView }
+            BeforeEach { $global:ErrorView = 'ConciseView' }
+            AfterAll { $global:ErrorView = $script:originalErrorView }
+
+            It "Uses a compact single-line message when the lengths differ" {
+                ShouldBeFailureMessage "actual" "expected" | Verify-Equal "Expected strings to be the same, but they differ at index 0. Expected: 'expected' (length 8), but was: 'actual' (length 6)."
+            }
+
+            It "Uses a compact single-line message when the lengths are equal" {
+                ShouldBeFailureMessage "abcXef" "abcYef" | Verify-Equal "Expected strings to be the same, but they differ at index 3. Expected: 'abcYef', but was: 'abcXef' (both length 6)."
+            }
+
+            It "Includes the reason in the compact message" {
+                ShouldBeFailureMessage "actual" "expected" -Because 'reason' | Verify-Equal "Expected strings to be the same, because reason, but they differ at index 0. Expected: 'expected' (length 8), but was: 'actual' (length 6)."
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Fix #2872

The string difference message from `Should-BeString` and `Should -Be`/`-BeExactly` is multi-line: the expected and actual length, the index where they differ, and a caret pointing at it. Under the default `ConciseView` this becomes an unreadable single line, because ConciseView collapses all the newlines. There is no message shape that survives it, I checked.

So under `ConciseView` we now emit a compact single line instead:

```
Expected strings to be the same, but they differ at index 2. Expected: 'ab' (length 2), but was: 'abc' (length 3).
```

Under `NormalView` the rich multi-line diff with the caret is unchanged. The new and the classic assertion produce the same message now.

Also fixes the caret in `Should-BeString`, it pointed one column to the left of the first difference. Now it points at the first differing character, same as `Should -Be` and as xunit/nunit/mstest.

Note: the collection and equivalence messages have the same ConciseView problem, that is a separate follow-up.

🤖
