### PR TITLE
Move Should-BeHashtable -Actual to Position 0

### DIFF
--- a/src/functions/assert/Hashtable/Should-BeHashtable.ps1
+++ b/src/functions/assert/Hashtable/Should-BeHashtable.ps1
@@ -82,7 +82,7 @@
     [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseProcessBlockForPipelineCommand', '')]
     [CmdletBinding()]
     param (
-        [Parameter(Position = 1, ValueFromPipeline = $true)]
+        [Parameter(Position = 0, ValueFromPipeline = $true)]
         $Actual,
         [int] $Count,
         [string[]] $Key,


### PR DESCRIPTION
Fix #2942

`Should-BeHashtable` is a single-subject assertion, but `-Actual` was at `Position = 1` instead of `Position = 0`, the same inconsistency #2933 fixed for the other single-subject assertions. Moved it to `Position = 0`.

Caught by the new convention tests in #2941, which allow-list it for now. That allow-list entry can be removed once this lands.

🤖
