### PR TITLE
Fix #2953: fail open when a bound parameter's ToString throws in the mock filter debug message (backport to 5.x)

### DIFF
--- a/src/functions/Mock.ps1
+++ b/src/functions/Mock.ps1
@@ -1161,6 +1161,21 @@ function Invoke-InMockScope {
     }
 }
 
+function Format-BoundParameterValueSafely {
+    # Stringify a bound-parameter value for the debug message. This is only ever used to provide
+    # context to the user, so it must fail open: some types have a ToString that throws (e.g. mocked
+    # SMO objects created via New-MockObject), and a value like that must not make the whole mock
+    # filter throw when it is not even referenced by the filter. See #2953.
+    param($Value)
+
+    try {
+        "$Value"
+    }
+    catch {
+        '<value could not be serialized>'
+    }
+}
+
 function Test-ParameterFilter {
     [CmdletBinding()]
     param (
@@ -1218,7 +1233,7 @@ function Test-ParameterFilter {
 
     if ($PesterPreference.Debug.WriteDebugMessages.Value) {
         $hasContext = 0 -lt $Context.Count
-        $c = $(if ($hasContext) { foreach ($p in $Context.GetEnumerator()) { "$($p.Key) = $($p.Value)" } }) -join ", "
+        $c = $(if ($hasContext) { foreach ($p in $Context.GetEnumerator()) { "$($p.Key) = $(Format-BoundParameterValueSafely $p.Value)" } }) -join ", "
         Write-PesterDebugMessage -Scope Mock -Message "Running mock filter { $scriptBlock } $(if ($hasContext) { "with context: $c" } else { "without any context"})."
     }
 

--- a/tst/functions/Mock.Tests.ps1
+++ b/tst/functions/Mock.Tests.ps1
@@ -3136,6 +3136,42 @@ Describe 'Mocking in manifest modules' {
     }
 }
 
+Describe 'When a bound parameter value has a ToString that throws and debug messages are on' {
+    # The mock filter debug message serializes the bound parameters, so a value whose ToString throws
+    # (e.g. a mocked SMO type) must not make the mock throw when the value is not referenced by the
+    # filter. This only happens with Debug.WriteDebugMessages on in Pester 5. See #2953.
+    BeforeAll {
+        $conf = [PesterConfiguration]::Default
+        $conf.Run.PassThru = $true
+        $conf.Output.Verbosity = 'None'
+        $conf.Debug.WriteDebugMessages = $true
+        $conf.Debug.WriteDebugMessagesFrom = 'Mock'
+        $conf.Run.Container = New-PesterContainer -ScriptBlock {
+            Describe 'inner' {
+                BeforeAll {
+                    function Get-Thing { param([object] $InputObject, [switch] $Other) }
+                    $throwingToString = [pscustomobject]@{ Name = 'demo' }
+                    $throwingToString | Add-Member -MemberType ScriptMethod -Name ToString -Value { throw 'ToString should not be called by the parameter filter serializer' } -Force
+                }
+
+                It 'does not throw when a non-matching parameter filter is present' {
+                    Mock Get-Thing { 'default' }
+                    Mock Get-Thing -ParameterFilter { $Other.IsPresent } { 'other' }
+
+                    { Get-Thing -InputObject $throwingToString } | Should -Not -Throw
+                }
+            }
+        }
+
+        $innerRun = Invoke-Pester -Configuration $conf
+    }
+
+    It 'The mock filter debug message does not crash the mock' {
+        $innerRun.Result | Should -Be 'Passed'
+        $innerRun.PassedCount | Should -Be 1
+    }
+}
+
 Describe 'Mocking with nested Pester runs' {
     BeforeAll {
         Mock Get-Date { 1 }


### PR DESCRIPTION
Backport of #2955 to rel/5.x.x.

In Pester 5 the mock filter serializes the bound parameters only into the debug message, so this only crashes a mock filter when Debug.WriteDebugMessages is on, but the root cause is the same as on main: a value whose ToString throws, for example a mocked SMO type created by New-MockObject, took down the mock even when the value was never referenced by the filter.

Each value now goes through a small helper that catches the failure and falls back to a placeholder.

The added test runs a nested Pester run with debug messages on and passes a value whose ToString throws.

🤖