### PR TITLE
Make Actual parameter position consistent across the new assertions

### DIFF
--- a/src/functions/assert/Boolean/Should-BeFalse.ps1
+++ b/src/functions/assert/Boolean/Should-BeFalse.ps1
@@ -47,7 +47,7 @@
     [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseProcessBlockForPipelineCommand', '')]
     [CmdletBinding()]
     param (
-        [Parameter(ValueFromPipeline = $true)]
+        [Parameter(Position = 0, ValueFromPipeline = $true)]
         $Actual,
         [String]$Because
     )

--- a/src/functions/assert/Boolean/Should-BeFalsy.ps1
+++ b/src/functions/assert/Boolean/Should-BeFalsy.ps1
@@ -47,7 +47,7 @@
     [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseProcessBlockForPipelineCommand', '')]
     [CmdletBinding()]
     param (
-        [Parameter(ValueFromPipeline = $true)]
+        [Parameter(Position = 0, ValueFromPipeline = $true)]
         $Actual,
         [String]$Because
     )

--- a/src/functions/assert/Boolean/Should-BeTrue.ps1
+++ b/src/functions/assert/Boolean/Should-BeTrue.ps1
@@ -47,7 +47,7 @@
     [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseProcessBlockForPipelineCommand', '')]
     [CmdletBinding()]
     param (
-        [Parameter(ValueFromPipeline = $true)]
+        [Parameter(Position = 0, ValueFromPipeline = $true)]
         $Actual,
         [String]$Because
     )

--- a/src/functions/assert/Boolean/Should-BeTruthy.ps1
+++ b/src/functions/assert/Boolean/Should-BeTruthy.ps1
@@ -48,7 +48,7 @@
     [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseProcessBlockForPipelineCommand', '')]
     [CmdletBinding()]
     param (
-        [Parameter(ValueFromPipeline = $true)]
+        [Parameter(Position = 0, ValueFromPipeline = $true)]
         $Actual,
         [String]$Because
     )

--- a/src/functions/assert/General/Should-BeNull.ps1
+++ b/src/functions/assert/General/Should-BeNull.ps1
@@ -34,7 +34,7 @@
     [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseProcessBlockForPipelineCommand', '')]
     [CmdletBinding()]
     param (
-        [Parameter(Position = 1, ValueFromPipeline = $true)]
+        [Parameter(Position = 0, ValueFromPipeline = $true)]
         $Actual,
         [String]$Because
     )

--- a/src/functions/assert/General/Should-NotBeNull.ps1
+++ b/src/functions/assert/General/Should-NotBeNull.ps1
@@ -34,7 +34,7 @@
     [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseProcessBlockForPipelineCommand', '')]
     [CmdletBinding()]
     param (
-        [Parameter(Position = 1, ValueFromPipeline = $true)]
+        [Parameter(Position = 0, ValueFromPipeline = $true)]
         $Actual,
         [String]$Because
     )

--- a/src/functions/assert/Time/Should-BeAfter.ps1
+++ b/src/functions/assert/Time/Should-BeAfter.ps1
@@ -71,7 +71,7 @@
     [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseProcessBlockForPipelineCommand', '')]
     [CmdletBinding(DefaultParameterSetName = "Now")]
     param (
-        [Parameter(Position = 2, ValueFromPipeline = $true)]
+        [Parameter(Position = 1, ValueFromPipeline = $true)]
         $Actual,
 
         [Parameter(ParameterSetName = "Now")]

--- a/src/functions/assert/Time/Should-BeBefore.ps1
+++ b/src/functions/assert/Time/Should-BeBefore.ps1
@@ -71,7 +71,7 @@
     [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseProcessBlockForPipelineCommand', '')]
     [CmdletBinding(DefaultParameterSetName = "Now")]
     param (
-        [Parameter(Position = 2, ValueFromPipeline = $true)]
+        [Parameter(Position = 1, ValueFromPipeline = $true)]
         $Actual,
 
         [Parameter(ParameterSetName = "Now")]

--- a/tst/functions/assert/Boolean/Should-BeFalse.Tests.ps1
+++ b/tst/functions/assert/Boolean/Should-BeFalse.Tests.ps1
@@ -29,6 +29,7 @@ Describe "Should-BeFalse" {
     }
 
     It "Can be called with positional parameters" {
-        { Should-BeFalse $true } | Verify-AssertionFailed
+        $err = { Should-BeFalse $true } | Verify-AssertionFailed
+        $err.Exception.Message | Verify-Equal "Expected [bool] `$false, but got: [bool] `$true."
     }
 }

--- a/tst/functions/assert/Boolean/Should-BeFalsy.Tests.ps1
+++ b/tst/functions/assert/Boolean/Should-BeFalsy.Tests.ps1
@@ -30,6 +30,7 @@ Describe "Should-BeFalsy" {
     }
 
     It "Can be called with positional parameters" {
-        { Should-BeFalsy $true } | Verify-AssertionFailed
+        $err = { Should-BeFalsy $true } | Verify-AssertionFailed
+        $err.Exception.Message | Verify-Equal "Expected [bool] `$false or a falsy value: 0, `"`", `$null or @(), but got: [bool] `$true."
     }
 }

--- a/tst/functions/assert/Boolean/Should-BeTrue.Tests.ps1
+++ b/tst/functions/assert/Boolean/Should-BeTrue.Tests.ps1
@@ -26,6 +26,7 @@ Describe "Should-BeTrue" {
     }
 
     It "Can be called with positional parameters" {
-        { Should-BeTrue $false } | Verify-AssertionFailed
+        $err = { Should-BeTrue $false } | Verify-AssertionFailed
+        $err.Exception.Message | Verify-Equal "Expected [bool] `$true, but got: [bool] `$false."
     }
 }

--- a/tst/functions/assert/Boolean/Should-BeTruthy.Tests.ps1
+++ b/tst/functions/assert/Boolean/Should-BeTruthy.Tests.ps1
@@ -25,6 +25,7 @@ Describe "Should-BeTruthy" {
     }
 
     It "Can be called with positional parameters" {
-        { Should-BeTruthy $false } | Verify-AssertionFailed
+        $err = { Should-BeTruthy $false } | Verify-AssertionFailed
+        $err.Exception.Message | Verify-Equal "Expected [bool] `$true or a truthy value, but got: [bool] `$false."
     }
 }


### PR DESCRIPTION
Fix #2933

The `Actual` parameter was bound inconsistently across the new assertions. Aligned them all to the same convention: `Actual` always binds from the pipeline, and takes `Position = 0` on single-subject assertions or `Position = 1` when a positional `Expected`/comparand already sits at `Position = 0`.

🤖
