### PR TITLE
Make Expected mandatory in Should-NotBeString, Should-BeFasterThan and Should-BeSlowerThan

### DIFF
--- a/src/functions/assert/String/Should-NotBeString.ps1
+++ b/src/functions/assert/String/Should-NotBeString.ps1
@@ -57,7 +57,7 @@ function Should-NotBeString {
     param (
         [Parameter(Position = 1, ValueFromPipeline = $true)]
         $Actual,
-        [Parameter(Position = 0)]
+        [Parameter(Position = 0, Mandatory)]
         [String]$Expected,
         [String]$Because,
         [switch]$CaseSensitive,

--- a/src/functions/assert/Time/Should-BeFasterThan.ps1
+++ b/src/functions/assert/Time/Should-BeFasterThan.ps1
@@ -47,7 +47,7 @@
     param (
         [Parameter(Position = 1, ValueFromPipeline = $true)]
         $Actual,
-        [Parameter(Position = 0)]
+        [Parameter(Position = 0, Mandatory)]
         $Expected,
         [string] $Because
     )

--- a/src/functions/assert/Time/Should-BeSlowerThan.ps1
+++ b/src/functions/assert/Time/Should-BeSlowerThan.ps1
@@ -54,7 +54,7 @@
     param (
         [Parameter(Position = 1, ValueFromPipeline = $true)]
         $Actual,
-        [Parameter(Position = 0)]
+        [Parameter(Position = 0, Mandatory)]
         $Expected,
         [string] $Because
     )

--- a/tst/functions/assert/String/Should-NotBeString.Tests.ps1
+++ b/tst/functions/assert/String/Should-NotBeString.Tests.ps1
@@ -60,5 +60,10 @@ Describe "Should-NotBeString" {
         $err = { Should-NotBeString -Expected "abc" -Actual 1 } | Verify-Throw
         $err.Exception | Verify-Type ([ArgumentException])
     }
+
+    It "Requires Expected" {
+        $err = { "abc" | Should-NotBeString } | Verify-Throw
+        $err.Exception | Verify-Type ([System.Management.Automation.ParameterBindingException])
+    }
 }
 

--- a/tst/functions/assert/Time/Should-BeFasterThan.Tests.ps1
+++ b/tst/functions/assert/Time/Should-BeFasterThan.Tests.ps1
@@ -54,4 +54,9 @@ Describe "Should-BeFasterThan" {
         $err = { $Actual | Should-BeFasterThan -Expected $Expected -Because $Because } | Verify-AssertionFailed
         $err.Exception.Message | Verify-Like '*because I said so*'
     }
+
+    It "Requires Expected" {
+        $err = { [timespan]::FromMilliseconds(1) | Should-BeFasterThan } | Verify-Throw
+        $err.Exception | Verify-Type ([System.Management.Automation.ParameterBindingException])
+    }
 }

--- a/tst/functions/assert/Time/Should-BeSlowerThan.Tests.ps1
+++ b/tst/functions/assert/Time/Should-BeSlowerThan.Tests.ps1
@@ -31,4 +31,9 @@ Describe "Should-BeSlowerThan" {
         $err = { $Actual | Should-BeSlowerThan -Expected $Expected -Because $Because } | Verify-AssertionFailed
         $err.Exception.Message | Verify-Like '*because I said so*'
     }
+
+    It "Requires Expected" {
+        $err = { [timespan]::FromMilliseconds(1) | Should-BeSlowerThan } | Verify-Throw
+        $err.Exception | Verify-Type ([System.Management.Automation.ParameterBindingException])
+    }
 }


### PR DESCRIPTION
Fix #2931

`Expected` was optional in `Should-NotBeString`, `Should-BeFasterThan` and `Should-BeSlowerThan`, unlike the other assertions. Made it mandatory.

🤖
