### PR TITLE
Hint that -ExpectedMessage uses wildcards when the message looks identical

### DIFF
--- a/src/functions/assertions/PesterThrow.ps1
+++ b/src/functions/assertions/PesterThrow.ps1
@@ -97,11 +97,18 @@
     }
 
     $filterOnMessage = -not [string]::IsNullOrWhitespace($ExpectedMessage)
+    $messageFailedOnWildcard = $false
     if ($filterOnMessage) {
         $unescapedExpectedMessage = [System.Management.Automation.WildcardPattern]::Unescape($ExpectedMessage)
         $filters += "message like $(Format-Nicely $unescapedExpectedMessage)"
         if ($actualExceptionWasThrown -and (-not (Get-DoValuesMatch $actualExceptionMessage $ExpectedMessage))) {
             $buts += "the message was $(Format-Nicely $actualExceptionMessage)"
+            # -ExpectedMessage matches with -like. When the actual message is identical to the expected
+            # one treated literally, the only reason the match failed is unescaped wildcard characters
+            # ([ ] * ?) in -ExpectedMessage. Flag it so the failure message is not baffling (#1793).
+            if ($actualExceptionMessage -eq $unescapedExpectedMessage) {
+                $messageFailedOnWildcard = $true
+            }
         }
     }
 
@@ -121,6 +128,10 @@
         $filter = Join-And $filters
         $but = Join-And $buts
         $failureMessage = "Expected an exception$(if($filter) { " with $filter" }) to be thrown,$(Format-Because $Because) but $but. $actualExceptionLine".Trim()
