### PR TITLE
Don't warn when a TestRegistry retry recovers

### DIFF
--- a/src/functions/TestRegistry.ps1
+++ b/src/functions/TestRegistry.ps1
@@ -86,8 +86,12 @@ function Invoke-TestRegistryWithRetry {
     catch [System.IO.IOException] {
         # when running in parallel this occasionally triggers
         # IOException: No more data is available
-        # let's just retry the operation
-        & $SafeCommands['Write-Warning'] "IO exception during a TestRegistry operation, retrying."
+        # let's just retry the operation. The operations we wrap are idempotent, so a retry that
+        # succeeds leaves no trace for the user to act on, and a retry that fails rethrows and the
+        # exception is the signal. Either way a warning is just noise, so this is a debug message.
+        if ($PesterPreference.Debug.WriteDebugMessages.Value) {
+            Write-PesterDebugMessage -Scope Runtime "IO exception during a TestRegistry operation, retrying."
+        }
         & $ScriptBlock
     }
 }

--- a/tst/functions/TestRegistry.Tests.ps1
+++ b/tst/functions/TestRegistry.Tests.ps1
@@ -34,6 +34,23 @@ Describe 'Invoke-TestRegistryWithRetry' {
         }
     }
 
+    It 'Does not warn when the retry recovers' {
+        InModuleScope -ModuleName Pester {
+            $calls = @{ Count = 0 }
+            $streams = Invoke-TestRegistryWithRetry {
+                $calls.Count++
+                if ($calls.Count -eq 1) {
+                    throw [System.IO.IOException] 'No more data is available'
+                }
+                'recovered'
+            } 3>&1
+
+            $calls.Count | Should -Be 2
+            @($streams | Where-Object { $_ -is [System.Management.Automation.WarningRecord] }) |
+                Should -BeNullOrEmpty -Because 'a recovered retry is idempotent, so there is nothing for the user to act on'
+        }
+    }
+
     It 'Rethrows when the transient IOException persists on retry' {
         InModuleScope -ModuleName Pester {
             { Invoke-TestRegistryWithRetry { throw [System.IO.IOException] 'No more data is available' } } |


### PR DESCRIPTION
`Invoke-TestRegistryWithRetry` writes the warning before it retries, so a run prints `IO exception during a TestRegistry operation, retrying.` even when the retry recovers and there is nothing for the user to act on. The operations it wraps (`Test-Path`, `New-Item`) are idempotent, and when the retry fails the exception propagates and that is the real signal. So the warning is noise in both outcomes.

Made it a `Write-PesterDebugMessage -Scope Runtime` instead.

Added a test that a recovered retry writes no warning. It fails without the change (5/6) and passes with it (6/6). Whole file green on PS 7.5.5 on macOS.

🤖