### PR TITLE
Stop printing both strings in full when Should-BeString fails on a big string

### DIFF
--- a/src/functions/assert/String/Should-BeString.ps1
+++ b/src/functions/assert/String/Should-BeString.ps1
@@ -164,15 +164,117 @@ function Get-StringDifferenceMessage {
     else {
         $lines += "String lengths are both $($Expected.Length)."
     }
+
+    # Big strings get a compact view. Printing both in full is what makes a 10 000 line comparison
+    # useless (#2951), but for a short string the full text with a caret under the difference is
+    # more precise than anything else, so that is left exactly as it was.
+    $expectedLines = $Expected -split '\r\n|\r|\n'
+    $actualLines = $Actual -split '\r\n|\r|\n'
+    $maxLines = [Math]::Max($expectedLines.Count, $actualLines.Count)
+    $isBig = 10 -lt $maxLines -or 120 -lt $maxLength
+
+    if ($isBig -and 1 -lt $maxLines) {
+        $lineCount = $maxLines
+
+        $differenceLine = $null
+        for ($i = 0; $i -lt $lineCount -and ($null -eq $differenceLine); ++$i) {
+            $e = if ($i -lt $expectedLines.Count) { $expectedLines[$i] } else { $null }
+            $a = if ($i -lt $actualLines.Count) { $actualLines[$i] } else { $null }
+            $same = if ($CaseSensitive) { $e -ceq $a } else { $e -eq $a }
+            if (-not $same) { $differenceLine = $i }
+        }
+
+        $lines += "Expected $($expectedLines.Count) line(s), actual $($actualLines.Count) line(s)."
+
+        if ($null -eq $differenceLine) {
+            # Every line is equal, so what differs is the line endings themselves. Splitting on them
+            # threw away the only difference there is, and showing the lines would print two blocks
+            # that look identical. Name the endings instead.
+            $describeEndings = {
+                param ([string] $Value)
+                $crlf = ([regex]::Matches($Value, "`r`n")).Count
+                $cr = ([regex]::Matches($Value, "`r(?!`n)")).Count
+                $lf = ([regex]::Matches($Value, "(?<!`r)`n")).Count
+                (@(
+                        if (0 -lt $crlf) { "$crlf CRLF" }
+                        if (0 -lt $cr) { "$cr CR" }
+                        if (0 -lt $lf) { "$lf LF" }
+                    ) -join ', ')
+            }
+
+            $lines += "Every line is the same, only the line endings differ."
+            $lines += "Expected: $(& $describeEndings $Expected)"
+            $lines += "But was:  $(& $describeEndings $Actual)"
+            $lines += "Use -NormalizeLineEnding to ignore this."
+            return $lines -join "`n"
+        }
+
+        $lines += "Lines differ at line $($differenceLine + 1)."
+        $lines += ""
+
+        $context = 2
+        $from = [Math]::Max(0, $differenceLine - $context)
+        $to = [Math]::Min($lineCount - 1, $differenceLine + $context)
+        $width = ($to + 1).ToString().Length
+
+        for ($i = $from; $i -le $to; ++$i) {
+            $e = if ($i -lt $expectedLines.Count) { $expectedLines[$i] } else { $null }
+            $a = if ($i -lt $actualLines.Count) { $actualLines[$i] } else { $null }
+            $number = ($i + 1).ToString().PadLeft($width)
+
+            if ($i -eq $differenceLine) {
+                # Expand only the lines that differ, so an invisible difference (a stray \r, a
+                # trailing space) is visible without turning every other line into escape codes.
+                $lines += "  $number | - $(Expand-SpecialCharacters -InputObject ([string]$e))"
+                $lines += "  $(' ' * $width) | + $(Expand-SpecialCharacters -InputObject ([string]$a))"
+            }
+            else {
+                $lines += "  $number |   $e"
+            }
+        }
+
+        return $lines -join "`n"
+    }
+
     $lines += "Strings differ at index $differenceIndex."
 
     $expectedExpanded = Expand-SpecialCharacters -InputObject $Expected
     $actualExpanded = Expand-SpecialCharacters -InputObject $Actual
 
     $prefix = "Expected: '"
-    $lines += "$prefix$expectedExpanded'"
-    $lines += "But was:  '$actualExpanded'"
-    $lines += (' ' * $prefix.Length) + ('-' * $differenceIndex) + '^'
+
+    if (-not $isBig) {
+        # Short enough to print whole, which is the most precise thing we can show.
+        $lines += "$prefix$expectedExpanded'"
+        $lines += "But was:  '$actualExpanded'"
+        $lines += (' ' * $prefix.Length) + ('-' * $differenceIndex) + '^'
+        return $lines -join "`n"
+    }
+
+    # Long. Show a window around the difference rather than the whole string, the way
+    # Should -BeExactly does in v5, so it stays readable.
+    $ellipsis = "..."
+    $window = 40
+
+    $start = [Math]::Max(0, $differenceIndex - $window)
+    $caretOffset = $differenceIndex - $start
+
+    $excerpt = {
+        param ([string] $Value)
+        $end = [Math]::Min($Value.Length, $start + $window * 2)
+        $text = if ($start -lt $Value.Length) { $Value.Substring($start, $end - $start) } else { "" }
+        $head = if (0 -lt $start) { $ellipsis } else { "" }
+        $tail = if ($end -lt $Value.Length) { $ellipsis } else { "" }
+        "$head$text$tail"
+    }
+
+    $expectedExcerpt = & $excerpt $expectedExpanded
+    $actualExcerpt = & $excerpt $actualExpanded
+    $caretPad = $caretOffset + $(if (0 -lt $start) { $ellipsis.Length } else { 0 })
+
+    $lines += "$prefix$expectedExcerpt'"
+    $lines += "But was:  '$actualExcerpt'"
+    $lines += (' ' * $prefix.Length) + ('-' * $caretPad) + '^'
 
     $lines -join "`n"
 }

