### PR TITLE
Keep the real error when user code throws, instead of reporting an escaped break

### DIFF
--- a/src/Pester.Runtime.ps1
+++ b/src/Pester.Runtime.ps1
@@ -1729,6 +1729,15 @@ function Invoke-ScriptBlock {
             # was absorbed by the do/while above. A labelled escape skips this assignment.
             $flowControlEscaped = $false
         }
+        catch {
+            # A real terminating error from user code, which also skips the assignment above. Without
+            # clearing the flag here the finally would throw the flow-control error record on top of
+            # it and the user would be told their code has a misspelled loop label, whatever it
+            # actually threw. A labelled break/continue escape is not catchable, so this only runs
+            # for genuine errors.
+            $flowControlEscaped = $false
+            throw
+        }
         finally {
             if ($flowControlEscaped) {
                 throw (New-EscapedFlowControlErrorRecord)

--- a/tst/Pester.RSpec.ts.ps1
+++ b/tst/Pester.RSpec.ts.ps1
@@ -3658,6 +3658,46 @@ Describe "Something" {
             $tests[0].ErrorRecord[0].FullyQualifiedErrorId | Verify-Equal 'PesterFlowControlStatementEscaped'
         }
 
+        t "a real error in a setup keeps its own message and is not reported as an escaped break (#2669)" {
+            # The guard flag starts set for user code and is cleared when the scriptblock returns.
+            # A genuine throw skips that, so without clearing it on the error path too the finally
+            # threw the flow control error record over the top of the real one, and anyone whose
+            # BeforeAll threw was told their code has a misspelled loop label.
+            $sb = {
+                Describe 'real error in setup' {
+                    BeforeAll { throw 'the database is down' }
+                    It 'is failed by the setup' { $true | Should -Be $true }
+                }
+            }
+
+            $r = Invoke-Pester -Configuration ([PesterConfiguration]@{
+                    Run    = @{ ScriptBlock = $sb; PassThru = $true }
+                    Output = @{ Verbosity = 'None' }
+                })
+
+            $r.Result | Verify-Equal 'Failed'
+            $block = $r.Containers[0].Blocks[0]
+            $block.ErrorRecord[0].Exception.Message | Verify-Equal 'the database is down'
+            if ('PesterFlowControlStatementEscaped' -eq $block.ErrorRecord[0].FullyQualifiedErrorId) {
+                throw 'the real error was replaced by the escaped flow control error'
+            }
+        }
+
+        t "a real error in a top-level setup keeps its own message (#2669)" {
+            $sb = {
+                BeforeAll { throw 'the database is down' }
+                Describe 'd' { It 'i' { $true | Should -Be $true } }
+            }
+
+            $r = Invoke-Pester -Configuration ([PesterConfiguration]@{
+                    Run    = @{ ScriptBlock = $sb; PassThru = $true }
+                    Output = @{ Verbosity = 'None' }
+                })
+
+            $r.Result | Verify-Equal 'Failed'
+            $r.Containers[0].ErrorRecord[0].Exception.Message | Verify-Equal 'the database is down'
+        }
+
         t "correctly labelled break and continue inside loops in user code are unaffected" {
             $sb = {
                 Describe 'labelled loops still work' {


### PR DESCRIPTION
Found while looking at #2646. A `BeforeAll` that throws reports the wrong error, and the real one is discarded:

| Where the throw is | Reported |
|---|---|
| top-level `BeforeAll` | *A 'break' or 'continue' statement with a label that does not match any enclosing loop escaped from your code…* |
| `Describe`-level `BeforeAll` | same |
| inside an `It` | correct |

So someone whose setup failed because a database was down is told their code has a misspelled loop label, and what it actually threw is gone.

## Cause

The #2669 guard in `Invoke-ScriptBlock`:

```powershell
$flowControlEscaped = $MoveBetweenScopes   # true for user code
try {
    do { ...invoke... } while ($false)
    $flowControlEscaped = $false           # skipped when user code throws
}
finally {
    if ($flowControlEscaped) { throw (New-EscapedFlowControlErrorRecord) }
}
```

A genuine `throw` skips the reset, so the `finally` throws the guard's error record on top of the real exception, and in PowerShell the exception from a `finally` wins.

## Fix

Clear the flag on the error path too. A labelled `break`/`continue` escape is not catchable, which is the whole premise of the guard, so the new `catch` only ever runs for real errors and the guard still works.

Verified all four cases:

```
top      -> TOP LEVEL ERROR
inner    -> INNER ERROR
intest   -> IN TEST ERROR
label    -> A 'break' or 'continue' statement with a label that does not match...
```

Two regression tests added next to the existing #2669 ones.

## Note

This is not #2646 itself. That one is about the *output* omitting the test names when a `BeforeAll` fails, and the result object already contains every test marked `Failed` — so it is a rendering fix at a different layer, and it is still open.

`tst` excluding the parallel file is at 2910 passed / 12 failed, identical to main's baseline on the same machine. The P phase is clean apart from the `Invoke-InRunspacePool` failure that #3004 fixes.

🤖
