### PR TITLE
Bump to 5.9.1

### DIFF
--- a/src/Pester.psd1
+++ b/src/Pester.psd1
@@ -4,7 +4,7 @@
     RootModule        = 'Pester.psm1'
 
     # Version number of this module.
-    ModuleVersion     = '5.9.0'
+    ModuleVersion     = '5.9.1'
 
     # ID used to uniquely identify this module
     GUID              = 'a699dea5-2c73-4616-a270-1f7abb777e71'
@@ -116,7 +116,7 @@
             LicenseUri   = "https://www.apache.org/licenses/LICENSE-2.0.html"
 
             # Release notes for this particular version of the module
-            ReleaseNotes = 'https://github.com/pester/Pester/releases/tag/5.9.0'
+            ReleaseNotes = 'https://github.com/pester/Pester/releases/tag/5.9.1'
 
             # Prerelease string of this module
             Prerelease   = ''


### PR DESCRIPTION
Bump ModuleVersion and the ReleaseNotes link to 5.9.1, so rel/5.x.x sits one patch ahead of the published 5.9.0 and is ready to release the fixes that have landed since (currently the #2953 mock filter fix, #2958).

🤖