### PR TITLE
Run Pester.BeforeContainer.ps1 for test files only

### DIFF
--- a/src/Pester.Runtime.ps1
+++ b/src/Pester.Runtime.ps1
@@ -1,4 +1,4 @@
-# PESTER_BUILD
+﻿# PESTER_BUILD
 if (-not (Get-Variable -Name "PESTER_BUILD" -ValueOnly -ErrorAction Ignore)) {
     . "$PSScriptRoot/Pester.Utility.ps1"
     . "$PSScriptRoot/functions/Pester.SafeCommands.ps1"
@@ -2206,9 +2206,13 @@ function Invoke-Test {
     $executedContainers = foreach ($container in $BlockContainer) {
         $containerIndex++
 
-        if ($null -ne $beforeContainerScriptBlock) {
+        if ($null -ne $beforeContainerScriptBlock -and 'File' -eq $container.Type) {
             # Dot-source so definitions land at the run session-state scope, visible to both the
             # discovery and the run of this container (and the containers after it).
+            # Files only. The convention is a file in the repository, dot-sourced before every test
+            # file, and a ScriptBlock container is not one. It also keeps the cost proportional: a
+            # test that runs Invoke-Pester over a scriptblock would otherwise pay for the repo's
+            # setup on every nested run.
             . $beforeContainerScriptBlock
         }
 

--- a/tst/Pester.RSpec.Parallel.ts.ps1
+++ b/tst/Pester.RSpec.Parallel.ts.ps1
@@ -252,6 +252,30 @@ Describe 'Module import' {
             finally { Remove-Item -Path $folder -Recurse -Force }
         }
 
+        t "does not run it for a ScriptBlock container, it is a setup for test files" {
+            # The convention is a file in the repository, dot-sourced before every test file, so a
+            # ScriptBlock container is not one. It also keeps the cost proportional: a test that runs
+            # Invoke-Pester over a scriptblock would otherwise pay for the whole repo's setup on every
+            # nested run, and a suite that does that a few hundred times pays it a few hundred times.
+            $folder = Join-Path ([IO.Path]::GetTempPath()) ([Guid]::NewGuid().Guid)
+            $null = New-Item -ItemType Directory -Path $folder -Force
+            try {
+                $marker = Join-Path $folder 'ran.txt'
+                Set-Content -Path (Join-Path $folder 'Pester.BeforeContainer.ps1') -Value "'ran' | Set-Content -LiteralPath '$marker'"
+
+                $c = [PesterConfiguration]::Default
+                $c.Run.ScriptBlock = { Describe 'd' { It 'passes' { 1 | Should -Be 1 } } }
+                $c.Run.RepoRoot = $folder
+                $c.Run.PassThru = $true
+                $c.Output.Verbosity = 'None'
+                $r = Invoke-Pester -Configuration $c
+
+                $r.PassedCount | Verify-Equal 1
+                (Test-Path -LiteralPath $marker) | Verify-False
+            }
+            finally { Remove-Item -Path $folder -Recurse -Force }
+        }
+
         t "runs the repo-root Pester.BeforeContainer.ps1 inside each parallel worker" {
             $folder = New-BeforeContainerTestFolder
             try {

--- a/tst/Pester.RSpec.ts.ps1
+++ b/tst/Pester.RSpec.ts.ps1
@@ -3448,22 +3448,19 @@ i -PassThru:$PassThru {
             # command like winrm/net in a setup block), which could not be reproduced deterministically.
             # Before #2655 that stray object was added to the strongly-typed Run.Containers list and
             # threw "Cannot find an overload for Add", taking down the whole run.
-            $sb = {
-                Describe 'd' {
-                    It 'passes' { $true | Should -Be $true }
-                }
-            }
-
             $repoRoot = Join-Path ([IO.Path]::GetTempPath()) ([Guid]::NewGuid().Guid)
             $null = New-Item -ItemType Directory -Path $repoRoot -Force
             Set-Content -Path (Join-Path $repoRoot 'Pester.BeforeContainer.ps1') -Value "'WinRM service is already running on this machine.'"
+            # A file container, because Pester.BeforeContainer.ps1 runs before test files.
+            $testFile = Join-Path $repoRoot 'Stray.Tests.ps1'
+            Set-Content -Path $testFile -Value "Describe 'd' { It 'passes' { `$true | Should -Be `$true } }"
 
             try {
                 $r = Invoke-Pester -Configuration ([PesterConfiguration]@{
                         Run    = @{
-                            ScriptBlock = $sb
-                            PassThru    = $true
-                            RepoRoot    = $repoRoot
+                            Path     = $testFile
+                            PassThru = $true
+                            RepoRoot = $repoRoot
                         }
                         Output = @{ Verbosity = 'None' }
                     }) -WarningVariable warnings 3> $null


### PR DESCRIPTION
`Pester.BeforeContainer.ps1` is a setup for test files, dot-sourced before each one, and a ScriptBlock container is not a file. It was running for those too.

That makes the cost grow with something nobody expects. A test that runs `Invoke-Pester` over a scriptblock pays for the whole repo's setup on every nested run, and a suite that does that a few hundred times pays it a few hundred times. Ours does: with a `Pester.BeforeContainer.ps1` in the repo root the file ran 621 times instead of 97, and cost 5.4s of a 17s unit run. With this it is back to 11.1s against 10.7s without the file at all.

The stray output test used a ScriptBlock container to get the repo-root setup to emit into the success stream. The container type is incidental to what it checks, so it uses a file now.

Found while trying to turn `Run.Parallel` on for our own suite, which needs a `Pester.BeforeContainer.ps1` to work at all.

🤖