### PR TITLE
Roll the SDK forward across majors on rel/5.x.x

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "rollForward": "latestFeature",
+    "rollForward": "latestMajor",
     "version": "8.0.100"
   }
 }


### PR DESCRIPTION
main already uses `rollForward: latestMajor`. On rel/5.x.x it is still `latestFeature`, which pins the build to the 8.0.x feature band, so `dotnet restore` fails to find an SDK on a machine that only has a newer major installed, for example .NET 10 on macOS.

Switching to `latestMajor` keeps 8.0.100 when it is present (CI), and otherwise rolls forward to whatever newer SDK is there. The target frameworks are unchanged, and a full `./build.ps1 -Clean` (both net452 and netstandard2.0) passes locally on macOS with only .NET 10 installed.

🤖