### PR TITLE
Rename -NormalizeNewline to -NormalizeLineEnding

### DIFF
--- a/src/functions/assert/String/Should-BeString.ps1
+++ b/src/functions/assert/String/Should-BeString.ps1
@@ -5,14 +5,14 @@
         [switch]$CaseSensitive,
         [switch]$IgnoreWhitespace,
         [switch]$TrimWhitespace,
-        [switch]$NormalizeNewline
+        [switch]$NormalizeLineEnding
     )
 
     if ($Actual -isnot [string]) {
         return $false
     }
 
-    if ($NormalizeNewline) {
+    if ($NormalizeLineEnding) {
         $Expected = $Expected -replace '\r\n|\r|\p{Zl}', "`n"
         $Actual = $Actual -replace '\r\n|\r|\p{Zl}', "`n"
     }
@@ -58,7 +58,7 @@ function Should-BeString {
     .PARAMETER TrimWhitespace
     Trims whitespace at the start and end of the string.
 
-    .PARAMETER NormalizeNewline
+    .PARAMETER NormalizeLineEnding
     Normalizes line endings before comparison, so that `\r\n`, `\r`, and the Unicode line separator are all treated as `\n`. Use this to compare multi-line strings across platforms without failing on line-ending style. Unlike `-IgnoreWhitespace`, the newlines and their positions are kept, so indentation and blank lines are still compared.
 
     .PARAMETER Because
@@ -110,13 +110,13 @@ function Should-BeString {
         [switch]$CaseSensitive,
         [switch]$IgnoreWhitespace,
         [switch]$TrimWhitespace,
-        [switch]$NormalizeNewline
+        [switch]$NormalizeLineEnding
     )
 
     $assert = New-ShouldAssertion -Caller $PSCmdlet -Actual $Actual -Buffer $local:Input
     $Actual = $assert.Actual()
 
-    $stringsAreEqual = Test-StringEqual -Expected $Expected -Actual $Actual -CaseSensitive:$CaseSensitive -IgnoreWhitespace:$IgnoreWhiteSpace -TrimWhitespace:$TrimWhitespace -NormalizeNewline:$NormalizeNewline
+    $stringsAreEqual = Test-StringEqual -Expected $Expected -Actual $Actual -CaseSensitive:$CaseSensitive -IgnoreWhitespace:$IgnoreWhiteSpace -TrimWhitespace:$TrimWhitespace -NormalizeLineEnding:$NormalizeLineEnding
     if (-not ($stringsAreEqual)) {
         if ($Actual -is [string]) {
             $assert.Fail((Get-StringDifferenceMessage -Expected $Expected -Actual $Actual -CaseSensitive:$CaseSensitive -Because $Because))

--- a/src/functions/assert/String/Should-NotBeString.ps1
+++ b/src/functions/assert/String/Should-NotBeString.ps1
@@ -25,7 +25,7 @@ function Should-NotBeString {
     .PARAMETER TrimWhitespace
     Trims whitespace at the start and end of the string.
 
-    .PARAMETER NormalizeNewline
+    .PARAMETER NormalizeLineEnding
     Normalizes line endings before comparison, so that `\r\n`, `\r`, and the Unicode line separator are all treated as `\n`. Use this to compare multi-line strings across platforms without failing on line-ending style. Unlike `-IgnoreWhitespace`, the newlines and their positions are kept, so indentation and blank lines are still compared.
 
     .PARAMETER Because
@@ -69,7 +69,7 @@ function Should-NotBeString {
         [switch]$CaseSensitive,
         [switch]$IgnoreWhitespace,
         [switch]$TrimWhitespace,
-        [switch]$NormalizeNewline
+        [switch]$NormalizeLineEnding
     )
 
     $assert = New-ShouldAssertion -Caller $PSCmdlet -Actual $Actual -Buffer $local:Input
@@ -79,7 +79,7 @@ function Should-NotBeString {
         throw [ArgumentException]"Actual is expected to be string, to avoid confusing behavior that -ne operator exhibits with collections. To assert on collections use Should-Any, Should-All or some other collection assertion."
     }
 
-    if (Test-StringEqual -Expected $Expected -Actual $Actual -CaseSensitive:$CaseSensitive -IgnoreWhitespace:$IgnoreWhiteSpace -TrimWhitespace:$TrimWhitespace -NormalizeNewline:$NormalizeNewline) {
+    if (Test-StringEqual -Expected $Expected -Actual $Actual -CaseSensitive:$CaseSensitive -IgnoreWhitespace:$IgnoreWhiteSpace -TrimWhitespace:$TrimWhitespace -NormalizeLineEnding:$NormalizeLineEnding) {
         if (-not $CustomMessage) {
             $formattedMessage = Get-StringNotEqualDefaultFailureMessage -Expected $Expected -Actual $Actual
         }

--- a/tst/functions/assert/String/Should-BeString.Tests.ps1
+++ b/tst/functions/assert/String/Should-BeString.Tests.ps1
@@ -69,15 +69,15 @@ InPesterModuleScope {
                 @{ l = "a`r`nb"; r = "a`rb"; lName = "CRLF"; rName = "CR" },
                 @{ l = "a$([char]0x2028)b"; r = "a`nb"; lName = "LS"; rName = "LF" }
             ) {
-                Test-StringEqual -Expected $l -Actual $r -NormalizeNewline | Verify-True
+                Test-StringEqual -Expected $l -Actual $r -NormalizeLineEnding | Verify-True
             }
 
             It "strings that differ in more than line ending style are not equal" {
-                Test-StringEqual -Expected "a`r`nb" -Actual "a`nc" -NormalizeNewline | Verify-False
+                Test-StringEqual -Expected "a`r`nb" -Actual "a`nc" -NormalizeLineEnding | Verify-False
             }
 
             It "keeps newline positions, so extra blank lines still differ" {
-                Test-StringEqual -Expected "a`r`nb" -Actual "a`r`n`r`nb" -NormalizeNewline | Verify-False
+                Test-StringEqual -Expected "a`r`nb" -Actual "a`r`n`r`nb" -NormalizeLineEnding | Verify-False
             }
         }
     }
@@ -162,11 +162,11 @@ But was:  'abc'
         }
 
         It "Can compare multi-line strings ignoring line ending style" {
-            "line1`nline2" | Should-BeString -Expected "line1`r`nline2" -NormalizeNewline
+            "line1`nline2" | Should-BeString -Expected "line1`r`nline2" -NormalizeLineEnding
         }
 
         It "Normalizing newlines still compares indentation and blank lines" {
-            { "a`nb" | Should-BeString -Expected "a`n`nb" -NormalizeNewline } | Verify-AssertionFailed
+            { "a`nb" | Should-BeString -Expected "a`n`nb" -NormalizeLineEnding } | Verify-AssertionFailed
         }
     }
 

--- a/tst/functions/assert/String/Should-NotBeString.Tests.ps1
+++ b/tst/functions/assert/String/Should-NotBeString.Tests.ps1
@@ -60,11 +60,11 @@ Describe "Should-NotBeString" {
         }
 
         It "Fails when strings differ only in line ending style" {
-            { "line1`nline2" | Should-NotBeString -Expected "line1`r`nline2" -NormalizeNewline } | Verify-AssertionFailed
+            { "line1`nline2" | Should-NotBeString -Expected "line1`r`nline2" -NormalizeLineEnding } | Verify-AssertionFailed
         }
 
         It "Passes when strings differ in more than line ending style" {
-            "a`nb" | Should-NotBeString -Expected "a`n`nb" -NormalizeNewline
+            "a`nb" | Should-NotBeString -Expected "a`n`nb" -NormalizeLineEnding
         }
     }
 


### PR DESCRIPTION
`-NormalizeLineEnding` is more generic and correct, the switch normalizes `\r\n`, `\r` and the Unicode line separator, not just `\n`. It is only in 6.1.0-rc1 so far, so renaming it now keeps the less accurate name out of a stable release.

Renamed on `Should-BeString` and `Should-NotBeString` (and the shared `Test-StringEqual`), tests updated. Help text is unchanged, it already described the behavior generically.

Fixes #2967

🤖