### PR TITLE
Run release tests with -NonInteractive so a missing mandatory parameter fails instead of hanging

### DIFF
--- a/publish/release.ps1
+++ b/publish/release.ps1
@@ -49,7 +49,7 @@ if ($SkipTests) {
     Write-Host "Skipping tests because -SkipTests was specified."
 }
 else {
-    pwsh -noprofile -c "$PSSCriptRoot/../test.ps1 -nobuild"
+    pwsh -noprofile -NonInteractive -c "$PSSCriptRoot/../test.ps1 -nobuild"
     if ($LASTEXITCODE -ne 0) {
         throw "test failed!"
     }


### PR DESCRIPTION
The release runs the tests as `pwsh -noprofile -c "test.ps1"` nested inside the AzureCLI task, whose host allows prompting. The "Requires Expected" tests on Should-NotBeString, Should-BeFasterThan and Should-BeSlowerThan (#2938) invoke the assertion with the now-mandatory Expected missing, so PowerShell prompts for the value and the release build blocks forever on the agent instead of throwing the ParameterBindingException the test expects.

The PR pipeline runs the same tests through the PowerShell task, which is non-interactive, so they throw and pass there. Adding -NonInteractive to the release test run makes it behave the same way. Publish-only script, does not affect the build.

🤖