### PR TITLE
Give the v4 workflow its own file name

### DIFF
--- a/.github/workflows/ci-v4.yml
+++ b/.github/workflows/ci-v4.yml
@@ -5,11 +5,14 @@
 # releasable: green CI here means a security fix can be validated and shipped
 # through the manual release process (release.ps1).
 #
-# The name differs from the workflow on main and on rel/5.x.x on purpose.
+# The file name and the workflow name differ from main and rel/5.x.x on purpose.
 # test-report.yml on main runs after every workflow named "CI" and renders its
 # results, and Pester 4 can only write NUnit 2.5 XML, which dorny/test-reporter
-# cannot read. The gate job below is still called "Done", same as everywhere
-# else, that is the name branch protection requires.
+# cannot read. A workflow is identified by its file path, and its name comes
+# from the copy on the default branch, so while this file was also called
+# ci.yml the rename alone did nothing and the report kept running and failing.
+# The gate job below is still called "Done", same as everywhere else, that is
+# the name branch protection requires.
 name: CI (v4)
 
 on:


### PR DESCRIPTION
Follow-up to #2989, the rename there did not do what I thought.

A workflow is identified by its file path, and its display name comes from the copy on the default branch. Since main now has `.github/workflows/ci.yml`, this branch's file at the same path is still labelled `CI`, no matter what `name:` says in it. So `test-report.yml` on main, which runs after every workflow named `CI`, kept firing for v4 runs and failing: Pester 4 writes NUnit 2.5 XML and dorny/test-reporter cannot read it. The run right after #2989 merged shows it, https://github.com/pester/Pester/actions/runs/32568961399.

`ci.yml` becomes `ci-v4.yml` here, which makes it a workflow of its own with its own name. The gate job is still `Done`, so branch protection is unaffected.

🤖