--- a/tst/functions/assert/String/Should-BeString.Tests.ps1
+++ b/tst/functions/assert/String/Should-BeString.Tests.ps1
@@ -224,3 +224,50 @@ But was:  'abc␊def'
 '@ -replace "`r`n", "`n")
     }
 }
+
+Describe "Should-BeString big strings" {
+    It "Reports the differing line and its context instead of printing both strings" {
+        # The case from #2951: comparing whole generated files. Printing 10 000 lines twice is not
+        # something anyone can read, and a character offset into it is not actionable either.
+        $actual = (1..40 | ForEach-Object { "Line {0:D2}" -f $_ }) -join "`n"
+        $expected = $actual -replace 'Line 20', 'Line 99'
+
+        $err = { $actual | Should-BeString $expected } | Verify-AssertionFailed
+        $message = $err.Exception.Message
+
+        $message | Verify-Like '*Lines differ at line 20.*'
+        $message | Verify-Like '*19 |   Line 19*'
+        $message | Verify-Like '*20 | - Line 99*'
+        $message | Verify-Like '*   | + Line 20*'
+        $message | Verify-Like '*21 |   Line 21*'
+        # lines far from the difference are not printed, the whole string is not dumped
+        if ($message -like '*Line 01*') { throw 'the whole string was printed' }
+    }
+
+    It "Says so when every line matches and only the line endings differ" {
+        $lf = (1..20 | ForEach-Object { "Line $_" }) -join "`n"
+        $crlf = (1..20 | ForEach-Object { "Line $_" }) -join "`r`n"
+
+        $err = { $crlf | Should-BeString $lf } | Verify-AssertionFailed
+        $message = $err.Exception.Message
+
+        $message | Verify-Like '*Every line is the same, only the line endings differ.*'
+        $message | Verify-Like '*Expected: 19 LF*'
+        $message | Verify-Like '*But was:  19 CRLF*'
+        $message | Verify-Like '*-NormalizeLineEnding*'
+    }
+
+    It "Truncates a long single line around the difference" {
+        $actual = ('x' * 200) + 'A' + ('y' * 200)
+        $expected = ('x' * 200) + 'B' + ('y' * 200)
+
+        $err = { $actual | Should-BeString $expected } | Verify-AssertionFailed
+        $message = $err.Exception.Message
+
+        $message | Verify-Like '*Strings differ at index 200.*'
+        $message | Verify-Like "*Expected: '...*...'*"
+        # the excerpt is far shorter than the 401 character strings it came from
+        $line = ($message -split "`n") | Where-Object { $_ -like "Expected: '*" }
+        if (200 -lt $line.Length) { throw "excerpt was not truncated, it is $($line.Length) characters" }
+    }
+}


### PR DESCRIPTION
Fix #2951

Comparing whole generated files against an expected copy is a real use for `Should-BeString`, and failing one printed both strings in their entirety with a caret under the first differing character. For the 10 000 line file in the issue that is a hundred thousand lines of output, and a character offset into it that nobody can act on. `Should -BeExactly` in v5 at least truncated.

Before, on the issue's example: both strings printed in full.

After:

```
Expected strings to be the same, but they were different.
String lengths are both 109999.
Expected 10000 line(s), actual 10000 line(s).
Lines differ at line 5433.

  5431 |   Line 05431
  5432 |   Line 05432
  5433 | - Line 99999
       | + Line 05433
  5434 |   Line 05434
  5435 |   Line 05435
```

## What changed

Strings small enough to read are left **exactly** as they were, the full text with a caret is the most precise thing we can show. Only bigger ones get a compact view:

| Input | Output |
|---|---|
| more than 10 lines | the differing line, two lines of context either side |
| more than 120 characters on one line | excerpt around the difference with ellipses, like v5 |
| anything smaller | unchanged |

Only the differing lines are passed through `Expand-SpecialCharacters`, so a trailing space or a stray CR is visible without turning every other line into escape codes.

## Line endings

Splitting on line endings throws away the difference when the difference *is* the line ending. The first version of this printed two identical looking blocks and claimed line 1 differed, which is worse than no diff at all. It now detects that every line matches and names the endings instead:

```
Every line is the same, only the line endings differ.
Expected: 19 LF
But was:  19 CRLF
Use -NormalizeLineEnding to ignore this.
```

## Not done here

No diff library. One difference in a big string needs "which line, plus context", which is a first-differing-line scan. A real diff engine earns its keep when there are many scattered differences and you need hunks, which is the snapshot testing case, and that deserves its own justification rather than being folded in here.

`Should-BeString -Output Hex` from #2562 is also still open.

## Tests

Three added: the differing-line-with-context case including an assertion that the whole string is *not* printed, the line-endings-only case, and the long single line truncation. The existing message-shape test passes untouched, and `tst/functions/assert` is at 1146 passed / 7 failed, identical to main's baseline on the same machine.

🤖
