### PR TITLE
Don't let reporting a failed parallel worker abort the rest of the run

### DIFF
--- a/src/functions/Pester.Parallel.ps1
+++ b/src/functions/Pester.Parallel.ps1
@@ -193,13 +193,19 @@ function Invoke-InRunspacePool {
             catch {
                 # One worker failing must not take the rest of the run with it, the remaining files
                 # still have results worth reporting. Surface it and keep going.
-                & $SafeCommands['Write-Error'] -ErrorRecord $_
+                #
+                # -ErrorAction Continue on purpose. Without it the caller's $ErrorActionPreference
+                # decides, and a caller that runs with 'Stop' (a CI script, or Pester's own test.ps1)
+                # turns reporting a failed worker into a terminating error that aborts this loop -
+                # which is the very thing the line above says must not happen, and it would drop the
+                # results of every file that had already finished.
+                & $SafeCommands['Write-Error'] -ErrorRecord $_ -ErrorAction Continue
             }
 
             # The worker has no console of its own, so anything it wrote to these streams would be
-            # lost. Re-emit it here.
+            # lost. Re-emit it here, non-terminating for the same reason as above.
             foreach ($errorRecord in $invocation.PowerShell.Streams.Error) {
-                & $SafeCommands['Write-Error'] -ErrorRecord $errorRecord
+                & $SafeCommands['Write-Error'] -ErrorRecord $errorRecord -ErrorAction Continue
             }
             foreach ($warningRecord in $invocation.PowerShell.Streams.Warning) {
                 & $SafeCommands['Write-Warning'] -Message $warningRecord.Message

--- a/tst/Pester.RSpec.Parallel.ts.ps1
+++ b/tst/Pester.RSpec.Parallel.ts.ps1
@@ -395,6 +395,26 @@ Describe 'Second' {
             ($errors -join ' ') | Verify-Like '*worker blew up*' 
         }
 
+        t "keeps going when one worker throws even if the caller runs with ErrorActionPreference Stop" {
+            # Reporting a failed worker must not itself be terminating. A caller running with 'Stop'
+            # (a CI script, or Pester's own test.ps1) would otherwise abort this loop on the first
+            # failure and lose the results of every file that already finished.
+            $out = & (Get-Module Pester) {
+                $ErrorActionPreference = 'Stop'
+                Invoke-InRunspacePool -InputObject @(1, 2, 3) -ThrottleLimit 3 -ScriptBlock {
+                    param($item)
+                    if (2 -eq $item) { throw 'worker blew up' }
+                    $item
+                }
+            } 2>&1
+
+            $errors = @($out | Where-Object { $_ -is [System.Management.Automation.ErrorRecord] })
+            $values = @($out | Where-Object { $_ -isnot [System.Management.Automation.ErrorRecord] })
+
+            ($values | Sort-Object) -join ',' | Verify-Equal '1,3'
+            ($errors.Count -gt 0) | Verify-True
+        }
+
         t "returns nothing for an empty input" {
             $r = & (Get-Module Pester) {
                 Invoke-InRunspacePool -InputObject @() -ThrottleLimit 2 -ScriptBlock { param($item) $item }

--- a/tst/functions/assert/Time/Should-BeFasterThan.Tests.ps1
+++ b/tst/functions/assert/Time/Should-BeFasterThan.Tests.ps1
@@ -24,8 +24,13 @@ InPesterModuleScope {
 }
 
 Describe "Should-BeFasterThan" {
+    # Measuring a scriptblock times everything around it as well: compiling it, GC, and whatever
+    # else the machine is doing. That overhead has no upper bound on a shared CI runner, so the
+    # ceiling here is deliberately far larger than the sleep it is checking. A 10ms sleep that takes
+    # 30 seconds means the machine is broken, not that the assertion is wrong. The opposite
+    # direction needs no such margin, a sleep never finishes early.
     It "Does not throw when actual is faster than expected" -ForEach @(
-        @{ Actual = { Start-Sleep -Milliseconds 10 }; Expected = "100ms" }
+        @{ Actual = { Start-Sleep -Milliseconds 10 }; Expected = "30s" }
     ) {
         $Actual | Should-BeFasterThan -Expected $Expected
     }

--- a/tst/functions/assert/Time/Should-BeSlowerThan.Tests.ps1
+++ b/tst/functions/assert/Time/Should-BeSlowerThan.Tests.ps1
@@ -13,8 +13,11 @@ Describe "Should-BeSlowerThan" {
         $Actual | Should-BeSlowerThan -Expected $Expected
     }
 
+    # Same reasoning as in Should-BeFasterThan.Tests.ps1: this asserts the measured time stays
+    # below the expected one, and scriptblock overhead on a shared runner has no upper bound, so
+    # the margin is large on purpose.
     It "Throws when scriptblock is faster than expected" -ForEach @(
-        @{ Actual = { Start-Sleep -Milliseconds 10 }; Expected = "1000ms" }
+        @{ Actual = { Start-Sleep -Milliseconds 10 }; Expected = "30s" }
     ) {
         { $Actual | Should-BeSlowerThan -Expected $Expected } | Verify-AssertionFailed
     }


### PR DESCRIPTION
Two flaky tests, one of which turned out to be a real bug in `Run.Parallel`.

## Reporting a failed worker aborted the run

`Invoke-InRunspacePool` reports a worker that threw with `Write-Error` and keeps going, because the remaining files still have results worth reporting. `Write-Error` obeys the caller's `$ErrorActionPreference` though, so a caller running with `Stop` gets a terminating error instead, the loop aborts on the first failing file, and the results of everything that already finished are dropped. CI scripts commonly run with `Stop`.

```powershell
$ErrorActionPreference = 'Stop'
Invoke-InRunspacePool -InputObject @(1,2,3) -ThrottleLimit 3 -ScriptBlock {
    param($item) if (2 -eq $item) { throw 'worker blew up' }; $item
}
# before: THREW, nothing returned
# after : 1,3 returned and the error reported
```

Both `Write-Error` calls are now explicitly `-ErrorAction Continue`, with a test that sets `Stop` itself so it stays fixed regardless of the harness.

Pester's own `test.ps1` sets `Stop` on line 43, so this reliably killed the P phase locally and with it the entire RSpec phase after it. With the fix the full local suite completes: **2915 passed, 0 failed, 3 skipped**.

## Timing assertions

`Should-BeFasterThan.Does not throw when actual is faster than expected` failed on `PS7 - macOS latest` on both #2993 and #2995 today and needed manual reruns.

Both flaky assertions bound the measured time from *above*, and measuring a scriptblock times compiling it, GC, and whatever else the machine is doing, which has no upper bound on a shared runner. Widened both from `100ms`/`1000ms` to `30s`, with a comment recording the asymmetry so they do not get tightened again: a 10ms sleep that takes 30 seconds means the machine is broken, and the opposite direction needs no margin because a sleep never finishes early.

🤖