+
+        if ($messageFailedOnWildcard) {
+            $failureMessage = "$failureMessage$([System.Environment]::NewLine)    Note: -ExpectedMessage matches using wildcards (-like). The messages are identical except for the wildcard characters [ ] * ? in -ExpectedMessage. Escape them with a backtick (``[) or use [System.Management.Automation.WildcardPattern]::Escape() to match them literally."
+        }
 
         $ActualValue = $actualExceptionMessage
         $ExpectedValue = if ($filterOnExceptionType) {

--- a/src/functions/assertions/PesterThrow.ps1
+++ b/src/functions/assertions/PesterThrow.ps1
@@ -127,11 +127,13 @@
     if ($buts.Count -ne 0) {
         $filter = Join-And $filters
         $but = Join-And $buts
-        $failureMessage = "Expected an exception$(if($filter) { " with $filter" }) to be thrown,$(Format-Because $Because) but $but. $actualExceptionLine".Trim()
-
-        if ($messageFailedOnWildcard) {
-            $failureMessage = "$failureMessage$([System.Environment]::NewLine)    Note: -ExpectedMessage matches using wildcards (-like). The messages are identical except for the wildcard characters [ ] * ? in -ExpectedMessage. Escape them with a backtick (``[) or use [System.Management.Automation.WildcardPattern]::Escape() to match them literally."
+        $wildcardHint = if ($messageFailedOnWildcard) {
+            "$([System.Environment]::NewLine)    Note: -ExpectedMessage matches using wildcards (-like). The messages are identical except for the wildcard characters [ ] * ? in -ExpectedMessage. Escape them with a backtick (``[) or use [System.Management.Automation.WildcardPattern]::Escape() to match them literally."
         }
+        else {
+            ""
+        }
+        $failureMessage = "Expected an exception$(if($filter) { " with $filter" }) to be thrown,$(Format-Because $Because) but $but.$wildcardHint $actualExceptionLine".Trim()
 
         $ActualValue = $actualExceptionMessage
         $ExpectedValue = if ($filterOnExceptionType) {

--- a/tst/functions/assertions/PesterThrow.Tests.ps1
+++ b/tst/functions/assertions/PesterThrow.Tests.ps1
@@ -183,8 +183,11 @@ InPesterModuleScope {
                 $testScriptPath = Join-Path $testDrive test.ps1
                 Set-Content -Path $testScriptPath -Value "throw 'value is [1]'"
 
+                # spell out the whole expected message (the hint sits before the 'from <path>' location)
+                $assertionMessage = "Expected an exception with message like 'value is [1]' to be thrown, but the message was 'value is [1]'. Note: -ExpectedMessage matches using wildcards (-like). The messages are identical except for the wildcard characters [ ] * ? in -ExpectedMessage. Escape them with a backtick (``[) or use [System.Management.Automation.WildcardPattern]::Escape() to match them literally."
+
                 $err = { { & $testScriptPath } | Should -Throw -ExpectedMessage 'value is [1]' } | Verify-AssertionFailed
-                $err.Exception.Message | Verify-Like '*matches using wildcards*'
+                $err.Exception.Message -replace "(`r|`n)", ' ' -replace '\s+', ' ' -replace ' from .*$', '' | Verify-Equal $assertionMessage
             }
 
             It 'does not hint at wildcard matching when the messages genuinely differ' {

--- a/tst/functions/assertions/PesterThrow.Tests.ps1
+++ b/tst/functions/assertions/PesterThrow.Tests.ps1
@@ -176,6 +176,28 @@ InPesterModuleScope {
                 $err.Exception.Message -replace "(`r|`n)" -replace '\s+', ' ' -replace '(char:).*$', '$1' | Verify-Equal $assertionMessage
             }
 
+            It 'hints at wildcard matching when the message is identical except for unescaped wildcard characters' {
+                # #1793: -ExpectedMessage matches with -like, so [ ] * ? are wildcards. When the expected
+                # and actual messages look identical, the failure is baffling without a hint pointing at it.
+                $testDrive = (Get-PSDrive TestDrive).Root
+                $testScriptPath = Join-Path $testDrive test.ps1
+                Set-Content -Path $testScriptPath -Value "throw 'value is [1]'"
+
+                $err = { { & $testScriptPath } | Should -Throw -ExpectedMessage 'value is [1]' } | Verify-AssertionFailed
+                $err.Exception.Message | Verify-Like '*matches using wildcards*'
+            }
+
+            It 'does not hint at wildcard matching when the messages genuinely differ' {
+                $testDrive = (Get-PSDrive TestDrive).Root
+                $testScriptPath = Join-Path $testDrive test.ps1
+                Set-Content -Path $testScriptPath -Value "throw 'error1'"
+
+                $err = { { & $testScriptPath } | Should -Throw -ExpectedMessage 'error2' } | Verify-AssertionFailed
+                if ($err.Exception.Message -like '*matches using wildcards*') {
+                    throw "Did not expect the wildcard hint, but got: $($err.Exception.Message)"
+                }
+            }
+
             It 'returns the correct assertion message when exceptions messages differ' {
                 $testDrive = (Get-PSDrive TestDrive).Root
                 $testScriptPath = Join-Path $testDrive test.ps1


### PR DESCRIPTION
`Should -Throw -ExpectedMessage` matches with `-like`, so `[ ] * ?` are wildcards. When the actual message is identical to the expected one except for those characters, the match fails, but the failure message printed the same text on both sides:

```
Expected an exception with message like 'value is [1]' to be thrown, but the message was 'value is [1]'.
```

Same text on both sides, no hint why it failed. This bites people migrating from v4, where the message match used `.Contains`, and it is the cause of a few issues and StackOverflow questions.

Now that case adds a note:

```
Note: -ExpectedMessage matches using wildcards (-like). The messages are identical except for the
wildcard characters [ ] * ? in -ExpectedMessage. Escape them with a backtick (`[) or use
[System.Management.Automation.WildcardPattern]::Escape() to match them literally.
```

The note only shows when the actual message equals the expected one treated literally, so it does not fire on genuine mismatches or on intentional wildcards that just did not match.

Fixes #1793

🤖