### PR TITLE
Add -NormalizeNewline to Should-BeString

### DIFF
--- a/src/functions/assert/String/Should-BeString.ps1
+++ b/src/functions/assert/String/Should-BeString.ps1
@@ -4,11 +4,17 @@
         $Actual,
         [switch]$CaseSensitive,
         [switch]$IgnoreWhitespace,
-        [switch]$TrimWhitespace
+        [switch]$TrimWhitespace,
+        [switch]$NormalizeNewline
     )
 
     if ($Actual -isnot [string]) {
         return $false
+    }
+
+    if ($NormalizeNewline) {
+        $Expected = $Expected -replace '\r\n|\r|\p{Zl}', "`n"
+        $Actual = $Actual -replace '\r\n|\r|\p{Zl}', "`n"
     }
 
     if ($IgnoreWhitespace) {
@@ -51,6 +57,9 @@ function Should-BeString {
 
     .PARAMETER TrimWhitespace
     Trims whitespace at the start and end of the string.
+
+    .PARAMETER NormalizeNewline
+    Normalizes line endings before comparison, so that `\r\n`, `\r`, and the Unicode line separator are all treated as `\n`. Use this to compare multi-line strings across platforms without failing on line-ending style. Unlike `-IgnoreWhitespace`, the newlines and their positions are kept, so indentation and blank lines are still compared.
 
     .PARAMETER Because
     The reason why the actual value should be equal to the expected value.
@@ -100,13 +109,14 @@ function Should-BeString {
         [String]$Because,
         [switch]$CaseSensitive,
         [switch]$IgnoreWhitespace,
-        [switch]$TrimWhitespace
+        [switch]$TrimWhitespace,
+        [switch]$NormalizeNewline
     )
 
     $assert = New-ShouldAssertion -Caller $PSCmdlet -Actual $Actual -Buffer $local:Input
     $Actual = $assert.Actual()
 
-    $stringsAreEqual = Test-StringEqual -Expected $Expected -Actual $Actual -CaseSensitive:$CaseSensitive -IgnoreWhitespace:$IgnoreWhiteSpace -TrimWhitespace:$TrimWhitespace
+    $stringsAreEqual = Test-StringEqual -Expected $Expected -Actual $Actual -CaseSensitive:$CaseSensitive -IgnoreWhitespace:$IgnoreWhiteSpace -TrimWhitespace:$TrimWhitespace -NormalizeNewline:$NormalizeNewline
     if (-not ($stringsAreEqual)) {
         if ($Actual -is [string]) {
             $assert.Fail((Get-StringDifferenceMessage -Expected $Expected -Actual $Actual -CaseSensitive:$CaseSensitive -Because $Because))

--- a/src/functions/assert/String/Should-NotBeString.ps1
+++ b/src/functions/assert/String/Should-NotBeString.ps1
@@ -25,6 +25,9 @@ function Should-NotBeString {
     .PARAMETER TrimWhitespace
     Trims whitespace at the start and end of the string.
 
+    .PARAMETER NormalizeNewline
+    Normalizes line endings before comparison, so that `\r\n`, `\r`, and the Unicode line separator are all treated as `\n`. Use this to compare multi-line strings across platforms without failing on line-ending style. Unlike `-IgnoreWhitespace`, the newlines and their positions are kept, so indentation and blank lines are still compared.
+
     .PARAMETER Because
     The reason why the actual value should not be equal to the expected value.
 
@@ -65,7 +68,8 @@ function Should-NotBeString {
         [String]$Because,
         [switch]$CaseSensitive,
         [switch]$IgnoreWhitespace,
-        [switch]$TrimWhitespace
+        [switch]$TrimWhitespace,
+        [switch]$NormalizeNewline
     )
 
     $assert = New-ShouldAssertion -Caller $PSCmdlet -Actual $Actual -Buffer $local:Input
@@ -75,7 +79,7 @@ function Should-NotBeString {
         throw [ArgumentException]"Actual is expected to be string, to avoid confusing behavior that -ne operator exhibits with collections. To assert on collections use Should-Any, Should-All or some other collection assertion."
     }
 
-    if (Test-StringEqual -Expected $Expected -Actual $Actual -CaseSensitive:$CaseSensitive -IgnoreWhitespace:$IgnoreWhiteSpace -TrimWhitespace:$TrimWhitespace) {
+    if (Test-StringEqual -Expected $Expected -Actual $Actual -CaseSensitive:$CaseSensitive -IgnoreWhitespace:$IgnoreWhiteSpace -TrimWhitespace:$TrimWhitespace -NormalizeNewline:$NormalizeNewline) {
         if (-not $CustomMessage) {
             $formattedMessage = Get-StringNotEqualDefaultFailureMessage -Expected $Expected -Actual $Actual
         }

--- a/tst/functions/assert/String/Should-BeString.Tests.ps1
+++ b/tst/functions/assert/String/Should-BeString.Tests.ps1
@@ -61,6 +61,25 @@ InPesterModuleScope {
                 Test-StringEqual -Expected $l -Actual $r -IgnoreWhiteSpace | Verify-True
             }
         }
+
+        Context "Normalizing newlines" {
+            It "strings that differ only in line ending style are equal. comparing '<lName>':'<rName>'" -TestCases @(
+                @{ l = "a`r`nb"; r = "a`nb"; lName = "CRLF"; rName = "LF" },
+                @{ l = "a`rb"; r = "a`nb"; lName = "CR"; rName = "LF" },
+                @{ l = "a`r`nb"; r = "a`rb"; lName = "CRLF"; rName = "CR" },
+                @{ l = "a$([char]0x2028)b"; r = "a`nb"; lName = "LS"; rName = "LF" }
+            ) {
+                Test-StringEqual -Expected $l -Actual $r -NormalizeNewline | Verify-True
+            }
+
+            It "strings that differ in more than line ending style are not equal" {
+                Test-StringEqual -Expected "a`r`nb" -Actual "a`nc" -NormalizeNewline | Verify-False
+            }
+
+            It "keeps newline positions, so extra blank lines still differ" {
+                Test-StringEqual -Expected "a`r`nb" -Actual "a`r`n`r`nb" -NormalizeNewline | Verify-False
+            }
+        }
     }
 }
 
@@ -140,6 +159,14 @@ But was:  'abc'
 
         It "Trimming whitespace does not remove it from inside of the string" {
             { "a bc" | Should-BeString -Expected "abc" -TrimWhitespace } | Verify-AssertionFailed
+        }
+
+        It "Can compare multi-line strings ignoring line ending style" {
+            "line1`nline2" | Should-BeString -Expected "line1`r`nline2" -NormalizeNewline
+        }
+
+        It "Normalizing newlines still compares indentation and blank lines" {
+            { "a`nb" | Should-BeString -Expected "a`n`nb" -NormalizeNewline } | Verify-AssertionFailed
         }
     }
 

--- a/tst/functions/assert/String/Should-NotBeString.Tests.ps1
+++ b/tst/functions/assert/String/Should-NotBeString.Tests.ps1
@@ -58,6 +58,14 @@ Describe "Should-NotBeString" {
         It "Trimming whitespace does not remove it from inside of the string" {
             "a bc" | Should-NotBeString -Expected "abc" -TrimWhitespace
         }
+
+        It "Fails when strings differ only in line ending style" {
+            { "line1`nline2" | Should-NotBeString -Expected "line1`r`nline2" -NormalizeNewline } | Verify-AssertionFailed
+        }
+
+        It "Passes when strings differ in more than line ending style" {
+            "a`nb" | Should-NotBeString -Expected "a`n`nb" -NormalizeNewline
+        }
     }
 
     It "Can be called with positional parameters" {


### PR DESCRIPTION
Fix #2952

Adds `-NormalizeNewline` to `Should-BeString`. When set, both sides are run through `-replace '\r\n|\r|\p{Zl}', "`n"` before comparing, so `\r\n`, `\r` and the Unicode line separator all count as `\n`. Unlike `-IgnoreWhitespace` it keeps the newlines and their positions, so indentation and blank lines are still compared. Added the same switch to `Should-NotBeString`, to keep the pair consistent with `-IgnoreWhitespace` and `-TrimWhitespace`.

@fflaten I am not happy with the name yet, which of these do you like most:

- `-NormalizeNewline` (what I used here)
- `-NormalizeLineEnding`

Names I avoided, and why:

- `-IgnoreNewline` / `-IgnoreLineEnding`, reads as "drop the newlines", which is what `-IgnoreWhitespace` already does (`-replace '\s'`). Here we keep them, we only unify the style, so `Ignore` is misleading.
- plural `-NormalizeNewlines` / `-NormalizeLineEndings`, the existing switches use singular collective nouns (`Whitespace`), so singular fits better.

Between the two I lean slightly to `-NormalizeLineEnding` because it clearly covers `\r` and the Unicode separator too, but `-NormalizeNewline` is shorter and still clear. Happy to rename before merge.

Tests cover CRLF, CR, LF and the Unicode line separator comparing equal, and that content differences and extra blank lines still fail.

🤖
