### PR TITLE
Run release tests with -NonInteractive so a missing mandatory parameter fails instead of hanging

### DIFF
--- a/publish/release.ps1
+++ b/publish/release.ps1
@@ -49,7 +49,7 @@ if ($SkipTests) {
     Write-Host "Skipping tests because -SkipTests was specified."
 }
 else {
-    pwsh -noprofile -c "$PSSCriptRoot/../test.ps1 -nobuild"
+    pwsh -noprofile -NonInteractive -c "$PSSCriptRoot/../test.ps1 -nobuild"
     if ($LASTEXITCODE -ne 0) {
         throw "test failed!"
     }


### PR DESCRIPTION
Hardening backport of the main fix. The release runs the tests as `pwsh -noprofile -c "test.ps1"` nested inside the AzureCLI task, whose host allows prompting, so a test invoking a command with a missing mandatory parameter would prompt and block forever on the agent instead of throwing. Adding -NonInteractive keeps the release test run non-interactive, like the PR pipeline. Publish-only script, does not affect the build.

🤖