### PR TITLE
Branding to 6.1.0

### DIFF
--- a/src/Pester.psd1
+++ b/src/Pester.psd1
@@ -172,10 +172,10 @@
             LicenseUri   = "https://www.apache.org/licenses/LICENSE-2.0.html"
 
             # Release notes for this particular version of the module
-            ReleaseNotes = 'https://github.com/pester/Pester/releases/tag/6.1.0-rc1'
+            ReleaseNotes = 'https://github.com/pester/Pester/releases/tag/6.1.0'
 
             # Prerelease string of this module
-            Prerelease   = 'rc1'
+            Prerelease   = ''
         }
 
         # Minimum assembly version required


### PR DESCRIPTION
Drop the prerelease tag and point the release notes link at the 6.1.0 tag.

🤖