### PR TITLE
Keep the error location when the error comes from inside Pester, and name the assertion

### DIFF
--- a/src/functions/Output.ps1
+++ b/src/functions/Output.ps1
@@ -454,12 +454,9 @@ function ConvertTo-FailureLines {
             # omit the lines internal to Pester
             if ((GetPesterOS) -ne 'Windows') {
                 [String]$isPesterFunction = '^at .*, .*/Pester.psm1: line [0-9]*$'
-                [String]$isShould = '^at (Should<End>|Invoke-Assertion), .*/Pester.psm1: line [0-9]*$'
-                # [String]$pattern6 = '^at <ScriptBlock>, (<No file>|.*/Pester.psm1): line [0-9]*$'
             }
             else {
                 [String]$isPesterFunction = '^at .*, .*\\Pester.psm1: line [0-9]*$'
-                [String]$isShould = '^at (Should<End>|Invoke-Assertion), .*\\Pester.psm1: line [0-9]*$'
             }
 
             # PESTER_BUILD
@@ -468,26 +465,42 @@ function ConvertTo-FailureLines {
                 # non inlined scripts will have different paths just omit everything from the src folder
                 $path = [regex]::Escape(($PSScriptRoot | & $SafeCommands['Split-Path']))
                 [String]$isPesterFunction = "^at .*, .*$path.*: line [0-9]*$"
-                [String]$isShould = "^at (Should<End>|Invoke-Assertion), .*$path.*: line [0-9]*$"
             }
             # end PESTER_BUILD
 
             # reducing the stack trace so we see only stack trace until the current It block and not up until the invocation of the
-            # whole test script itself. This is achieved by shortening the stack trace when any Runtime function is hit.
-            # what we don't want to do here is shorten the stack on the Should or Invoke-Assertion. That would remove any
-            # lines describing potential functions that are invoked in the test. e.g. doing function a() { 1 | Should -Be 2 }; a
-            # we want to be able to see that we invoked the assertion inside of function a
-            # the internal calls to Should and Invoke-Assertion are filtered out later by the second match
+            # whole test script itself. This is achieved by shortening the stack trace when a Pester frame is hit after we already
+            # collected at least one frame from the user code.
+            # the frames below the user code are Pester as well, e.g. Should, or Ensure-ExpectedIsNotCollection when the error is
+            # thrown from an assertion, or Mock when the error comes from Mock. We skip those, but we must not stop on them,
+            # otherwise we throw away the whole trace, including the line in the test file that the user needs. Skipping instead of
+            # stopping also keeps any function that the user invoked in the test, e.g. doing function a() { 1 | Should -Be 2 }; a
+            # shows that we invoked the assertion inside of function a.
+            # an assertion failure already has the line with the assertion itself, taken from TargetObject above,
+            # skip the first frame of the trace when it points at the same place so we don't print it twice
+            $skipFrame = if ($ErrorRecord.FullyQualifiedErrorId -eq 'PesterAssertionFailed') {
+                "$($ErrorRecord.TargetObject.File):$($ErrorRecord.TargetObject.Line)"
+            }
+
+            $userFrameFound = $false
             foreach ($line in $traceLines) {
-                if ($line -match $isPesterFunction -and $line -notmatch $isShould) {
-                    break
+                if ($line -match $isPesterFunction) {
+                    if ($userFrameFound) {
+                        break
+                    }
+
+                    continue
                 }
 
-                $isPesterInternalFunction = $line -match $isPesterFunction
+                if (-not $userFrameFound) {
+                    $userFrameFound = $true
 
-                if (-not $isPesterInternalFunction) {
-                    $lines.Trace += $line
+                    if ($null -ne $skipFrame -and $line -replace '^at [^,]*, ' -replace ':\s*line\s*(\d+)\s*$', ':$1' -eq $skipFrame) {
+                        continue
+                    }
                 }
+
+                $lines.Trace += $line
             }
         }
 

--- a/src/functions/assert/Common/Ensure-ExpectedIsNotCollection.ps1
+++ b/src/functions/assert/Common/Ensure-ExpectedIsNotCollection.ps1
@@ -1,11 +1,16 @@
 function Ensure-ExpectedIsNotCollection {
     param(
-        $InputObject
+        $InputObject,
+        # Name of the assertion that is doing the check, so the message can say which assertion refused
+        # the collection. The stack trace shows the line in the test file, not the assertion, so without
+        # the name here there is nothing that tells the user which assertion complained.
+        [string] $Assertion
     )
 
     if (Is-Collection $InputObject)
     {
-        throw [ArgumentException]'You provided a collection to the -Expected parameter. Using a collection on the -Expected side is not allowed by this assertion, because it leads to unexpected behavior. To compare collections use Should-BeCollection, or a more specialized collection assertion such as Should-Any or Should-All.'
+        $by = if ([string]::IsNullOrWhiteSpace($Assertion)) { 'this assertion' } else { $Assertion }
+        throw [ArgumentException]"You provided a collection to the -Expected parameter. Using a collection on the -Expected side is not allowed by $by, because it leads to unexpected behavior. To compare collections use Should-BeCollection, or a more specialized collection assertion such as Should-Any or Should-All."
     }
 
     $InputObject

--- a/src/functions/assert/Common/New-ShouldAssertion.ps1
+++ b/src/functions/assert/Common/New-ShouldAssertion.ps1
@@ -108,9 +108,10 @@ class ShouldAssertion {
     }
 
     # Returns $Expected unchanged, or throws when it is a collection. Guards assertions that only
-    # make sense against a single value.
+    # make sense against a single value. The caller's name goes into the message, so the user sees
+    # which assertion refused the collection.
     [object] EnsureScalar([object] $Expected) {
-        return (Ensure-ExpectedIsNotCollection $Expected)
+        return (Ensure-ExpectedIsNotCollection -InputObject $Expected -Assertion $this.Caller.MyInvocation.MyCommand.Name)
     }
 
     # Returns whether a value is treated as a collection.

--- a/src/functions/assert/General/Should-BeSame.ps1
+++ b/src/functions/assert/General/Should-BeSame.ps1
@@ -55,7 +55,7 @@
         [String]$Because
     )
 
-    $null = Ensure-ExpectedIsNotCollection $Expected
+    $null = Ensure-ExpectedIsNotCollection -InputObject $Expected -Assertion $PSCmdlet.MyInvocation.MyCommand.Name
 
     if ($Expected -is [ValueType] -or $Expected -is [string]) {
         throw [ArgumentException]"Should-BeSame compares objects by reference. You provided a value type or a string, those are not reference types and you most likely don't need to compare them by reference, see https://github.com/nohwnd/Assert/issues/6.`n`nAre you trying to compare two values to see if they are equal? Use Should-BeEqual instead."

--- a/src/functions/assert/General/Should-NotBeSame.ps1
+++ b/src/functions/assert/General/Should-NotBeSame.ps1
@@ -54,7 +54,7 @@
         [String]$Because
     )
 
-    $null = Ensure-ExpectedIsNotCollection $Expected
+    $null = Ensure-ExpectedIsNotCollection -InputObject $Expected -Assertion $PSCmdlet.MyInvocation.MyCommand.Name
 
     $assert = New-ShouldAssertion -Caller $PSCmdlet -Actual $Actual -Buffer $local:Input
     $Actual = $assert.Actual()

--- a/tst/functions/Output.Tests.ps1
+++ b/tst/functions/Output.Tests.ps1
@@ -376,6 +376,81 @@ InModuleScope -ModuleName Pester -ScriptBlock {
                 $r.Trace.Count | Should -Be 1
             }
         }
+
+        Context 'error thrown from inside a Pester function' {
+            BeforeAll {
+                $testPath = Join-Path $TestDrive test.ps1
+                Set-Content -Path $testPath -Value @'
+1, 2, 3 | Should-Be 1, 2, 3
+'@
+
+                try {
+                    & $testPath
+                }
+                catch {
+                    $e = $_
+                }
+
+                $r = $e | ConvertTo-FailureLines
+            }
+
+            It 'keeps the line from the test file.' {
+                $r.Trace[0] | Should -Be "at <ScriptBlock>, ${testPath}:1"
+            }
+
+            It 'drops the frames that are inside Pester.' {
+                $r.Trace -join [Environment]::NewLine | Should -Not -Match 'Should-Be|EnsureScalar|Ensure-ExpectedIsNotCollection'
+            }
+        }
+
+        Context 'assertion fails inside a function defined in file' {
+            BeforeAll {
+                $testPath = Join-Path $TestDrive test.ps1
+                Set-Content -Path $testPath -Value @'
+function f1 {
+    1 | Should-Be 2
+}
+f1
+'@
+
+                try {
+                    & $testPath
+                }
+                catch {
+                    $e = $_
+                }
+
+                $r = $e | ConvertTo-FailureLines
+            }
+
+            It 'produces the line with the assertion, and the line that called the function.' {
+                $r.Trace[0] | Should -Be "at 1 | Should-Be 2, ${testPath}:2"
+                $r.Trace[1] | Should -Be "at <ScriptBlock>, ${testPath}:4"
+            }
+        }
+
+        Context 'assertion fails directly in file' {
+            BeforeAll {
+                $testPath = Join-Path $TestDrive test.ps1
+                Set-Content -Path $testPath -Value @'
+1 | Should-Be 2
+'@
+
+                try {
+                    & $testPath
+                }
+                catch {
+                    $e = $_
+                }
+
+                $r = $e | ConvertTo-FailureLines
+            }
+
+            It 'does not print the same file and line twice.' {
+                $r.Trace[0] | Should -Be "at 1 | Should-Be 2, ${testPath}:1"
+                @($r.Trace -match ([regex]::Escape("${testPath}:1"))).Count | Should -Be 1
+            }
+        }
     }
 
     Describe Format-ErrorMessage {
@@ -387,6 +462,8 @@ InModuleScope -ModuleName Pester -ScriptBlock {
                 catch [System.DivideByZeroException] {
                     $errorRecord = $_
                 }
+                # the line above where 1/0 is, taken from the record so adding tests to this file does not break it
+                $divideLine = $errorRecord.InvocationInfo.ScriptLineNumber
                 $errorRecord | Add-Member -Name "DisplayErrorMessage" -MemberType NoteProperty -Value "Failed to divide 1/0"
 
                 $stackTraceText = $errorRecord.Exception.ToString() + "$([Environment]::NewLine)at <ScriptBlock>, ${PSCommandPath}:230"
@@ -431,7 +508,7 @@ InModuleScope -ModuleName Pester -ScriptBlock {
                 $errorMessage = Format-ErrorMessage -Err $errorRecord -StackTraceVerbosity $_
                 $messages = $errorMessage -split [Environment]::NewLine
                 $messages[0] | Should -BeExactly "System.DivideByZeroException: Attempted to divide by zero."
-                $messages[1] | Should -BeExactly "at <ScriptBlock>, ${PSCommandPath}: line 385"
+                $messages[1] | Should -BeExactly "at <ScriptBlock>, ${PSCommandPath}: line $divideLine"
                 $messages.Count | Should -BeGreaterThan 1
             }
 

--- a/tst/functions/assert/Common/Ensure-ExpectedIsNotCollection.Tests.ps1
+++ b/tst/functions/assert/Common/Ensure-ExpectedIsNotCollection.Tests.ps1
@@ -12,6 +12,11 @@ InPesterModuleScope {
             $err.Exception.Message | Verify-Equal 'You provided a collection to the -Expected parameter. Using a collection on the -Expected side is not allowed by this assertion, because it leads to unexpected behavior. To compare collections use Should-BeCollection, or a more specialized collection assertion such as Should-Any or Should-All.'
         }
 
+        It "Given a collection and an assertion name it names the assertion in the message" {
+            $err = { Ensure-ExpectedIsNotCollection -InputObject @() -Assertion 'Should-Be' } | Verify-Throw
+            $err.Exception.Message | Verify-Equal 'You provided a collection to the -Expected parameter. Using a collection on the -Expected side is not allowed by Should-Be, because it leads to unexpected behavior. To compare collections use Should-BeCollection, or a more specialized collection assertion such as Should-Any or Should-All.'
+        }
+
 
         It "Given a value it passes it to output when it is not a collection" {
             Ensure-ExpectedIsNotCollection -InputObject 'a' | Verify-Equal 'a'


### PR DESCRIPTION
Fix #2980
Fix #2977

Two changes, they belong together. `1, 2, 3 | Should-Be 1, 2, 3` said "this assertion" and printed no location at all. The location part is the wider one, any error thrown from inside a Pester function lost its whole stack trace, `Mock` for a command that does not exist had the same problem.

`demo.tests.ps1`:

```powershell
Describe 'Stack trace' {
    It 'collection on -Expected' {
        1, 2, 3 | Should-Be 1, 2, 3
    }
    It 'collection on -Expected, assertion that calls the guard directly' {
        1 | Should-BeSame 1, 2
    }
    It 'mock of a command that does not exist' {
        Mock Get-NoSuchCommand { }
    }
    It 'assertion fails inside a helper function' {
        function Test-Thing ($Value) {
            $Value | Should-Be 2
        }
        Test-Thing -Value 1
    }
}
```

Before, on 6.1.0 with the default `StackTraceVerbosity`:

```
  [-] collection on -Expected 27ms
   ArgumentException: You provided a collection to the -Expected parameter. Using a collection on the -Expected side is not allowed by this assertion, because it leads to unexpected behavior. To compare collections use Should-BeCollection, or a more specialized collection assertion such as Should-Any or Should-All.
  [-] collection on -Expected, assertion that calls the guard directly 2ms
   ArgumentException: You provided a collection to the -Expected parameter. Using a collection on the -Expected side is not allowed by this assertion, because it leads to unexpected behavior. To compare collections use Should-BeCollection, or a more specialized collection assertion such as Should-Any or Should-All.
  [-] mock of a command that does not exist 13ms
   CommandNotFoundException: Could not find Command Get-NoSuchCommand
  [-] assertion fails inside a helper function 32ms
   Expected [int] 2, but got [int] 1.
   at $Value | Should-Be 2, demo.tests.ps1:13
```

Three of the four have no location. The fourth points at the assertion on line 13, but not at line 15 that called the function, so in a bigger suite you do not know which of the calls to `Test-Thing` failed.

After:

```
  [-] collection on -Expected 36ms
   ArgumentException: You provided a collection to the -Expected parameter. Using a collection on the -Expected side is not allowed by Should-Be, because it leads to unexpected behavior. To compare collections use Should-BeCollection, or a more specialized collection assertion such as Should-Any or Should-All.
   at <ScriptBlock>, demo.tests.ps1:3
  [-] collection on -Expected, assertion that calls the guard directly 3ms
   ArgumentException: You provided a collection to the -Expected parameter. Using a collection on the -Expected side is not allowed by Should-BeSame, because it leads to unexpected behavior. To compare collections use Should-BeCollection, or a more specialized collection assertion such as Should-Any or Should-All.
   at <ScriptBlock>, demo.tests.ps1:6
  [-] mock of a command that does not exist 19ms
   CommandNotFoundException: Could not find Command Get-NoSuchCommand
   at <ScriptBlock>, demo.tests.ps1:9
  [-] assertion fails inside a helper function 43ms
   Expected [int] 2, but got [int] 1.
   at $Value | Should-Be 2, demo.tests.ps1:13
   at <ScriptBlock>, demo.tests.ps1:15
```

Every line number points at the line in the file above that caused the failure.

## Why?

`ConvertTo-FailureLines` walked the trace and broke on the first frame that was inside Pester, with `Should<End>|Invoke-Assertion` as the only exemption:

```powershell
foreach ($line in $traceLines) {
    if ($line -match $isPesterFunction -and $line -notmatch $isShould) {
        break
    }
    ...
}
```

That exemption is Pester 4 and 5. This is the trace of the first test, `StackTraceVerbosity = Full`:

```
at Ensure-ExpectedIsNotCollection, .../Pester.psm1:6816
at EnsureScalar, .../Pester.psm1:7370
at Should-Be, .../Pester.psm1:8654
at <ScriptBlock>, demo.tests.ps1:3            <- the line the user needs
at <ScriptBlock>, .../Pester.psm1:2068
at Invoke-ScriptBlock, .../Pester.psm1:2215
at Invoke-TestItem, .../Pester.psm1:1283
... 21 more frames of the runtime
```

The first frame is Pester and it is not `Should<End>`, so we broke on it and the trace came out empty, one line above the one we wanted. `StackTraceVerbosity = Full` was the only way to see it, and then you get all 28 frames.

Assertion failures kept their line only because of the special case above the loop, which builds it from `TargetObject` when `FullyQualifiedErrorId` is `PesterAssertionFailed`. Everything else lost the location.

Adding `Ensure-ExpectedIsNotCollection` to the exemption list fixes `Should-Be` and breaks again on the next internal helper we write. The rule is positional now instead. Skip Pester frames until the first frame that comes from user code, stop on the first Pester frame after that. Applied to the trace above it skips the first three, keeps `demo.tests.ps1:3`, and stops on `Pester.psm1:2068`.

Since the trace does not show `Should-Be` anymore either, the message has to name the assertion. `Ensure-ExpectedIsNotCollection` takes a name, `EnsureScalar` passes `$this.Caller`, which is the `$PSCmdlet` of the assertion, so every assertion that guards a scalar names itself with nothing to do per assertion. `Should-BeSame` and `Should-NotBeSame` pass their own name because they call the guard directly and not through `$assert`.

## Behavior change

The fourth test is the one to look at. An assertion that fails inside a helper function now prints the call as a second line, which is what the comment in the loop already asked for:

> we want to be able to see that we invoked the assertion inside of function a

When the assertion sits directly in the `It` nothing changes. The frame from the trace is then the same file and line as the line built from `TargetObject`, and it is skipped so the location is not printed twice.

## Tests

`Output.Tests.ps1` gets four: an error thrown from inside Pester keeps the line from the test file, the frames inside Pester are dropped, an assertion that fails in a function produces both the assertion line and the call, and the same file and line is not printed twice when the assertion is directly in the file. `Ensure-ExpectedIsNotCollection.Tests.ps1` gets one for the name in the message.

The `Format-ErrorMessage` tests had the line number of the `1 / 0` written into them as `385`, adding tests above them moved it. They read it from the error record now.

Full suite passes locally, 2896 tests.
🤖
