### PR TITLE
Bump prerelease to 6.1.0-rc1

### DIFF
--- a/src/Pester.psd1
+++ b/src/Pester.psd1
@@ -172,10 +172,10 @@
             LicenseUri   = "https://www.apache.org/licenses/LICENSE-2.0.html"
 
             # Release notes for this particular version of the module
-            ReleaseNotes = 'https://github.com/pester/Pester/releases/tag/6.1.0-alpha3'
+            ReleaseNotes = 'https://github.com/pester/Pester/releases/tag/6.1.0-rc1'
 
             # Prerelease string of this module
-            Prerelease   = 'alpha3'
+            Prerelease   = 'rc1'
         }
 
         # Minimum assembly version required


### PR DESCRIPTION
Move the prerelease tag from `alpha3` to `rc1` and point the release notes link at the 6.1.0-rc1 tag.

🤖