### PR TITLE
Add -TrimWhitespace to Should-NotBeString

### DIFF
--- a/src/functions/assert/String/Should-NotBeString.ps1
+++ b/src/functions/assert/String/Should-NotBeString.ps1
@@ -22,6 +22,9 @@ function Should-NotBeString {
     .PARAMETER IgnoreWhitespace
     Indicates that the comparison should ignore whitespace.
 
+    .PARAMETER TrimWhitespace
+    Trims whitespace at the start and end of the string.
+
     .PARAMETER Because
     The reason why the actual value should not be equal to the expected value.
 
@@ -61,7 +64,8 @@ function Should-NotBeString {
         [String]$Expected,
         [String]$Because,
         [switch]$CaseSensitive,
-        [switch]$IgnoreWhitespace
+        [switch]$IgnoreWhitespace,
+        [switch]$TrimWhitespace
     )
 
     $assert = New-ShouldAssertion -Caller $PSCmdlet -Actual $Actual -Buffer $local:Input
@@ -71,7 +75,7 @@ function Should-NotBeString {
         throw [ArgumentException]"Actual is expected to be string, to avoid confusing behavior that -ne operator exhibits with collections. To assert on collections use Should-Any, Should-All or some other collection assertion."
     }
 
-    if (Test-StringEqual -Expected $Expected -Actual $Actual -CaseSensitive:$CaseSensitive -IgnoreWhitespace:$IgnoreWhiteSpace) {
+    if (Test-StringEqual -Expected $Expected -Actual $Actual -CaseSensitive:$CaseSensitive -IgnoreWhitespace:$IgnoreWhiteSpace -TrimWhitespace:$TrimWhitespace) {
         if (-not $CustomMessage) {
             $formattedMessage = Get-StringNotEqualDefaultFailureMessage -Expected $Expected -Actual $Actual
         }

--- a/tst/functions/assert/String/Should-NotBeString.Tests.ps1
+++ b/tst/functions/assert/String/Should-NotBeString.Tests.ps1
@@ -45,6 +45,19 @@ Describe "Should-NotBeString" {
         It "Can compare strings without whitespace" {
             { Should-NotBeString -Expected " a b c " -Actual "abc" -IgnoreWhitespace } | Verify-AssertionFailed
         }
+
+        It "Fails when strings differ only by whitespace at the start or end" -ForEach @(
+            @{ Value = " abc" }
+            @{ Value = "abc " }
+            @{ Value = "abc`t" }
+            @{ Value = "`tabc" }
+        ) {
+            { $Value | Should-NotBeString -Expected "abc" -TrimWhitespace } | Verify-AssertionFailed
+        }
+
+        It "Trimming whitespace does not remove it from inside of the string" {
+            "a bc" | Should-NotBeString -Expected "abc" -TrimWhitespace
+        }
     }
 
     It "Can be called with positional parameters" {


### PR DESCRIPTION
Fix #2930

`Should-NotBeString` was missing `-TrimWhitespace`, which `Should-BeString` already has. Added it for parity.

🤖
