### PR TITLE
Expand data-backed <template> names for skipped tests

### DIFF
--- a/src/Pester.Runtime.ps1
+++ b/src/Pester.Runtime.ps1
@@ -553,6 +553,58 @@ function New-Test {
     }
 }
 
+function Expand-NameForSkippedTest {
+    # A skipped test never runs its setup, which is where <template> names are normally expanded
+    # (see the expansion setup in Invoke-TestItem). So a skipped data-driven test used to show the
+    # raw template, e.g. 'Value <_>' three times instead of 'Value foo' / 'Value bar' / ... (#2427).
+    #
+    # Here we expand only the templates that are directly backed by the -ForEach data: <_> (the whole
+    # data item) and <Key> (a top-level key when the data is a dictionary). Anything else, a nested
+    # property like <_.Name>, an index/method call, or a variable that would only exist after setup,
+    # is left as the literal <template> text. That is deliberate: we must not run user expressions to
+    # render the name of a test the user asked to skip, and we only have the data, not the setup state.
+    param (
+        [string] $Name,
+        $Data,
+        # The FormatNicelyForTemplate scriptblock captured on the state ($State.FormatNicelyForTemplate),
+        # so skipped and executed tests format the same values identically, and so this keeps working
+        # when the runtime is tested in isolation without Format2.ps1 loaded.
+        $FormatNicelyForTemplate
+    )
+
+    if ($Name -notlike '*<*') { return $Name }
+
+    $dataIsDictionary = $Data -is [System.Collections.IDictionary]
+
+    $expanded = [System.Text.StringBuilder]::new($Name.Length)
+    $pos = 0
+    # Same <template> / `< / `> matching as the executed-test expansion, minus the escaping needed
+    # only when building an expandable string, because here we build a literal string and never invoke it.
+    foreach ($match in [regex]::Matches($Name, '(?<!`)<([^>`]+)>|`([<>])')) {
+        $null = $expanded.Append($Name.Substring($pos, $match.Index - $pos))
+        if ($match.Groups[1].Success) {
+            $token = $match.Groups[1].Value
+            if ($token -eq '_') {
+                $null = $expanded.Append((& $FormatNicelyForTemplate $Data))
+            }
+            elseif ($dataIsDictionary -and $Data.Contains($token)) {
+                $null = $expanded.Append((& $FormatNicelyForTemplate $Data[$token]))
+            }
+            else {
+                # Not resolvable from the data alone, keep the original <token> untouched.
+                $null = $expanded.Append($match.Value)
+            }
+        }
+        else {
+            # `< or `> escapes a literal angle bracket, same as in the executed-test expansion.
+            $null = $expanded.Append($match.Groups[2].Value)
+        }
+        $pos = $match.Index + $match.Length
+    }
+    $null = $expanded.Append($Name.Substring($pos))
+    $expanded.ToString()
+}
+
 function Invoke-TestItem {
     [CmdletBinding()]
     param (
@@ -614,6 +666,14 @@ function Invoke-TestItem {
             if ($PesterPreference.Debug.WriteDebugMessages.Value) {
                 $path = $Test.Path -join '.'
                 Write-PesterDebugMessage -Scope Skip "($path) Test is skipped."
+            }
+
+            # A skipped test never runs the setup that expands <template> names, so expand the
+            # data-backed templates here from the -ForEach data we already have. Same guard as the
+            # executed path uses before binding data (#2427).
+            if (($null -ne $Test.Data -or -not [string]::IsNullOrEmpty($Test.GroupId)) -and ($Test.Name -like '*<*')) {
+                $Test.ExpandedName = Expand-NameForSkippedTest -Name $Test.Name -Data $Test.Data -FormatNicelyForTemplate $State.FormatNicelyForTemplate
+                $Test.ExpandedPath = "$($block.ExpandedPath).$($Test.ExpandedName)"
             }
 
             # setting the test as passed here, this is by choice

--- a/tst/Pester.RSpec.ts.ps1
+++ b/tst/Pester.RSpec.ts.ps1
@@ -2138,6 +2138,41 @@ i -PassThru:$PassThru {
             $r.Containers[0].Blocks[0].ExpandedName | Verify-Equal "d 1"
         }
 
+        t "<_> and <key> expand from -ForEach data even when the test is skipped (#2427)" {
+            $sb = {
+                Describe "d" {
+                    It "array <_>" -Skip -ForEach @("foo", "bar") { }
+                    It "hashtable <Name> <Value>" -Skip -ForEach @(@{ Name = "a"; Value = 1 }, @{ Name = "b"; Value = 2 }) { }
+                }
+            }
+
+            $container = New-PesterContainer -ScriptBlock $sb
+            $r = Invoke-Pester -Container $container -PassThru
+            $tests = $r.Containers[0].Blocks[0].Tests
+            $tests[0].Result | Verify-Equal "Skipped"
+            $tests[0].ExpandedName | Verify-Equal "array foo"
+            $tests[1].ExpandedName | Verify-Equal "array bar"
+            $tests[2].ExpandedName | Verify-Equal "hashtable a 1"
+            $tests[3].ExpandedName | Verify-Equal "hashtable b 2"
+        }
+
+        t "skipped test leaves templates not backed by data as the literal <template> (#2427)" {
+            # A skipped test never runs setup, so anything that needs more than the raw data, a nested
+            # property, or a variable that only setup would define, cannot be resolved and stays literal.
+            $sb = {
+                Describe "d" {
+                    It "nested <_.Length>" -Skip -ForEach @("foo") { }
+                    It "unknown <Missing>" -Skip -ForEach @(@{ Name = "a" }) { }
+                }
+            }
+
+            $container = New-PesterContainer -ScriptBlock $sb
+            $r = Invoke-Pester -Container $container -PassThru
+            $tests = $r.Containers[0].Blocks[0].Tests
+            $tests[0].ExpandedName | Verify-Equal "nested <_.Length>"
+            $tests[1].ExpandedName | Verify-Equal "unknown <Missing>"
+        }
+
         t "<_> expands to `$_ in It even if It does not define any data" {
             $sb = {
                 Describe "d <_>" {


### PR DESCRIPTION
A skipped test never runs its setup, and setup is where `<_>` and `<key>` templates in the test name get expanded. So a skipped data-driven test showed the raw template, `array <_>` repeated, instead of `array foo`, `array bar`, and you could not tell the skipped cases apart.

Now the templates the `-ForEach` data can fill in directly are expanded from the data we already have: `<_>` for the whole item and `<key>` for a dictionary key.

```powershell
Describe 'd' {
    It 'array <_>' -Skip -ForEach @('foo', 'bar') { }
    It 'hashtable <Name> <Value>' -Skip -ForEach @(@{ Name = 'a'; Value = 1 }) { }
}

# before:                 after:
# array <_>               array foo
# array <_>               array bar
# hashtable <Name> <Value>  hashtable a 1
```

Anything that needs more than the data, a nested property like `<_.Length>`, a method call, or a variable that only setup would define, is left as the literal `<template>`. That is on purpose: I did not want to run user code just to render the name of a test that was skipped, and for a skipped test we only have the data, not the setup state. So a skipped `<_.Length>` stays literal even though a run test would show `3`.

Scoped to `It`. Skipped blocks with templates are a separate thing (#2635).

Fixes #2427

🤖