### PR TITLE
Test that Expected is mandatory via metadata, not by invoking without it

### DIFF
--- a/tst/functions/assert/String/Should-NotBeString.Tests.ps1
+++ b/tst/functions/assert/String/Should-NotBeString.Tests.ps1
@@ -83,8 +83,13 @@ Describe "Should-NotBeString" {
     }
 
     It "Requires Expected" {
-        $err = { "abc" | Should-NotBeString } | Verify-Throw
-        $err.Exception | Verify-Type ([System.Management.Automation.ParameterBindingException])
+        # Don't invoke with Expected missing to test this: a missing mandatory parameter makes
+        # PowerShell prompt for it, which hangs an interactive test.ps1 run and the release build.
+        # Check the parameter metadata instead. See #2963.
+        (Get-Command Should-NotBeString).Parameters['Expected'].Attributes |
+            Where-Object { $_ -is [System.Management.Automation.ParameterAttribute] } |
+            ForEach-Object Mandatory |
+            Verify-True
     }
 }
 

--- a/tst/functions/assert/Time/Should-BeFasterThan.Tests.ps1
+++ b/tst/functions/assert/Time/Should-BeFasterThan.Tests.ps1
@@ -56,7 +56,12 @@ Describe "Should-BeFasterThan" {
     }
 
     It "Requires Expected" {
-        $err = { [timespan]::FromMilliseconds(1) | Should-BeFasterThan } | Verify-Throw
-        $err.Exception | Verify-Type ([System.Management.Automation.ParameterBindingException])
+        # Don't invoke with Expected missing to test this: a missing mandatory parameter makes
+        # PowerShell prompt for it, which hangs an interactive test.ps1 run and the release build.
+        # Check the parameter metadata instead. See #2963.
+        (Get-Command Should-BeFasterThan).Parameters['Expected'].Attributes |
+            Where-Object { $_ -is [System.Management.Automation.ParameterAttribute] } |
+            ForEach-Object Mandatory |
+            Verify-True
     }
 }

--- a/tst/functions/assert/Time/Should-BeSlowerThan.Tests.ps1
+++ b/tst/functions/assert/Time/Should-BeSlowerThan.Tests.ps1
@@ -33,7 +33,12 @@ Describe "Should-BeSlowerThan" {
     }
 
     It "Requires Expected" {
-        $err = { [timespan]::FromMilliseconds(1) | Should-BeSlowerThan } | Verify-Throw
-        $err.Exception | Verify-Type ([System.Management.Automation.ParameterBindingException])
+        # Don't invoke with Expected missing to test this: a missing mandatory parameter makes
+        # PowerShell prompt for it, which hangs an interactive test.ps1 run and the release build.
+        # Check the parameter metadata instead. See #2963.
+        (Get-Command Should-BeSlowerThan).Parameters['Expected'].Attributes |
+            Where-Object { $_ -is [System.Management.Automation.ParameterAttribute] } |
+            ForEach-Object Mandatory |
+            Verify-True
     }
 }


### PR DESCRIPTION
Follow-up to #2963. The "Requires Expected" tests on Should-NotBeString, Should-BeFasterThan and Should-BeSlowerThan (#2938) invoked the assertion with the mandatory Expected missing and expected a ParameterBindingException. That only throws in a non-interactive host. Interactively (a local `test.ps1` run, or the release build before #2963) a missing mandatory parameter prompts for the value and hangs forever.

Check the parameter metadata reports Mandatory instead, so the test never prompts regardless of host. #2963 keeps the release non-interactive as defense in depth.

🤖