### PR TITLE
Point Should-BeString caret at the first differing character

### DIFF
--- a/src/functions/assert/String/Should-BeString.ps1
+++ b/src/functions/assert/String/Should-BeString.ps1
@@ -162,7 +162,7 @@ function Get-StringDifferenceMessage {
     $prefix = "Expected: '"
     $lines += "$prefix$expectedExpanded'"
     $lines += "But was:  '$actualExpanded'"
-    $lines += (' ' * ($prefix.Length - 1)) + ('-' * $differenceIndex) + '^'
+    $lines += (' ' * $prefix.Length) + ('-' * $differenceIndex) + '^'
 
     $lines -join "`n"
 }

--- a/tst/functions/assert/String/Should-BeString.Tests.ps1
+++ b/tst/functions/assert/String/Should-BeString.Tests.ps1
@@ -111,7 +111,7 @@ Actual length:   3
 Strings differ at index 0.
 Expected: ''
 But was:  'abc'
-          ^
+           ^
 '@ -replace "`r`n", "`n")
         }
     }
@@ -155,7 +155,7 @@ String lengths are both 3.
 Strings differ at index 0.
 Expected: 'abc'
 But was:  'bde'
-          ^
+           ^
 '@ -replace "`r`n", "`n")
     }
 
@@ -167,7 +167,7 @@ String lengths are both 11.
 Strings differ at index 0.
 Expected: 'Hello World'
 But was:  'hello world'
-          ^
+           ^
 '@ -replace "`r`n", "`n")
     }
 
@@ -180,7 +180,7 @@ Actual length:   3
 Strings differ at index 3.
 Expected: 'abcdef'
 But was:  'abc'
-          ---^
+           ---^
 '@ -replace "`r`n", "`n")
     }
 
@@ -193,7 +193,7 @@ Actual length:   7
 Strings differ at index 3.
 Expected: 'abc␍␊def'
 But was:  'abc␊def'
-          ---^
+           ---^
 '@ -replace "`r`n", "`n")
     }
 }


### PR DESCRIPTION
Fix #2928

The caret in the `Should-BeString` difference message pointed one column to the left of the first differing character. Now it points at the first differing character, same as classic `Should -Be`.

🤖
