### PR TITLE
Add a Done gate to the v4 CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,13 @@
 # and PowerShell 7 — nothing else is guaranteed. The goal is to keep the branch
 # releasable: green CI here means a security fix can be validated and shipped
 # through the manual release process (release.ps1).
-name: CI
+#
+# The name differs from the workflow on main and on rel/5.x.x on purpose.
+# test-report.yml on main runs after every workflow named "CI" and renders its
+# results, and Pester 4 can only write NUnit 2.5 XML, which dorny/test-reporter
+# cannot read. The gate job below is still called "Done", same as everywhere
+# else, that is the name branch protection requires.
+name: CI (v4)
 
 on:
   push:
@@ -47,9 +53,24 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: results-${{ matrix.id }}
           retention-days: 7
           if-no-files-found: ignore
           path: TestResults.xml
+
+  # Single gate after the matrix so branch protection and auto-merge only need to
+  # require "Done" instead of listing every leg. Same name as the gate on main
+  # and on rel/5.x.x, so one branch policy covers all of them.
+  done:
+    name: Done
+    needs: test
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: All test legs passed
+        run: |
+          echo "Test matrix result: ${{ needs.test.result }}"
+          [ "${{ needs.test.result }}" = "success" ] || exit 1
+          echo "done"


### PR DESCRIPTION
Adds a `Done` job after the test matrix, so branch protection on this branch requires one check instead of every leg. Same check name as main (#2905) and rel/5.x.x (#2988), which is the point, one branch policy then covers all three.

The workflow is renamed to `CI (v4)`. `test-report.yml` on main runs after every workflow named `CI` and renders the results, and Pester 4 can only write NUnit 2.5 XML, which dorny/test-reporter cannot read. The job names are untouched, so the check is still `Done` here.

`upload-artifact` goes to v7 while here, v4 still ran it on Node 20.

Note this branch has no `code-analysis.yml`, so `PSScriptAnalyzer` can never report here and has to come off this branch's rule.

🤖
